### PR TITLE
Audit fix 4: WS reconnect, guarded scene-buffer clear, multiplayer liveness polls

### DIFF
--- a/frontend/src/game/GamePage.tsx
+++ b/frontend/src/game/GamePage.tsx
@@ -290,6 +290,15 @@ export function GamePage() {
     threadingResetForNewScene();
   }, [active, sceneId, threadingResetForNewScene]);
 
+  // The stored composer mode is context-bound the same way tabs are (2026-07
+  // audit): a whisper mode set as character A survived switching to character
+  // B (whose activeThreadTab is null, so effectiveComposerMode fell through
+  // to the stored mode) — typing Enter then whispered A's target AS B. Reset
+  // it on the same [active, sceneId] pair every other context reset uses.
+  useEffect(() => {
+    setComposerMode(undefined);
+  }, [active, sceneId]);
+
   // Continuously mark the ACTIVE TAB's thread seen as its interactions grow —
   // this is the thread the player is actively viewing (the room anchor when
   // no tab is active), so it never accumulates unread. Unselected threads are

--- a/frontend/src/hooks/__tests__/handleRoomStatePayload.test.ts
+++ b/frontend/src/hooks/__tests__/handleRoomStatePayload.test.ts
@@ -78,7 +78,7 @@ describe('handleRoomStatePayload', () => {
           hub: null,
         },
       });
-      expect(mockDispatch).toHaveBeenCalledTimes(3);
+      expect(mockDispatch).toHaveBeenCalledTimes(2);
     });
 
     it('threads the civic-hub tidings block through to the room (#1450)', () => {
@@ -144,10 +144,12 @@ describe('handleRoomStatePayload', () => {
       handleRoomStatePayload(character, payload, mockDispatch);
 
       const calls = (mockDispatch as unknown as ReturnType<typeof vi.fn>).mock.calls;
-      expect(calls.length).toBe(3);
+      // 2026-07 audit: the unconditional clearSceneInteractions dispatch is
+      // gone — the WS-buffer clear now lives inside setSessionScene, guarded
+      // on an actual scene-id change (room_state fires on every arrival).
+      expect(calls.length).toBe(2);
       expect(calls[0][0].type).toBe('game/setSessionRoom');
       expect(calls[1][0].type).toBe('game/setSessionScene');
-      expect(calls[2][0].type).toBe('game/clearSceneInteractions');
     });
   });
 

--- a/frontend/src/hooks/__tests__/handleScenePayload.test.ts
+++ b/frontend/src/hooks/__tests__/handleScenePayload.test.ts
@@ -165,8 +165,10 @@ describe('handleScenePayload', () => {
         character: 'TestCharacter',
         scene: null,
       });
