### PR TITLE
Audit2 S1: magic correctness — web imbuing, Sineating PKs, weave race, XP invalidations

### DIFF
--- a/frontend/src/events/queries.ts
+++ b/frontend/src/events/queries.ts
@@ -93,12 +93,24 @@ export async function removeInvitation(invitationId: number): Promise<void> {
   }
 }
 
-export async function searchPersonas(query: string): Promise<{ id: number; name: string }[]> {
+export interface PersonaSearchResult {
+  /** Persona pk. */
+  id: number;
+  name: string;
+  /** Owning CharacterSheet pk — some callers key on the sheet, not the persona (#audit2). */
+  character_sheet: number | null;
+}
+
+export async function searchPersonas(query: string): Promise<PersonaSearchResult[]> {
   const res = await apiFetch(`/api/personas/?search=${encodeURIComponent(query)}`);
   if (!res.ok) throw new Error('Failed to search personas');
   const data = await res.json();
   const results = Array.isArray(data) ? data : data.results;
-  return results.map((p: { id: number; name: string }) => ({ id: p.id, name: p.name }));
+  return results.map((p: { id: number; name: string; character_sheet: number | null }) => ({
+    id: p.id,
+    name: p.name,
+    character_sheet: p.character_sheet ?? null,
+  }));
 }
 
 export async function searchOrganizations(query: string): Promise<{ id: number; name: string }[]> {

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -31939,6 +31939,15 @@ export interface components {
       readonly participation_rule: components['schemas']['ParticipationRuleEnum'];
       readonly min_participants: number | null;
       readonly max_participants: number | null;
+      /**
+       * @description True for the Rite of Imbuing (2026-07 audit).
+       *
+       *     Web imbuing resolves the ritual by this flag — the serializer never
+       *     exposes ``service_function_path`` (server-internal), and the old
+       *     client-side path filter matched a field that was never sent, so the
+       *     Imbue button could not succeed on any server.
+       */
+      readonly is_imbuing: boolean;
     };
     /**
      * @description Write serializer for the nested check_config on a PATCH.

--- a/frontend/src/magic/CLAUDE.md
+++ b/frontend/src/magic/CLAUDE.md
@@ -130,7 +130,13 @@ REST API client for all soul-tether, thread, character-resonance, thread-spendin
 - `retireThread(id)` — DELETE `/api/magic/threads/{id}/` → `void`
 - `crossXPLock(threadId, body)` — POST `/api/magic/threads/{id}/cross_xp_lock/` → `CrossXPLockResponse` (`{thread_id, unlocked_level, xp_spent}`)
 - `imbueThread(body)` — wraps `performRitual` with imbuing ritual id + kwargs
-- `imbueThreadAuto(characterSheetId, threadId, amount)` — resolves ritual id then imbues
+- `imbueThreadAuto(characterSheetId, threadId, amount)` — resolves the Rite of
+  Imbuing via the serialized `is_imbuing` flag (NOT `service_function_path`,
+  which the serializer never sends — the old filter made web imbuing dead on
+  every server, #audit2), then POSTs `rituals/perform/` with
+  `{ thread_id, amount }`. The canonical rite is CEREMONY-kind and the web is
+  its client-hosted UI, so the backend fuses the `imbue` finisher into that
+  one POST (performing the ceremony alone would only mint the pending effect).
 - `previewPull(body)` — POST `/api/magic/thread-pull-preview/` → `PullPreviewResponse`
 
 **Teaching offer mutations:**

--- a/frontend/src/magic/__tests__/SineatingRequestDialog.test.tsx
+++ b/frontend/src/magic/__tests__/SineatingRequestDialog.test.tsx
@@ -221,7 +221,9 @@ describe('SineatingRequestDialog', () => {
 
   it('shows persona search results after typing and selecting fills the field', async () => {
     setupMocks();
-    vi.mocked(eventsQueries.searchPersonas).mockResolvedValue([{ id: 20, name: 'Rael' }]);
+    vi.mocked(eventsQueries.searchPersonas).mockResolvedValue([
+      { id: 20, name: 'Rael', character_sheet: 55 },
+    ]);
 
     render(<SineatingRequestDialog {...defaultProps} />, { wrapper: createWrapper() });
 
@@ -266,7 +268,9 @@ describe('SineatingRequestDialog', () => {
 
   it('submitting fires useRequestSineating().mutate with the correct body shape', async () => {
     const { mutate } = setupMocks();
-    vi.mocked(eventsQueries.searchPersonas).mockResolvedValue([{ id: 20, name: 'Rael' }]);
+    vi.mocked(eventsQueries.searchPersonas).mockResolvedValue([
+      { id: 20, name: 'Rael', character_sheet: 55 },
+    ]);
 
     render(<SineatingRequestDialog {...defaultProps} />, { wrapper: createWrapper() });
 
@@ -301,7 +305,7 @@ describe('SineatingRequestDialog', () => {
     expect(mutate).toHaveBeenCalledWith(
       {
         actor_sheet_id: 10,
-        sineater_sheet_id: 20,
+        sineater_sheet_id: 55,
         resonance_id: 3,
         max_units: 5,
         scene_id: 5,
@@ -321,7 +325,9 @@ describe('SineatingRequestDialog', () => {
     const { mutate } = setupMocks();
     const onSuccess = vi.fn();
     const onOpenChange = vi.fn();
-    vi.mocked(eventsQueries.searchPersonas).mockResolvedValue([{ id: 20, name: 'Rael' }]);
+    vi.mocked(eventsQueries.searchPersonas).mockResolvedValue([
+      { id: 20, name: 'Rael', character_sheet: 55 },
+    ]);
 
     // Make mutate invoke its onSuccess callback immediately
     mutate.mockImplementation((_body: unknown, callbacks: { onSuccess?: () => void }) => {

--- a/frontend/src/magic/api.ts
+++ b/frontend/src/magic/api.ts
@@ -481,12 +481,12 @@ export async function crossXPLock(
 // ---------------------------------------------------------------------------
 // Imbue Thread
 //
-// Imbuing is a SERVICE ritual — POST /api/magic/rituals/perform/ with kwargs
-// { thread_id, amount }. getImbuingRitualId() looks up the Ritual whose
-// service_function_path contains 'spend_resonance_for_imbuing'.
+// The canonical Rite of Imbuing is CEREMONY-kind; the web is its specialized
+// host UI (Ritual.client_hosted) — POST /api/magic/rituals/perform/ with
+// kwargs { thread_id, amount } performs the ceremony AND applies the imbue in
+// one call (the backend fuses the finisher). getImbuingRitualId() resolves the
+// ritual via the serialized is_imbuing flag.
 // ---------------------------------------------------------------------------
-
-const _IMBUING_SERVICE_PATH = 'spend_resonance_for_imbuing';
 
 /**
  * @internal
@@ -503,7 +503,7 @@ export function __resetImbuingRitualIdCacheForTests(): void {
 }
 
 /**
- * Resolves the Ritual PK whose service_function_path wraps spend_resonance_for_imbuing.
+ * Resolves the Rite of Imbuing's PK via the serialized is_imbuing flag.
  * Result is cached in module scope.
  */
 async function getImbuingRitualId(): Promise<number> {
@@ -512,15 +512,10 @@ async function getImbuingRitualId(): Promise<number> {
   const paginatedList = await getRituals();
   const rituals = paginatedList.results ?? [];
 
-  // The Ritual schema omits service_function_path from generated types (it is
-  // server-internal); cast through unknown to access the field safely.
-  const imbuing = rituals.find((r) => {
-    const raw = r as unknown as { service_function_path?: string };
-    return (
-      typeof raw.service_function_path === 'string' &&
-      raw.service_function_path.includes(_IMBUING_SERVICE_PATH)
-    );
-  });
+  // Serialized is_imbuing flag (2026-07 audit): the old filter matched
+  // service_function_path — a field the serializer never sends — so this
+  // find() always failed and web imbuing was unreachable on every server.
+  const imbuing = rituals.find((r) => r.is_imbuing);
 
   if (!imbuing) {
     throw new Error('Imbuing ritual not found — ensure the Ritual seed exists on this server');

--- a/frontend/src/magic/components/SineatingRequestDialog.tsx
+++ b/frontend/src/magic/components/SineatingRequestDialog.tsx
@@ -40,8 +40,11 @@ import { useRequestSineating, useCharacterResonances } from '../queries';
 // ---------------------------------------------------------------------------
 
 interface PersonaOption {
+  /** Persona pk (display + selection). */
   id: number;
   name: string;
+  /** Owning CharacterSheet pk — the id the backend actually wants (#audit2). */
+  character_sheet: number | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -147,6 +150,7 @@ export function SineatingRequestDialog({
   const unitsValid = Number.isFinite(unitsNum) && unitsNum >= 1 && unitsNum <= availableUnits;
   const canSubmit =
     selectedSineater !== null &&
+    selectedSineater.character_sheet !== null &&
     resonanceId !== null &&
     sceneId !== null &&
     unitsValid &&
@@ -154,12 +158,22 @@ export function SineatingRequestDialog({
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
-    if (!canSubmit || selectedSineater === null || resonanceId === null || sceneId === null) return;
+    if (
+      !canSubmit ||
+      selectedSineater === null ||
+      selectedSineater.character_sheet === null ||
+      resonanceId === null ||
+      sceneId === null
+    )
+      return;
 
     requestMutation.mutate(
       {
         actor_sheet_id: sinnerSheetId,
-        sineater_sheet_id: selectedSineater.id,
+        // The CharacterSheet pk (2026-07 audit): this was selectedSineater.id,
+        // a Persona pk — CharacterSheet.objects.get(pk=...) then mis-targeted
+        // or 404'd whenever the two id sequences diverged.
+        sineater_sheet_id: selectedSineater.character_sheet,
         resonance_id: resonanceId,
         max_units: unitsNum,
         scene_id: sceneId,
@@ -257,7 +271,10 @@ export function SineatingRequestDialog({
                 </SelectTrigger>
                 <SelectContent>
                   {resonanceList.map((cr) => (
-                    <SelectItem key={cr.id} value={String(cr.id)}>
+                    // value = cr.resonance (Resonance pk), NOT cr.id (the
+                    // CharacterResonance row pk) — the backend resolves a
+                    // Resonance, so the row pk mis-targeted/404'd (2026-07 audit).
+                    <SelectItem key={cr.resonance} value={String(cr.resonance)}>
                       {cr.resonance_name}
                     </SelectItem>
                   ))}

--- a/frontend/src/magic/components/threads/WeaveThreadWizard.tsx
+++ b/frontend/src/magic/components/threads/WeaveThreadWizard.tsx
@@ -20,7 +20,7 @@
  * Internal step state — does NOT use react-router subroutes.
  */
 
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Button } from '@/components/ui/button';
 import {
@@ -358,6 +358,9 @@ export function WeaveThreadWizard({
   const [anchorOptions, setAnchorOptions] = useState<AnchorOption[]>([]);
   const [anchorLoading, setAnchorLoading] = useState(false);
   const [anchorError, setAnchorError] = useState<string | null>(null);
+  // Monotonic token for the anchor/partner fetch — only the newest kind
+  // selection's response may write state (see selectKind, 2026-07 audit).
+  const anchorRequestTokenRef = useRef(0);
   // RELATIONSHIP_TRACK only (#2159): partner candidates for the "with whom"
   // step, fetched once per kind selection (see selectKind below).
   const [partnerOptions, setPartnerOptions] = useState<PartnerOption[]>([]);
@@ -406,6 +409,11 @@ export function WeaveThreadWizard({
     const meta = KIND_META[kind];
     if (!meta?.supported) return;
 
+    // Stale-response guard (2026-07 audit): pick kind A (slow fetch), Back,
+    // pick kind B (fast) — A's response used to resolve last and overwrite
+    // B's anchors, so selecting one submitted a target of the wrong kind.
+    // Only the newest selection's result may write state.
+    const token = ++anchorRequestTokenRef.current;
     setAnchorLoading(true);
     try {
       if (kind === 'RELATIONSHIP_TRACK') {
@@ -413,15 +421,18 @@ export function WeaveThreadWizard({
           characterSheetId == null
             ? []
             : await fetchRelationshipPartnerOptions(characterSheetId, summary);
+        if (token !== anchorRequestTokenRef.current) return;
         setPartnerOptions(options);
       } else {
         const options = await fetchAnchorOptions(kind, summary);
+        if (token !== anchorRequestTokenRef.current) return;
         setAnchorOptions(options);
       }
     } catch (err) {
+      if (token !== anchorRequestTokenRef.current) return;
       setAnchorError(err instanceof Error ? err.message : 'Failed to load options.');
     } finally {
-      setAnchorLoading(false);
+      if (token === anchorRequestTokenRef.current) setAnchorLoading(false);
     }
   }
 

--- a/frontend/src/magic/queries.ts
+++ b/frontend/src/magic/queries.ts
@@ -430,6 +430,9 @@ export function useCrossXPLock() {
       qc.invalidateQueries({
         queryKey: [...magicKeys.all, 'thread-hub-summary'],
       }).catch(() => {});
+      // Crossing an XP-lock spends account XP (2026-07 audit): without this the
+      // ThreadDetailPage "Available: N XP" affordability stayed stale up to 5min.
+      qc.invalidateQueries({ queryKey: ['account-progression'] }).catch(() => {});
     },
   });
 }
@@ -467,6 +470,8 @@ export function useAcceptTeachingOffer() {
       qc.invalidateQueries({
         queryKey: [...magicKeys.all, 'thread-hub-summary'],
       }).catch(() => {});
+      // Accepting a teaching offer pays XP (2026-07 audit) — refresh the balance.
+      qc.invalidateQueries({ queryKey: ['account-progression'] }).catch(() => {});
     },
   });
 }

--- a/frontend/src/rituals/__tests__/fields.test.tsx
+++ b/frontend/src/rituals/__tests__/fields.test.tsx
@@ -478,8 +478,8 @@ describe('Field Components', () => {
 
     it('shows search results after typing and calls onChange with persona id', async () => {
       vi.mocked(searchPersonas).mockResolvedValue([
-        { id: 10, name: 'Aria Voss' },
-        { id: 11, name: 'Kael Dorne' },
+        { id: 10, name: 'Aria Voss', character_sheet: 110 },
+        { id: 11, name: 'Kael Dorne', character_sheet: 111 },
       ]);
       const onChange = vi.fn();
       const Wrapper = createWrapper();

--- a/frontend/src/rituals/__tests__/queries.test.tsx
+++ b/frontend/src/rituals/__tests__/queries.test.tsx
@@ -58,6 +58,7 @@ const mockRitual = {
   participation_rule: 'SINGLE_ACTOR' as const,
   min_participants: null,
   max_participants: null,
+  is_imbuing: false,
 };
 
 describe('Rituals Query Hooks', () => {

--- a/frontend/src/stories/__tests__/ScheduleEventDialog.test.tsx
+++ b/frontend/src/stories/__tests__/ScheduleEventDialog.test.tsx
@@ -115,8 +115,8 @@ describe('ScheduleEventDialog', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(eventsQueries.searchPersonas).mockResolvedValue([
-      { id: 1, name: 'Lady Avaris' },
-      { id: 2, name: 'Lord Brennan' },
+      { id: 1, name: 'Lady Avaris', character_sheet: 501 },
+      { id: 2, name: 'Lord Brennan', character_sheet: 502 },
     ]);
   });
 

--- a/src/schema.json
+++ b/src/schema.json
@@ -56999,6 +56999,16 @@ components:
           type: integer
           readOnly: true
           nullable: true
+        is_imbuing:
+          type: boolean
+          description: |-
+            True for the Rite of Imbuing (2026-07 audit).
+
+            Web imbuing resolves the ritual by this flag — the serializer never
+            exposes ``service_function_path`` (server-internal), and the old
+            client-side path filter matched a field that was never sent, so the
+            Imbue button could not succeed on any server.
+          readOnly: true
       required:
       - author_account_id
       - check_config
@@ -57009,6 +57019,7 @@ components:
       - hedge_accessible
       - id
       - input_schema
+      - is_imbuing
       - max_participants
       - min_participants
       - name

--- a/src/world/magic/constants.py
+++ b/src/world/magic/constants.py
@@ -453,3 +453,23 @@ def anima_band_for(current: int, maximum: int) -> str:
         if ratio >= threshold:
             return label
     return ANIMA_BANDS[-1][1]
+
+
+# The Rite of Imbuing's two identities (2026-07 audit). The CANONICAL seeded
+# ritual is CEREMONY-kind with an empty service path, identified by NAME — the
+# same identity the ImbueAction finisher and PendingRitualEffectPrerequisite
+# already match on. IMBUING_SERVICE_PATH additionally marks a staff-authored
+# SERVICE-dispatch variant, which RitualPerformView special-cases (thread_id
+# resolution). RitualSerializer.is_imbuing exposes the combined predicate so
+# web clients can find the ritual without the API leaking service paths (the
+# old frontend filtered on a field the serializer never sent, making web
+# imbuing unreachable on every server).
+IMBUING_RITUAL_NAME = "Rite of Imbuing"
+IMBUING_SERVICE_PATH = "world.magic.services.spend_resonance_for_imbuing"
+
+
+def is_imbuing_ritual(*, name: str, service_function_path: str) -> bool:
+    """Single predicate for "is this the Rite of Imbuing" — serializer + view share it."""
+    return name.casefold() == IMBUING_RITUAL_NAME.casefold() or (
+        service_function_path == IMBUING_SERVICE_PATH
+    )

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -20,7 +20,12 @@ if TYPE_CHECKING:
     from world.magic.audere import AudereThreshold
 from world.conditions.models import CapabilityType, ConditionTemplate, DamageType
 from world.items.models import ItemInstance
-from world.magic.constants import ALTERATION_TIER_CAPS, TargetKind, anima_band_for
+from world.magic.constants import (
+    ALTERATION_TIER_CAPS,
+    TargetKind,
+    anima_band_for,
+    is_imbuing_ritual,
+)
 from world.magic.models import (
     Cantrip,
     CharacterAnima,
@@ -1081,6 +1086,7 @@ class RitualSerializer(serializers.ModelSerializer):
         source="author_account", read_only=True, allow_null=True
     )
     check_config = serializers.SerializerMethodField()
+    is_imbuing = serializers.SerializerMethodField()
 
     class Meta:
         model = Ritual
@@ -1099,6 +1105,7 @@ class RitualSerializer(serializers.ModelSerializer):
             "participation_rule",
             "min_participants",
             "max_participants",
+            "is_imbuing",
         ]
         read_only_fields = fields
 
@@ -1108,6 +1115,16 @@ class RitualSerializer(serializers.ModelSerializer):
         if config is None:
             return None
         return RitualCheckConfigSerializer(config).data
+
+    def get_is_imbuing(self, obj: Ritual) -> bool:
+        """True for the Rite of Imbuing (2026-07 audit).
+
+        Web imbuing resolves the ritual by this flag — the serializer never
+        exposes ``service_function_path`` (server-internal), and the old
+        client-side path filter matched a field that was never sent, so the
+        Imbue button could not succeed on any server.
+        """
+        return is_imbuing_ritual(name=obj.name, service_function_path=obj.service_function_path)
 
 
 class RitualCheckConfigPatchSerializer(serializers.Serializer):

--- a/src/world/magic/tests/test_api.py
+++ b/src/world/magic/tests/test_api.py
@@ -1103,8 +1103,41 @@ class RitualPerformViewTests(APITestCase):
             [status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN],
         )
 
-    def test_imbuing_ceremony_dispatch_creates_pending_effect(self) -> None:
-        """Rite of Imbuing is CEREMONY-kind: POST creates a PendingRitualEffect."""
+    def test_imbuing_ceremony_web_post_fuses_perform_and_finisher(self) -> None:
+        """One web POST performs the CEREMONY AND applies the imbue (2026-07 audit).
+
+        The old contract only minted the PendingRitualEffect and silently
+        dropped thread/amount — a dead state, since the web has no separate
+        finisher UI (the telnet ``imbue`` command is the CEREMONY finisher).
+        """
+        self.client.force_authenticate(user=self.account)
+        starting_level = self.thread.level
+        response = self.client.post(
+            reverse("magic:ritual-perform"),
+            {
+                "character_sheet_id": self.sheet.pk,
+                "ritual_id": self.ritual.pk,
+                "kwargs": {"thread_id": self.thread.pk, "amount": 5},
+                "components": [],
+            },
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
+        self.assertEqual(response.data["ritual_id"], self.ritual.pk)
+        self.assertEqual(response.data["execution_kind"], "CEREMONY")
+        self.assertIn("result", response.data)
+        self.thread.refresh_from_db()
+        self.assertGreater(self.thread.level, starting_level)
+        # The finisher consumed the pending effect the perform minted.
+        self.assertFalse(
+            PendingRitualEffect.objects.filter(
+                character=self.sheet,
+                ritual=self.ritual,
+            ).exists(),
+        )
+
+    def test_imbuing_ceremony_requires_thread_kwargs(self) -> None:
+        """A bare imbuing perform 400s — the web has no finisher to consume it."""
         self.client.force_authenticate(user=self.account)
         response = self.client.post(
             reverse("magic:ritual-perform"),
@@ -1116,17 +1149,7 @@ class RitualPerformViewTests(APITestCase):
             },
             format="json",
         )
-        self.assertEqual(response.status_code, status.HTTP_200_OK, response.data)
-        self.assertEqual(response.data["ritual_id"], self.ritual.pk)
-        self.assertEqual(response.data["execution_kind"], "CEREMONY")
-        self.assertNotIn("result", response.data)
-        self.assertTrue(
-            PendingRitualEffect.objects.filter(
-                character=self.sheet,
-                ritual=self.ritual,
-            ).exists(),
-            "A PendingRitualEffect must be created for a CEREMONY-kind ritual.",
-        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_imbuing_ceremony_duplicate_returns_400(self) -> None:
         """A second Rite of Imbuing before the first is consumed returns 400."""
@@ -1138,7 +1161,7 @@ class RitualPerformViewTests(APITestCase):
             {
                 "character_sheet_id": self.sheet.pk,
                 "ritual_id": self.ritual.pk,
-                "kwargs": {},
+                "kwargs": {"thread_id": self.thread.pk, "amount": 5},
             },
             format="json",
         )
@@ -1257,7 +1280,7 @@ class RitualPerformViewTests(APITestCase):
             {
                 "character_sheet_id": self.sheet.pk,
                 "ritual_id": self.ritual.pk,
-                "kwargs": {},
+                "kwargs": {"thread_id": self.thread.pk, "amount": 5},
                 "components": [own_item.pk],
             },
             format="json",
@@ -1396,6 +1419,24 @@ class RitualSerializerTests(APITestCase):
         self.assertIn("description", data)
         self.assertIn("narrative_prose", data)
         self.assertIn("hedge_accessible", data)
+
+    def test_is_imbuing_flags_the_imbuing_ritual_only(self) -> None:
+        """The web Imbue flow resolves the ritual by this flag (2026-07 audit).
+
+        The old frontend filtered on ``service_function_path`` — a field the
+        serializer never sends — so web imbuing was unreachable everywhere.
+        """
+        from world.magic.factories import ImbuingRitualFactory, RitualFactory
+        from world.magic.serializers import RitualSerializer
+
+        # NOTE: this class's self.ritual is a RENAMED ImbuingRitualFactory row
+        # ("test_ritual") — deliberately NOT the canonical rite, so it must not
+        # flag. The canonical row (default name) must.
+        canonical = ImbuingRitualFactory()
+        self.assertTrue(RitualSerializer(canonical).data["is_imbuing"])
+        self.assertFalse(RitualSerializer(self.ritual).data["is_imbuing"])
+        other = RitualFactory(name="not_imbuing")
+        self.assertFalse(RitualSerializer(other).data["is_imbuing"])
 
 
 class RitualViewSetTests(APITestCase):

--- a/src/world/magic/views.py
+++ b/src/world/magic/views.py
@@ -37,6 +37,7 @@ from world.magic.constants import (
     RitualExecutionKind,
     SuggestionStatus,
     TargetKind,
+    is_imbuing_ritual,
 )
 from world.magic.exceptions import (
     InvalidImbueAmount,
@@ -170,7 +171,7 @@ from world.stories.pagination import StandardResultsSetPagination
 _ERR_THREAD_NOT_FOUND = "Thread not found or not owned by the actor."
 _ERR_RESONANCE_NOT_FOUND = "Resonance not found."
 _ERR_IMBUING_REQUIRES_THREAD = "Imbuing ritual requires thread_id in kwargs (int)."
-_IMBUING_SERVICE_PATH = "world.magic.services.spend_resonance_for_imbuing"
+_ERR_IMBUING_REQUIRES_AMOUNT = "Imbuing ritual requires amount in kwargs (positive int)."
 
 # =============================================================================
 # Lookup Table ViewSets (Read-Only)
@@ -1004,6 +1005,38 @@ class RitualPerformView(APIView):
 
     permission_classes = [IsAuthenticated]
 
+    @staticmethod
+    def _resolve_imbuing_kwargs(sheet: CharacterSheet, kwargs: dict) -> Response | None:
+        """Resolve/validate the imbuing ``thread_id``/``amount`` kwargs in place.
+
+        Returns a 400 ``Response`` on invalid input, else ``None`` (with
+        ``kwargs["thread"]`` resolved to an owned, non-retired Thread).
+        """
+        thread_id = kwargs.pop("thread_id", None)
+        if not isinstance(thread_id, int):
+            return Response(
+                {"detail": _ERR_IMBUING_REQUIRES_THREAD},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        thread = Thread.objects.filter(
+            pk=thread_id,
+            owner=sheet,
+            retired_at__isnull=True,
+        ).first()
+        if thread is None:
+            return Response(
+                {"detail": _ERR_THREAD_NOT_FOUND},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        kwargs["thread"] = thread
+        amount = kwargs.get("amount")
+        if not isinstance(amount, int) or amount < 1:
+            return Response(
+                {"detail": _ERR_IMBUING_REQUIRES_AMOUNT},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return None
+
     def post(self, request: Request) -> Response:
         """Validate, resolve, and dispatch the ritual; return a result payload."""
         serializer = RitualPerformRequestSerializer(
@@ -1018,26 +1051,16 @@ class RitualPerformView(APIView):
         kwargs: dict = dict(data.get("kwargs") or {})
         components = list(data.get("components") or [])
 
-        # Imbuing (and potentially other SERVICE rituals) takes a Thread. The
-        # primitive-only kwargs surface carries ``thread_id``; resolve here.
-        if ritual.service_function_path == _IMBUING_SERVICE_PATH:
-            thread_id = kwargs.pop("thread_id", None)
-            if not isinstance(thread_id, int):
-                return Response(
-                    {"detail": _ERR_IMBUING_REQUIRES_THREAD},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-            thread = Thread.objects.filter(
-                pk=thread_id,
-                owner=sheet,
-                retired_at__isnull=True,
-            ).first()
-            if thread is None:
-                return Response(
-                    {"detail": _ERR_THREAD_NOT_FOUND},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-            kwargs["thread"] = thread
+        # Imbuing takes a Thread. The primitive-only kwargs surface carries
+        # ``thread_id``; resolve here (covers both the canonical CEREMONY
+        # ritual and a staff-authored SERVICE variant).
+        imbuing = is_imbuing_ritual(
+            name=ritual.name, service_function_path=ritual.service_function_path
+        )
+        if imbuing:
+            error = self._resolve_imbuing_kwargs(sheet, kwargs)
+            if error is not None:
+                return error
 
         from actions.definitions.ritual import PerformRitualAction  # noqa: PLC0415
 
@@ -1055,6 +1078,40 @@ class RitualPerformView(APIView):
             return Response(
                 {"detail": action_result.message},
                 status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        # The canonical Rite of Imbuing is CEREMONY-kind: performing it only
+        # mints the PendingRitualEffect the telnet ``imbue`` finisher consumes.
+        # The web is the "specialized host UI" (Ritual.client_hosted) and sends
+        # one POST — fuse the finisher here so thread/amount actually apply
+        # (2026-07 audit: without this the pending effect was created and the
+        # imbue silently never happened).
+        if imbuing and ritual.execution_kind == RitualExecutionKind.CEREMONY:
+            from actions.definitions.imbue import ImbueAction  # noqa: PLC0415
+
+            finisher_result = ImbueAction().run(
+                actor=sheet.character,
+                thread=kwargs["thread"],
+                amount=kwargs["amount"],
+            )
+            if not finisher_result.success:
+                return Response(
+                    {"detail": finisher_result.message},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            imbue_result = finisher_result.data.get("result")
+            return Response(
+                {
+                    "ritual_id": ritual.pk,
+                    "execution_kind": ritual.execution_kind,
+                    "result": (
+                        asdict(imbue_result)
+                        if dataclasses.is_dataclass(imbue_result)
+                        else imbue_result
+                    ),
+                    "message": finisher_result.message,
+                },
+                status=status.HTTP_200_OK,
             )
 
         result = action_result.data.get("result")


### PR DESCRIPTION
## What

First of the second audit series — the magic-module correctness cluster. All three feature-level bugs passed the existing test suite because the tests mock the exact layer that was broken.

- **Web imbuing was dead on arrival.** The frontend resolved the Rite of Imbuing by `service_function_path` — a field `RitualSerializer` never sends — so the `find()` always failed and the Imbue button could never succeed on any server. Adds a serialized `is_imbuing` flag backed by a shared `is_imbuing_ritual()` predicate (name-based, since the canonical rite is CEREMONY-kind with an empty service path). Because that rite is CEREMONY and the web is its `client_hosted` UI, `RitualPerformView` now **fuses the imbue finisher into the single web POST** — performing the ceremony alone only minted a `PendingRitualEffect` that the web (which has no separate finisher UI, unlike telnet's `imbue` command) could never consume, so the imbue silently never applied.
- **SineatingRequestDialog submitted wrong-model PKs.** `sineater_sheet_id` was a Persona pk where the backend does `CharacterSheet.objects.get(pk=…)`, and `resonance_id` was the `CharacterResonance` row pk where the backend resolves a `Resonance`. Both mis-targeted or 404'd on any DB where the id sequences diverge. `searchPersonas` now carries `character_sheet`; the resonance picker keys on `cr.resonance`. (Sibling components already did it right.)
- **WeaveThreadWizard.selectKind stale-response race.** Pick kind A (slow), Back, pick kind B (fast) — A's response resolved last and overwrote B's anchors, so selecting one wove a thread against the wrong kind. Adds a monotonic request token guarding every state write.
- **Missing XP invalidations.** `useCrossXPLock` / `useAcceptTeachingOffer` spend account XP but never invalidated `['account-progression']`, leaving the ThreadDetailPage affordability display stale for up to 5 min.

## Tests

New backend coverage proving the fused imbuing POST advances the thread and consumes the pending effect, plus the `is_imbuing` flag (canonical rite flags, renamed variant doesn't); `world.magic` API suite green (61). Frontend magic/rituals/events/tables suites green (525); `tsc -b` clean.

**Note:** touches `magic/queries.ts`, which the still-queued #2419 also edits — expect a small rebase on the `threadHubSummary` invalidation lines if #2419 merges first (keep the bare-prefix form + the new account-progression line).

🤖 Generated with [Claude Code](https://claude.com/claude-code)