### PR TITLE
Audit fix 1: pose/action authorship is the worn face, derived server-side

### DIFF
--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -771,6 +771,17 @@ lookup across all rows instead of re-querying per row. Scene poses submitted fro
 `/game` take the REST `submit-pose` path, keyed by `scene_id` — a pose belongs to
 a scene, not a room, so this is unrelated to room id.
 
+**Pose/action authorship is the worn face, derived server-side (#981 audit fix):**
+the client's `persona_id`/`initiator_persona` only *selects the acting character*
+(ownership-validated); `submit_pose`, the action-request create path, and the
+technique-cast create path all re-derive the recorded persona via
+`active_persona_for_sheet`, and `record_interaction`'s no-persona fallback (the
+telnet/WS path) does the same — never `primary_persona` directly, so a client
+passing the primary id can never unmask a worn ESTABLISHED alt or TEMPORARY mask.
+Frontend mirrors this with `actingPersonaId()` (`frontend/src/roster/persona.ts`)
+everywhere a persona id feeds an IC write or self-matching read (attention
+routing, own-pose exclusion).
+
 **Places query room-id vs scene-id (fold-in fix, unrelated to the above):**
 `PlaceBar`'s `sceneId` prop is actually used as the ROOM id by
 `fetchPlaces(?room=)` (confirmed by reading `PlaceBar.tsx` + `actionQueries.ts`)

--- a/frontend/src/conditions/components/TreatActionPanel.tsx
+++ b/frontend/src/conditions/components/TreatActionPanel.tsx
@@ -3,6 +3,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { HeartPulse } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useAppSelector } from '@/store/hooks';
+import { actingPersonaId } from '@/roster/persona';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { extractErrorMessage } from '@/lib/errors';
 import { useTreatmentCandidates } from '../queries';
@@ -44,7 +45,7 @@ export function TreatActionPanel({ sceneId, targetPersonaId }: Props) {
     [myRosterEntries, activeCharacterName]
   );
   const characterId = activeEntry?.character_id ?? null;
-  const initiatorPersonaId = activeEntry?.primary_persona_id ?? null;
+  const initiatorPersonaId = actingPersonaId(activeEntry);
 
   const { data, isLoading } = useTreatmentCandidates(targetPersonaId, characterId);
   const candidates = data?.candidates ?? [];

--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -17,6 +17,7 @@ import { JournalTab } from '@/journals/components/JournalTab';
 import { StatusPanel } from '@/status/components/StatusPanel';
 import { InventorySidebarPanel } from '@/inventory/components/InventorySidebarPanel';
 import { VoyagePanel } from '@/travel/components/VoyagePanel';
+import { actingPersonaId } from '@/roster/persona';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { useFocusStack, type FocusEntry } from '@/inventory/hooks/useFocusStack';
 import { Link } from 'react-router-dom';
