### PR TITLE
Audit fix 3: query-key factories produce matchable prefixes; dead keys retargeted

### DIFF
--- a/frontend/src/conditions/queries.ts
+++ b/frontend/src/conditions/queries.ts
@@ -36,7 +36,10 @@ export function useDamageTypes() {
  */
 export function useTreatmentCandidates(targetPersonaId: number | null, characterId: number | null) {
   return useQuery({
-    queryKey: ['conditions', 'treatment-candidates', targetPersonaId],
+    // characterId is IN the key (2026-07 audit): the fetch sends it as the
+    // X-Character-ID header, so an account switching active characters was
+    // served the previous character's cached candidates for the same target.
+    queryKey: ['conditions', 'treatment-candidates', targetPersonaId, characterId],
     queryFn: () => fetchTreatmentCandidates(targetPersonaId as number, characterId as number),
     enabled: targetPersonaId != null && characterId != null,
   });

--- a/frontend/src/magic/__tests__/queries.test.tsx
+++ b/frontend/src/magic/__tests__/queries.test.tsx
@@ -474,7 +474,10 @@ describe('magicKeys', () => {
     ]);
     expect(magicKeys.threadList()).toEqual(['magic', 'threads', 'list']);
     expect(magicKeys.thread(7)).toEqual(['magic', 'threads', 7]);
-    expect(magicKeys.threadHubSummary()).toEqual(['magic', 'thread-hub-summary']);
+    // Sheet-scoped (2026-07 audit): null = unresolved sheet, a distinct cache
+    // row from any real character's summary so alt data can't cross-serve.
+    expect(magicKeys.threadHubSummary()).toEqual(['magic', 'thread-hub-summary', null]);
+    expect(magicKeys.threadHubSummary(42)).toEqual(['magic', 'thread-hub-summary', 42]);
     expect(magicKeys.characterResonanceList()).toEqual(['magic', 'character-resonances', 'list']);
     expect(magicKeys.teachingOffers()).toEqual(['magic', 'teaching-offers', 'list']);
   });

--- a/frontend/src/magic/queries.ts
+++ b/frontend/src/magic/queries.ts
@@ -55,7 +55,11 @@ export const magicKeys = {
   threadList: () => [...magicKeys.threads(), 'list'] as const,
   thread: (id: number) => [...magicKeys.threads(), id] as const,
 
-  threadHubSummary: () => [...magicKeys.all, 'thread-hub-summary'] as const,
+  // Scoped by sheet id (2026-07 audit): an unscoped key cached one alt's
+  // balances/prospects and served them to every other character the account
+  // viewed within staleTime. `null` = caller hasn't resolved a sheet yet.
+  threadHubSummary: (characterSheetId?: number) =>
+    [...magicKeys.all, 'thread-hub-summary', characterSheetId ?? null] as const,
 
   characterResonances: () => [...magicKeys.all, 'character-resonances'] as const,
   characterResonanceList: () => [...magicKeys.characterResonances(), 'list'] as const,
@@ -291,7 +295,7 @@ export function useRespondToStageAdvance() {
  */
 export function useThreadHubSummary(characterSheetId?: number) {
   return useQuery({
-    queryKey: magicKeys.threadHubSummary(),
+    queryKey: magicKeys.threadHubSummary(characterSheetId),
     queryFn: () => api.getThreadHubSummary(characterSheetId),
     throwOnError: true,
   });
@@ -343,7 +347,9 @@ export function useWeaveThread() {
     mutationFn: (body: WeaveThreadRequest) => api.weaveThread(body),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: magicKeys.threadList() }).catch(() => {});
-      qc.invalidateQueries({ queryKey: magicKeys.threadHubSummary() }).catch(() => {});
+      qc.invalidateQueries({
+        queryKey: [...magicKeys.all, 'thread-hub-summary'],
+      }).catch(() => {});
     },
   });
 }
@@ -373,7 +379,9 @@ export function useRetireThread() {
     mutationFn: (threadId: number) => api.retireThread(threadId),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: magicKeys.threadList() }).catch(() => {});
