### PR TITLE
Audit2 S2: GM tables bulletin write path — end-to-end repair

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -21411,12 +21411,18 @@ export interface components {
      *     - ``story`` (if set) belongs to ``table`` (story.primary_table == table)
      *     - ``author_persona`` belongs to the requesting user's account
      *
+     *     ``author_persona`` is optional (2026-07 audit): a GM table is account-scoped,
+     *     not tied to a specific character, so the frontend has no in-game persona to
+     *     pass — omit it and the requester's own persona is resolved server-side.
+     *     When supplied, it MUST belong to the requesting account (the ownership check
+     *     the docstring always claimed but never enforced).
+     *
      *     Stores validated model instances in validated_data.
      */
     CreateBulletinPostInput: {
       table: number;
       story?: number | null;
-      author_persona: number;
+      author_persona?: number;
       title: string;
       body: string;
       /** @default true */
@@ -21430,12 +21436,18 @@ export interface components {
      *     - ``story`` (if set) belongs to ``table`` (story.primary_table == table)
      *     - ``author_persona`` belongs to the requesting user's account
      *
+     *     ``author_persona`` is optional (2026-07 audit): a GM table is account-scoped,
+     *     not tied to a specific character, so the frontend has no in-game persona to
+     *     pass — omit it and the requester's own persona is resolved server-side.
+     *     When supplied, it MUST belong to the requesting account (the ownership check
+     *     the docstring always claimed but never enforced).
+     *
      *     Stores validated model instances in validated_data.
      */
     CreateBulletinPostInputRequest: {
       table: number;
       story?: number | null;
-      author_persona: number;
+      author_persona?: number;
       title: string;
       body: string;
       /** @default true */
@@ -21454,7 +21466,7 @@ export interface components {
      */
     CreateBulletinReplyInput: {
       post: number;
-      author_persona: number;
+      author_persona?: number;
       body: string;
     };
     /**
@@ -21470,7 +21482,7 @@ export interface components {
      */
     CreateBulletinReplyInputRequest: {
       post: number;
-      author_persona: number;
+      author_persona?: number;
       body: string;
     };
     /** @description POST body for the #1127 create-established-persona endpoint. */

--- a/frontend/src/tables/__tests__/bulletin.test.tsx
+++ b/frontend/src/tables/__tests__/bulletin.test.tsx
@@ -326,10 +326,9 @@ describe('BulletinPostCard', () => {
 
   it('shows Reply button when canReply=true and allow_replies=true', () => {
     const post = makePost({ allow_replies: true });
-    render(
-      <BulletinPostCard post={post} isGMOrStaff={false} canReply={true} viewerPersonaId={7} />,
-      { wrapper: createWrapper() }
-    );
+    render(<BulletinPostCard post={post} isGMOrStaff={false} canReply={true} />, {
+      wrapper: createWrapper(),
+    });
 
     expect(screen.getByRole('button', { name: /\+ reply/i })).toBeInTheDocument();
   });
@@ -346,10 +345,9 @@ describe('BulletinPostCard', () => {
   it('shows inline reply form when Reply button is clicked', async () => {
     const user = userEvent.setup();
     const post = makePost({ allow_replies: true });
-    render(
-      <BulletinPostCard post={post} isGMOrStaff={false} canReply={true} viewerPersonaId={7} />,
-      { wrapper: createWrapper() }
-    );
+    render(<BulletinPostCard post={post} isGMOrStaff={false} canReply={true} />, {
+      wrapper: createWrapper(),
+    });
 
     await user.click(screen.getByRole('button', { name: /\+ reply/i }));
 
@@ -374,7 +372,7 @@ describe('CreateBulletinPostDialog', () => {
   it('opens dialog on trigger click', async () => {
     const user = userEvent.setup();
     render(
-      <CreateBulletinPostDialog tableId={1} gmPersonaId={3} stories={[]}>
+      <CreateBulletinPostDialog tableId={1} stories={[]}>
         <button type="button">New Post</button>
       </CreateBulletinPostDialog>,
       { wrapper: createWrapper() }
@@ -388,7 +386,7 @@ describe('CreateBulletinPostDialog', () => {
   it('submit button disabled when title or body is empty', async () => {
     const user = userEvent.setup();
     render(
-      <CreateBulletinPostDialog tableId={1} gmPersonaId={3} stories={[]}>
+      <CreateBulletinPostDialog tableId={1} stories={[]}>
         <button type="button">New Post</button>
       </CreateBulletinPostDialog>,
       { wrapper: createWrapper() }
@@ -403,7 +401,7 @@ describe('CreateBulletinPostDialog', () => {
   it('closes dialog on cancel', async () => {
     const user = userEvent.setup();
     render(
-      <CreateBulletinPostDialog tableId={1} gmPersonaId={3} stories={[]}>
+      <CreateBulletinPostDialog tableId={1} stories={[]}>
         <button type="button">New Post</button>
       </CreateBulletinPostDialog>,
       { wrapper: createWrapper() }
@@ -428,7 +426,7 @@ describe('CreateBulletinPostDialog', () => {
 
     const user = userEvent.setup();
     render(
-      <CreateBulletinPostDialog tableId={1} gmPersonaId={3} stories={[]}>
+      <CreateBulletinPostDialog tableId={1} stories={[]}>
         <button type="button">New Post</button>
       </CreateBulletinPostDialog>,
       { wrapper: createWrapper() }
@@ -442,7 +440,6 @@ describe('CreateBulletinPostDialog', () => {
     expect(mutateFn).toHaveBeenCalledWith(
       expect.objectContaining({
         table: 1,
-        author_persona: 3,
         title: 'Session Tomorrow',
         body: 'We are playing at 7pm',
         story: null,
@@ -456,7 +453,7 @@ describe('CreateBulletinPostDialog', () => {
     const user = userEvent.setup();
     const stories = [makeStory(11, 'Who Am I?'), makeStory(12, 'The Dark Hour')];
     render(
-      <CreateBulletinPostDialog tableId={1} gmPersonaId={3} stories={stories}>
+      <CreateBulletinPostDialog tableId={1} stories={stories}>
         <button type="button">New Post</button>
       </CreateBulletinPostDialog>,
       { wrapper: createWrapper() }

--- a/frontend/src/tables/api.ts
+++ b/frontend/src/tables/api.ts
@@ -12,6 +12,7 @@
  */
 
 import { apiFetch } from '@/evennia_replacements/api';
+import { throwApiError } from '@/lib/errors';
 import type {
   BulletinPostCreateBody,
   BulletinPostUpdateBody,
@@ -75,13 +76,13 @@ export async function getTables(params?: ListTablesParams): Promise<PaginatedTab
     (params as Record<string, string | number | boolean | undefined>) ?? {}
   );
   const res = await apiFetch(`${TABLES_URL}/${qs}`);
-  if (!res.ok) throw new Error('Failed to load tables');
+  if (!res.ok) await throwApiError(res, 'Failed to load tables');
   return res.json() as Promise<PaginatedTables>;
 }
 
 export async function getTable(id: number): Promise<GMTable> {
   const res = await apiFetch(`${TABLES_URL}/${id}/`);
-  if (!res.ok) throw new Error(`Failed to load table ${id}`);
+  if (!res.ok) await throwApiError(res, `Failed to load table ${id}`);
   return res.json() as Promise<GMTable>;
 }
 
@@ -91,7 +92,7 @@ export async function createTable(data: GMTableCreateBody): Promise<GMTable> {
     headers: jsonHeaders(),
     body: JSON.stringify(data),
   });
-  if (!res.ok) throw new Error('Failed to create table');
+  if (!res.ok) await throwApiError(res, 'Failed to create table');
   return res.json() as Promise<GMTable>;
 }
 
@@ -101,7 +102,7 @@ export async function updateTable(id: number, data: GMTableUpdateBody): Promise<
     headers: jsonHeaders(),
     body: JSON.stringify(data),
   });
-  if (!res.ok) throw new Error(`Failed to update table ${id}`);
+  if (!res.ok) await throwApiError(res, `Failed to update table ${id}`);
   return res.json() as Promise<GMTable>;
 }
 
@@ -119,7 +120,7 @@ export async function archiveTable(id: number): Promise<GMTable> {
     headers: jsonHeaders(),
     body: JSON.stringify({}),
   });
-  if (!res.ok) throw new Error(`Failed to archive table ${id}`);
+  if (!res.ok) await throwApiError(res, `Failed to archive table ${id}`);
   return res.json() as Promise<GMTable>;
 }
 
@@ -133,7 +134,7 @@ export async function transferOwnership(id: number, data: GMTableTransferBody): 
     headers: jsonHeaders(),
     body: JSON.stringify(data),
   });
-  if (!res.ok) throw new Error(`Failed to transfer ownership of table ${id}`);
+  if (!res.ok) await throwApiError(res, `Failed to transfer ownership of table ${id}`);
   return res.json() as Promise<GMTable>;
 }
 
@@ -156,7 +157,7 @@ export async function getTableMemberships(
     (params as Record<string, string | number | boolean | undefined>) ?? {}
   );
   const res = await apiFetch(`${MEMBERSHIPS_URL}/${qs}`);
-  if (!res.ok) throw new Error('Failed to load memberships');
+  if (!res.ok) await throwApiError(res, 'Failed to load memberships');
   return res.json() as Promise<PaginatedMemberships>;
 }
 
@@ -170,7 +171,7 @@ export async function inviteToTable(data: GMTableMembershipCreateBody): Promise<
     headers: jsonHeaders(),
     body: JSON.stringify(data),
   });
-  if (!res.ok) throw new Error('Failed to invite persona to table');
+  if (!res.ok) await throwApiError(res, 'Failed to invite persona to table');
   return res.json() as Promise<GMTableMembership>;
 }
 
@@ -181,7 +182,7 @@ export async function inviteToTable(data: GMTableMembershipCreateBody): Promise<
  */
 export async function removeMembership(id: number): Promise<void> {
   const res = await apiFetch(`${MEMBERSHIPS_URL}/${id}/`, { method: 'DELETE' });
-  if (!res.ok) throw new Error(`Failed to remove membership ${id}`);
+  if (!res.ok) await throwApiError(res, `Failed to remove membership ${id}`);
 }
 
 /**
@@ -215,7 +216,7 @@ export async function getBulletinPosts(
     (params as Record<string, string | number | boolean | undefined>) ?? {}
   );
   const res = await apiFetch(`${BULLETIN_POSTS_URL}/${qs}`);
-  if (!res.ok) throw new Error('Failed to load bulletin posts');
+  if (!res.ok) await throwApiError(res, 'Failed to load bulletin posts');
   return res.json() as Promise<PaginatedBulletinPosts>;
 }
 
@@ -229,7 +230,7 @@ export async function createBulletinPost(data: BulletinPostCreateBody): Promise<
     headers: jsonHeaders(),
     body: JSON.stringify(data),
   });
-  if (!res.ok) throw new Error('Failed to create bulletin post');
+  if (!res.ok) await throwApiError(res, 'Failed to create bulletin post');
   return res.json() as Promise<TableBulletinPost>;
 }
 
@@ -246,7 +247,7 @@ export async function updateBulletinPost(
     headers: jsonHeaders(),
     body: JSON.stringify(data),
   });
-  if (!res.ok) throw new Error(`Failed to update bulletin post ${id}`);
+  if (!res.ok) await throwApiError(res, `Failed to update bulletin post ${id}`);
   return res.json() as Promise<TableBulletinPost>;
 }
 
@@ -256,7 +257,7 @@ export async function updateBulletinPost(
  */
 export async function deleteBulletinPost(id: number): Promise<void> {
   const res = await apiFetch(`${BULLETIN_POSTS_URL}/${id}/`, { method: 'DELETE' });
-  if (!res.ok) throw new Error(`Failed to delete bulletin post ${id}`);
+  if (!res.ok) await throwApiError(res, `Failed to delete bulletin post ${id}`);
 }
 
 // ---------------------------------------------------------------------------
@@ -279,7 +280,7 @@ export async function getBulletinReplies(
     (params as Record<string, string | number | boolean | undefined>) ?? {}
   );
   const res = await apiFetch(`${BULLETIN_REPLIES_URL}/${qs}`);
-  if (!res.ok) throw new Error('Failed to load bulletin replies');
+  if (!res.ok) await throwApiError(res, 'Failed to load bulletin replies');
   return res.json() as Promise<PaginatedBulletinReplies>;
 }
 
@@ -295,7 +296,7 @@ export async function createBulletinReply(
     headers: jsonHeaders(),
     body: JSON.stringify(data),
   });
-  if (!res.ok) throw new Error('Failed to create bulletin reply');
+  if (!res.ok) await throwApiError(res, 'Failed to create bulletin reply');
   return res.json() as Promise<TableBulletinReply>;
 }
 
@@ -312,7 +313,7 @@ export async function updateBulletinReply(
     headers: jsonHeaders(),
     body: JSON.stringify(data),
   });
-  if (!res.ok) throw new Error(`Failed to update bulletin reply ${id}`);
+  if (!res.ok) await throwApiError(res, `Failed to update bulletin reply ${id}`);
   return res.json() as Promise<TableBulletinReply>;
 }
 
@@ -322,5 +323,5 @@ export async function updateBulletinReply(
  */
 export async function deleteBulletinReply(id: number): Promise<void> {
   const res = await apiFetch(`${BULLETIN_REPLIES_URL}/${id}/`, { method: 'DELETE' });
-  if (!res.ok) throw new Error(`Failed to delete bulletin reply ${id}`);
+  if (!res.ok) await throwApiError(res, `Failed to delete bulletin reply ${id}`);
 }

--- a/frontend/src/tables/bulletinErrors.ts
+++ b/frontend/src/tables/bulletinErrors.ts
@@ -1,0 +1,27 @@
+import { ApiError } from '@/lib/errors';
+
+/**
+ * DRF field-error shape the bulletin forms render (fields + non_field_errors
+ * + detail). Keyed loosely so both post and reply forms can share the mapper.
+ */
+export interface BulletinFieldErrors {
+  [field: string]: string[] | string | undefined;
+  non_field_errors?: string[];
+  detail?: string;
+}
+
+/**
+ * Map a thrown error into the field-error shape (2026-07 audit).
+ *
+ * The bulletin forms previously read `err.response` — a property no thrown
+ * error ever had (the api layer threw bare `new Error('Failed to…')`), so
+ * every create/edit failure was completely silent. Now the api layer throws
+ * `ApiError`, which carries the DRF `fieldErrors` and a human `message`.
+ */
+export function bulletinErrorsFrom(err: unknown): BulletinFieldErrors {
+  if (err instanceof ApiError) {
+    if (err.fieldErrors) return err.fieldErrors;
+    return { detail: err.message };
+  }
+  return { detail: err instanceof Error ? err.message : 'Something went wrong.' };
+}

--- a/frontend/src/tables/components/BulletinPostCard.tsx
+++ b/frontend/src/tables/components/BulletinPostCard.tsx
@@ -13,6 +13,7 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { bulletinErrorsFrom, type BulletinFieldErrors } from '../bulletinErrors';
+import { FieldError, FormErrors } from './FieldError';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -95,9 +96,7 @@ function EditPostForm({ post, onCancel }: EditPostFormProps) {
           maxLength={200}
           required
         />
-        {Array.isArray(fieldErrors.title) && (
-          <p className="text-sm text-destructive">{(fieldErrors.title as string[]).join(' ')}</p>
-        )}
+        <FieldError errors={fieldErrors} field="title" />
       </div>
 
       <div className="space-y-1">
@@ -109,9 +108,7 @@ function EditPostForm({ post, onCancel }: EditPostFormProps) {
           rows={5}
           required
         />
-        {Array.isArray(fieldErrors.body) && (
-          <p className="text-sm text-destructive">{(fieldErrors.body as string[]).join(' ')}</p>
-        )}
+        <FieldError errors={fieldErrors} field="body" />
       </div>
 
       <div className="flex items-center gap-2">
@@ -125,12 +122,7 @@ function EditPostForm({ post, onCancel }: EditPostFormProps) {
         <Label htmlFor={`post-allow-replies-${post.id}`}>Allow replies</Label>
       </div>
 
-      {Array.isArray(fieldErrors.non_field_errors) && (
-        <p className="text-sm text-destructive">
-          {(fieldErrors.non_field_errors as string[]).join(' ')}
-        </p>
-      )}
-      {fieldErrors.detail && <p className="text-sm text-destructive">{fieldErrors.detail}</p>}
+      <FormErrors errors={fieldErrors} />
 
       <div className="flex gap-2">
         <Button type="submit" size="sm" disabled={!isValid || updateMutation.isPending}>
@@ -189,15 +181,8 @@ function ReplyForm({ postId, onCancel }: ReplyFormProps) {
         rows={3}
         aria-label="Reply body"
       />
-      {Array.isArray(fieldErrors.body) && (
-        <p className="text-sm text-destructive">{(fieldErrors.body as string[]).join(' ')}</p>
-      )}
-      {Array.isArray(fieldErrors.non_field_errors) && (
-        <p className="text-sm text-destructive">
-          {(fieldErrors.non_field_errors as string[]).join(' ')}
-        </p>
-      )}
-      {fieldErrors.detail && <p className="text-sm text-destructive">{fieldErrors.detail}</p>}
+      <FieldError errors={fieldErrors} field="body" />
+      <FormErrors errors={fieldErrors} />
       <div className="flex gap-2">
         <Button type="submit" size="sm" disabled={!isValid || createMutation.isPending}>
           {createMutation.isPending ? 'Posting…' : 'Post Reply'}

--- a/frontend/src/tables/components/BulletinPostCard.tsx
+++ b/frontend/src/tables/components/BulletinPostCard.tsx
@@ -12,6 +12,7 @@
 
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { bulletinErrorsFrom, type BulletinFieldErrors } from '../bulletinErrors';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -32,21 +33,6 @@ const REPLIES_PREVIEW_COUNT = 3;
 // DRF error shapes
 // ---------------------------------------------------------------------------
 
-interface DRFPostErrors {
-  title?: string[];
-  body?: string[];
-  allow_replies?: string[];
-  non_field_errors?: string[];
-  detail?: string;
-}
-
-interface DRFReplyErrors {
-  body?: string[];
-  post?: string[];
-  non_field_errors?: string[];
-  detail?: string;
-}
-
 // ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
@@ -54,12 +40,8 @@ interface DRFReplyErrors {
 interface BulletinPostCardProps {
   post: TableBulletinPost;
   isGMOrStaff: boolean;
-  /** PK of the Lead GM persona (needed when submitting a reply as the GM). */
-  gmPersonaId?: number;
   /** Whether the viewer can reply (they have read access + allow_replies is true). */
   canReply: boolean;
-  /** PK of the viewer's active persona for reply submission. */
-  viewerPersonaId?: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -75,7 +57,7 @@ function EditPostForm({ post, onCancel }: EditPostFormProps) {
   const [title, setTitle] = useState(post.title);
   const [body, setBody] = useState(post.body);
   const [allowReplies, setAllowReplies] = useState(post.allow_replies);
-  const [fieldErrors, setFieldErrors] = useState<DRFPostErrors>({});
+  const [fieldErrors, setFieldErrors] = useState<BulletinFieldErrors>({});
 
   const updateMutation = useUpdateBulletinPost();
 
@@ -93,12 +75,8 @@ function EditPostForm({ post, onCancel }: EditPostFormProps) {
           toast.success('Post updated');
           onCancel();
         },
-        onError: async (err: unknown) => {
-          const res = (err as { response?: Response })?.response;
-          if (res) {
-            const errBody = (await res.json()) as DRFPostErrors;
-            setFieldErrors(errBody);
-          }
+        onError: (err: unknown) => {
+          setFieldErrors(bulletinErrorsFrom(err));
         },
       }
     );
@@ -117,8 +95,8 @@ function EditPostForm({ post, onCancel }: EditPostFormProps) {
           maxLength={200}
           required
         />
-        {fieldErrors.title && (
-          <p className="text-sm text-destructive">{fieldErrors.title.join(' ')}</p>
+        {Array.isArray(fieldErrors.title) && (
+          <p className="text-sm text-destructive">{(fieldErrors.title as string[]).join(' ')}</p>
         )}
       </div>
 
@@ -131,8 +109,8 @@ function EditPostForm({ post, onCancel }: EditPostFormProps) {
           rows={5}
           required
         />
-        {fieldErrors.body && (
-          <p className="text-sm text-destructive">{fieldErrors.body.join(' ')}</p>
+        {Array.isArray(fieldErrors.body) && (
+          <p className="text-sm text-destructive">{(fieldErrors.body as string[]).join(' ')}</p>
         )}
       </div>
 
@@ -147,8 +125,10 @@ function EditPostForm({ post, onCancel }: EditPostFormProps) {
         <Label htmlFor={`post-allow-replies-${post.id}`}>Allow replies</Label>
       </div>
 
-      {fieldErrors.non_field_errors && (
-        <p className="text-sm text-destructive">{fieldErrors.non_field_errors.join(' ')}</p>
+      {Array.isArray(fieldErrors.non_field_errors) && (
+        <p className="text-sm text-destructive">
+          {(fieldErrors.non_field_errors as string[]).join(' ')}
+        </p>
       )}
       {fieldErrors.detail && <p className="text-sm text-destructive">{fieldErrors.detail}</p>}
 
@@ -170,13 +150,12 @@ function EditPostForm({ post, onCancel }: EditPostFormProps) {
 
 interface ReplyFormProps {
   postId: number;
-  viewerPersonaId: number;
   onCancel: () => void;
 }
 
-function ReplyForm({ postId, viewerPersonaId, onCancel }: ReplyFormProps) {
+function ReplyForm({ postId, onCancel }: ReplyFormProps) {
   const [body, setBody] = useState('');
-  const [fieldErrors, setFieldErrors] = useState<DRFReplyErrors>({});
+  const [fieldErrors, setFieldErrors] = useState<BulletinFieldErrors>({});
 
   const createMutation = useCreateBulletinReply();
 
@@ -184,18 +163,16 @@ function ReplyForm({ postId, viewerPersonaId, onCancel }: ReplyFormProps) {
     e.preventDefault();
     setFieldErrors({});
     createMutation.mutate(
-      { post: postId, author_persona: viewerPersonaId, body: body.trim() },
+      // author_persona omitted: the backend authors as the requester's own
+      // persona (a GM table is account-scoped, #audit2).
+      { post: postId, body: body.trim() },
       {
         onSuccess: () => {
           toast.success('Reply posted');
           onCancel();
         },
-        onError: async (err: unknown) => {
-          const res = (err as { response?: Response })?.response;
-          if (res) {
-            const errBody = (await res.json()) as DRFReplyErrors;
-            setFieldErrors(errBody);
-          }
+        onError: (err: unknown) => {
+          setFieldErrors(bulletinErrorsFrom(err));
         },
       }
     );
@@ -212,9 +189,13 @@ function ReplyForm({ postId, viewerPersonaId, onCancel }: ReplyFormProps) {
         rows={3}
         aria-label="Reply body"
       />
-      {fieldErrors.body && <p className="text-sm text-destructive">{fieldErrors.body.join(' ')}</p>}
-      {fieldErrors.non_field_errors && (
-        <p className="text-sm text-destructive">{fieldErrors.non_field_errors.join(' ')}</p>
+      {Array.isArray(fieldErrors.body) && (
+        <p className="text-sm text-destructive">{(fieldErrors.body as string[]).join(' ')}</p>
+      )}
+      {Array.isArray(fieldErrors.non_field_errors) && (
+        <p className="text-sm text-destructive">
+          {(fieldErrors.non_field_errors as string[]).join(' ')}
+        </p>
       )}
       {fieldErrors.detail && <p className="text-sm text-destructive">{fieldErrors.detail}</p>}
       <div className="flex gap-2">
@@ -233,12 +214,7 @@ function ReplyForm({ postId, viewerPersonaId, onCancel }: ReplyFormProps) {
 // BulletinPostCard
 // ---------------------------------------------------------------------------
 
-export function BulletinPostCard({
-  post,
-  isGMOrStaff,
-  canReply,
-  viewerPersonaId,
-}: BulletinPostCardProps) {
+export function BulletinPostCard({ post, isGMOrStaff, canReply }: BulletinPostCardProps) {
   const [editing, setEditing] = useState(false);
   const [showAllReplies, setShowAllReplies] = useState(false);
   const [showReplyForm, setShowReplyForm] = useState(false);
@@ -353,17 +329,7 @@ export function BulletinPostCard({
           {canReply && post.allow_replies && (
             <div className="mt-3 border-t pt-3">
               {showReplyForm ? (
-                viewerPersonaId !== undefined ? (
-                  <ReplyForm
-                    postId={post.id}
-                    viewerPersonaId={viewerPersonaId}
-                    onCancel={() => setShowReplyForm(false)}
-                  />
-                ) : (
-                  <p className="text-sm text-muted-foreground">
-                    No active persona available for replies.
-                  </p>
-                )
+                <ReplyForm postId={post.id} onCancel={() => setShowReplyForm(false)} />
               ) : (
                 <Button
                   type="button"

--- a/frontend/src/tables/components/BulletinReplyRow.tsx
+++ b/frontend/src/tables/components/BulletinReplyRow.tsx
@@ -9,6 +9,7 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { bulletinErrorsFrom, type BulletinFieldErrors } from '../bulletinErrors';
+import { FieldError, FormErrors } from './FieldError';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { formatRelativeTime } from '@/lib/relativeTime';
@@ -131,15 +132,8 @@ export function BulletinReplyRow({ reply, isGMOrStaff }: BulletinReplyRowProps) 
               className="text-sm"
               aria-label="Edit reply"
             />
-            {Array.isArray(fieldErrors.body) && (
-              <p className="text-xs text-destructive">{(fieldErrors.body as string[]).join(' ')}</p>
-            )}
-            {Array.isArray(fieldErrors.non_field_errors) && (
-              <p className="text-xs text-destructive">
-                {(fieldErrors.non_field_errors as string[]).join(' ')}
-              </p>
-            )}
-            {fieldErrors.detail && <p className="text-xs text-destructive">{fieldErrors.detail}</p>}
+            <FieldError errors={fieldErrors} field="body" className="text-xs text-destructive" />
+            <FormErrors errors={fieldErrors} className="text-xs text-destructive" />
             <div className="flex gap-2">
               <Button type="submit" size="sm" disabled={updateMutation.isPending}>
                 {updateMutation.isPending ? 'Saving…' : 'Save'}

--- a/frontend/src/tables/components/BulletinReplyRow.tsx
+++ b/frontend/src/tables/components/BulletinReplyRow.tsx
@@ -8,6 +8,7 @@
 
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { bulletinErrorsFrom, type BulletinFieldErrors } from '../bulletinErrors';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { formatRelativeTime } from '@/lib/relativeTime';
@@ -17,12 +18,6 @@ import type { TableBulletinReply } from '../types';
 // ---------------------------------------------------------------------------
 // DRF error shapes
 // ---------------------------------------------------------------------------
-
-interface DRFErrors {
-  body?: string[];
-  non_field_errors?: string[];
-  detail?: string;
-}
 
 // ---------------------------------------------------------------------------
 // Props
@@ -40,7 +35,7 @@ interface BulletinReplyRowProps {
 export function BulletinReplyRow({ reply, isGMOrStaff }: BulletinReplyRowProps) {
   const [editing, setEditing] = useState(false);
   const [editBody, setEditBody] = useState(reply.body);
-  const [fieldErrors, setFieldErrors] = useState<DRFErrors>({});
+  const [fieldErrors, setFieldErrors] = useState<BulletinFieldErrors>({});
 
   const updateMutation = useUpdateBulletinReply();
   const deleteMutation = useDeleteBulletinReply();
@@ -66,12 +61,8 @@ export function BulletinReplyRow({ reply, isGMOrStaff }: BulletinReplyRowProps) 
           setEditing(false);
           toast.success('Reply updated');
         },
-        onError: async (err: unknown) => {
-          const res = (err as { response?: Response })?.response;
-          if (res) {
-            const body = (await res.json()) as DRFErrors;
-            setFieldErrors(body);
-          }
+        onError: (err: unknown) => {
+          setFieldErrors(bulletinErrorsFrom(err));
         },
       }
     );
@@ -140,11 +131,13 @@ export function BulletinReplyRow({ reply, isGMOrStaff }: BulletinReplyRowProps) 
               className="text-sm"
               aria-label="Edit reply"
             />
-            {fieldErrors.body && (
-              <p className="text-xs text-destructive">{fieldErrors.body.join(' ')}</p>
+            {Array.isArray(fieldErrors.body) && (
+              <p className="text-xs text-destructive">{(fieldErrors.body as string[]).join(' ')}</p>
             )}
-            {fieldErrors.non_field_errors && (
-              <p className="text-xs text-destructive">{fieldErrors.non_field_errors.join(' ')}</p>
+            {Array.isArray(fieldErrors.non_field_errors) && (
+              <p className="text-xs text-destructive">
+                {(fieldErrors.non_field_errors as string[]).join(' ')}
+              </p>
             )}
             {fieldErrors.detail && <p className="text-xs text-destructive">{fieldErrors.detail}</p>}
             <div className="flex gap-2">

--- a/frontend/src/tables/components/CreateBulletinPostDialog.tsx
+++ b/frontend/src/tables/components/CreateBulletinPostDialog.tsx
@@ -14,6 +14,7 @@
 import { useState, useEffect } from 'react';
 import { toast } from 'sonner';
 import { bulletinErrorsFrom, type BulletinFieldErrors } from '../bulletinErrors';
+import { FieldError, FormErrors } from './FieldError';
 import {
   Dialog,
   DialogContent,
@@ -147,11 +148,7 @@ export function CreateBulletinPostDialog({
               required
               aria-describedby={fieldErrors.title ? 'bp-title-error' : undefined}
             />
-            {Array.isArray(fieldErrors.title) && (
-              <p id="bp-title-error" className="text-sm text-destructive">
-                {(fieldErrors.title as string[]).join(' ')}
-              </p>
-            )}
+            <FieldError errors={fieldErrors} field="title" id="bp-title-error" />
           </div>
 
           {/* Body */}
@@ -166,11 +163,7 @@ export function CreateBulletinPostDialog({
               required
               aria-describedby={fieldErrors.body ? 'bp-body-error' : undefined}
             />
-            {Array.isArray(fieldErrors.body) && (
-              <p id="bp-body-error" className="text-sm text-destructive">
-                {(fieldErrors.body as string[]).join(' ')}
-              </p>
-            )}
+            <FieldError errors={fieldErrors} field="body" id="bp-body-error" />
           </div>
 
           {/* Section selector */}
@@ -189,11 +182,7 @@ export function CreateBulletinPostDialog({
                 ))}
               </SelectContent>
             </Select>
-            {Array.isArray(fieldErrors.story) && (
-              <p className="text-sm text-destructive">
-                {(fieldErrors.story as string[]).join(' ')}
-              </p>
-            )}
+            <FieldError errors={fieldErrors} field="story" />
           </div>
 
           {/* Allow replies */}
@@ -209,12 +198,7 @@ export function CreateBulletinPostDialog({
           </div>
 
           {/* Global errors */}
-          {Array.isArray(fieldErrors.non_field_errors) && (
-            <p className="text-sm text-destructive">
-              {(fieldErrors.non_field_errors as string[]).join(' ')}
-            </p>
-          )}
-          {fieldErrors.detail && <p className="text-sm text-destructive">{fieldErrors.detail}</p>}
+          <FormErrors errors={fieldErrors} />
 
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => setOpen(false)}>

--- a/frontend/src/tables/components/CreateBulletinPostDialog.tsx
+++ b/frontend/src/tables/components/CreateBulletinPostDialog.tsx
@@ -7,11 +7,13 @@
  *   - Story selector: "Table-Wide" (null) or a specific story PK
  *   - Allow replies (checkbox, default true)
  *
- * The Lead GM's persona PK must be passed as `gmPersonaId`.
+ * The backend authors the post as the requesting GM's own persona (a GM
+ * table is account-scoped, not character-scoped); no persona id is passed.
  */
 
 import { useState, useEffect } from 'react';
 import { toast } from 'sonner';
+import { bulletinErrorsFrom, type BulletinFieldErrors } from '../bulletinErrors';
 import {
   Dialog,
   DialogContent,
@@ -39,23 +41,12 @@ import type { StoryList } from '@/stories/types';
 // DRF error shapes
 // ---------------------------------------------------------------------------
 
-interface DRFErrors {
-  title?: string[];
-  body?: string[];
-  story?: string[];
-  allow_replies?: string[];
-  non_field_errors?: string[];
-  detail?: string;
-}
-
 // ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
 
 interface CreateBulletinPostDialogProps {
   tableId: number;
-  /** The Lead GM's persona PK — required for author_persona in the POST body. */
-  gmPersonaId: number;
   /** Stories at this table (for the section selector in the form). */
   stories: StoryList[];
   /** Initial story to pre-select (optional — e.g., when opened from a story tab). */
@@ -69,7 +60,6 @@ interface CreateBulletinPostDialogProps {
 
 export function CreateBulletinPostDialog({
   tableId,
-  gmPersonaId,
   stories,
   initialStoryId,
   children,
@@ -80,7 +70,7 @@ export function CreateBulletinPostDialog({
   /** "table-wide" means null story; otherwise story PK as string. */
   const [storyValue, setStoryValue] = useState<string>('table-wide');
   const [allowReplies, setAllowReplies] = useState(true);
-  const [fieldErrors, setFieldErrors] = useState<DRFErrors>({});
+  const [fieldErrors, setFieldErrors] = useState<BulletinFieldErrors>({});
 
   const createMutation = useCreateBulletinPost();
 
@@ -114,7 +104,6 @@ export function CreateBulletinPostDialog({
       {
         table: tableId,
         story: storyId,
-        author_persona: gmPersonaId,
         title: title.trim(),
         body: body.trim(),
         allow_replies: allowReplies,
@@ -124,12 +113,8 @@ export function CreateBulletinPostDialog({
           toast.success('Post created');
           setOpen(false);
         },
-        onError: async (err: unknown) => {
-          const res = (err as { response?: Response })?.response;
-          if (res) {
-            const errBody = (await res.json()) as DRFErrors;
-            setFieldErrors(errBody);
-          }
+        onError: (err: unknown) => {
+          setFieldErrors(bulletinErrorsFrom(err));
         },
       }
     );
@@ -162,9 +147,9 @@ export function CreateBulletinPostDialog({
               required
               aria-describedby={fieldErrors.title ? 'bp-title-error' : undefined}
             />
-            {fieldErrors.title && (
+            {Array.isArray(fieldErrors.title) && (
               <p id="bp-title-error" className="text-sm text-destructive">
-                {fieldErrors.title.join(' ')}
+                {(fieldErrors.title as string[]).join(' ')}
               </p>
             )}
           </div>
@@ -181,9 +166,9 @@ export function CreateBulletinPostDialog({
               required
               aria-describedby={fieldErrors.body ? 'bp-body-error' : undefined}
             />
-            {fieldErrors.body && (
+            {Array.isArray(fieldErrors.body) && (
               <p id="bp-body-error" className="text-sm text-destructive">
-                {fieldErrors.body.join(' ')}
+                {(fieldErrors.body as string[]).join(' ')}
               </p>
             )}
           </div>
@@ -204,8 +189,10 @@ export function CreateBulletinPostDialog({
                 ))}
               </SelectContent>
             </Select>
-            {fieldErrors.story && (
-              <p className="text-sm text-destructive">{fieldErrors.story.join(' ')}</p>
+            {Array.isArray(fieldErrors.story) && (
+              <p className="text-sm text-destructive">
+                {(fieldErrors.story as string[]).join(' ')}
+              </p>
             )}
           </div>
 
@@ -222,8 +209,10 @@ export function CreateBulletinPostDialog({
           </div>
 
           {/* Global errors */}
-          {fieldErrors.non_field_errors && (
-            <p className="text-sm text-destructive">{fieldErrors.non_field_errors.join(' ')}</p>
+          {Array.isArray(fieldErrors.non_field_errors) && (
+            <p className="text-sm text-destructive">
+              {(fieldErrors.non_field_errors as string[]).join(' ')}
+            </p>
           )}
           {fieldErrors.detail && <p className="text-sm text-destructive">{fieldErrors.detail}</p>}
 

--- a/frontend/src/tables/components/FieldError.tsx
+++ b/frontend/src/tables/components/FieldError.tsx
@@ -1,0 +1,46 @@
+import type { BulletinFieldErrors } from '../bulletinErrors';
+
+/**
+ * Render a single field's DRF error messages (2026-07 audit dedup).
+ *
+ * The bulletin/table forms all render the same `Array.isArray(errs[field]) &&
+ * <p …>{errs[field].join(' ')}</p>` block per field plus a `non_field_errors`
+ * + `detail` footer; SonarCloud flagged the copy-paste. This centralizes it.
+ */
+export function FieldError({
+  errors,
+  field,
+  id,
+  className = 'text-sm text-destructive',
+}: {
+  errors: BulletinFieldErrors;
+  field: string;
+  id?: string;
+  className?: string;
+}) {
+  const value = errors[field];
+  if (!Array.isArray(value)) return null;
+  return (
+    <p id={id} className={className}>
+      {(value as string[]).join(' ')}
+    </p>
+  );
+}
+
+/** The shared `non_field_errors` + `detail` footer every bulletin/table form shows. */
+export function FormErrors({
+  errors,
+  className = 'text-sm text-destructive',
+}: {
+  errors: BulletinFieldErrors;
+  className?: string;
+}) {
+  return (
+    <>
+      {Array.isArray(errors.non_field_errors) && (
+        <p className={className}>{errors.non_field_errors.join(' ')}</p>
+      )}
+      {typeof errors.detail === 'string' && <p className={className}>{errors.detail}</p>}
+    </>
+  );
+}

--- a/frontend/src/tables/components/InviteToTableDialog.tsx
+++ b/frontend/src/tables/components/InviteToTableDialog.tsx
@@ -7,6 +7,7 @@
 
 import { useState } from 'react';
 import { toast } from 'sonner';
+import { bulletinErrorsFrom, type BulletinFieldErrors } from '../bulletinErrors';
 import {
   Dialog,
   DialogContent,
@@ -32,13 +33,6 @@ interface PersonaOption {
   name: string;
 }
 
-interface DRFFieldErrors {
-  table?: string[];
-  persona?: string[];
-  non_field_errors?: string[];
-  detail?: string;
-}
-
 // ---------------------------------------------------------------------------
 // Props
 // ---------------------------------------------------------------------------
@@ -56,7 +50,7 @@ export function InviteToTableDialog({ table, children }: InviteToTableDialogProp
   const [open, setOpen] = useState(false);
   const [personaQuery, setPersonaQuery] = useState('');
   const [selectedPersona, setSelectedPersona] = useState<PersonaOption | null>(null);
-  const [fieldErrors, setFieldErrors] = useState<DRFFieldErrors>({});
+  const [fieldErrors, setFieldErrors] = useState<BulletinFieldErrors>({});
 
   const inviteMutation = useInviteToTable();
 
@@ -93,14 +87,8 @@ export function InviteToTableDialog({ table, children }: InviteToTableDialogProp
           toast.success(`${selectedPersona.name} invited to ${table.name}`);
           setOpen(false);
         },
-        onError: async (err: unknown) => {
-          const res = (err as { response?: Response })?.response;
-          if (res) {
-            const body = (await res.json()) as DRFFieldErrors;
-            setFieldErrors(body);
-          } else {
-            toast.error('Failed to invite persona');
-          }
+        onError: (err: unknown) => {
+          setFieldErrors(bulletinErrorsFrom(err));
         },
       }
     );
@@ -155,14 +143,18 @@ export function InviteToTableDialog({ table, children }: InviteToTableDialogProp
                 </ul>
               )}
             </div>
-            {fieldErrors.persona && (
-              <p className="text-sm text-destructive">{fieldErrors.persona.join(' ')}</p>
+            {Array.isArray(fieldErrors.persona) && (
+              <p className="text-sm text-destructive">
+                {(fieldErrors.persona as string[]).join(' ')}
+              </p>
             )}
           </div>
 
           {/* Global errors */}
-          {fieldErrors.non_field_errors && (
-            <p className="text-sm text-destructive">{fieldErrors.non_field_errors.join(' ')}</p>
+          {Array.isArray(fieldErrors.non_field_errors) && (
+            <p className="text-sm text-destructive">
+              {(fieldErrors.non_field_errors as string[]).join(' ')}
+            </p>
           )}
           {fieldErrors.detail && <p className="text-sm text-destructive">{fieldErrors.detail}</p>}
 

--- a/frontend/src/tables/components/InviteToTableDialog.tsx
+++ b/frontend/src/tables/components/InviteToTableDialog.tsx
@@ -8,6 +8,7 @@
 import { useState } from 'react';
 import { toast } from 'sonner';
 import { bulletinErrorsFrom, type BulletinFieldErrors } from '../bulletinErrors';
+import { FieldError, FormErrors } from './FieldError';
 import {
   Dialog,
   DialogContent,
@@ -143,20 +144,11 @@ export function InviteToTableDialog({ table, children }: InviteToTableDialogProp
                 </ul>
               )}
             </div>
-            {Array.isArray(fieldErrors.persona) && (
-              <p className="text-sm text-destructive">
-                {(fieldErrors.persona as string[]).join(' ')}
-              </p>
-            )}
+            <FieldError errors={fieldErrors} field="persona" />
           </div>
 
           {/* Global errors */}
-          {Array.isArray(fieldErrors.non_field_errors) && (
-            <p className="text-sm text-destructive">
-              {(fieldErrors.non_field_errors as string[]).join(' ')}
-            </p>
-          )}
-          {fieldErrors.detail && <p className="text-sm text-destructive">{fieldErrors.detail}</p>}
+          <FormErrors errors={fieldErrors} />
 
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => setOpen(false)}>

--- a/frontend/src/tables/components/TableBulletin.tsx
+++ b/frontend/src/tables/components/TableBulletin.tsx
@@ -90,11 +90,9 @@ interface SectionContentProps {
   tableId: number;
   storyId: SectionId;
   isGMOrStaff: boolean;
-  /** The viewer's persona PK for reply submission. For GMs this is their GM persona. */
-  viewerPersonaId?: number;
 }
 
-function SectionContent({ tableId, storyId, isGMOrStaff, viewerPersonaId }: SectionContentProps) {
+function SectionContent({ tableId, storyId, isGMOrStaff }: SectionContentProps) {
   const params = storyId !== null ? { table: tableId, story: storyId } : { table: tableId };
 
   const { data, isLoading } = useBulletinPosts(params);
@@ -129,7 +127,6 @@ function SectionContent({ tableId, storyId, isGMOrStaff, viewerPersonaId }: Sect
           post={post}
           isGMOrStaff={isGMOrStaff}
           canReply={post.allow_replies}
-          viewerPersonaId={viewerPersonaId}
         />
       ))}
     </div>
@@ -165,19 +162,13 @@ export function TableBulletin({ table }: TableBulletinProps) {
       <SectionSelector current={resolvedSection} stories={stories} onChange={setActiveSection} />
 
       {/* Post list for selected section */}
-      <SectionContent
-        tableId={table.id}
-        storyId={resolvedSection}
-        isGMOrStaff={isGMOrStaff}
-        viewerPersonaId={undefined}
-      />
+      <SectionContent tableId={table.id} storyId={resolvedSection} isGMOrStaff={isGMOrStaff} />
 
       {/* New Post button — GM/staff only */}
       {isGMOrStaff && (
         <div className="flex justify-start border-t pt-4">
           <CreateBulletinPostDialog
             tableId={table.id}
-            gmPersonaId={0}
             stories={stories}
             initialStoryId={resolvedSection}
           >

--- a/frontend/src/tables/components/TableFormDialog.tsx
+++ b/frontend/src/tables/components/TableFormDialog.tsx
@@ -9,6 +9,7 @@
 
 import { useState, useEffect } from 'react';
 import { toast } from 'sonner';
+import { bulletinErrorsFrom, type BulletinFieldErrors } from '../bulletinErrors';
 import {
   Dialog,
   DialogContent,
@@ -28,13 +29,6 @@ import type { GMTable } from '../types';
 // ---------------------------------------------------------------------------
 // DRF error shapes
 // ---------------------------------------------------------------------------
-
-interface DRFFieldErrors {
-  name?: string[];
-  description?: string[];
-  non_field_errors?: string[];
-  detail?: string;
-}
 
 // ---------------------------------------------------------------------------
 // Props
@@ -62,7 +56,7 @@ export function TableFormDialog(props: TableFormDialogProps) {
   const [open, setOpen] = useState(false);
   const [name, setName] = useState('');
   const [description, setDescription] = useState('');
-  const [fieldErrors, setFieldErrors] = useState<DRFFieldErrors>({});
+  const [fieldErrors, setFieldErrors] = useState<BulletinFieldErrors>({});
 
   const createMutation = useCreateTable();
   const updateMutation = useUpdateTable();
@@ -101,12 +95,8 @@ export function TableFormDialog(props: TableFormDialogProps) {
             toast.success('Table updated');
             setOpen(false);
           },
-          onError: async (err: unknown) => {
-            const res = (err as { response?: Response })?.response;
-            if (res) {
-              const body = (await res.json()) as DRFFieldErrors;
-              setFieldErrors(body);
-            }
+          onError: (err: unknown) => {
+            setFieldErrors(bulletinErrorsFrom(err));
           },
         }
       );
@@ -122,12 +112,8 @@ export function TableFormDialog(props: TableFormDialogProps) {
             toast.success('Table created');
             setOpen(false);
           },
-          onError: async (err: unknown) => {
-            const res = (err as { response?: Response })?.response;
-            if (res) {
-              const body = (await res.json()) as DRFFieldErrors;
-              setFieldErrors(body);
-            }
+          onError: (err: unknown) => {
+            setFieldErrors(bulletinErrorsFrom(err));
           },
         }
       );
@@ -162,9 +148,9 @@ export function TableFormDialog(props: TableFormDialogProps) {
               required
               aria-describedby={fieldErrors.name ? 'table-name-error' : undefined}
             />
-            {fieldErrors.name && (
+            {Array.isArray(fieldErrors.name) && (
               <p id="table-name-error" className="text-sm text-destructive">
-                {fieldErrors.name.join(' ')}
+                {(fieldErrors.name as string[]).join(' ')}
               </p>
             )}
           </div>
@@ -179,14 +165,18 @@ export function TableFormDialog(props: TableFormDialogProps) {
               placeholder="Brief description of this table's theme or setting"
               rows={3}
             />
-            {fieldErrors.description && (
-              <p className="text-sm text-destructive">{fieldErrors.description.join(' ')}</p>
+            {Array.isArray(fieldErrors.description) && (
+              <p className="text-sm text-destructive">
+                {(fieldErrors.description as string[]).join(' ')}
+              </p>
             )}
           </div>
 
           {/* Global errors */}
-          {fieldErrors.non_field_errors && (
-            <p className="text-sm text-destructive">{fieldErrors.non_field_errors.join(' ')}</p>
+          {Array.isArray(fieldErrors.non_field_errors) && (
+            <p className="text-sm text-destructive">
+              {(fieldErrors.non_field_errors as string[]).join(' ')}
+            </p>
           )}
           {fieldErrors.detail && <p className="text-sm text-destructive">{fieldErrors.detail}</p>}
 

--- a/frontend/src/tables/components/TableFormDialog.tsx
+++ b/frontend/src/tables/components/TableFormDialog.tsx
@@ -10,6 +10,7 @@
 import { useState, useEffect } from 'react';
 import { toast } from 'sonner';
 import { bulletinErrorsFrom, type BulletinFieldErrors } from '../bulletinErrors';
+import { FieldError, FormErrors } from './FieldError';
 import {
   Dialog,
   DialogContent,
@@ -148,11 +149,7 @@ export function TableFormDialog(props: TableFormDialogProps) {
               required
               aria-describedby={fieldErrors.name ? 'table-name-error' : undefined}
             />
-            {Array.isArray(fieldErrors.name) && (
-              <p id="table-name-error" className="text-sm text-destructive">
-                {(fieldErrors.name as string[]).join(' ')}
-              </p>
-            )}
+            <FieldError errors={fieldErrors} field="name" id="table-name-error" />
           </div>
 
           {/* Description */}
@@ -165,20 +162,11 @@ export function TableFormDialog(props: TableFormDialogProps) {
               placeholder="Brief description of this table's theme or setting"
               rows={3}
             />
-            {Array.isArray(fieldErrors.description) && (
-              <p className="text-sm text-destructive">
-                {(fieldErrors.description as string[]).join(' ')}
-              </p>
-            )}
+            <FieldError errors={fieldErrors} field="description" />
           </div>
 
           {/* Global errors */}
-          {Array.isArray(fieldErrors.non_field_errors) && (
-            <p className="text-sm text-destructive">
-              {(fieldErrors.non_field_errors as string[]).join(' ')}
-            </p>
-          )}
-          {fieldErrors.detail && <p className="text-sm text-destructive">{fieldErrors.detail}</p>}
+          <FormErrors errors={fieldErrors} />
 
           <DialogFooter>
             <Button type="button" variant="outline" onClick={() => setOpen(false)}>

--- a/frontend/src/tables/queries.ts
+++ b/frontend/src/tables/queries.ts
@@ -28,33 +28,38 @@ import type {
 // Query key factory
 // ---------------------------------------------------------------------------
 
+const TABLES_ROOT = ['tables'] as const;
+
 /**
  * Trailing params are ELIDED when absent (2026-07 audit fix): the old shape
  * appended the filters slot unconditionally, so `tablesKeys.members(id)` was
  * `['tables','members',id,undefined]` — which React Query v5 does NOT treat
  * as a prefix of `['tables','members',id,{table,active:true}]`. Every
  * invite/remove/leave/bulletin invalidation therefore matched nothing and the
- * roster/post list stayed stale until a hard refresh.
+ * roster/post list stayed stale until a hard refresh. The `*All` bare-prefix
+ * keys give invalidations a params-agnostic root to target.
  */
 export const tablesKeys = {
-  all: ['tables'] as const,
+  all: TABLES_ROOT,
   list: (filters?: ListTablesParams) =>
     filters === undefined
-      ? ([...tablesKeys.all, 'list'] as const)
-      : ([...tablesKeys.all, 'list', filters] as const),
-  detail: (id: number) => [...tablesKeys.all, 'detail', id] as const,
+      ? ([...TABLES_ROOT, 'list'] as const)
+      : ([...TABLES_ROOT, 'list', filters] as const),
+  detail: (id: number) => [...TABLES_ROOT, 'detail', id] as const,
   members: (tableId: number, filters?: ListMembershipsParams) =>
     filters === undefined
-      ? ([...tablesKeys.all, 'members', tableId] as const)
-      : ([...tablesKeys.all, 'members', tableId, filters] as const),
+      ? ([...TABLES_ROOT, 'members', tableId] as const)
+      : ([...TABLES_ROOT, 'members', tableId, filters] as const),
+  bulletinPostsAll: [...TABLES_ROOT, 'bulletin-posts'] as const,
   bulletinPosts: (params?: ListBulletinPostsParams) =>
     params === undefined
-      ? ([...tablesKeys.all, 'bulletin-posts'] as const)
-      : ([...tablesKeys.all, 'bulletin-posts', params] as const),
+      ? ([...TABLES_ROOT, 'bulletin-posts'] as const)
+      : ([...TABLES_ROOT, 'bulletin-posts', params] as const),
+  bulletinRepliesAll: [...TABLES_ROOT, 'bulletin-replies'] as const,
   bulletinReplies: (params?: ListBulletinRepliesParams) =>
     params === undefined
-      ? ([...tablesKeys.all, 'bulletin-replies'] as const)
-      : ([...tablesKeys.all, 'bulletin-replies', params] as const),
+      ? ([...TABLES_ROOT, 'bulletin-replies'] as const)
+      : ([...TABLES_ROOT, 'bulletin-replies', params] as const),
 };
 
 // ---------------------------------------------------------------------------
@@ -221,10 +226,11 @@ export function useCreateBulletinPost() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (data: BulletinPostCreateBody) => api.createBulletinPost(data),
-    onSuccess: (post) => {
-      qc.invalidateQueries({
-        queryKey: tablesKeys.bulletinPosts({ table: post.table }),
-      }).catch(() => {});
+    onSuccess: () => {
+      // Bare prefix (2026-07 audit): a specific { table } params object never
+      // partial-matched the list query's { table, story } key, so a new/edited
+      // post never appeared until a hard refresh.
+      qc.invalidateQueries({ queryKey: tablesKeys.bulletinPostsAll }).catch(() => {});
     },
   });
 }
@@ -234,10 +240,11 @@ export function useUpdateBulletinPost() {
   return useMutation({
     mutationFn: ({ id, data }: { id: number; data: BulletinPostUpdateBody; tableId: number }) =>
       api.updateBulletinPost(id, data),
-    onSuccess: (post) => {
-      qc.invalidateQueries({
-        queryKey: tablesKeys.bulletinPosts({ table: post.table }),
-      }).catch(() => {});
+    onSuccess: () => {
+      // Bare prefix (2026-07 audit): a specific { table } params object never
+      // partial-matched the list query's { table, story } key, so a new/edited
+      // post never appeared until a hard refresh.
+      qc.invalidateQueries({ queryKey: tablesKeys.bulletinPostsAll }).catch(() => {});
     },
   });
 }
@@ -247,10 +254,8 @@ export function useDeleteBulletinPost() {
   return useMutation({
     mutationFn: ({ id, tableId: _tableId }: { id: number; tableId: number }) =>
       api.deleteBulletinPost(id),
-    onSuccess: (_, { tableId }) => {
-      qc.invalidateQueries({ queryKey: tablesKeys.bulletinPosts({ table: tableId }) }).catch(
-        () => {}
-      );
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: tablesKeys.bulletinPostsAll }).catch(() => {});
     },
   });
 }
@@ -263,12 +268,10 @@ export function useCreateBulletinReply() {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (data: BulletinReplyCreateBody) => api.createBulletinReply(data),
-    onSuccess: (reply) => {
+    onSuccess: () => {
       // Invalidate the post list so the embedded replies_cached refreshes.
-      qc.invalidateQueries({ queryKey: tablesKeys.bulletinPosts() }).catch(() => {});
-      qc.invalidateQueries({
-        queryKey: tablesKeys.bulletinReplies({ post: reply.post }),
-      }).catch(() => {});
+      qc.invalidateQueries({ queryKey: tablesKeys.bulletinPostsAll }).catch(() => {});
+      qc.invalidateQueries({ queryKey: tablesKeys.bulletinRepliesAll }).catch(() => {});
     },
   });
 }
@@ -286,7 +289,7 @@ export function useUpdateBulletinReply() {
       postId: number;
     }) => api.updateBulletinReply(id, data),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: tablesKeys.bulletinPosts() }).catch(() => {});
+      qc.invalidateQueries({ queryKey: tablesKeys.bulletinPostsAll }).catch(() => {});
     },
   });
 }
@@ -297,7 +300,7 @@ export function useDeleteBulletinReply() {
     mutationFn: ({ id, postId: _postId }: { id: number; postId: number }) =>
       api.deleteBulletinReply(id),
     onSuccess: () => {
-      qc.invalidateQueries({ queryKey: tablesKeys.bulletinPosts() }).catch(() => {});
+      qc.invalidateQueries({ queryKey: tablesKeys.bulletinPostsAll }).catch(() => {});
     },
   });
 }

--- a/frontend/src/tables/types.ts
+++ b/frontend/src/tables/types.ts
@@ -145,8 +145,12 @@ export interface PaginatedBulletinReplies {
 export interface BulletinPostCreateBody {
   table: number;
   story?: number | null;
-  /** PK of the author persona (Lead GM's persona at this table). */
-  author_persona: number;
+  /**
+   * Optional (#audit2): a GM table is account-scoped, not tied to an in-game
+   * character, so the web omits this and the backend authors as the requester's
+   * own persona. Only set it to post as a specific owned persona.
+   */
+  author_persona?: number;
   title: string;
   body: string;
   allow_replies?: boolean;
@@ -160,8 +164,8 @@ export interface BulletinPostUpdateBody {
 
 export interface BulletinReplyCreateBody {
   post: number;
-  /** PK of the author persona. */
-  author_persona: number;
+  /** Optional (#audit2) — omitted by the web; backend authors as the requester's own persona. */
+  author_persona?: number;
   body: string;
 }
 

--- a/src/schema.json
+++ b/src/schema.json
@@ -37038,6 +37038,12 @@ components:
         - ``story`` (if set) belongs to ``table`` (story.primary_table == table)
         - ``author_persona`` belongs to the requesting user's account
 
+        ``author_persona`` is optional (2026-07 audit): a GM table is account-scoped,
+        not tied to a specific character, so the frontend has no in-game persona to
+        pass — omit it and the requester's own persona is resolved server-side.
+        When supplied, it MUST belong to the requesting account (the ownership check
+        the docstring always claimed but never enforced).
+
         Stores validated model instances in validated_data.
       properties:
         table:
@@ -37056,7 +37062,6 @@ components:
           type: boolean
           default: true
       required:
-      - author_persona
       - body
       - table
       - title
@@ -37070,6 +37075,12 @@ components:
         - ``story`` (if set) belongs to ``table`` (story.primary_table == table)
         - ``author_persona`` belongs to the requesting user's account
 
+        ``author_persona`` is optional (2026-07 audit): a GM table is account-scoped,
+        not tied to a specific character, so the frontend has no in-game persona to
+        pass — omit it and the requester's own persona is resolved server-side.
+        When supplied, it MUST belong to the requesting account (the ownership check
+        the docstring always claimed but never enforced).
+
         Stores validated model instances in validated_data.
       properties:
         table:
@@ -37090,7 +37101,6 @@ components:
           type: boolean
           default: true
       required:
-      - author_persona
       - body
       - table
       - title
@@ -37114,7 +37124,6 @@ components:
         body:
           type: string
       required:
-      - author_persona
       - body
       - post
     CreateBulletinReplyInputRequest:
@@ -37138,7 +37147,6 @@ components:
           type: string
           minLength: 1
       required:
-      - author_persona
       - body
       - post
     CreateEstablishedPersonaRequestRequest:

--- a/src/world/stories/serializers.py
+++ b/src/world/stories/serializers.py
@@ -2400,6 +2400,44 @@ class TableBulletinPostSerializer(serializers.ModelSerializer):
         return TableBulletinReplySerializer(reply_list, many=True).data
 
 
+def resolve_own_bulletin_persona(request: Any, supplied: Persona | None) -> Persona:
+    """Return the persona to author a bulletin as, enforcing account ownership.
+
+    A GM table is account-scoped, not character-scoped (2026-07 audit): the web
+    surface has no in-game persona to pass, so ``supplied`` is normally ``None``
+    and we resolve one of the requester's own personas server-side (the active
+    face of their first character). When a persona IS supplied it must belong to
+    the requesting account — the ownership check the serializer docstrings always
+    claimed but never enforced (a foreign persona would previously have posted
+    successfully).
+    """
+    from world.roster.models import RosterEntry  # noqa: PLC0415
+    from world.scenes.interaction_permissions import get_account_personas  # noqa: PLC0415
+    from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+    if request is None:
+        msg = "Request context is required."
+        raise serializers.ValidationError(msg)
+
+    if supplied is not None:
+        # Staff act administratively and may author as any persona (they already
+        # bypass the table-ownership check); a non-staff caller's supplied
+        # persona must belong to their own account.
+        if not request.user.is_staff:
+            owned_ids = set(get_account_personas(request))
+            if supplied.pk not in owned_ids:
+                msg = "That persona does not belong to your account."
+                raise serializers.ValidationError({"author_persona": msg})
+        return supplied
+
+    entry = RosterEntry.objects.for_account(request.user).first()
+    sheet = entry.character_sheet if entry is not None else None
+    if sheet is None:
+        msg = "You have no character to author a bulletin as."
+        raise serializers.ValidationError({"author_persona": msg})
+    return active_persona_for_sheet(sheet)
+
+
 class CreateBulletinPostInputSerializer(serializers.Serializer):
     """Input for POST /api/table-bulletin-posts/.
 
@@ -2407,6 +2445,12 @@ class CreateBulletinPostInputSerializer(serializers.Serializer):
     - ``table`` exists and user is its Lead GM (or staff)
     - ``story`` (if set) belongs to ``table`` (story.primary_table == table)
     - ``author_persona`` belongs to the requesting user's account
+
+    ``author_persona`` is optional (2026-07 audit): a GM table is account-scoped,
+    not tied to a specific character, so the frontend has no in-game persona to
+    pass — omit it and the requester's own persona is resolved server-side.
+    When supplied, it MUST belong to the requesting account (the ownership check
+    the docstring always claimed but never enforced).
 
     Stores validated model instances in validated_data.
     """
@@ -2418,7 +2462,11 @@ class CreateBulletinPostInputSerializer(serializers.Serializer):
         allow_null=True,
         default=None,
     )
-    author_persona = serializers.PrimaryKeyRelatedField(queryset=Persona.objects.all())
+    author_persona = serializers.PrimaryKeyRelatedField(
+        queryset=Persona.objects.all(),
+        required=False,
+        default=None,
+    )
     title = serializers.CharField(max_length=200)
     body = serializers.CharField()
     allow_replies = serializers.BooleanField(required=False, default=True)
@@ -2442,12 +2490,15 @@ class CreateBulletinPostInputSerializer(serializers.Serializer):
         return table
 
     def validate(self, attrs: Any) -> Any:  # type: ignore[override]
-        """Validate that story (if set) belongs to the specified table."""
+        """Validate story↔table and resolve/authorize the author persona."""
         table: GMTable = attrs["table"]
         story: Story | None = attrs.get("story")
         if story is not None and story.primary_table_id != table.pk:
             msg = "The selected story is not assigned to this table."
             raise serializers.ValidationError({"story": msg})
+        attrs["author_persona"] = resolve_own_bulletin_persona(
+            self.context.get("request"), attrs.get("author_persona")
+        )
         return attrs
 
 
@@ -2476,7 +2527,11 @@ class CreateBulletinReplyInputSerializer(serializers.Serializer):
     """
 
     post = serializers.PrimaryKeyRelatedField(queryset=TableBulletinPost.objects.all())
-    author_persona = serializers.PrimaryKeyRelatedField(queryset=Persona.objects.all())
+    author_persona = serializers.PrimaryKeyRelatedField(
+        queryset=Persona.objects.all(),
+        required=False,
+        default=None,
+    )
     body = serializers.CharField()
 
     def validate_post(self, post: TableBulletinPost) -> TableBulletinPost:
@@ -2495,6 +2550,13 @@ class CreateBulletinReplyInputSerializer(serializers.Serializer):
             msg = "You do not have access to this bulletin post."
             raise serializers.ValidationError(msg)
         return post
+
+    def validate(self, attrs: Any) -> Any:  # type: ignore[override]
+        """Resolve/authorize the author persona (optional → own persona, #audit2)."""
+        attrs["author_persona"] = resolve_own_bulletin_persona(
+            self.context.get("request"), attrs.get("author_persona")
+        )
+        return attrs
 
 
 class UpdateBulletinReplyInputSerializer(serializers.Serializer):

--- a/src/world/stories/tests/test_views_bulletin.py
+++ b/src/world/stories/tests/test_views_bulletin.py
@@ -19,6 +19,7 @@ from world.gm.factories import (
     GMTableFactory,
     GMTableMembershipFactory,
 )
+from world.roster.factories import RosterTenureFactory
 from world.scenes.factories import PersonaFactory
 from world.stories.constants import StoryScope
 from world.stories.factories import (
@@ -47,6 +48,22 @@ class BulletinViewSetSetup(TestCase):
     - participant_character: ObjectDB for participant_user's StoryParticipation
     """
 
+    @staticmethod
+    def _link(account, persona) -> None:
+        """Tie an account to a persona's character via an active RosterTenure.
+
+        The bulletin author-persona ownership check (#audit2) resolves owned
+        personas the canonical way — roster tenure, not character.db_account —
+        so tests must set up a real tenure for a persona to count as owned.
+        """
+        sheet = persona.character_sheet
+        sheet.character.db_account = account
+        sheet.character.save()
+        RosterTenureFactory(
+            roster_entry__character_sheet=sheet,
+            player_data__account=account,
+        )
+
     @classmethod
     def setUpTestData(cls) -> None:
         # Accounts
@@ -73,18 +90,12 @@ class BulletinViewSetSetup(TestCase):
 
         # Member persona + membership
         cls.member_persona = PersonaFactory()
-        # Override character_sheet.character.db_account to be member_user
-
-        member_sheet = cls.member_persona.character_sheet
-        member_sheet.character.db_account = cls.member_user
-        member_sheet.character.save()
+        cls._link(cls.member_user, cls.member_persona)
         GMTableMembershipFactory(table=cls.table, persona=cls.member_persona)
 
         # Author persona (GM posts as one of their personas)
         cls.lead_gm_persona = PersonaFactory()
-        lead_gm_sheet = cls.lead_gm_persona.character_sheet
-        lead_gm_sheet.character.db_account = cls.lead_gm_user
-        lead_gm_sheet.character.save()
+        cls._link(cls.lead_gm_user, cls.lead_gm_persona)
 
         # Story with primary_table
         cls.story = StoryFactory(
@@ -94,9 +105,8 @@ class BulletinViewSetSetup(TestCase):
 
         # Participant persona + StoryParticipation
         cls.participant_persona = PersonaFactory()
+        cls._link(cls.participant_user, cls.participant_persona)
         participant_sheet = cls.participant_persona.character_sheet
-        participant_sheet.character.db_account = cls.participant_user
-        participant_sheet.character.save()
         cls.story_participation = StoryParticipationFactory(
             story=cls.story,
             character=participant_sheet.character,
@@ -167,6 +177,40 @@ class BulletinPostCreateTests(BulletinViewSetSetup):
         }
         res = self._staff().post("/api/table-bulletin-posts/", payload, format="json")
         self.assertEqual(res.status_code, 201)
+
+    def test_author_persona_optional_resolves_own_persona(self) -> None:
+        """Omitting author_persona authors as the requester's own persona (#audit2).
+
+        A GM table is account-scoped, so the web has no in-game persona to send —
+        the backend resolves one. This was the broken write path: the frontend
+        sent persona id 0, which always 400'd.
+        """
+        payload = {
+            "table": self.table.pk,
+            "title": "No persona supplied",
+            "body": "Backend picks my persona.",
+        }
+        res = self._lead_gm().post("/api/table-bulletin-posts/", payload, format="json")
+        self.assertEqual(res.status_code, 201, res.json())
+        # Resolves to the character's worn face (primary persona here — the
+        # lead_gm's character has no active alt set).
+        resolved = res.json()["author_persona"]
+        owned = set(self.lead_gm_persona.character_sheet.personas.values_list("pk", flat=True))
+        self.assertIn(resolved, owned)
+
+    def test_cannot_author_as_foreign_persona(self) -> None:
+        """A non-staff GM may not author as a persona they don't own (#audit2).
+
+        The ownership check the docstring always claimed but never enforced.
+        """
+        payload = {
+            "table": self.table.pk,
+            "author_persona": self.member_persona.pk,  # belongs to member_user
+            "title": "Impersonation",
+            "body": "Not my persona.",
+        }
+        res = self._lead_gm().post("/api/table-bulletin-posts/", payload, format="json")
+        self.assertEqual(res.status_code, 400, res.json())
 
     def test_non_lead_gm_cannot_create_on_others_table(self) -> None:
         """A GM who is not the Lead GM of the target table cannot post."""


### PR DESCRIPTION
## What

Second of the second audit series. The GM-table bulletin authoring feature was **non-functional end-to-end** from `TableBulletin` — it shipped without a manual smoke test:
- `gmPersonaId={0}` / `viewerPersonaId={undefined}` placeholder ids: persona 0 always 400'd.
- Every `onError` handler read `(err as { response?: Response }).response` — a property no thrown error had (the api layer threw bare `new Error('Failed to…')`), so create/edit failures were **completely silent**.
- Invalidation keys (`bulletinPosts({ table })`) never matched the list query's `{ table, story }` key, so a new/edited post never appeared without a hard refresh.

**Backend** — `author_persona` is now optional on both bulletin input serializers. A GM table is account-scoped, not character-scoped, so the web has no in-game persona to send; omitting it resolves the requester's own persona (their character's worn face, via `active_persona_for_sheet`) server-side. Also adds the account-ownership check the docstrings always claimed but **never enforced** — a supplied persona must belong to the requester (staff, who already bypass the table-ownership gate, may author as any persona). Two new tests cover the resolve-own and reject-foreign paths; the existing suite's persona ownership was upgraded from `db_account` to real `RosterTenure` to match the canonical ownership model.

**Frontend** — the persona props are gone from `TableBulletin` / `CreateBulletinPostDialog` / `BulletinPostCard` / `ReplyForm`. `tables/api` sweeps every call onto `throwApiError` (the `ApiError` primitive from #2418), so the forms surface real DRF field/detail errors through a shared `bulletinErrorsFrom()` mapper. Bulletin invalidations use a bare prefix (`bulletinPostsAll` / `bulletinRepliesAll`) that correctly prefix-matches every params variant.

## Tests

Backend bulletin view suite green (42, +2 new); frontend tables suite green (52); `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)