### PR TITLE
Audit fix 2: typed API errors, FormData uploads, route-level error boundary

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense } from 'react';
 import { Routes, Route, Navigate, useParams } from 'react-router-dom';
 import { Layout } from './components/Layout';
+import { ErrorBoundary } from './components/ErrorBoundary';
 import { GuestOnlyRoute } from './components/GuestOnlyRoute';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { RequireCharacter } from './components/RequireCharacter';
@@ -301,717 +302,733 @@ export function CombatRouteRedirect() {
 function App() {
   return (
     <Layout>
-      <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route
-          path="/login"
-          element={
-            <GuestOnlyRoute>
-              <LoginPage />
-            </GuestOnlyRoute>
-          }
-        />
-        <Route
-          path="/register"
-          element={
-            <GuestOnlyRoute>
-              <RegisterPage />
-            </GuestOnlyRoute>
-          }
-        />
-        <Route path="/register/verify-email" element={<EmailVerificationPendingPage />} />
-        <Route path="/verify-email/:key" element={<EmailVerifyPage />} />
-        <Route path="/auth/callback" element={<AuthCallbackPage />} />
-        <Route path="/account/unverified" element={<UnverifiedAccountPage />} />
-        <Route path="/how-to-start" element={<HowToStartPage />} />
-        <Route path="/profile/*" element={<ProfilePage />}>
-          <Route path="mail" element={<MailPage />} />
-          <Route path="media" element={<PlayerMediaPage />} />
-          <Route path="settings" element={<SettingsPage />} />
+      {/* Route-level boundary (2026-07 audit): ~130 queries use throwOnError
+          with only main.tsx's root boundary above the Layout — one transient
+          failure on any unwrapped page replaced the ENTIRE app (nav included)
+          with the fallback. Catching inside Layout keeps the chrome alive;
+          the root boundary remains the last resort. */}
+      <ErrorBoundary>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
           <Route
-            path="privacy"
+            path="/login"
             element={
-              <Suspense fallback={<PageLoadingFallback />}>
-                <PrivacyPage />
-              </Suspense>
+              <GuestOnlyRoute>
+                <LoginPage />
+              </GuestOnlyRoute>
             }
           />
           <Route
-            path="boundaries"
+            path="/register"
             element={
-              <Suspense fallback={<PageLoadingFallback />}>
-                <BoundariesPage />
-              </Suspense>
+              <GuestOnlyRoute>
+                <RegisterPage />
+              </GuestOnlyRoute>
             }
           />
-          <Route path="blocks" element={<BlocksSettingsPage />} />
-          <Route path="mutes" element={<MutesSettingsPage />} />
-          <Route index element={<Navigate to="mail" replace />} />
-        </Route>
-        <Route path="/roster" element={<RosterListPage />} />
-        <Route path="/characters/create" element={<CharacterCreationPage />} />
-        <Route path="/characters/:id" element={<CharacterSheetPage />} />
-        <Route path="/missions/journal" element={<JournalPage />} />
-        <Route
-          path="/journals"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
+          <Route path="/register/verify-email" element={<EmailVerificationPendingPage />} />
+          <Route path="/verify-email/:key" element={<EmailVerifyPage />} />
+          <Route path="/auth/callback" element={<AuthCallbackPage />} />
+          <Route path="/account/unverified" element={<UnverifiedAccountPage />} />
+          <Route path="/how-to-start" element={<HowToStartPage />} />
+          {/* Guarded (2026-07 audit): unauthenticated visits fired the subtree's
+            account-scoped queries straight into 403s. */}
+          <Route
+            path="/profile/*"
+            element={
               <ProtectedRoute>
-                <JournalsPage />
+                <ProfilePage />
               </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route path="/tidings" element={<TidingsPage />} />
-        <Route path="/scenes" element={<ScenesListPage />} />
-        <Route path="/scenes/:id" element={<SceneDetailPage />} />
-        <Route path="/scenes/:id/combat" element={<CombatRouteRedirect />} />
-        <Route path="/scenes/:id/battle" element={<BattleMapPage />} />
-        <Route path="/battles/:id" element={<BattleWriteupPage />} />
-        <Route path="/events" element={<EventsListPage />} />
-        <Route
-          path="/events/new"
-          element={
-            <ProtectedRoute>
-              <EventCreatePage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/events/:id/edit"
-          element={
-            <ProtectedRoute>
-              <EventEditPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route path="/events/:id" element={<EventDetailPage />} />
-        <Route
-          path="/xp-kudos"
-          element={
-            <ProtectedRoute>
-              <RequireCharacter>
-                <XpKudosPage />
-              </RequireCharacter>
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/feedback"
-          element={
-            <ProtectedRoute>
-              <FeedbackPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/bug-report"
-          element={
-            <ProtectedRoute>
-              <BugReportPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/report-player"
-          element={
-            <ProtectedRoute>
-              <PlayerReportPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route path="/game" element={<GamePage />} />
-        <Route path="/codex" element={<CodexPage />} />
-        <Route
-          path="/market"
-          element={
-            <ProtectedRoute>
-              <MarketPage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/wardrobe"
-          element={
-            <ProtectedRoute>
-              <WardrobePage />
-            </ProtectedRoute>
-          }
-        />
-        <Route
-          path="/staff"
-          element={
-            <StaffRoute>
-              <StaffHubPage />
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/inbox"
-          element={
-            <StaffRoute>
-              <StaffInboxPage />
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/missions"
-          element={
-            <StaffRoute>
-              <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-                <MissionBrowserPage />
+            }
+          >
+            <Route path="mail" element={<MailPage />} />
+            <Route path="media" element={<PlayerMediaPage />} />
+            <Route path="settings" element={<SettingsPage />} />
+            <Route
+              path="privacy"
+              element={
+                <Suspense fallback={<PageLoadingFallback />}>
+                  <PrivacyPage />
+                </Suspense>
+              }
+            />
+            <Route
+              path="boundaries"
+              element={
+                <Suspense fallback={<PageLoadingFallback />}>
+                  <BoundariesPage />
+                </Suspense>
+              }
+            />
+            <Route path="blocks" element={<BlocksSettingsPage />} />
+            <Route path="mutes" element={<MutesSettingsPage />} />
+            <Route index element={<Navigate to="mail" replace />} />
+          </Route>
+          <Route path="/roster" element={<RosterListPage />} />
+          <Route path="/characters/create" element={<CharacterCreationPage />} />
+          <Route path="/characters/:id" element={<CharacterSheetPage />} />
+          <Route path="/missions/journal" element={<JournalPage />} />
+          <Route
+            path="/journals"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <JournalsPage />
+                </ProtectedRoute>
               </Suspense>
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/missions/new"
-          element={
-            <StaffRoute>
-              <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-                <CreateMissionPage />
-              </Suspense>
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/missions/:id/canvas"
-          element={
-            <StaffRoute>
-              <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-                <MissionCanvasPage />
-              </Suspense>
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/missions/:id/nodes/:nodeId"
-          element={
-            <StaffRoute>
-              <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-                <MissionNodePage />
-              </Suspense>
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/missions/:id/nodes/:nodeId/options/:optionId"
-          element={
-            <StaffRoute>
-              <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-                <MissionOptionPage />
-              </Suspense>
-            </StaffRoute>
-          }
-        />
-        {/* NPC-mediated giver editor lives on the npc-services framework
+            }
+          />
+          <Route path="/tidings" element={<TidingsPage />} />
+          <Route path="/scenes" element={<ScenesListPage />} />
+          <Route path="/scenes/:id" element={<SceneDetailPage />} />
+          <Route path="/scenes/:id/combat" element={<CombatRouteRedirect />} />
+          <Route path="/scenes/:id/battle" element={<BattleMapPage />} />
+          <Route path="/battles/:id" element={<BattleWriteupPage />} />
+          <Route path="/events" element={<EventsListPage />} />
+          <Route
+            path="/events/new"
+            element={
+              <ProtectedRoute>
+                <EventCreatePage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/events/:id/edit"
+            element={
+              <ProtectedRoute>
+                <EventEditPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/events/:id" element={<EventDetailPage />} />
+          <Route
+            path="/xp-kudos"
+            element={
+              <ProtectedRoute>
+                <RequireCharacter>
+                  <XpKudosPage />
+                </RequireCharacter>
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/feedback"
+            element={
+              <ProtectedRoute>
+                <FeedbackPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/bug-report"
+            element={
+              <ProtectedRoute>
+                <BugReportPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/report-player"
+            element={
+              <ProtectedRoute>
+                <PlayerReportPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route path="/game" element={<GamePage />} />
+          <Route path="/codex" element={<CodexPage />} />
+          <Route
+            path="/market"
+            element={
+              <ProtectedRoute>
+                <MarketPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/wardrobe"
+            element={
+              <ProtectedRoute>
+                <WardrobePage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/staff"
+            element={
+              <StaffRoute>
+                <StaffHubPage />
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/inbox"
+            element={
+              <StaffRoute>
+                <StaffInboxPage />
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/missions"
+            element={
+              <StaffRoute>
+                <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+                  <MissionBrowserPage />
+                </Suspense>
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/missions/new"
+            element={
+              <StaffRoute>
+                <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+                  <CreateMissionPage />
+                </Suspense>
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/missions/:id/canvas"
+            element={
+              <StaffRoute>
+                <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+                  <MissionCanvasPage />
+                </Suspense>
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/missions/:id/nodes/:nodeId"
+            element={
+              <StaffRoute>
+                <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+                  <MissionNodePage />
+                </Suspense>
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/missions/:id/nodes/:nodeId/options/:optionId"
+            element={
+              <StaffRoute>
+                <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+                  <MissionOptionPage />
+                </Suspense>
+              </StaffRoute>
+            }
+          />
+          {/* NPC-mediated giver editor lives on the npc-services framework
             (NPCRole + NPCServiceOffer) per #686/#728; trigger-based givers
             (ROOM_TRIGGER + ENVIRONMENTAL_DETAIL) get their own editor — #729. */}
-        <Route
-          path="/staff/npc-services/roles"
-          element={
-            <StaffRoute>
-              <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-                <NPCRolesLibraryPage />
-              </Suspense>
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/npc-services/roles/:id"
-          element={
-            <StaffRoute>
-              <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-                <NPCRoleEditorPage />
-              </Suspense>
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/missions/givers"
-          element={
-            <StaffRoute>
-              <Suspense fallback={<Skeleton className="h-64 w-full" />}>
-                <TriggerGiversPage />
-              </Suspense>
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/applications"
-          element={
-            <StaffRoute>
-              <StaffApplicationsPage />
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/applications/:id"
-          element={
-            <StaffRoute>
-              <StaffApplicationDetailPage />
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/feedback"
-          element={
-            <StaffRoute>
-              <StaffFeedbackPage />
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/feedback/:id"
-          element={
-            <StaffRoute>
-              <StaffFeedbackDetailPage />
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/bug-reports"
-          element={
-            <StaffRoute>
-              <StaffBugReportsPage />
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/bug-reports/:id"
-          element={
-            <StaffRoute>
-              <StaffBugReportDetailPage />
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/player-reports"
-          element={
-            <StaffRoute>
-              <StaffPlayerReportsPage />
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/player-reports/:id"
-          element={
-            <StaffRoute>
-              <StaffPlayerReportDetailPage />
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/system-errors"
-          element={
-            <StaffRoute>
-              <StaffSystemErrorsPage />
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/system-errors/:id"
-          element={
-            <StaffRoute>
-              <StaffSystemErrorDetailPage />
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/gm-applications"
-          element={
-            <StaffRoute>
-              <StaffGMApplicationsPage />
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/gm-applications/:id"
-          element={
-            <StaffRoute>
-              <StaffGMApplicationDetailPage />
-            </StaffRoute>
-          }
-        />
-        <Route
-          path="/staff/accounts/:id/history"
-          element={
-            <StaffRoute>
-              <StaffAccountHistoryPage />
-            </StaffRoute>
-          }
-        />
-        <Route path="/characters/create/application" element={<CharacterCreationPage />} />
-
-        {/* ------------------------------------------------------------------ */}
-        {/* Stories (Phase 4) — lazy-loaded, route-level code splitting         */}
-        {/* ------------------------------------------------------------------ */}
-        <Route
-          path="/stories"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <Navigate to="my-active" replace />
-            </Suspense>
-          }
-        />
-        <Route
-          path="/stories/my-active"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <MyActiveStoriesPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/stories/gm-queue"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <GMQueuePage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/gm/dashboard"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <GMDashboardPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/stories/agm-opportunities"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <AGMOpportunitiesPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/stories/my-claims"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <MyAGMClaimsPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/stories/staff-workload"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
+          <Route
+            path="/staff/npc-services/roles"
+            element={
               <StaffRoute>
-                <StaffWorkloadPage />
+                <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+                  <NPCRolesLibraryPage />
+                </Suspense>
               </StaffRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/stories/author"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <StoryAuthorPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/stories/author/:storyId"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <StoryAuthorPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        {/* /stories/:id must come after the named /stories/* paths */}
-        <Route
-          path="/stories/:id"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <StoryDetailPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-
-        {/* ------------------------------------------------------------------ */}
-        {/* Phase 5 — tables, era admin, browse stories, mute settings, offers  */}
-        {/* ------------------------------------------------------------------ */}
-        <Route
-          path="/tables"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <TablesListPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/tables/:id"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <TableDetailPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/stories/eras"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
+            }
+          />
+          <Route
+            path="/staff/npc-services/roles/:id"
+            element={
               <StaffRoute>
-                <EraAdminPage />
+                <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+                  <NPCRoleEditorPage />
+                </Suspense>
               </StaffRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/stories/browse"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <BrowseStoriesPage />
-            </Suspense>
-          }
-        />
-        <Route
-          path="/stories/my-offers"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <MyStoryOffersPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/crossover/inbox"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <CrossoverInboxPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/narrative/mute-settings"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <MuteSettingsPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
+            }
+          />
+          <Route
+            path="/staff/missions/givers"
+            element={
+              <StaffRoute>
+                <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+                  <TriggerGiversPage />
+                </Suspense>
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/applications"
+            element={
+              <StaffRoute>
+                <StaffApplicationsPage />
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/applications/:id"
+            element={
+              <StaffRoute>
+                <StaffApplicationDetailPage />
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/feedback"
+            element={
+              <StaffRoute>
+                <StaffFeedbackPage />
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/feedback/:id"
+            element={
+              <StaffRoute>
+                <StaffFeedbackDetailPage />
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/bug-reports"
+            element={
+              <StaffRoute>
+                <StaffBugReportsPage />
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/bug-reports/:id"
+            element={
+              <StaffRoute>
+                <StaffBugReportDetailPage />
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/player-reports"
+            element={
+              <StaffRoute>
+                <StaffPlayerReportsPage />
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/player-reports/:id"
+            element={
+              <StaffRoute>
+                <StaffPlayerReportDetailPage />
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/system-errors"
+            element={
+              <StaffRoute>
+                <StaffSystemErrorsPage />
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/system-errors/:id"
+            element={
+              <StaffRoute>
+                <StaffSystemErrorDetailPage />
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/gm-applications"
+            element={
+              <StaffRoute>
+                <StaffGMApplicationsPage />
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/gm-applications/:id"
+            element={
+              <StaffRoute>
+                <StaffGMApplicationDetailPage />
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/accounts/:id/history"
+            element={
+              <StaffRoute>
+                <StaffAccountHistoryPage />
+              </StaffRoute>
+            }
+          />
+          <Route path="/characters/create/application" element={<CharacterCreationPage />} />
 
-        {/* ------------------------------------------------------------------ */}
-        {/* Rituals                                                              */}
-        {/* ------------------------------------------------------------------ */}
-        <Route
-          path="/rituals"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <RitualsListPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/rituals/sessions/inbox"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <RitualSessionInboxPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/rituals/sessions/:id"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <RitualSessionDetailPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
+          {/* ------------------------------------------------------------------ */}
+          {/* Stories (Phase 4) — lazy-loaded, route-level code splitting         */}
+          {/* ------------------------------------------------------------------ */}
+          <Route
+            path="/stories"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <Navigate to="my-active" replace />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/stories/my-active"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <MyActiveStoriesPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/stories/gm-queue"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <GMQueuePage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/gm/dashboard"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <GMDashboardPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/stories/agm-opportunities"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <AGMOpportunitiesPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/stories/my-claims"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <MyAGMClaimsPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/stories/staff-workload"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <StaffRoute>
+                  <StaffWorkloadPage />
+                </StaffRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/stories/author"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <StoryAuthorPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/stories/author/:storyId"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <StoryAuthorPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          {/* /stories/:id must come after the named /stories/* paths */}
+          <Route
+            path="/stories/:id"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <StoryDetailPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
 
-        {/* ------------------------------------------------------------------ */}
-        {/* Covenants (Slice B Phase 9)                                         */}
-        {/* ------------------------------------------------------------------ */}
-        <Route
-          path="/covenants"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <CovenantsListPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/covenants/:id"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <CovenantDetailPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
+          {/* ------------------------------------------------------------------ */}
+          {/* Phase 5 — tables, era admin, browse stories, mute settings, offers  */}
+          {/* ------------------------------------------------------------------ */}
+          <Route
+            path="/tables"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <TablesListPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/tables/:id"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <TableDetailPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/stories/eras"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <StaffRoute>
+                  <EraAdminPage />
+                </StaffRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/stories/browse"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <BrowseStoriesPage />
+              </Suspense>
+            }
+          />
+          <Route
+            path="/stories/my-offers"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <MyStoryOffersPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/crossover/inbox"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <CrossoverInboxPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/narrative/mute-settings"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <MuteSettingsPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
 
-        {/* ------------------------------------------------------------------ */}
-        {/* Org stub page — click-through destination (#1446, seeds #1884)     */}
-        {/* ------------------------------------------------------------------ */}
-        <Route
-          path="/orgs/:id"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <OrgPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
+          {/* ------------------------------------------------------------------ */}
+          {/* Rituals                                                              */}
+          {/* ------------------------------------------------------------------ */}
+          <Route
+            path="/rituals"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <RitualsListPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/rituals/sessions/inbox"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <RitualSessionInboxPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/rituals/sessions/:id"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <RitualSessionDetailPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
 
-        {/* ------------------------------------------------------------------ */}
-        {/* Org books — the family-books / management screen (#930)            */}
-        {/* ------------------------------------------------------------------ */}
-        <Route
-          path="/books"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <BooksShelfPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/books/:orgId"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <OrgBooksPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
+          {/* ------------------------------------------------------------------ */}
+          {/* Covenants (Slice B Phase 9)                                         */}
+          {/* ------------------------------------------------------------------ */}
+          <Route
+            path="/covenants"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <CovenantsListPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/covenants/:id"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <CovenantDetailPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
 
-        {/* ------------------------------------------------------------------ */}
-        {/* Thread Hub + Thread Detail                                          */}
-        {/* ------------------------------------------------------------------ */}
-        <Route
-          path="/threads"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <RequireCharacter>
-                  <ThreadHubPage />
-                </RequireCharacter>
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/threads/teaching"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <RequireCharacter>
-                  <WeavingTeachingOffersPage />
-                </RequireCharacter>
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/threads/:id"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <RequireCharacter>
-                  <ThreadDetailPage />
-                </RequireCharacter>
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
-        <Route
-          path="/sanctums"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <RequireCharacter>
-                  <SanctumDashboardPage />
-                </RequireCharacter>
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
+          {/* ------------------------------------------------------------------ */}
+          {/* Org stub page — click-through destination (#1446, seeds #1884)     */}
+          {/* ------------------------------------------------------------------ */}
+          <Route
+            path="/orgs/:id"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <OrgPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
 
-        {/* ------------------------------------------------------------------ */}
-        {/* Technique builder                                                   */}
-        {/* ------------------------------------------------------------------ */}
-        <Route
-          path="/techniques/build"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <TechniqueBuilderPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
+          {/* ------------------------------------------------------------------ */}
+          {/* Org books — the family-books / management screen (#930)            */}
+          {/* ------------------------------------------------------------------ */}
+          <Route
+            path="/books"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <BooksShelfPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/books/:orgId"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <OrgBooksPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
 
-        {/* ------------------------------------------------------------------ */}
-        {/* Magic progression dashboard (#536)                                 */}
-        {/* ------------------------------------------------------------------ */}
-        <Route
-          path="/magic/progression"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <RequireCharacter>
-                  <MagicProgressionPage />
-                </RequireCharacter>
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
+          {/* ------------------------------------------------------------------ */}
+          {/* Thread Hub + Thread Detail                                          */}
+          {/* ------------------------------------------------------------------ */}
+          <Route
+            path="/threads"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <RequireCharacter>
+                    <ThreadHubPage />
+                  </RequireCharacter>
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/threads/teaching"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <RequireCharacter>
+                    <WeavingTeachingOffersPage />
+                  </RequireCharacter>
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/threads/:id"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <RequireCharacter>
+                    <ThreadDetailPage />
+                  </RequireCharacter>
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/sanctums"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <RequireCharacter>
+                    <SanctumDashboardPage />
+                  </RequireCharacter>
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
 
-        {/* ------------------------------------------------------------------ */}
-        {/* Mage Scars — pending alteration resolution (#877)                   */}
-        {/* ------------------------------------------------------------------ */}
-        <Route
-          path="/magic/alterations"
-          element={
-            <Suspense fallback={<PageLoadingFallback />}>
-              <ProtectedRoute>
-                <AlterationResolutionPage />
-              </ProtectedRoute>
-            </Suspense>
-          }
-        />
+          {/* ------------------------------------------------------------------ */}
+          {/* Technique builder                                                   */}
+          {/* ------------------------------------------------------------------ */}
+          <Route
+            path="/techniques/build"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <TechniqueBuilderPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
 
-        <Route path="*" element={<NotFoundPage />} />
-      </Routes>
+          {/* ------------------------------------------------------------------ */}
+          {/* Magic progression dashboard (#536)                                 */}
+          {/* ------------------------------------------------------------------ */}
+          <Route
+            path="/magic/progression"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <RequireCharacter>
+                    <MagicProgressionPage />
+                  </RequireCharacter>
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+
+          {/* ------------------------------------------------------------------ */}
+          {/* Mage Scars — pending alteration resolution (#877)                   */}
+          {/* ------------------------------------------------------------------ */}
+          <Route
+            path="/magic/alterations"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <AlterationResolutionPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+
+          <Route path="*" element={<NotFoundPage />} />
+        </Routes>
+      </ErrorBoundary>
       <RouletteModal />
       <Toaster />
       <DuelChallengeNotifier />

--- a/frontend/src/evennia_replacements/api.test.ts
+++ b/frontend/src/evennia_replacements/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { postLogin } from './api';
+import { apiFetch, postLogin } from './api';
 
 // Mock fetch globally
 const mockFetch = vi.fn();
@@ -9,6 +9,27 @@ globalThis.fetch = mockFetch;
 vi.mock('@/lib/utils', () => ({
   getCookie: vi.fn().mockReturnValue('mock-csrf-token'),
 }));
+
+describe('apiFetch content-type handling (2026-07 audit)', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    mockFetch.mockResolvedValue({ ok: true });
+  });
+
+  it('labels JSON bodies application/json', async () => {
+    await apiFetch('/api/x/', { method: 'POST', body: JSON.stringify({ a: 1 }) });
+    const headers = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Content-Type')).toBe('application/json');
+  });
+
+  it('never sets Content-Type on a FormData body (fetch supplies the multipart boundary)', async () => {
+    const form = new FormData();
+    form.append('image_file', new Blob(['x']), 'x.png');
+    await apiFetch('/api/roster/media/', { method: 'POST', body: form });
+    const headers = mockFetch.mock.calls[0][1].headers as Headers;
+    expect(headers.get('Content-Type')).toBeNull();
+  });
+});
 
 describe('postLogin', () => {
   beforeEach(() => {

--- a/frontend/src/evennia_replacements/api.ts
+++ b/frontend/src/evennia_replacements/api.ts
@@ -16,7 +16,12 @@ export function apiFetch(url: string, options: RequestInit = {}) {
   const headers = new Headers(options.headers);
 
   if (method !== 'GET') {
-    headers.set('Content-Type', 'application/json');
+    // A FormData body must NOT be labeled application/json — fetch derives the
+    // correct multipart Content-Type (with boundary) only when none is set.
+    // Forcing JSON here made every multipart upload a guaranteed DRF 400.
+    if (!(options.body instanceof FormData)) {
+      headers.set('Content-Type', 'application/json');
+    }
     headers.set('X-CSRFToken', getCSRFToken());
   }
 

--- a/frontend/src/lib/__tests__/errors.test.ts
+++ b/frontend/src/lib/__tests__/errors.test.ts
@@ -1,0 +1,50 @@
+/** ApiError + throwApiError/readErrorDetail (2026-07 audit error-path fix). */
+import { describe, expect, it } from 'vitest';
+
+import { ApiError, extractErrorMessage, readErrorDetail, throwApiError } from '../errors';
+
+function jsonResponse(body: unknown, status = 400): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+describe('throwApiError', () => {
+  it('carries status and detail from a {detail} body', async () => {
+    const err = await throwApiError(jsonResponse({ detail: 'Scene not found.' }, 404), 'fb').catch(
+      (e: unknown) => e
+    );
+    expect(err).toBeInstanceOf(ApiError);
+    const apiErr = err as ApiError;
+    expect(apiErr.status).toBe(404);
+    expect(apiErr.detail).toBe('Scene not found.');
+    expect(apiErr.message).toBe('Scene not found.');
+  });
+
+  it('flattens DRF field errors into the message', async () => {
+    const body = { name: ['This field may not be blank.'], tier: ['Must be positive.'] };
+    const err = (await throwApiError(jsonResponse(body), 'fb').catch(
+      (e: unknown) => e
+    )) as ApiError;
+    expect(err.fieldErrors).toEqual(body);
+    expect(err.message).toBe('name: This field may not be blank.; tier: Must be positive.');
+  });
+
+  it('falls back on a non-JSON body but keeps the status', async () => {
+    const res = new Response('<html>proxy error</html>', { status: 502 });
+    const err = (await throwApiError(res, 'Failed to save.').catch((e: unknown) => e)) as ApiError;
+    expect(err.status).toBe(502);
+    expect(err.message).toBe('Failed to save.');
+    expect(err.detail).toBeNull();
+  });
+
+  it('readErrorDetail is a status-carrying alias', async () => {
+    const err = (await readErrorDetail(jsonResponse({ detail: 'Nope.' }, 403), 'fb').catch(
+      (e: unknown) => e
+    )) as ApiError;
+    expect(err).toBeInstanceOf(ApiError);
+    expect(err.status).toBe(403);
+    expect(extractErrorMessage(err)).toBe('Nope.');
+  });
+});

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -3,6 +3,11 @@
  * that was duplicated across ~10 magic/ritual dialogs, plus the api-layer
  * `{detail}` parse-and-throw pattern: `readErrorDetail` is the single home for
  * the per-module `parseErrorDetail` copies, swept onto it in #1195.
+ *
+ * 2026-07 audit: errors thrown here are now `ApiError`s carrying the HTTP
+ * status and any DRF field errors, so downstream code can distinguish 4xx
+ * from 5xx (React Query's retry policy skips 4xx) and dialogs can surface
+ * per-field validation detail instead of a generic string.
  */
 
 /** Best-effort human-readable message from an unknown thrown value. */
@@ -15,18 +20,74 @@ export function extractErrorMessage(
 }
 
 /**
- * Parse a non-ok DRF Response's `{detail}` and throw an Error carrying it,
- * falling back to `fallback` when the body is missing/blank/non-JSON.
+ * A non-ok API response, preserving what the generic string-throw pattern
+ * discarded: the HTTP status, the DRF `{detail}`, and DRF field-validation
+ * errors (`{field: ["msg", …]}`). `message` is always human-readable — the
+ * detail when present, else flattened field errors, else the caller's
+ * fallback — so existing `err.message` render sites keep working unchanged.
  */
-export async function readErrorDetail(res: Response, fallback: string): Promise<never> {
-  let detail = fallback;
+export class ApiError extends Error {
+  readonly status: number;
+  readonly detail: string | null;
+  readonly fieldErrors: Record<string, string[]> | null;
+
+  constructor(
+    message: string,
+    opts: { status: number; detail?: string | null; fieldErrors?: Record<string, string[]> | null }
+  ) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = opts.status;
+    this.detail = opts.detail ?? null;
+    this.fieldErrors = opts.fieldErrors ?? null;
+  }
+}
+
+/** "name: this field is required; tier: must be positive" from a DRF error body. */
+function flattenFieldErrors(fieldErrors: Record<string, string[]>): string {
+  return Object.entries(fieldErrors)
+    .map(([field, messages]) => `${field}: ${messages.join(' ')}`)
+    .join('; ');
+}
+
+/**
+ * Parse a non-ok DRF Response and throw an `ApiError` carrying status,
+ * `{detail}`, and any field-validation errors. The thrown message prefers
+ * detail, then flattened field errors, then `fallback`.
+ */
+export async function throwApiError(res: Response, fallback: string): Promise<never> {
+  let detail: string | null = null;
+  let fieldErrors: Record<string, string[]> | null = null;
   try {
-    const data = (await res.json()) as { detail?: string };
-    if (typeof data.detail === 'string' && data.detail.trim()) {
-      detail = data.detail;
+    const data: unknown = await res.json();
+    if (data && typeof data === 'object') {
+      const body = data as Record<string, unknown>;
+      if (typeof body.detail === 'string' && body.detail.trim()) {
+        detail = body.detail;
+      } else {
+        // DRF validation shape: {field: ["msg", ...]} (incl. non_field_errors).
+        const collected: Record<string, string[]> = {};
+        for (const [key, value] of Object.entries(body)) {
+          if (Array.isArray(value) && value.every((v) => typeof v === 'string')) {
+            collected[key] = value as string[];
+          }
+        }
+        if (Object.keys(collected).length > 0) fieldErrors = collected;
+      }
     }
   } catch {
     // body wasn't JSON; keep the fallback
   }
-  throw new Error(detail);
+  const message = detail ?? (fieldErrors ? flattenFieldErrors(fieldErrors) : fallback);
+  throw new ApiError(message, { status: res.status, detail, fieldErrors });
+}
+
+/**
+ * Parse a non-ok DRF Response's `{detail}` and throw an error carrying it,
+ * falling back to `fallback` when the body is missing/blank/non-JSON.
+ * (Alias of `throwApiError` — kept for its many existing call sites; both
+ * now throw status-carrying `ApiError`s with field-error flattening.)
+ */
+export async function readErrorDetail(res: Response, fallback: string): Promise<never> {
+  return throwApiError(res, fallback);
 }

--- a/frontend/src/queryClient.ts
+++ b/frontend/src/queryClient.ts
@@ -1,10 +1,23 @@
 import { QueryClient } from '@tanstack/react-query';
+import { ApiError } from '@/lib/errors';
+
+/**
+ * Retry transient failures only. A 4xx is deterministic — retrying a 403/404
+ * three times just triples the request load and adds ~seconds of spinner
+ * before the same failure surfaces (and auth failures hammered the backend
+ * exactly when the session was invalid). Only `ApiError` carries a status;
+ * plain string-Errors from not-yet-migrated call sites keep the old policy.
+ */
+function retryTransientOnly(failureCount: number, error: unknown): boolean {
+  if (error instanceof ApiError && error.status < 500) return false;
+  return failureCount < 2;
+}
 
 export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 1000 * 60 * 5, // 5 minutes
-      retry: 2,
+      retry: retryTransientOnly,
     },
   },
 });

--- a/frontend/src/roster/components/MediaUploadForm.tsx
+++ b/frontend/src/roster/components/MediaUploadForm.tsx
@@ -5,6 +5,7 @@ import { useTenureGalleriesQuery, useUploadPlayerMedia, useAssociateMedia } from
 import MyTenureSelect from '@/components/MyTenureSelect';
 import { SubmitButton } from '@/components/SubmitButton';
 import type { Option } from '@/shared/types';
+import { extractErrorMessage } from '@/lib/errors';
 
 interface UploadFormValues {
   image_file: FileList;
@@ -45,18 +46,28 @@ export function MediaUploadForm({ onUploadComplete }: { onUploadComplete?: () =>
     setPreview(null);
   }, [fileList]);
 
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
   const onSubmit = async (data: UploadFormValues) => {
+    setSubmitError(null);
     const formData = new FormData();
     formData.append('image_file', data.image_file[0]);
     if (data.title) formData.append('title', data.title);
     if (data.description) formData.append('description', data.description);
-    const result = await uploadMutation.mutateAsync(formData);
-    if (data.tenure) {
-      await associateMutation.mutateAsync({
-        mediaId: result.id,
-        tenureId: data.tenure,
-        galleryId: data.gallery?.value,
-      });
+    try {
+      const result = await uploadMutation.mutateAsync(formData);
+      if (data.tenure) {
+        await associateMutation.mutateAsync({
+          mediaId: result.id,
+          tenureId: data.tenure,
+          galleryId: data.gallery?.value,
+        });
+      }
+    } catch (err) {
+      // Without this catch the rejection escaped handleSubmit unhandled —
+      // a failed upload gave the user zero feedback.
+      setSubmitError(extractErrorMessage(err, 'Upload failed.'));
+      return;
     }
     reset();
     onUploadComplete?.();
@@ -105,6 +116,7 @@ export function MediaUploadForm({ onUploadComplete }: { onUploadComplete?: () =>
             )}
           />
         )}
+        {submitError && <p className="text-sm text-destructive">{submitError}</p>}
         <SubmitButton
           className="rounded bg-blue-500 px-2 py-1 text-white"
           isLoading={uploadMutation.isPending || associateMutation.isPending}


### PR DESCRIPTION
## What

Item 2 of the 2026-07-16 audit attack order — defuses the white-screen / silent-failure class at its shared root.

- **`apiFetch` FormData fix**: the wrapper force-labeled every non-GET body `application/json`, so the multipart media upload (its only FormData caller) was a guaranteed DRF 400. Content-Type is now left unset for FormData so fetch supplies the boundary.
- **`ApiError`** (`lib/errors`): carries `status`, DRF `detail`, and flattened field-validation errors. `readErrorDetail` (the established shared helper) now throws it, upgrading its existing call sites for free; `throwApiError` is the forward-facing name.
- **Retry policy**: React Query no longer retries 4xx `ApiError`s — a 403/404 was fetched 3× with backoff before surfacing, tripling request load exactly when a session was invalid.
- **Route-level ErrorBoundary** inside `Layout`: ~130 `throwOnError` queries sat above a single root boundary, so one transient failure on any unwrapped page (e.g. the homepage's 30 s status poll) replaced the entire app with the fallback. The chrome now survives; the root boundary stays as last resort.
- **`/profile/*` guarded** with `ProtectedRoute` — anonymous visits fired account-scoped queries into triple-retried 403s and crashed to the boundary instead of redirecting to login.
- **MediaUploadForm** catches and renders upload failures (previously an unhandled rejection with zero user feedback).

The 614-site sweep of hand-rolled `throw new Error('Failed to X')` calls onto `throwApiError` is deliberately NOT in this PR — it proceeds incrementally now that the primitive exists.

## Tests

New `lib/__tests__/errors.test.ts` (detail body, field-error flattening, non-JSON fallback, alias) and `apiFetch` Content-Type cases in `api.test.ts`. lib/evennia_replacements/roster/pages/mail suites green; `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)