-      qc.invalidateQueries({ queryKey: magicKeys.threadHubSummary() }).catch(() => {});
+      qc.invalidateQueries({
+        queryKey: [...magicKeys.all, 'thread-hub-summary'],
+      }).catch(() => {});
     },
   });
 }
@@ -400,7 +408,9 @@ export function useImbueThread() {
     }) => api.imbueThreadAuto(characterSheetId, threadId, amount),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: magicKeys.thread(variables.threadId) }).catch(() => {});
-      qc.invalidateQueries({ queryKey: magicKeys.threadHubSummary() }).catch(() => {});
+      qc.invalidateQueries({
+        queryKey: [...magicKeys.all, 'thread-hub-summary'],
+      }).catch(() => {});
       qc.invalidateQueries({ queryKey: magicKeys.characterResonanceList() }).catch(() => {});
     },
   });
@@ -417,7 +427,9 @@ export function useCrossXPLock() {
       api.crossXPLock(threadId, body),
     onSuccess: (_data, variables) => {
       qc.invalidateQueries({ queryKey: magicKeys.thread(variables.threadId) }).catch(() => {});
-      qc.invalidateQueries({ queryKey: magicKeys.threadHubSummary() }).catch(() => {});
+      qc.invalidateQueries({
+        queryKey: [...magicKeys.all, 'thread-hub-summary'],
+      }).catch(() => {});
     },
   });
 }
@@ -452,7 +464,9 @@ export function useAcceptTeachingOffer() {
       api.acceptTeachingOffer(offerId, body),
     onSuccess: () => {
       qc.invalidateQueries({ queryKey: magicKeys.teachingOffers() }).catch(() => {});
-      qc.invalidateQueries({ queryKey: magicKeys.threadHubSummary() }).catch(() => {});
+      qc.invalidateQueries({
+        queryKey: [...magicKeys.all, 'thread-hub-summary'],
+      }).catch(() => {});
     },
   });
 }
@@ -521,17 +535,19 @@ export function usePriceTechnique() {
 /**
  * Author a technique via the budget policy layer.
  *
- * Invalidates the technique list on success so any downstream technique
- * lists refresh. magicKeys does not have a techniqueList key, so we use
- * a literal ['techniques'] queryKey to match any technique list query.
+ * Invalidates the CG technique list (the only technique-list query) on
+ * success so the builder's downstream pickers refresh.
  */
 export function useAuthorTechnique() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (body: TechniqueDesignRequest) => api.authorTechnique(body),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: ['techniques'] }).catch(() => {});
-      qc.invalidateQueries({ queryKey: magicKeys.all }).catch(() => {});
+      // 2026-07 audit: the literal ['techniques'] key matched no query anywhere
+      // (the CG technique list lives under character-creation's factory), and
+      // the magicKeys.all blast refetched every magic query incl. 5s-poll
+      // inboxes. Invalidate the real consumer instead.
+      qc.invalidateQueries({ queryKey: ['character-creation', 'techniques'] }).catch(() => {});
     },
   });
 }

--- a/frontend/src/scenes/components/ActionPanel.tsx
+++ b/frontend/src/scenes/components/ActionPanel.tsx
@@ -90,7 +90,9 @@ export function ActionPanel({ sceneId }: Props) {
   // action may have spent anima/resonance, so both invalidate the same set
   // of caches (#2158).
   function invalidateActionOutcomeQueries() {
-    queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
+    // 2026-07 audit: 'scene-messages' matched no query anywhere — the feed's
+    // real key is 'scene-interactions' (useSceneInteractions).
+    queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] });
     queryClient.invalidateQueries({ queryKey: ['pending-requests', sceneId] });
     if (characterId !== null) {
       queryClient.invalidateQueries({ queryKey: magicKeys.characterAnima(characterId) });

--- a/frontend/src/scenes/components/ConsentPrompt.tsx
+++ b/frontend/src/scenes/components/ConsentPrompt.tsx
@@ -202,7 +202,9 @@ export function ConsentPrompt({ sceneId }: Props) {
     onSuccess: (data) => {
       toastDispositionMessage(data);
       queryClient.invalidateQueries({ queryKey: ['pending-requests', sceneId] });
-      queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
+      // 2026-07 audit: 'scene-messages' matched no query anywhere — the feed's
+      // real key is 'scene-interactions' (useSceneInteractions).
+      queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] });
     },
   });
 
