### PR TITLE
Audit2 S4: EpisodeFormDialog data loss — seed from full detail, not list shape

### DIFF
--- a/frontend/src/stories/__tests__/EpisodeFormDialog.test.tsx
+++ b/frontend/src/stories/__tests__/EpisodeFormDialog.test.tsx
@@ -27,6 +27,7 @@ import type { EpisodeLike } from '../components/EpisodeFormDialog';
 vi.mock('../queries', () => ({
   useCreateEpisode: vi.fn(),
   useUpdateEpisode: vi.fn(),
+  useEpisode: vi.fn(),
   useProgressionRequirements: vi.fn(),
   useCreateProgressionRequirement: vi.fn(),
   useDeleteProgressionRequirement: vi.fn(),
@@ -93,6 +94,15 @@ function setupMocks() {
     isError: false,
     error: null,
   } as unknown as ReturnType<typeof queries.useBeatList>);
+
+  // Default: no detail loaded (create mode / not-yet-fetched). Edit-mode tests
+  // that need a seeded form set this per-test.
+  vi.mocked(queries.useEpisode).mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    isError: false,
+    error: null,
+  } as unknown as ReturnType<typeof queries.useEpisode>);
 
   return { createMock, updateMock };
 }
@@ -224,6 +234,13 @@ describe('EpisodeFormDialog — Task E2 GM/player text split + episode fields', 
   it('submits the new fields in the update body on edit', async () => {
     const user = userEvent.setup();
     const { updateMock } = setupMocks();
+    // Edit mode fetches the full episode; return it so the form seeds + enables.
+    vi.mocked(queries.useEpisode).mockReturnValue({
+      data: existingEpisode,
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as unknown as ReturnType<typeof queries.useEpisode>);
     updateMock.mockImplementation((_vars: unknown, callbacks: Record<string, unknown>) => {
       const cb = callbacks as { onSuccess?: (data: unknown) => void };
       cb.onSuccess?.({ id: 21 });
@@ -250,6 +267,41 @@ describe('EpisodeFormDialog — Task E2 GM/player text split + episode fields', 
             resting_conclusion: 'The party rests, content with their progress.',
             is_ending: false,
           }),
+        }),
+        expect.any(Object)
+      );
+    });
+  });
+
+  it('preserves is_ending when opened from list-shaped data (2026-07 audit)', async () => {
+    const user = userEvent.setup();
+    const { updateMock } = setupMocks();
+    updateMock.mockImplementation((_vars: unknown, callbacks: Record<string, unknown>) => {
+      (callbacks as { onSuccess?: (d: unknown) => void }).onSuccess?.({ id: 21 });
+    });
+
+    // The caller (author tree / DAG) passes list-serializer data that OMITS
+    // is_ending — but the detail query supplies the true value. A rename must
+    // not reset is_ending to false.
+    const listShaped = { id: 21, title: 'Episode One', order: 1 } as EpisodeLike;
+    vi.mocked(queries.useEpisode).mockReturnValue({
+      data: { ...listShaped, is_ending: true, description: 'GM notes.', summary: 'Recap.' },
+      isLoading: false,
+      isError: false,
+      error: null,
+    } as unknown as ReturnType<typeof queries.useEpisode>);
+
+    renderWithProviders(<EpisodeFormDialog {...defaultProps} episode={listShaped} />);
+
+    const title = screen.getByLabelText(/title/i);
+    await user.clear(title);
+    await user.type(title, 'Episode One Renamed');
+    await user.click(screen.getByRole('button', { name: /save episode/i }));
+
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({ title: 'Episode One Renamed', is_ending: true }),
         }),
         expect.any(Object)
       );

