### PR TITLE
Audit fix 6: pagination — follow-all-pages reads, picker caps, unbounded viewsets

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -26490,6 +26490,21 @@ export interface components {
       previous?: string | null;
       results: components['schemas']['BuildingKind'][];
     };
+    PaginatedCanonReviewList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['CanonReview'][];
+    };
     PaginatedCatalogSuggestionDetailList: {
       /** @example 123 */
       count: number;
@@ -26564,6 +26579,21 @@ export interface components {
        */
       previous?: string | null;
       results: components['schemas']['ChapterList'][];
+    };
+    PaginatedCharacterAchievementList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['CharacterAchievement'][];
     };
     PaginatedCharacterCovenantRoleList: {
       /** @example 123 */
@@ -35847,6 +35877,10 @@ export interface operations {
     parameters: {
       query?: {
         character_sheet?: number;
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        /** @description Number of results to return per page. */
+        page_size?: number;
       };
       header?: never;
       path?: never;
@@ -35859,7 +35893,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['CharacterAchievement'][];
+          'application/json': components['schemas']['PaginatedCharacterAchievementList'];
         };
       };
     };
@@ -37808,6 +37842,10 @@ export interface operations {
       query?: {
         /** @description Which field to use when ordering the results. */
         ordering?: string;
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        /** @description Number of results to return per page. */
+        page_size?: number;
         /**
          * @description * `pending` - Pending
          *     * `cleared` - Cleared
@@ -37832,7 +37870,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['CanonReview'][];
+          'application/json': components['schemas']['PaginatedCanonReviewList'];
         };
       };
     };

--- a/frontend/src/inventory/api.ts
+++ b/frontend/src/inventory/api.ts
@@ -9,6 +9,7 @@
  */
 
 import { apiFetch } from '@/evennia_replacements/api';
+import { fetchAllPages } from '@/lib/pagination';
 import type { components } from '@/generated/api';
 import type {
   BodyRegion,
@@ -58,12 +59,10 @@ async function readError(res: Response, fallback: string): Promise<string> {
 // ---------------------------------------------------------------------------
 
 export async function listOutfits(characterSheetId: number): Promise<Outfit[]> {
-  const res = await apiFetch(`${BASE_URL}/outfits/?character_sheet=${characterSheetId}`);
-  if (!res.ok) {
-    throw new Error(await readError(res, 'Failed to load outfits'));
-  }
-  const data = (await res.json()) as PaginatedResponse<Outfit>;
-  return data.results;
+  return fetchAllPages<Outfit>(
+    `${BASE_URL}/outfits/?character_sheet=${characterSheetId}`,
+    'Failed to load outfits'
+  );
 }
 
 export async function getOutfit(id: number): Promise<Outfit> {
@@ -139,12 +138,13 @@ export async function deleteOutfitSlot(id: number): Promise<void> {
 // ---------------------------------------------------------------------------
 
 export async function listInventory(characterId: number): Promise<ItemInstance[]> {
-  const res = await apiFetch(`${BASE_URL}/inventory/?character=${characterId}`);
-  if (!res.ok) {
-    throw new Error(await readError(res, 'Failed to load inventory'));
-  }
-  const data = (await res.json()) as PaginatedResponse<ItemInstance>;
-  return data.results;
+  // Follow every page (2026-07 audit): the endpoint paginates at 50 and this
+  // read hydrates the wardrobe's instance lookup — a worn item past page 1
+  // vanished from Currently Worn and made its Wear/Drop buttons no-op.
+  return fetchAllPages<ItemInstance>(
+    `${BASE_URL}/inventory/?character=${characterId}`,
+    'Failed to load inventory'
+  );
 }
 
 export async function postUseItem(itemId: number): Promise<UseItemResult> {
@@ -156,12 +156,10 @@ export async function postUseItem(itemId: number): Promise<UseItemResult> {
 }
 
 export async function listEquipped(characterId: number): Promise<EquippedItem[]> {
-  const res = await apiFetch(`${BASE_URL}/equipped-items/?character=${characterId}`);
-  if (!res.ok) {
-    throw new Error(await readError(res, 'Failed to load equipped items'));
-  }
-  const data = (await res.json()) as PaginatedResponse<EquippedItem>;
-  return data.results;
+  return fetchAllPages<EquippedItem>(
+    `${BASE_URL}/equipped-items/?character=${characterId}`,
+    'Failed to load equipped items'
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/lib/pagination.ts
+++ b/frontend/src/lib/pagination.ts
@@ -1,0 +1,38 @@
+import { apiFetch } from '@/evennia_replacements/api';
+import { readErrorDetail } from '@/lib/errors';
+
+interface Paginated<T> {
+  next: string | null;
+  results: T[];
+}
+
+/** Backstop against a paginator whose `next` never terminates. */
+const MAX_PAGES = 40;
+
+/**
+ * Fetch every page of a DRF-paginated list endpoint, following `next` links
+ * (2026-07 audit). For "load the whole collection" callers — inventories,
+ * journals, pickers — that previously read only `results` of page 1 and
+ * silently truncated at the server page size (e.g. a >50-item inventory lost
+ * worn items past page 1, turning Wear/Drop buttons into no-ops).
+ *
+ * Not a replacement for real pagination UI on unbounded lists — use this only
+ * where the full set is genuinely needed and plausibly bounded.
+ */
+export async function fetchAllPages<T>(firstUrl: string, errorMessage: string): Promise<T[]> {
+  const all: T[] = [];
+  let url: string | null = firstUrl;
+  let pages = 0;
+  while (url !== null && pages < MAX_PAGES) {
+    const res = await apiFetch(url);
+    if (!res.ok) {
+      await readErrorDetail(res, errorMessage);
+    }
+    const data = (await res.json()) as Paginated<T>;
+    all.push(...data.results);
+    // `next` is absolute from DRF; pass through as-is (same-origin).
+    url = data.next;
+    pages += 1;
+  }
+  return all;
+}

--- a/frontend/src/missions/api.ts
+++ b/frontend/src/missions/api.ts
@@ -9,6 +9,7 @@
 
 import type { EntitySearchResult } from '@/components/EntitySearchField';
 import { apiFetch } from '@/evennia_replacements/api';
+import { fetchAllPages } from '@/lib/pagination';
 
 import type {
   BeatView,
@@ -82,7 +83,7 @@ function buildQueryString(params: object): string {
 // ---------------------------------------------------------------------------
 
 export async function listMissionTemplates(
-  filters: MissionTemplateFilters & { page?: number } = {}
+  filters: MissionTemplateFilters & { page?: number; page_size?: number } = {}
 ): Promise<PaginatedResponse<MissionTemplate>> {
   const res = await apiFetch(`${BASE_URL}/templates/${buildQueryString(filters)}`);
   if (!res.ok) throw new Error('Failed to load mission templates');
@@ -350,7 +351,13 @@ export async function listPredicateLeaves(): Promise<PredicateLeaf[]> {
 // ---------------------------------------------------------------------------
 
 export async function listGivers(
-  filters: { giver_kind?: string; is_active?: boolean; name?: string; page?: number } = {}
+  filters: {
+    giver_kind?: string;
+    is_active?: boolean;
+    name?: string;
+    page?: number;
+    page_size?: number;
+  } = {}
 ): Promise<PaginatedResponse<MissionGiver>> {
   const res = await apiFetch(`${BASE_URL}/givers/${buildQueryString(filters)}`);
   if (!res.ok) throw new Error('Failed to load mission givers');
@@ -416,9 +423,14 @@ export async function resolveMissionGiverTarget(
 // ---------------------------------------------------------------------------
 
 export async function listJournal(): Promise<PaginatedResponse<JournalEntry>> {
-  const res = await apiFetch(`${BASE_URL}/journal/`);
-  if (!res.ok) throw new Error('Failed to load your journal');
-  return res.json();
+  // Follow every page (2026-07 audit): the journal paginates at 25 and
+  // concluded runs accumulate forever — older entries (and, depending on
+  // ordering, active stories in the StoryTray) silently vanished past page 1.
+  const results = await fetchAllPages<JournalEntry>(
+    `${BASE_URL}/journal/`,
+    'Failed to load your journal'
+  );
+  return { count: results.length, next: null, previous: null, results };
 }
 
 export async function getBeat(instanceId: number): Promise<BeatView | null> {

--- a/frontend/src/missions/pages/TriggerGiversPage.tsx
+++ b/frontend/src/missions/pages/TriggerGiversPage.tsx
@@ -62,7 +62,8 @@ function numOrNull(raw: string): number | null {
 }
 
 export function TriggerGiversPage() {
-  const { data, isLoading } = useGivers();
+  // page_size: paginator max (2026-07 audit) — the list truncated at 25 givers.
+  const { data, isLoading } = useGivers({ page_size: 100 });
   const givers = data?.results ?? [];
 
   return (
@@ -162,7 +163,10 @@ function CreateGiverCard() {
 function GiverCard({ giver }: { giver: MissionGiver }) {
   const patch = usePatchGiver();
   const del = useDeleteGiver();
-  const { data: templatesData } = useMissionTemplates({});
+  // page_size: paginator max (2026-07 audit) — same 25-row truncation as the
+  // NPCRoleEditorPage picker; an existing giver's assignments couldn't even
+  // be re-saved consistently once templates passed one page.
+  const { data: templatesData } = useMissionTemplates({ page_size: 100 });
   const templates = templatesData?.results ?? [];
 
   const [kind, setKind] = useState<string>(giver.giver_kind ?? 'room_trigger');

--- a/frontend/src/missions/queries.ts
+++ b/frontend/src/missions/queries.ts
@@ -97,7 +97,7 @@ export const missionKeys = {
 const FIVE_MINUTES = 5 * 60 * 1000;
 
 export function useMissionTemplates(
-  filters: MissionTemplateFilters & { page?: number } = {}
+  filters: MissionTemplateFilters & { page?: number; page_size?: number } = {}
 ): UseQueryResult<PaginatedResponse<MissionTemplate>> {
   return useQuery({
     queryKey: missionKeys.templateList(filters),
@@ -294,7 +294,7 @@ export function useMissionCategories(): UseQueryResult<PaginatedResponse<Mission
 // ---------------------------------------------------------------------------
 
 export function useGivers(
-  filters: { giver_kind?: string; is_active?: boolean; name?: string } = {}
+  filters: { giver_kind?: string; is_active?: boolean; name?: string; page_size?: number } = {}
 ): UseQueryResult<PaginatedResponse<MissionGiver>> {
   return useQuery({
     queryKey: missionKeys.giversFor(filters),

--- a/frontend/src/npc_services/pages/NPCRoleEditorPage.tsx
+++ b/frontend/src/npc_services/pages/NPCRoleEditorPage.tsx
@@ -573,7 +573,9 @@ function AddOfferForm({ roleId }: { roleId: number }) {
   const createOffer = useCreateOffer(roleId);
   const createDetails = useCreateMissionDetails(roleId);
   const deleteOffer = useDeleteOffer(roleId);
-  const { data: templatesData } = useMissionTemplates({});
+  // page_size: the paginator max (2026-07 audit) — this picker read only page 1
+  // (25 rows), so the 26th authored template couldn't be assigned to an offer.
+  const { data: templatesData } = useMissionTemplates({ page_size: 100 });
   const templates = templatesData?.results ?? [];
 
   const submit = () => {

--- a/src/schema.json
+++ b/src/schema.json
@@ -69,6 +69,18 @@ paths:
         name: character_sheet
         schema:
           type: integer
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
       tags:
       - achievements
       security:
@@ -78,9 +90,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/CharacterAchievement'
+                $ref: '#/components/schemas/PaginatedCharacterAchievementList'
           description: ''
   /api/achievements/character-achievements/{id}/:
     get:
@@ -2495,6 +2505,18 @@ paths:
         description: Which field to use when ordering the results.
         schema:
           type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
       - in: query
         name: status
         schema:
@@ -2528,9 +2550,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/CanonReview'
+                $ref: '#/components/schemas/PaginatedCanonReviewList'
           description: ''
   /api/canon-reviews/{id}/:
     get:
@@ -47447,6 +47467,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/BuildingKind'
+    PaginatedCanonReviewList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/CanonReview'
     PaginatedCatalogSuggestionDetailList:
       type: object
       required:
@@ -47562,6 +47605,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ChapterList'
+    PaginatedCharacterAchievementList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/CharacterAchievement'
     PaginatedCharacterCovenantRoleList:
       type: object
       required:

--- a/src/world/achievements/tests/test_views.py
+++ b/src/world/achievements/tests/test_views.py
@@ -132,7 +132,8 @@ class CharacterAchievementViewSetTests(TestCase):
         """List endpoint returns character achievements."""
         response = self.client.get("/api/achievements/character-achievements/")
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 2
+        # Paginated envelope (2026-07 audit fix).
+        assert len(response.data["results"]) == 2
 
     def test_filter_by_character_sheet(self) -> None:
         """Filter by character_sheet returns only that character's achievements."""
@@ -140,8 +141,8 @@ class CharacterAchievementViewSetTests(TestCase):
             f"/api/achievements/character-achievements/?character_sheet={self.sheet.pk}"
         )
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 1
-        assert response.data[0]["achievement"]["name"] == "First"
+        assert len(response.data["results"]) == 1
+        assert response.data["results"][0]["achievement"]["name"] == "First"
 
     def test_includes_discovery_info(self) -> None:
         """Character achievement includes discovery information."""

--- a/src/world/achievements/views.py
+++ b/src/world/achievements/views.py
@@ -18,6 +18,7 @@ from world.achievements.serializers import (
     CharacterAchievementSerializer,
     CharacterTitleSerializer,
 )
+from world.stories.pagination import StandardResultsSetPagination
 
 
 class AchievementViewSet(ReadOnlyModelViewSet):
@@ -57,6 +58,9 @@ class CharacterAchievementViewSet(ReadOnlyModelViewSet):
 
     serializer_class = CharacterAchievementSerializer
     permission_classes = [IsAuthenticated]
+    # Paginated (2026-07 audit): the character_sheet filter is optional, so a
+    # bare GET returned every character-achievement row game-wide.
+    pagination_class = StandardResultsSetPagination
     filter_backends = [DjangoFilterBackend]
     filterset_fields = ["character_sheet"]
 

--- a/src/world/stories/tests/test_canon_review.py
+++ b/src/world/stories/tests/test_canon_review.py
@@ -439,7 +439,8 @@ class CanonReviewViewSetTests(APITestCase):
         self.client.force_authenticate(user=self.staff)
         resp = self.client.get(self.CANON_LIST_URL)
         self.assertEqual(resp.status_code, 200)
-        self.assertTrue(any(r["id"] == self.review.pk for r in resp.data))
+        # Paginated envelope (2026-07 audit fix).
+        self.assertTrue(any(r["id"] == self.review.pk for r in resp.data["results"]))
 
     def test_staff_can_clear_pending_review(self) -> None:
         self.client.force_authenticate(user=self.staff)

--- a/src/world/stories/views.py
+++ b/src/world/stories/views.py
@@ -3970,6 +3970,9 @@ class CanonReviewViewSet(
     queryset = CanonReview.objects.select_related("story", "reviewer").order_by("-created_at")
     serializer_class = CanonReviewSerializer
     permission_classes = [permissions.IsAuthenticated, permissions.IsAdminUser]
+    # Paginated (2026-07 audit): resolved reviews accumulate forever — the
+    # unpaginated list eventually returned the entire review history.
+    pagination_class = StandardResultsSetPagination
     filter_backends = [DjangoFilterBackend, filters.OrderingFilter]
     filterset_fields = ["status", "tier"]
     ordering_fields = ["created_at", "resolved_at"]


### PR DESCRIPTION
## What

Item 6 of the 2026-07-16 audit attack order — the pagination sweep, both sides of the seam.

**Frontend** (consumers silently truncating at the server page size):
- New `lib/pagination.fetchAllPages` helper follows DRF `next` links (40-page backstop), for load-the-whole-collection readers.
- **Inventory/wardrobe**: `listInventory`/`listEquipped`/`listOutfits` follow all pages — a >50-item inventory lost worn items past page 1, which vanished from Currently Worn/PaperDoll and turned their Wear/Drop/Give buttons into silent no-ops (`resolveGameObjectId` returned null).
- **Mission journal**: concluded runs accumulate forever; entries past 25 silently dropped (and, ordering-dependent, active stories could fall out of the StoryTray).
- **Staff pickers** (NPCRoleEditorPage + TriggerGiversPage template/giver pickers): request the paginator max (100) — at 25, the 26th authored template couldn't be assigned to an offer, and an existing giver's assignments couldn't be re-saved consistently.

**Backend** (unbounded lists):
- `CanonReviewViewSet` paginated — resolved reviews accumulate forever, so the staff queue eventually fetched the entire review history in one response.
- `CharacterAchievementViewSet` paginated — the `character_sheet` filter is optional, so a bare GET returned every character-achievement row game-wide (also an account-aggregate scrape surface).
- `gen-api-types` regenerated for both (known local drift hunks hand-reverted to CI's form); the four affected backend tests updated to the envelope shape.

The audit's broader recommendation — a settings-level `DEFAULT_PAGINATION_CLASS` so unbounded is opt-out rather than default (33 viewsets currently ship bare arrays, three envelope shapes coexist) — is deliberately NOT in this PR: it changes the response shape of every currently-unpaginated endpoint at once and needs its own coordinated sweep.

## Tests

Backend achievements (76) + canon-review (37) green after envelope updates; frontend inventory/missions/lib/npc_services suites green (295); `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)