-      expect(clearSceneInteractions).toHaveBeenCalledWith('TestCharacter');
-      expect(mockDispatch).toHaveBeenCalledTimes(2);
+      // 2026-07 audit: the buffer clear moved into setSessionScene's guarded
+      // scene-transition reset — the handler no longer dispatches it.
+      expect(clearSceneInteractions).not.toHaveBeenCalled();
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
     });
 
     it('dispatches null even when payload.scene has data', () => {
@@ -468,7 +470,7 @@ describe('handleScenePayload', () => {
       expect(mockDispatch).toHaveBeenCalledTimes(1);
     });
 
-    it('calls dispatch twice for end action (setSessionScene + clearSceneInteractions)', () => {
+    it('calls dispatch once for end action (setSessionScene owns the buffer clear)', () => {
       const payload: ScenePayload = {
         action: 'end',
         scene: createSceneSummary(1, 'Test'),
@@ -476,7 +478,7 @@ describe('handleScenePayload', () => {
 
       handleScenePayload('Char', payload, mockDispatch);
 
-      expect(mockDispatch).toHaveBeenCalledTimes(2);
+      expect(mockDispatch).toHaveBeenCalledTimes(1);
     });
 
     it('dispatches the correct action type', () => {
@@ -540,7 +542,7 @@ describe('handleScenePayload', () => {
         scene: null,
       });
 
-      expect(mockDispatch).toHaveBeenCalledTimes(4);
+      expect(mockDispatch).toHaveBeenCalledTimes(3);
     });
 
     it('handles complete payload with owner status true', () => {

--- a/frontend/src/hooks/handleRoomStatePayload.ts
+++ b/frontend/src/hooks/handleRoomStatePayload.ts
@@ -1,6 +1,6 @@
 import type { RoomStatePayload } from './types';
 import type { AppDispatch } from '@/store/store';
-import { clearSceneInteractions, setSessionRoom, setSessionScene } from '@/store/gameSlice';
+import { setSessionRoom, setSessionScene } from '@/store/gameSlice';
 import type { MyRosterEntry } from '@/roster/types';
 
 export function handleRoomStatePayload(
@@ -26,6 +26,8 @@ export function handleRoomStatePayload(
       },
     })
   );
+  // setSessionScene owns the scene-transition reset (baseline, tabs, and the
+  // WS interaction buffer) — guarded on an actual scene-id change, so the
+  // room_state broadcast fired by every arrival no longer wipes the live feed.
   dispatch(setSessionScene({ character, scene: payload.scene ?? null }));
-  dispatch(clearSceneInteractions(character));
 }

--- a/frontend/src/hooks/handleScenePayload.ts
+++ b/frontend/src/hooks/handleScenePayload.ts
@@ -1,6 +1,6 @@
 import type { ScenePayload } from './types';
 import type { AppDispatch } from '@/store/store';
-import { clearSceneInteractions, setSessionScene } from '@/store/gameSlice';
+import { setSessionScene } from '@/store/gameSlice';
 import type { MyRosterEntry } from '@/roster/types';
 
 export function handleScenePayload(
@@ -9,8 +9,7 @@ export function handleScenePayload(
   dispatch: AppDispatch
 ) {
   const scene = payload.action === 'end' ? null : payload.scene;
+  // Scene end = scene -> null = an id change, so setSessionScene's guarded
+  // transition reset clears the WS buffer; no separate dispatch needed.
   dispatch(setSessionScene({ character, scene }));
-  if (payload.action === 'end') {
-    dispatch(clearSceneInteractions(character));
-  }
 }

--- a/frontend/src/hooks/useGameSocket.ts
+++ b/frontend/src/hooks/useGameSocket.ts
@@ -35,8 +35,28 @@ import type { MyRosterEntry } from '@/roster/types';
 import { getWebSocketUrl } from '@/config';
 import { toast } from 'sonner';
 import { fetchAccount } from '@/evennia_replacements/api';
+import { queryClient } from '@/queryClient';
 
 const sockets: Record<string, WebSocket> = {};
+// Names with a connect() in flight (pre-socket-creation await window) — the
+// synchronous guard that prevents two near-simultaneous connects from each
+// opening a socket and leaking the first (2026-07 audit).
+const connecting = new Set<string>();
+// Per-character reconnect bookkeeping (2026-07 audit): an abnormal close used
+// to just mark the session disconnected and stop — a network blip silently
+// froze the feed until the user manually re-clicked their character tab.
+const reconnectAttempts: Record<string, number> = {};
+const reconnectTimers: Record<string, ReturnType<typeof setTimeout>> = {};
+const MAX_RECONNECT_ATTEMPTS = 6;
+
+function clearReconnect(character: string) {
+  reconnectAttempts[character] = 0;
+  const timer = reconnectTimers[character];
+  if (timer !== undefined) {
+    clearTimeout(timer);
+    delete reconnectTimers[character];
+  }
+}
 
 export function useGameSocket() {
   const dispatch = useAppDispatch();
@@ -44,12 +64,16 @@ export function useGameSocket() {
   const navigate = useNavigate();
 
   const disconnectAll = useCallback(() => {
+    // Explicit disconnect: cancel any pending reconnects first so a closing
+    // socket doesn't immediately resurrect itself.
+    Object.keys(reconnectTimers).forEach(clearReconnect);
     Object.values(sockets).forEach((socket) => socket.close());
   }, []);
 
   const connect = useCallback(
     async (character: MyRosterEntry['name']) => {
-      if (sockets[character]) return;
+      if (sockets[character] || connecting.has(character)) return;
+      connecting.add(character);
 
       let currentAccount = account;
       if (!currentAccount) {
@@ -58,10 +82,12 @@ export function useGameSocket() {
           if (currentAccount) {
             dispatch(setAccount(currentAccount));
           } else {
+            connecting.delete(character);
             navigate('/login');
             return;
           }
         } catch {
+          connecting.delete(character);
           navigate('/login');
           return;
         }
@@ -71,23 +97,41 @@ export function useGameSocket() {
       const url = getWebSocketUrl(window.location);
       const socket = new WebSocket(url);
       sockets[character] = socket;
+      connecting.delete(character);
 
       socket.addEventListener('open', () => {
+        clearReconnect(character);
         dispatch(setSessionConnectionStatus({ character, status: true }));
         const puppet: OutgoingMessage = [WS_MESSAGE_TYPE.TEXT, [`@ic ${character}`], {}];
         socket.send(JSON.stringify(puppet));
+        // Backfill anything that arrived while no socket was listening: the
+        // REST feed is the source of record and may still be "fresh" for up
+        // to staleTime, so force it stale on every (re)connect.
+        queryClient.invalidateQueries({ queryKey: ['scene-interactions'] }).catch(() => {});
       });
 
       socket.addEventListener('close', (event) => {
         dispatch(setSessionConnectionStatus({ character, status: false }));
         delete sockets[character];
         if (event.code === 1000) {
+          clearReconnect(character);
           // Only reset game state if this was the last active connection
           const remainingConnections = Object.keys(sockets).length;
           if (remainingConnections === 0) {
             dispatch(resetGame());
           }
+          return;
         }
+        // Abnormal close: reconnect with capped exponential backoff
+        // (1s, 2s, 4s, ... 30s). The open handler re-puppets and backfills.
+        const attempt = (reconnectAttempts[character] ?? 0) + 1;
+        if (attempt > MAX_RECONNECT_ATTEMPTS) return;
+        reconnectAttempts[character] = attempt;
+        const delay = Math.min(1000 * 2 ** (attempt - 1), 30_000);
+        reconnectTimers[character] = setTimeout(() => {
+          delete reconnectTimers[character];
+          connect(character).catch(() => {});
+        }, delay);
       });
 
       socket.addEventListener('message', (event) => {
@@ -173,6 +217,14 @@ export function useGameSocket() {
           // Control message: COMMANDS
           if (msgType === WS_MESSAGE_TYPE.COMMANDS) {
             handleCommandPayload(character, args as CommandSpec[]);
+            return;
+          }
+
+          // Broadcast to every account session on each successful puppet —
+          // nothing to do client-side (the open handler already re-puppets),
+          // but without this branch the frame fell through to parseGameMessage
+          // and rendered as raw JSON noise in the system lane (2026-07 audit).
+          if (msgType === WS_MESSAGE_TYPE.PUPPET_CHANGED) {
             return;
           }
 

--- a/frontend/src/missions/queries.ts
+++ b/frontend/src/missions/queries.ts
@@ -359,6 +359,10 @@ export function useBeat(
     queryKey: missionKeys.beat(instanceId ?? 0, roomKey),
     queryFn: () => getBeat(instanceId as number),
     enabled: instanceId !== undefined,
+    // Liveness (2026-07 audit): a beat can be resolved by another participant
+    // or fast-forwarded by an external act — nothing pushes that, so poll
+    // while the card is mounted.
+    refetchInterval: 10_000,
   });
 }
 
@@ -403,6 +407,11 @@ export function useGroupBeat(
     queryKey: missionKeys.groupBeat(instanceId ?? 0, roomKey),
     queryFn: () => getGroupBeat(instanceId as number),
     enabled: instanceId !== undefined,
+    // Liveness (2026-07 audit): group ballots are inherently multiplayer —
+    // without a poll, participant B never saw A's vote land, and the
+    // "waiting for the server to resolve" countdown state waited forever
+    // (only a tab refocus ever refetched). 5s matches the rituals inbox.
+    refetchInterval: 5_000,
   });
 }
 

--- a/frontend/src/rituals/queries.ts
+++ b/frontend/src/rituals/queries.ts
@@ -131,6 +131,11 @@ export function useRitualSessionDetail(id: number) {
     queryKey: ritualSessionKeys.detail(id),
     queryFn: () => api.fetchRitualSessionDetail(id),
     enabled: id > 0,
+    // Liveness (2026-07 audit): the detail page promises "polling for live
+    // updates" but only the inbox/outbox polled — the initiator's "waiting
+    // for participants" panel and disabled Fire button never updated without
+    // a manual reload, deadlocking the fire flow. Matches the inbox cadence.
+    refetchInterval: 5_000,
     throwOnError: true,
   });
 }

--- a/frontend/src/store/__tests__/gameSlice.test.ts
+++ b/frontend/src/store/__tests__/gameSlice.test.ts
@@ -503,16 +503,22 @@ describe('gameSlice', () => {
         expect(result.sessions['TestCharacter'].messages[0].content).toBe('Hello world');
       });
 
-      it('generates id using Date.now().toString()', () => {
+      it('generates unique monotonic ids (2026-07 audit: Date.now() collided on burst frames)', () => {
         const initialState = createStateWithSession('TestCharacter', {}, 'TestCharacter');
-        const message = createGameMessage('Hello');
 
-        const result = reducer(
+        let state = reducer(
           initialState,
-          addSessionMessage({ character: 'TestCharacter', message })
+          addSessionMessage({ character: 'TestCharacter', message: createGameMessage('One') })
+        );
+        state = reducer(
+          state,
+          addSessionMessage({ character: 'TestCharacter', message: createGameMessage('Two') })
         );
 
-        expect(result.sessions['TestCharacter'].messages[0].id).toBe(MOCK_TIMESTAMP.toString());
+        const [first, second] = state.sessions['TestCharacter'].messages;
+        expect(first.id).not.toBe(second.id);
+        expect(first.id).toMatch(/^m\d+$/);
+        expect(second.id).toMatch(/^m\d+$/);
       });
 
       it('preserves all message properties', () => {
@@ -528,7 +534,7 @@ describe('gameSlice', () => {
         expect(addedMessage.content).toBe('Test content');
         expect(addedMessage.type).toBe(GAME_MESSAGE_TYPE.ACTION);
         expect(addedMessage.timestamp).toBe(1234567890);
-        expect(addedMessage.id).toBe(MOCK_TIMESTAMP.toString());
+        expect(addedMessage.id).toMatch(/^m\d+$/);
       });
 
       it('appends to existing messages', () => {

--- a/frontend/src/store/gameSlice.ts
+++ b/frontend/src/store/gameSlice.ts
@@ -57,6 +57,9 @@ interface GameState {
   active: MyRosterEntry['name'] | null;
 }
 
+// Module-scope monotonic id for session messages (see addSessionMessage).
+let nextMessageId = 0;
+
 const initialState: GameState = {
   sessions: {},
   active: null,
@@ -110,7 +113,11 @@ export const gameSlice = createSlice({
       const { character, message } = action.payload;
       const session = state.sessions[character];
       if (session) {
-        session.messages.push({ ...message, id: Date.now().toString() });
+        // Monotonic counter, NOT Date.now() (2026-07 audit): multi-line server
+        // output lands as several frames in the same millisecond, and the id
+        // is used as a React key — duplicate keys dropped/misrendered rows.
+        nextMessageId += 1;
+        session.messages.push({ ...message, id: `m${nextMessageId}` });
         if (state.active !== character) {
           session.unread += 1;
         }
@@ -160,6 +167,13 @@ export const gameSlice = createSlice({
           // scene's table/whisper set is a mis-send vector.
           session.openThreadTabs = [];
           session.activeThreadTab = null;
+          // The WS interaction buffer is scene-contextual too (2026-07 audit):
+          // this clear used to be a separate unconditional dispatch on EVERY
+          // room_state frame — and the backend broadcasts room_state to all
+          // occupants whenever anything enters the room, so mid-scene arrivals
+          // erased every pose/whisper buffered since the last REST fetch.
+          // Clearing only on a real scene change keeps the feed intact.
+          session.sceneInteractions = [];
         }
         session.scene = scene;
       }


### PR DESCRIPTION
## What

Item 4 of the 2026-07-16 audit attack order — the liveness pass over the real-time core.

**WebSocket layer (`useGameSocket`):**
- **Reconnect with capped exponential backoff** on abnormal close (1s→30s, 6 attempts). There was no reconnect path at all (`hooks/CLAUDE.md` claimed otherwise) — a network blip silently froze the feed until the player manually re-clicked their character tab. The open handler re-puppets and invalidates `['scene-interactions']` so messages from the outage window backfill instead of staying "fresh" for up to 5 min.
- **Double-connect guard**: two `connect()` calls racing the account fetch each opened a socket; the first leaked with a live listener, duplicating every frame until reload. A synchronous `connecting` set closes the window.
- **`PUPPET_CHANGED` swallowed** — it broadcast to every account session on each puppet and fell through to the raw-JSON fallback, spamming multi-character players' system lanes.

**Scene feed correctness:**
- The WS interaction-buffer clear moves into `setSessionScene`'s guarded scene-transition reset. The backend broadcasts `room_state` to all occupants whenever *anything* enters the room, and the old unconditional clear erased every buffered pose/whisper mid-scene for everyone present (gone for up to staleTime). Now it clears only on a real scene-id change; the two handler dispatch sites drop their redundant clears.
- Session message ids are a monotonic counter, not `Date.now()` — burst frames in the same millisecond produced duplicate React keys and dropped log rows.
- `composerMode` resets on `[active, sceneId]` — a whisper mode set as character A survived a puppet switch (B's null tab fell through to the stored mode) and mis-sent as B, violating the "audience derived, not stored" doctrine the tab system already enforces.

**Multiplayer polls** (surfaces that waited on a refetch nothing triggered): group mission ballots 5s (participant B never saw A's vote; the post-countdown "waiting to resolve" state waited forever), beat cards 10s, ritual session detail 5s (the initiator's "waiting for participants" panel + disabled Fire button deadlocked without a manual reload — the docstring promised polling that didn't exist).

## Tests

Handler/reducer tests updated to the new contracts (guarded clear, monotonic ids — including a new uniqueness-under-burst assertion). hooks/store/game/missions/rituals/scenes suites green (905 tests); `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)