@@ -238,7 +240,9 @@ export function ConsentPrompt({ sceneId }: Props) {
     onSuccess: (data) => {
       toastDispositionMessage(data);
       queryClient.invalidateQueries({ queryKey: ['pending-targets', sceneId] });
-      queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
+      // 2026-07 audit: 'scene-messages' matched no query anywhere — the feed's
+      // real key is 'scene-interactions' (useSceneInteractions).
+      queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] });
     },
   });
 

--- a/frontend/src/scenes/components/PersonaContextMenu.tsx
+++ b/frontend/src/scenes/components/PersonaContextMenu.tsx
@@ -182,7 +182,9 @@ export function PersonaContextMenu({
       delivery_receiver_ids?: number[];
     }) => createActionRequest(sceneId, params),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
+      // 2026-07 audit: 'scene-messages' matched no query anywhere — the feed's
+      // real key is 'scene-interactions' (useSceneInteractions).
+      queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] });
       queryClient.invalidateQueries({ queryKey: ['pending-requests', sceneId] });
     },
   });

--- a/frontend/src/scenes/components/PlaceBar.tsx
+++ b/frontend/src/scenes/components/PlaceBar.tsx
@@ -22,7 +22,9 @@ export function PlaceBar({ sceneId }: Props) {
     mutationFn: (placeId: number) => joinPlace(sceneId, placeId),
     onSuccess: (_data, placeId) => {
       setCurrentPlaceId(placeId);
-      queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
+      // 2026-07 audit: 'scene-messages' matched no query anywhere — the feed's
+      // real key is 'scene-interactions' (useSceneInteractions).
+      queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] });
     },
   });
 
@@ -30,7 +32,9 @@ export function PlaceBar({ sceneId }: Props) {
     mutationFn: (placeId: number) => leavePlace(sceneId, placeId),
     onSuccess: () => {
       setCurrentPlaceId(null);
-      queryClient.invalidateQueries({ queryKey: ['scene-messages', sceneId] });
+      // 2026-07 audit: 'scene-messages' matched no query anywhere — the feed's
+      // real key is 'scene-interactions' (useSceneInteractions).
+      queryClient.invalidateQueries({ queryKey: ['scene-interactions', sceneId] });
     },
   });
 