--- a/frontend/src/stories/components/EpisodeFormDialog.tsx
+++ b/frontend/src/stories/components/EpisodeFormDialog.tsx
@@ -8,7 +8,7 @@
  * (Task 9.4).
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import {
   Dialog,
@@ -21,8 +21,9 @@ import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
-import { useCreateEpisode, useUpdateEpisode } from '../queries';
+import { useCreateEpisode, useEpisode, useUpdateEpisode } from '../queries';
 import type { Episode, Maturity } from '../types';
+import { ApiError } from '@/lib/errors';
 import { ProgressionRequirementsEditor } from './ProgressionRequirementsEditor';
 import { PromoteMaturityButton } from './PromoteMaturityButton';
 
@@ -86,6 +87,13 @@ export function EpisodeFormDialog({
 }: EpisodeFormDialogProps) {
   const isEdit = episode !== undefined;
 
+  // Fetch the FULL episode in edit mode (2026-07 audit): the passed EpisodeLike
+  // often comes from the list serializer, which omits is_ending / description /
+  // summary / resting_conclusion — so seeding the form from it and saving wiped
+  // those fields (a rename silently reset is_ending to false). The detail query
+  // supplies them; we re-seed once it arrives.
+  const { data: detail } = useEpisode(isEdit && open ? episode.id : 0);
+
   const [title, setTitle] = useState(episode?.title ?? '');
   const [description, setDescription] = useState(episode?.description ?? '');
   const [summary, setSummary] = useState(episode?.summary ?? '');
@@ -96,9 +104,23 @@ export function EpisodeFormDialog({
   );
   const [fieldErrors, setFieldErrors] = useState<DRFFieldErrors>({});
 
+  // Re-seed from the authoritative detail once it loads (edit mode only).
+  useEffect(() => {
+    if (!detail) return;
+    setTitle(detail.title ?? '');
+    setDescription(detail.description ?? '');
+    setSummary(detail.summary ?? '');
+    setRestingConclusion(detail.resting_conclusion ?? '');
+    setIsEnding(detail.is_ending ?? false);
+    setOrder(detail.order !== undefined ? String(detail.order) : '');
+  }, [detail]);
+
   const createMutation = useCreateEpisode();
   const updateMutation = useUpdateEpisode();
   const isPending = createMutation.isPending || updateMutation.isPending;
+  // In edit mode, block submit until the full episode has loaded so a save
+  // can never PATCH a not-yet-seeded is_ending / description over real data.
+  const detailLoading = isEdit && open && detail === undefined;
 
   function resetForm() {
     setTitle(episode?.title ?? '');
@@ -116,17 +138,11 @@ export function EpisodeFormDialog({
   }
 
   function handleError(err: unknown) {
-    if (err && typeof err === 'object' && 'response' in err) {
-      const response = (err as { response?: Response }).response;
-      if (response) {
-        void response
-          .json()
-          .then((data: unknown) => {
-            if (data && typeof data === 'object') setFieldErrors(data as DRFFieldErrors);
-          })
-          .catch(() => toast.error('An error occurred. Please try again.'));
-        return;
-      }
+    // ApiError (from apiFetch, #2418) carries DRF field errors + a message;
+    // the old code read err.response, a property no thrown error ever had.
+    if (err instanceof ApiError && err.fieldErrors) {
+      setFieldErrors(err.fieldErrors as DRFFieldErrors);
+      return;
     }
     toast.error(err instanceof Error ? err.message : 'An error occurred. Please try again.');
   }
@@ -135,12 +151,15 @@ export function EpisodeFormDialog({
     e.preventDefault();
     setFieldErrors({});
 
+    // On edit the fields are fully loaded, so send explicit empty strings for
+    // cleared text fields (the old `|| undefined` omitted them, making
+    // description/summary impossible to clear). On create, omit blanks.
     const data = {
       chapter: chapterId,
       title: title.trim(),
-      description: description.trim() || undefined,
-      summary: summary.trim() || undefined,
-      resting_conclusion: restingConclusion.trim() || undefined,
+      description: isEdit ? description.trim() : description.trim() || undefined,
+      summary: isEdit ? summary.trim() : summary.trim() || undefined,
+      resting_conclusion: isEdit ? restingConclusion.trim() : restingConclusion.trim() || undefined,
       is_ending: isEnding,
       order: order !== '' ? Number(order) : undefined,
     };
@@ -331,7 +350,7 @@ export function EpisodeFormDialog({
             >
               Cancel
             </Button>
-            <Button type="submit" disabled={isPending}>
+            <Button type="submit" disabled={isPending || detailLoading}>
               {isPending
                 ? isEdit
                   ? 'Saving…'


### PR DESCRIPTION
## What

Fourth of the second audit series — a genuine data-loss bug. Editing an episode from the author tree or DAG passes **list-serializer** data (`EpisodeListSerializer` omits `is_ending`, `description`, `summary`, `resting_conclusion`), so the form seeded those fields from `undefined` and the PATCH always sent `is_ending: false` — **a rename silently reset an ending episode to non-ending**. Text fields were likewise unclearable (`.trim() || undefined` omitted them from the body).

- Edit mode now fetches the full episode (`useEpisode`) and re-seeds the form once it loads; submit is disabled until then so a save can't PATCH a not-yet-seeded `is_ending` over real data.
- On edit, cleared text fields send an explicit `''` (was omitted), so `description`/`summary` can actually be cleared.
- `handleError` reads `ApiError.fieldErrors` (from #2418's `apiFetch`) instead of the nonexistent `err.response`, so validation errors surface.

## Tests

New regression test: opening from list-shaped data and renaming preserves `is_ending: true`. EpisodeFormDialog suite green (8), full stories suite green (379); `tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)