### PR TITLE
Audit2 S3: mission invites visible without any participation

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -12309,6 +12309,30 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/missions/journal/pending-invites/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Pending mission invites for the puppet, independent of participations (#audit2).
+     *
+     *     The journal list returns nothing for a character with no participations,
+     *     so a brand-new character invited to their first mission never saw the
+     *     invite. Invites are persona-scoped, so they get their own endpoint —
+     *     the web reads this instead of piggybacking on journal entry 0.
+     */
+    get: operations['missions_journal_pending_invites_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/missions/journal/respond/': {
     parameters: {
       query?: never;
@@ -52056,6 +52080,25 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['Opportunities'];
+        };
+      };
+    };
+  };
+  missions_journal_pending_invites_list: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PendingMissionInvite'][];
         };
       };
     };

--- a/frontend/src/missions/api.ts
+++ b/frontend/src/missions/api.ts
@@ -15,6 +15,7 @@ import type {
   BeatView,
   GroupBeatResult,
   JournalEntry,
+  PendingMissionInvite,
   MissionCategory,
   MissionGiver,
   MissionGiverRequest,
@@ -431,6 +432,17 @@ export async function listJournal(): Promise<PaginatedResponse<JournalEntry>> {
     'Failed to load your journal'
   );
   return { count: results.length, next: null, previous: null, results };
+}
+
+/**
+ * Pending mission invites for the puppet — independent of participations (#audit2).
+ * A brand-new character with zero missions has an empty journal, so invites
+ * are read from a dedicated endpoint rather than journal entry 0.
+ */
+export async function listPendingInvites(): Promise<PendingMissionInvite[]> {
+  const res = await apiFetch(`${BASE_URL}/journal/pending-invites/`);
+  if (!res.ok) throw new Error('Failed to load your mission invites');
+  return res.json() as Promise<PendingMissionInvite[]>;
 }
 
 export async function getBeat(instanceId: number): Promise<BeatView | null> {

--- a/frontend/src/missions/pages/JournalPage.tsx
+++ b/frontend/src/missions/pages/JournalPage.tsx
@@ -16,7 +16,7 @@ import { useState } from 'react';
 
 import { OpportunitiesTab } from '../components/OpportunitiesTab';
 import { PendingInvitesSection } from '../components/PendingInvitesSection';
-import { useJournal, useTellTale } from '../queries';
+import { useJournal, usePendingInvites, useTellTale } from '../queries';
 import type { JournalEntry } from '../types';
 
 export function JournalPage() {
@@ -24,8 +24,10 @@ export function JournalPage() {
   const entries = data?.results ?? [];
   const active = entries.filter((entry) => entry.status === 'active');
   const past = entries.filter((entry) => entry.status !== 'active');
-  // Invites are persona-scoped (not per-entry) — surface the union once.
-  const pendingInvites = entries[0]?.pending_invites ?? [];
+  // Dedicated endpoint (2026-07 audit): reading entries[0].pending_invites
+  // meant a character with an empty journal (a brand-new PC invited to their
+  // first mission) never saw the invite.
+  const { data: pendingInvites = [] } = usePendingInvites();
 
   return (
     <div className="container mx-auto max-w-3xl px-4 py-6">

--- a/frontend/src/missions/queries.ts
+++ b/frontend/src/missions/queries.ts
@@ -15,6 +15,7 @@ import {
   getOpportunities,
   inviteToMission,
   listJournal,
+  listPendingInvites,
   resolveBeat,
   respondToMissionInvite,
   castGroupVote,
@@ -47,6 +48,7 @@ import type {
   BeatView,
   GroupBeatResult,
   JournalEntry,
+  PendingMissionInvite,
   MissionCategory,
   MissionGiver,
   MissionGiverRequest,
@@ -82,6 +84,7 @@ export const missionKeys = {
   categories: () => [...missionKeys.all, 'categories'] as const,
   givers: () => [...missionKeys.all, 'givers'] as const,
   journal: () => [...missionKeys.all, 'journal'] as const,
+  pendingInvites: () => [...missionKeys.all, 'pending-invites'] as const,
   opportunities: () => [...missionKeys.all, 'opportunities'] as const,
   // roomKey threads the player's current room into the key so a move
   // refetches liveness — the server computes "live here" from the puppet.
@@ -339,6 +342,15 @@ export function useJournal(): UseQueryResult<PaginatedResponse<JournalEntry>> {
   });
 }
 
+/** Pending mission invites for the puppet (#audit2) — surfaces even with an empty journal. */
+export function usePendingInvites(): UseQueryResult<PendingMissionInvite[]> {
+  return useQuery({
+    queryKey: missionKeys.pendingInvites(),
+    queryFn: listPendingInvites,
+    refetchInterval: 15_000,
+  });
+}
+
 export function useOpportunities() {
   return useQuery({
     queryKey: missionKeys.opportunities(),
@@ -456,7 +468,10 @@ export function useInviteToMission() {
       instanceId: number;
       invitee_character_id: number;
     }) => inviteToMission(instanceId, { invitee_character_id }),
-    onSuccess: () => qc.invalidateQueries({ queryKey: missionKeys.journal() }).catch(() => {}),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: missionKeys.journal() }).catch(() => {});
+      qc.invalidateQueries({ queryKey: missionKeys.pendingInvites() }).catch(() => {});
+    },
   });
 }
 
@@ -465,6 +480,9 @@ export function useRespondToMissionInvite() {
   return useMutation({
     mutationFn: (body: { invite_id: number; response: 'accept' | 'decline' }) =>
       respondToMissionInvite(body),
-    onSuccess: () => qc.invalidateQueries({ queryKey: missionKeys.journal() }).catch(() => {}),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: missionKeys.journal() }).catch(() => {});
+      qc.invalidateQueries({ queryKey: missionKeys.pendingInvites() }).catch(() => {});
+    },
   });
 }