@@ -93,7 +94,7 @@ export function GamePage() {
   const activeCharacterId = activeEntry?.character_id ?? null;
   // Lifted from GameWindow (#2156 review fold-in) — dedupes the roster query
   // that both GamePage and GameWindow used to call independently.
-  const personaId = activeEntry?.primary_persona_id ?? null;
+  const personaId = actingPersonaId(activeEntry);
   // The active character's own RosterEntry id (#2156 Task 7) — the FriendButton's
   // `viewerEntryId` inside the character-card drawer.
   const viewerEntryId = activeEntry?.id ?? null;

--- a/frontend/src/game/components/GameTopBar.tsx
+++ b/frontend/src/game/components/GameTopBar.tsx
@@ -4,6 +4,7 @@ import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { setActiveSession, startSession } from '@/store/gameSlice';
 import { useGameSocket } from '@/hooks/useGameSocket';
 import { Avatar, AvatarImage, AvatarFallback } from '@/components/ui/avatar';
+import { actingPersonaId } from '@/roster/persona';
 import type { MyRosterEntry } from '@/roster/types';
 import { WeatherWidget } from '@/weather/components/WeatherWidget';
 import { ComfortWidget } from '@/comfort/components/ComfortWidget';
@@ -106,7 +107,7 @@ export function GameTopBar({ characters }: GameTopBarProps) {
       ) : null}
 
       {altCharacters.map((char) => {
-        const attention = sessionAttention(sessions[char.name], char.primary_persona_id);
+        const attention = sessionAttention(sessions[char.name], actingPersonaId(char));
         return (
           <button
             key={char.id}

--- a/frontend/src/game/components/GameWindow.tsx
+++ b/frontend/src/game/components/GameWindow.tsx
@@ -13,6 +13,7 @@ import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { setActiveSession } from '@/store/gameSlice';
 import { useGameSocket } from '@/hooks/useGameSocket';
 import { Link } from 'react-router-dom';
+import { actingPersonaId } from '@/roster/persona';
 import type { MyRosterEntry } from '@/roster/types';
 import { sessionAttention } from '@/game/attention';
 
@@ -195,7 +196,7 @@ export function GameWindow({
       {sessionNames.length >= 2 && (
         <div className="mb-2 flex gap-2 border-b">
           {sessionNames.map((name) => {
-            const personaId = characters.find((c) => c.name === name)?.primary_persona_id ?? null;
+            const personaId = actingPersonaId(characters.find((c) => c.name === name));
             const attention = sessionAttention(sessions[name], personaId);
             return (
               <button

--- a/frontend/src/hooks/handleInteractionPayload.ts
+++ b/frontend/src/hooks/handleInteractionPayload.ts
@@ -4,6 +4,7 @@ import type { InteractionWsPayload } from './types';
 import type { AppDispatch } from '@/store/store';
 import { store } from '@/store/store';
 import { addSceneInteraction, openThreadTab, setActiveSession } from '@/store/gameSlice';
+import { actingPersonaId } from '@/roster/persona';
 import type { MyRosterEntry } from '@/roster/types';
 import { queryClient } from '@/queryClient';
 import { getThreadKey } from '@/scenes/hooks/useThreading';
@@ -55,7 +56,7 @@ const MAX_TOASTED_WHISPER_IDS = 500;
  */
 function ownPersonaId(character: MyRosterEntry['name']): number | null {
   const rosterEntries = queryClient.getQueryData<MyRosterEntry[]>(['my-roster-entries']);
-  return rosterEntries?.find((entry) => entry.name === character)?.primary_persona_id ?? null;
+  return actingPersonaId(rosterEntries?.find((entry) => entry.name === character));
 }
 
 function maybeToastWhisperAttention(

--- a/frontend/src/roster/persona.ts
+++ b/frontend/src/roster/persona.ts
@@ -1,0 +1,21 @@
+import type { MyRosterEntry } from './types';
+
+/**
+ * The persona id a character is ACTING as right now — the worn face (#981).
+ *
+ * `active_persona_id` is serialized with the primary fallback already applied
+ * server-side (`RosterEntrySerializer.get_active_persona_id`), so it is the
+ * single source of truth for "which face is this character presenting"; the
+ * extra `primary_persona_id` fallback here only covers stale cached payloads.
+ *
+ * Use this — never `primary_persona_id` directly — anywhere the id feeds an
+ * IC-meaningful write (pose/action initiator) or self-matching read
+ * (attention routing, own-pose exclusion). Reading the primary while a mask
+ * or ESTABLISHED alt is worn both unmasks the disguise on writes and breaks
+ * self-matching on reads, since the server broadcasts the worn face.
+ */
+export function actingPersonaId(
+  entry: Pick<MyRosterEntry, 'active_persona_id' | 'primary_persona_id'> | null | undefined
+): number | null {
+  return entry?.active_persona_id ?? entry?.primary_persona_id ?? null;
+}

--- a/frontend/src/scenes/components/ActionPanel.tsx
+++ b/frontend/src/scenes/components/ActionPanel.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { useAppSelector } from '@/store/hooks';
+import { actingPersonaId } from '@/roster/persona';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import {
   fetchAvailableActions,
@@ -106,7 +107,7 @@ export function ActionPanel({ sceneId }: Props) {
     [myRosterEntries, activeCharacterName]
   );
   const characterId = activeEntry?.character_id ?? null;
-  const initiatorPersonaId = activeEntry?.primary_persona_id ?? null;
+  const initiatorPersonaId = actingPersonaId(activeEntry);
 
   const { data, isLoading } = useQuery({
     queryKey: ['available-actions', characterId],

--- a/frontend/src/scenes/components/EndorsementControl.tsx
+++ b/frontend/src/scenes/components/EndorsementControl.tsx
@@ -31,6 +31,7 @@
 
 import { useMemo } from 'react';
 import { useAppSelector } from '@/store/hooks';
+import { actingPersonaId } from '@/roster/persona';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import {
   DropdownMenu,
@@ -85,7 +86,7 @@ export function EndorsementControl({ interaction, sceneId, kind }: EndorsementCo
   const activeCharacterName = useAppSelector((state) => state.game.active);
   const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
   const viewerPersonaId = useMemo(
-    () => myRosterEntries.find((e) => e.name === activeCharacterName)?.primary_persona_id ?? null,
+    () => actingPersonaId(myRosterEntries.find((e) => e.name === activeCharacterName)),
     [myRosterEntries, activeCharacterName]
   );
 

--- a/frontend/src/scenes/components/PoseUnit.tsx
+++ b/frontend/src/scenes/components/PoseUnit.tsx
@@ -15,6 +15,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import { useAppSelector } from '@/store/hooks';
+import { actingPersonaId } from '@/roster/persona';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { PersonaAvatar } from '@/components/PersonaAvatar';
 import { FormattedContent } from '@/components/FormattedContent';
@@ -217,7 +218,7 @@ export function PoseUnit({
   const activeCharacterName = useAppSelector((state) => state.game.active);
   const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
   const viewerPersonaId = useMemo(
-    () => myRosterEntries.find((e) => e.name === activeCharacterName)?.primary_persona_id ?? null,
+    () => actingPersonaId(myRosterEntries.find((e) => e.name === activeCharacterName)),
     [myRosterEntries, activeCharacterName]
   );
   const isSelfPose = viewerPersonaId != null && interaction.persona.id === viewerPersonaId;

--- a/frontend/src/scenes/components/ReactionStrip.tsx
+++ b/frontend/src/scenes/components/ReactionStrip.tsx
@@ -12,6 +12,7 @@
 import { useMemo } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAppSelector } from '@/store/hooks';
+import { actingPersonaId } from '@/roster/persona';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { reactToWindow, reactToInteraction } from '../queries';
 import type { ReactionWindowPayload } from '../types';
@@ -31,7 +32,7 @@ export function ReactionStrip({ windows, sceneId, interactionId }: ReactionStrip
   const activeCharacterName = useAppSelector((state) => state.game.active);
   const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
   const personaId = useMemo(
-    () => myRosterEntries.find((e) => e.name === activeCharacterName)?.primary_persona_id ?? null,
+    () => actingPersonaId(myRosterEntries.find((e) => e.name === activeCharacterName)),
     [myRosterEntries, activeCharacterName]
   );
   const mutation = useMutation({

--- a/frontend/src/scenes/components/SpeakerQueueBar.tsx
+++ b/frontend/src/scenes/components/SpeakerQueueBar.tsx
@@ -13,6 +13,7 @@ import {
 } from '../actionQueries';
 import type { SpeakerQueue as SpeakerQueueType } from '../actionTypes';
 import { useAppSelector } from '@/store/hooks';
+import { actingPersonaId } from '@/roster/persona';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 
 interface Props {
@@ -34,7 +35,7 @@ export function SpeakerQueueBar({ roomId }: Props) {
     () => myRosterEntries.find((e) => e.name === activeCharacter) ?? null,
     [myRosterEntries, activeCharacter]
   );
-  const personaId = activeEntry?.primary_persona_id ?? null;
+  const personaId = actingPersonaId(activeEntry);
 
   const queue = data?.results?.[0] ?? null;
   const myEntry = queue?.entries.find((e) => e.persona === personaId) ?? null;

--- a/frontend/src/scenes/pages/SceneDetailPage.tsx
+++ b/frontend/src/scenes/pages/SceneDetailPage.tsx
@@ -22,6 +22,7 @@ import { CharacterCardDrawer } from '@/game/components/CharacterCardDrawer';
 import type { PoseUnitAvatarClickPersona } from '../components/PoseUnit';
 import type { ActionAttachmentInfo } from '../actionTypes';
 import { useAppSelector } from '@/store/hooks';
+import { actingPersonaId } from '@/roster/persona';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { PendingActionAttachments } from '../components/PendingActionAttachments';
 import { usePendingUnlinkedActions } from '../hooks/usePendingUnlinkedActions';
@@ -73,7 +74,7 @@ export function SceneDetailPage() {
     () => myRosterEntries.find((e) => e.name === activeCharacter) ?? null,
     [myRosterEntries, activeCharacter]
   );
-  const personaId = activeEntry?.primary_persona_id ?? null;
+  const personaId = actingPersonaId(activeEntry);
   const characterSheetId = activeEntry?.character_id ?? 0;
   // The active character's own RosterEntry id (#2156 Task 7) — the FriendButton's
   // `viewerEntryId` inside the character-card drawer.

--- a/src/world/scenes/action_views.py
+++ b/src/world/scenes/action_views.py
@@ -44,6 +44,7 @@ from world.scenes.action_services import (
 from world.scenes.cast_services import request_technique_cast
 from world.scenes.interaction_permissions import get_account_personas
 from world.scenes.models import Persona, Scene
+from world.scenes.services import active_persona_for_sheet
 
 # Repeated API error detail strings. Centralized to avoid the duplicated-literal
 # SonarCloud smell (python:S1192).
@@ -320,7 +321,12 @@ class SceneActionRequestViewSet(PuppetActorMixin, viewsets.ModelViewSet):
                 {"detail": _INITIATOR_NOT_FOUND_DETAIL},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        initiator_persona = get_object_or_404(Persona, pk=initiator_persona_id)
+        # The submitted persona only SELECTS the acting character; the recorded
+        # initiator is always that character's currently-worn face (#981), derived
+        # server-side so a client passing the primary persona can never unmask a
+        # worn alt/mask (mirrors the hostile-dispatch path below and telnet).
+        selected_initiator = get_object_or_404(Persona, pk=initiator_persona_id)
+        initiator_persona = active_persona_for_sheet(selected_initiator.character_sheet)
 
         primary_id = target_ids[0] if target_ids else None
         target_persona = (
@@ -609,7 +615,9 @@ class SceneActionRequestViewSet(PuppetActorMixin, viewsets.ModelViewSet):
                 {"detail": _INITIATOR_NOT_FOUND_DETAIL},
                 status=status.HTTP_400_BAD_REQUEST,
             )
-        initiator_persona = get_object_or_404(Persona, pk=initiator_persona_id)
+        # Same worn-face derivation as the action-request create path (#981).
+        selected_initiator = get_object_or_404(Persona, pk=initiator_persona_id)
+        initiator_persona = active_persona_for_sheet(selected_initiator.character_sheet)
 
         target_persona: Persona | None = None
         if target_persona_id is not None:

--- a/src/world/scenes/interaction_services.py
+++ b/src/world/scenes/interaction_services.py
@@ -683,9 +683,12 @@ def record_interaction(  # noqa: PLR0913 - all fields needed for interaction cre
 ) -> Interaction | None:
     """Record an IC interaction to the database.
 
-    Reads the character's primary persona from their CharacterSheet, unless an
-    explicit ``persona`` override is supplied (the REST pose path lets the writer
-    pose as any owned persona — established/mask alt included — not just primary).
+    Attributes authorship to the character's **currently-worn face**
+    (``active_persona_for_sheet`` — the active persona when set, else PRIMARY),
+    unless an explicit ``persona`` override is supplied. Never defaults to
+    ``primary_persona`` directly: a character presenting as an ESTABLISHED alt
+    or TEMPORARY mask must be recorded as that face, or the permanent scene
+    record unmasks the disguise (#981 alt-leak rule).
     Skips recording if no persona could be resolved either way.
 
     For public interactions (no place, no receivers), the interaction is
@@ -704,8 +707,10 @@ def record_interaction(  # noqa: PLR0913 - all fields needed for interaction cre
     branch (there is no row to attach anything to).
     """
     if persona is None:
+        from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
         try:
-            persona = character.sheet_data.primary_persona
+            persona = active_persona_for_sheet(character.sheet_data)
         except ObjectDoesNotExist:
             return None
 

--- a/src/world/scenes/interaction_views.py
+++ b/src/world/scenes/interaction_views.py
@@ -68,6 +68,7 @@ from world.scenes.reaction_toggle_services import (
     toggle_interaction_favorite,
     toggle_interaction_reaction,
 )
+from world.scenes.services import active_persona_for_sheet
 
 
 class InteractionCursorPagination(CursorPagination):
@@ -329,7 +330,12 @@ class InteractionViewSet(
         serializer.is_valid(raise_exception=True)
         data = serializer.validated_data
 
-        persona = Persona.objects.get(pk=data["persona_id"])
+        # The submitted persona_id (ownership-validated) only SELECTS the acting
+        # character; authorship is always the character's currently-worn face
+        # (#981 active persona), derived server-side so a client passing the
+        # primary persona can never unmask a worn ESTABLISHED alt or mask.
+        selected = Persona.objects.get(pk=data["persona_id"])
+        persona = active_persona_for_sheet(selected.character_sheet)
         scene: Scene | None = (
             Scene.objects.get(pk=data["scene_id"]) if data.get("scene_id") else None
         )

--- a/src/world/scenes/tests/test_interaction_services.py
+++ b/src/world/scenes/tests/test_interaction_services.py
@@ -460,6 +460,35 @@ class TestRecordInteraction(TestCase):
         assert result is not None
         assert result.persona == identity_a.primary_persona
 
+    def test_masked_character_records_worn_face_not_primary(self) -> None:
+        """The default-persona fallback is the WORN face, never primary (#981 alt-leak).
+
+        The telnet/WS pose path passes no explicit persona — if the fallback
+        read ``primary_persona`` directly, every pose made while masked would
+        unmask the disguise in the permanent scene record.
+        """
+        from world.scenes.factories import PersonaFactory
+        from world.scenes.services import set_active_persona
+
+        room = ObjectDBFactory(
+            db_key="Hall",
+            db_typeclass_path="typeclasses.rooms.Room",
+        )
+        char_a = CharacterFactory(db_key="Alice", location=room)
+        char_b = CharacterFactory(db_key="Bob", location=room)
+        identity_a = CharacterSheetFactory(character=char_a)
+        CharacterSheetFactory(character=char_b)
+        mask = PersonaFactory(character_sheet=identity_a, name="The Gray Hood")
+        set_active_persona(identity_a, mask)
+
+        result = record_interaction(
+            character=char_a,
+            content="waves.",
+            mode=InteractionMode.POSE,
+        )
+        assert result is not None
+        assert result.persona == mask
+
     def test_creates_with_place(self) -> None:
         room = ObjectDBFactory(
             db_key="Hall",

--- a/src/world/scenes/tests/test_interaction_views.py
+++ b/src/world/scenes/tests/test_interaction_views.py
@@ -427,6 +427,39 @@ class PoseSubmitViewTests(APITestCase):
         )
         assert response.status_code == status.HTTP_400_BAD_REQUEST
 
+    def test_submit_pose_masked_records_worn_face_not_primary(self) -> None:
+        """Authorship is the sheet's ACTIVE persona even when the client sends primary (#981).
+
+        The submitted persona_id only selects the acting character — a client
+        passing the primary persona while an alt/mask is worn must not unmask
+        the disguise in the permanent scene record.
+        """
+        from world.scenes.factories import PersonaFactory
+        from world.scenes.services import set_active_persona
+
+        mask = PersonaFactory(character_sheet=self.identity, name="The Gray Hood")
+        set_active_persona(self.identity, mask)
+
+        response = self.client.post(
+            self.url,
+            {"persona_id": self.persona.pk, "content": "A pose while masked."},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        interaction = Interaction.objects.get(pk=response.data["id"])
+        assert interaction.persona_id == mask.pk
+
+    def test_submit_pose_unmasked_records_primary(self) -> None:
+        """With no active face set, authorship stays the primary persona."""
+        response = self.client.post(
+            self.url,
+            {"persona_id": self.persona.pk, "content": "A bare-faced pose."},
+            format="json",
+        )
+        assert response.status_code == status.HTTP_201_CREATED
+        interaction = Interaction.objects.get(pk=response.data["id"])
+        assert interaction.persona_id == self.persona.pk
+
     def test_submit_pose_creates_interaction_in_scene(self) -> None:
         """Providing scene_id attaches the pose to that scene."""
         scene = SceneFactory()


### PR DESCRIPTION
## What

Fixes the highest-severity finding from the 2026-07-16 frontend audit: the web pose path (`submit_pose`), the action-request create path, and the technique-cast create path all recorded the **client-submitted persona verbatim**, and `record_interaction`'s no-persona fallback (the telnet/WS path) read `primary_persona` directly. Since the web composer always sent `primary_persona_id`, any character presenting as an ESTABLISHED alt or TEMPORARY mask was **unmasked in the permanent scene record** — a direct violation of the #981 alt-privacy rule ("gate every IC-meaningful read on `active_persona_for_sheet`, never `primary_persona` directly").

## Backend

The client's `persona_id`/`initiator_persona` now only *selects the acting character* (ownership validation unchanged); the recorded persona is re-derived server-side via `active_persona_for_sheet` at all four seams — so no client bug can ever unmask a disguise again. One dispatch path (hostile-check) already did this ("mirrors telnet"); the rest now match.

## Frontend

New `actingPersonaId()` helper (`roster/persona.ts`) — worn face with primary fallback — swapped in at every acting-identity and attention/self-matching read of `primary_persona_id` (GamePage, SceneDetailPage, ActionPanel, TreatActionPanel, SpeakerQueueBar, EndorsementControl, ReactionStrip, PoseUnit, GameTopBar, GameWindow, handleInteractionPayload). This also fixes attention routing while masked: whispers target the worn face, so self-matching on primary silently broke unread/direct badges for masked characters. OOC staff-facing surfaces (submissions) deliberately unchanged.

## Tests

- `test_submit_pose_masked_records_worn_face_not_primary` + unmasked control (view layer)
- `test_masked_character_records_worn_face_not_primary` (record_interaction fallback)
- Full `scenes` interaction/action suites green (162), frontend game/scenes/hooks/conditions suites green (624).

Part of the audit attack order (item 1 of 8); docs updated in `docs/systems/scenes.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)