--- a/frontend/src/scenes/pages/SceneDetailPage.tsx
+++ b/frontend/src/scenes/pages/SceneDetailPage.tsx
@@ -117,7 +117,8 @@ export function SceneDetailPage() {
       }),
     onSuccess: () => {
       setActionAttachment(null);
-      queryClient.invalidateQueries({ queryKey: ['scene-messages', id] });
+      // 2026-07 audit: 'scene-messages' matched no query — the feed key is 'scene-interactions'.
+      queryClient.invalidateQueries({ queryKey: ['scene-interactions', id] });
       queryClient.invalidateQueries({ queryKey: ['pending-requests', id] });
     },
     onError: () => {

--- a/frontend/src/secrets/queries.ts
+++ b/frontend/src/secrets/queries.ts
@@ -11,8 +11,9 @@ import {
 import type { GossipActionPayload, SubmitGrievancePayload } from './api';
 
 export const secretKeys = {
+  knownAll: ['secrets', 'known'] as const,
   known: (subjectId: number, viewerId: number) =>
-    ['secrets', 'known', subjectId, viewerId] as const,
+    [...secretKeys.knownAll, subjectId, viewerId] as const,
   grievanceOptions: ['secrets', 'grievance-options'] as const,
 };
 
@@ -40,13 +41,14 @@ export function useSubmitGrievanceMutation() {
   return useMutation({
     mutationFn: (payload: SubmitGrievancePayload) => submitGrievance(payload),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['secrets', 'known'] });
+      queryClient.invalidateQueries({ queryKey: secretKeys.knownAll });
     },
   });
 }
 
 export const gossipKeys = {
-  list: (viewerId: number) => ['secrets', 'gossip', viewerId] as const,
+  all: ['secrets', 'gossip'] as const,
+  list: (viewerId: number) => [...gossipKeys.all, viewerId] as const,
 };
 
 /** The active character's spreadable gossip + regional heat. Disabled until there's an active
@@ -65,7 +67,7 @@ export function useGossipActionMutation() {
   return useMutation({
     mutationFn: (payload: GossipActionPayload) => gossipAction(payload),
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['secrets', 'gossip'] });
+      queryClient.invalidateQueries({ queryKey: gossipKeys.all });
     },
   });
 }

--- a/frontend/src/stories/queries.ts
+++ b/frontend/src/stories/queries.ts
@@ -63,8 +63,25 @@ export type { BeatOutcome };
 // Query key factory
 // ---------------------------------------------------------------------------
 
+const storiesAll = ['stories'] as const;
+
+/**
+ * Params-eliding list-key builder (2026-07 audit fix). The old shape appended
+ * `params` unconditionally, so a no-arg invalidation call produced
+ * `['stories','beats',undefined]` — which React Query v5's partial matching
+ * does NOT treat as a prefix of `['stories','beats',{episode:5}]`. Every
+ * no-arg `storiesKeys.xxx()` invalidation therefore matched nothing the user
+ * was looking at. Eliding the slot makes the no-arg form a true prefix.
+ */
+function listKey<P>(segment: string) {
+  return (params?: P) =>
+    params === undefined
+      ? ([...storiesAll, segment] as const)
+      : ([...storiesAll, segment, params] as const);
+}
+
 export const storiesKeys = {
-  all: ['stories'] as const,
+  all: storiesAll,
 
   // Dashboards
   myActive: () => [...storiesKeys.all, 'my-active'] as const,
@@ -72,38 +89,36 @@ export const storiesKeys = {
   staffWorkload: () => [...storiesKeys.all, 'staff-workload'] as const,
 
   // Stories
-  storyList: (params?: ListStoriesParams) => [...storiesKeys.all, 'list', params] as const,
+  storyList: listKey<ListStoriesParams>('list'),
   story: (id: number) => [...storiesKeys.all, 'story', id] as const,
 
   // Chapters
-  chapterList: (params?: ListChaptersParams) => [...storiesKeys.all, 'chapters', params] as const,
+  chapterList: listKey<ListChaptersParams>('chapters'),
   chapter: (id: number) => [...storiesKeys.all, 'chapter', id] as const,
 
   // Episodes
-  episodeList: (params?: ListEpisodesParams) => [...storiesKeys.all, 'episodes', params] as const,
+  episodeList: listKey<ListEpisodesParams>('episodes'),
   episode: (id: number) => [...storiesKeys.all, 'episode', id] as const,
 
   // Beats
-  beatList: (params?: ListBeatsParams) => [...storiesKeys.all, 'beats', params] as const,
+  beatList: listKey<ListBeatsParams>('beats'),
   beat: (id: number) => [...storiesKeys.all, 'beat', id] as const,
 
   // Progress
-  groupProgress: (params?: ListGroupProgressParams) =>
-    [...storiesKeys.all, 'group-progress', params] as const,
-  globalProgress: (params?: { story?: number; is_active?: boolean; page?: number }) =>
-    [...storiesKeys.all, 'global-progress', params] as const,
+  groupProgress: listKey<ListGroupProgressParams>('group-progress'),
+  globalProgress: listKey<{ story?: number; is_active?: boolean; page?: number }>(
+    'global-progress'
+  ),
 
   // Contributions
-  contributions: (params?: ListContributionsParams) =>
-    [...storiesKeys.all, 'contributions', params] as const,
+  contributions: listKey<ListContributionsParams>('contributions'),
 
   // AGM Claims
-  agmClaims: (params?: ListClaimsParams) => [...storiesKeys.all, 'agm-claims', params] as const,
+  agmClaims: listKey<ListClaimsParams>('agm-claims'),
   agmClaim: (id: number) => [...storiesKeys.all, 'agm-claim', id] as const,
 
   // Session requests
-  sessionRequests: (params?: ListSessionRequestsParams) =>
-    [...storiesKeys.all, 'session-requests', params] as const,
+  sessionRequests: listKey<ListSessionRequestsParams>('session-requests'),
   sessionRequest: (id: number) => [...storiesKeys.all, 'session-request', id] as const,
 
   // Story log
@@ -113,38 +128,33 @@ export const storiesKeys = {
   storyNotes: (storyId: number) => [...storiesKeys.all, 'story-notes', storyId] as const,
 
   // Transitions (Wave 9)
-  transitionList: (params?: ListTransitionsParams) =>
-    [...storiesKeys.all, 'transitions', params] as const,
+  transitionList: listKey<ListTransitionsParams>('transitions'),
   transition: (id: number) => [...storiesKeys.all, 'transition', id] as const,
 
   // EpisodeProgressionRequirements (Wave 9)
-  progressionRequirements: (params?: ListProgressionRequirementsParams) =>
-    [...storiesKeys.all, 'progression-requirements', params] as const,
+  progressionRequirements: listKey<ListProgressionRequirementsParams>('progression-requirements'),
 
   // TransitionRequiredOutcomes (Wave 9)
-  transitionRequiredOutcomes: (params?: ListTransitionRequiredOutcomesParams) =>
-    [...storiesKeys.all, 'transition-required-outcomes', params] as const,
+  transitionRequiredOutcomes: listKey<ListTransitionRequiredOutcomesParams>(
+    'transition-required-outcomes'
+  ),
 
   // StoryGMOffers (Wave 5)
-  storyGMOffers: (params?: ListStoryGMOffersParams) =>
-    [...storiesKeys.all, 'story-gm-offers', params] as const,
+  storyGMOffers: listKey<ListStoryGMOffersParams>('story-gm-offers'),
   storyGMOffer: (id: number) => [...storiesKeys.all, 'story-gm-offer', id] as const,
 
   // GMProfiles (Wave 5)
-  gmProfiles: (params?: ListGMProfilesParams) =>
-    [...storiesKeys.all, 'gm-profiles', params] as const,
+  gmProfiles: listKey<ListGMProfilesParams>('gm-profiles'),
 
   // Eras (Wave 6)
-  eraList: (params?: ListErasParams) => [...storiesKeys.all, 'eras', params] as const,
+  eraList: listKey<ListErasParams>('eras'),
   era: (id: number) => [...storiesKeys.all, 'era', id] as const,
 
   // StoryProtectedSubject (#2001 Task 8)
-  protectedSubjects: (params?: ListProtectedSubjectsParams) =>
-    [...storiesKeys.all, 'protected-subjects', params] as const,
+  protectedSubjects: listKey<ListProtectedSubjectsParams>('protected-subjects'),
 
   // CustodyClearance (#2001 Task 8)
-  custodyClearances: (params?: ListCustodyClearancesParams) =>
-    [...storiesKeys.all, 'custody-clearances', params] as const,
+  custodyClearances: listKey<ListCustodyClearancesParams>('custody-clearances'),
 };
 
 // ---------------------------------------------------------------------------
@@ -769,6 +779,12 @@ export function useSaveTransitionWithOutcomes() {
     onSuccess: (transition) => {
       qc.invalidateQueries({ queryKey: storiesKeys.transitionList() }).catch(() => {});
       qc.invalidateQueries({ queryKey: storiesKeys.transition(transition.id) }).catch(() => {});
+      // The atomic save replaces the transition's full outcome set — without
+      // this, TransitionFormDialog repopulated its routing rows from the stale
+      // outcome cache on reopen and a second save silently reverted the edit.
+      qc.invalidateQueries({
+        queryKey: storiesKeys.transitionRequiredOutcomes(),
+      }).catch(() => {});
     },
   });
 }