--- a/src/schema.json
+++ b/src/schema.json
@@ -19202,6 +19202,29 @@ paths:
               schema:
                 $ref: '#/components/schemas/Opportunities'
           description: ''
+  /api/missions/journal/pending-invites/:
+    get:
+      operationId: missions_journal_pending_invites_list
+      description: |-
+        Pending mission invites for the puppet, independent of participations (#audit2).
+
+        The journal list returns nothing for a character with no participations,
+        so a brand-new character invited to their first mission never saw the
+        invite. Invites are persona-scoped, so they get their own endpoint —
+        the web reads this instead of piggybacking on journal entry 0.
+      tags:
+      - missions
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/PendingMissionInvite'
+          description: ''
   /api/missions/journal/respond/:
     post:
       operationId: missions_journal_respond_create

--- a/src/world/missions/services/journal.py
+++ b/src/world/missions/services/journal.py
@@ -105,6 +105,17 @@ def journal_for(character: ObjectDB) -> list[JournalEntry]:
     ]
 
 
+def pending_invites_for_character(character: ObjectDB) -> tuple[JournalInvite, ...]:
+    """PENDING mission invites for a character — independent of participations (#audit2).
+
+    ``journal_for`` returns ``[]`` for a character with no mission participations,
+    which dropped invites entirely for exactly the population most likely to have
+    one: a brand-new character invited to their first mission. Invites are
+    persona-scoped (not per-participation), so they get their own read surface.
+    """
+    return _pending_invites_for(character)
+
+
 def _pending_invites_for(character: ObjectDB) -> tuple[JournalInvite, ...]:
     """PENDING MissionInvites addressed to any of this character's personas (#2049).
 

--- a/src/world/missions/tests/test_api_mission_invite.py
+++ b/src/world/missions/tests/test_api_mission_invite.py
@@ -149,6 +149,26 @@ class MissionInviteEndpointTests(TestCase):
             ).exists()
         )
 
+    def test_pending_invites_endpoint_lists_invitees_invite(self) -> None:
+        """GET .../pending-invites/ surfaces an invite for a non-participant (#audit2).
+
+        The invitee has zero participations, so the journal list is empty; the
+        dedicated endpoint must still return their pending invite — the bug was
+        that a brand-new character never saw their first mission invite.
+        """
+        self.client.post(
+            f"/api/missions/journal/{self.instance.pk}/invite/",
+            {"invitee_character_id": self.invitee.pk},
+            format="json",
+        )
+        with mock.patch("world.missions.views._puppet_character", return_value=self.invitee):
+            journal = self.client.get("/api/missions/journal/")
+            invites = self.client.get("/api/missions/journal/pending-invites/")
+        self.assertEqual(journal.json()["results"], [])  # no participations
+        rows = invites.json()
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(rows[0]["instance_id"], self.instance.pk)
+
     def test_respond_foreign_invite_is_404(self) -> None:
         """An invite addressed to someone else 404s for the invitee."""
         third = CharacterFactory()

--- a/src/world/missions/tests/test_journal_invite_payload.py
+++ b/src/world/missions/tests/test_journal_invite_payload.py
@@ -55,6 +55,27 @@ class JournalInvitePayloadTest(TestCase):
         self.assertEqual(entries[0].pending_invites, ())
         self.assertEqual(entries[0].participant_count, 1)
 
+    def test_invite_surfaces_without_any_participation(self):
+        """A PENDING invite surfaces even with zero mission participations (#audit2).
+
+        journal_for returns [] for a participation-less character, so an invite
+        to a brand-new character's first mission was invisible on the web; the
+        dedicated resolver returns it regardless.
+        """
+        from world.missions.services.journal import pending_invites_for_character
+
+        instance, holder = _holder_instance("no-part")
+        invitee = _pc()  # never shared into the mission — zero participations
+        invite = invite_to_mission(
+            instance,
+            holder.sheet_data.primary_persona,
+            invitee.sheet_data.primary_persona,
+        )
+        self.assertEqual(journal_for(invitee), [])
+        invites = pending_invites_for_character(invitee)
+        self.assertEqual(len(invites), 1)
+        self.assertEqual(invites[0].invite_id, invite.pk)
+
     def test_participant_count_reflects_group(self):
         """A 2-participant instance reports participant_count == 2."""
         instance, holder = _holder_instance("group")

--- a/src/world/missions/views.py
+++ b/src/world/missions/views.py
@@ -80,6 +80,7 @@ from world.missions.serializers import (
     MissionTemplateDetailSerializer,
     MissionTemplateSerializer,
     OpportunitiesSerializer,
+    PendingMissionInviteSerializer,
     ResolvedBeatSerializer,
     SupportDeclareRequestSerializer,
     TaleRequestSerializer,
@@ -487,6 +488,24 @@ class MissionJournalViewSet(viewsets.ViewSet):
         page = paginator.paginate_queryset(cast("Any", entries), request)
         serializer = JournalEntrySerializer(page, many=True)
         return paginator.get_paginated_response(serializer.data)
+
+    @extend_schema(responses={200: PendingMissionInviteSerializer(many=True)})
+    @action(detail=False, methods=("GET",), url_path="pending-invites")
+    def pending_invites(self, request: Request) -> Response:
+        """Pending mission invites for the puppet, independent of participations (#audit2).
+
+        The journal list returns nothing for a character with no participations,
+        so a brand-new character invited to their first mission never saw the
+        invite. Invites are persona-scoped, so they get their own endpoint —
+        the web reads this instead of piggybacking on journal entry 0.
+        """
+        from world.missions.services.journal import (  # noqa: PLC0415
+            pending_invites_for_character,
+        )
+
+        character = _puppet_character(request)
+        invites = pending_invites_for_character(character)
+        return Response(PendingMissionInviteSerializer(invites, many=True).data)
 
     @extend_schema(
         responses={


### PR DESCRIPTION
## What

Third of the second audit series. `journal_for()` returns `[]` for a character with no mission participations, and the web read pending invites from `entries[0].pending_invites` — so a **brand-new character invited to their first mission never saw the invite** (the exact population most likely to have one). Telnet was the only way to accept.

- **Backend**: `pending_invites_for_character()` + a dedicated `GET /api/missions/journal/pending-invites/` action returning persona-scoped invites independent of participations.
- **Frontend**: `usePendingInvites()` (15 s poll); `JournalPage` sources `PendingInvitesSection` from it instead of journal entry 0; invite/respond mutations invalidate the new key.

## Tests

Backend service test (invite surfaces with zero participations) + API test (`pending-invites` endpoint returns the invitee's invite while the journal list is empty); missions suites green (12 backend / 82 frontend). `gen-api-types` regenerated (known drift hand-reverted); `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)