--- a/frontend/src/tables/queries.ts
+++ b/frontend/src/tables/queries.ts
@@ -28,16 +28,33 @@ import type {
 // Query key factory
 // ---------------------------------------------------------------------------
 
+/**
+ * Trailing params are ELIDED when absent (2026-07 audit fix): the old shape
+ * appended the filters slot unconditionally, so `tablesKeys.members(id)` was
+ * `['tables','members',id,undefined]` — which React Query v5 does NOT treat
+ * as a prefix of `['tables','members',id,{table,active:true}]`. Every
+ * invite/remove/leave/bulletin invalidation therefore matched nothing and the
+ * roster/post list stayed stale until a hard refresh.
+ */
 export const tablesKeys = {
   all: ['tables'] as const,
-  list: (filters?: ListTablesParams) => [...tablesKeys.all, 'list', filters] as const,
+  list: (filters?: ListTablesParams) =>
+    filters === undefined
+      ? ([...tablesKeys.all, 'list'] as const)
+      : ([...tablesKeys.all, 'list', filters] as const),
   detail: (id: number) => [...tablesKeys.all, 'detail', id] as const,
   members: (tableId: number, filters?: ListMembershipsParams) =>
-    [...tablesKeys.all, 'members', tableId, filters] as const,
+    filters === undefined
+      ? ([...tablesKeys.all, 'members', tableId] as const)
+      : ([...tablesKeys.all, 'members', tableId, filters] as const),
   bulletinPosts: (params?: ListBulletinPostsParams) =>
-    [...tablesKeys.all, 'bulletin-posts', params] as const,
+    params === undefined
+      ? ([...tablesKeys.all, 'bulletin-posts'] as const)
+      : ([...tablesKeys.all, 'bulletin-posts', params] as const),
   bulletinReplies: (params?: ListBulletinRepliesParams) =>
-    [...tablesKeys.all, 'bulletin-replies', params] as const,
+    params === undefined
+      ? ([...tablesKeys.all, 'bulletin-replies'] as const)
+      : ([...tablesKeys.all, 'bulletin-replies', params] as const),
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Item 3 of the 2026-07-16 audit attack order — the cache-invalidation sweep. The repeated defect: key factories that append the optional params slot unconditionally produce `['stories','beats',undefined]`, which React Query v5's partial matching does **not** treat as a prefix of `['stories','beats',{episode:5}]` — so a no-arg invalidation call matched nothing the user was looking at.

- **stories**: factory rebuilt on a params-eliding `listKey` helper (~15 list keys). Fixes mark-beat, accept-offer, cancel-claim, era-advance, episode/chapter/beat/transition CRUD all leaving their visible lists stale until refocus. Also adds the missing `transitionRequiredOutcomes` invalidation to the atomic transition save (stale rows silently reverted routing edits on the second save).
- **tables**: same elision for `list`/`members`/`bulletinPosts`/`bulletinReplies` — invite/remove/leave and bulletin CRUD now actually refresh the roster and post list.
- **Dead keys**: six scenes call sites invalidated `['scene-messages']` (no query uses it) → retargeted to the feed's real `['scene-interactions', sceneId]`; `useAuthorTechnique` invalidated a dead `['techniques']` key plus a `magicKeys.all` blast that refetched every 5s-poll inbox → now targets the CG technique list it feeds.
- **Cross-character cache leaks**: `magicKeys.threadHubSummary` now scoped by character sheet id (the unscoped key served one alt's XP/balance summary to sibling characters — alt-privacy adjacent); `useTreatmentCandidates` keys on the `characterId` it fetches with (switching active characters served the previous character's candidates).
- **secrets**: raw-literal invalidators routed through factory prefixes (working, but drift-prone).

## Tests

Magic key-shape test updated for the scoped hub key (+ scoped variant asserted). stories/tables/magic/secrets/conditions/scenes suites green (1163 tests); `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)