### PR TITLE
Audit2 S5: backend N+1 + read-only-GET fixes

### DIFF
--- a/src/world/goals/tests/test_views.py
+++ b/src/world/goals/tests/test_views.py
@@ -159,6 +159,28 @@ class CharacterGoalViewSetTests(TestCase):
         assert response.data["points_remaining"] == MAX_GOAL_POINTS - 15
 
     @patch("world.goals.views.CharacterGoalViewSet._get_character")
+    def test_list_goals_is_read_only(self, mock_get_char):
+        """The list GET creates no GoalRevision row (2026-07 audit).
+
+        It used get_or_create — a write inside a GET that also stamped a new
+        character with last_revised_at=now, locking them out of revising for a
+        week. A character who never revised should read can_revise=True with no
+        row written.
+        """
+        from world.goals.models import GoalRevision
+
+        mock_get_char.return_value = self.character
+        assert not GoalRevision.objects.filter(character=self.character).exists()
+
+        response = self.client.get("/api/goals/my-goals/")
+
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["revision"]["can_revise"] is True
+        assert response.data["revision"]["last_revised_at"] is None
+        # The GET must not have written a revision row.
+        assert not GoalRevision.objects.filter(character=self.character).exists()
+
+    @patch("world.goals.views.CharacterGoalViewSet._get_character")
     def test_list_goals_no_character(self, mock_get_char):
         """Returns 404 when user has no character."""
         mock_get_char.return_value = None

--- a/src/world/goals/views.py
+++ b/src/world/goals/views.py
@@ -73,15 +73,19 @@ class CharacterGoalViewSet(CharacterContextMixin, viewsets.ViewSet):
         goals = CharacterGoal.objects.filter(character=character).select_related("domain")
         total_points = sum(g.points for g in goals)
 
-        revision, _ = GoalRevision.objects.get_or_create(character=character)
+        # Read-only (2026-07 audit): this list GET used get_or_create, a DB write
+        # inside a GET (breaks read-replica/caching assumptions and, worse, a
+        # brand-new character was created with last_revised_at=now, so they
+        # couldn't revise for a week). A missing revision means never-revised.
+        revision = GoalRevision.objects.filter(character=character).first()
 
         data = {
             "goals": CharacterGoalSerializer(goals, many=True).data,
             "total_points": total_points,
             "points_remaining": MAX_GOAL_POINTS - total_points,
             "revision": {
-                "last_revised_at": revision.last_revised_at,
-                "can_revise": revision.can_revise(),
+                "last_revised_at": revision.last_revised_at if revision else None,
+                "can_revise": revision.can_revise() if revision else True,
             },
         }
 

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -2882,8 +2882,11 @@ class RitualSessionListSerializer(serializers.ModelSerializer):
             return {"role": "unknown", "state": None}
         user = request.user
         initiator = obj.initiator
-        # Check if initiator's sheet belongs to this user.
-        my_sheet_ids = set(RosterEntry.objects.for_account(user).character_ids())
+        # Prefer the per-request sheet-id set the viewset seeds into context
+        # (2026-07 audit) — falls back to a direct query for other callers.
+        my_sheet_ids = self.context.get("my_sheet_ids")
+        if my_sheet_ids is None:
+            my_sheet_ids = set(RosterEntry.objects.for_account(user).character_ids())
         if initiator is not None and initiator.pk in my_sheet_ids:
             return {"role": "initiator", "state": None}
         # Check participant rows. Use participants_cached when prefetched.

--- a/src/world/magic/views.py
+++ b/src/world/magic/views.py
@@ -2130,6 +2130,21 @@ class RitualSessionViewSet(viewsets.ModelViewSet):
     filterset_class = RitualSessionFilterSet
     permission_classes = [IsAuthenticated]
 
+    def get_serializer_context(self) -> dict:
+        """Compute the requester's sheet ids ONCE (2026-07 audit).
+
+        RitualSessionListSerializer.get_my_role re-ran
+        ``RosterEntry.for_account(...).character_ids()`` per row on an
+        unpaginated list; seed it here so the serializer reads from context.
+        """
+        context = super().get_serializer_context()
+        user = self.request.user
+        if user.is_authenticated:
+            context["my_sheet_ids"] = set(
+                RosterEntry.objects.for_account(cast(AccountDB, user)).character_ids()
+            )
+        return context
+
     def get_queryset(self):
         """Scope to sessions where user is initiator or invited participant."""
         from django.db.models import Q  # noqa: PLC0415

--- a/src/world/societies/serializers.py
+++ b/src/world/societies/serializers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from django.core.exceptions import ObjectDoesNotExist
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
@@ -108,23 +109,30 @@ class OrganizationSerializer(serializers.ModelSerializer):
     def get_house(self, obj) -> dict | None:
         if obj.family is None:
             return None
-        from world.societies.houses.models import FealtyEdge  # noqa: PLC0415
-        from world.societies.houses.services import vassals_of  # noqa: PLC0415
 
-        edge = FealtyEdge.objects.filter(vassal=obj).select_related("liege").first()
+        # Read the prefetched relations (OrganizationViewSet queryset, 2026-07
+        # audit) — `.all()` uses the prefetch cache; titles are sorted in Python
+        # to avoid a fresh ordered query per org. The liege edge (`fealty`,
+        # OneToOne) and direct vassals (`vassal_edges`) are prefetched too, so
+        # the whole house payload costs zero extra queries per org on a list.
+        try:
+            liege_edge = obj.fealty  # reverse OneToOne, prefetched
+        except ObjectDoesNotExist:
+            liege_edge = None
+        titles = sorted(obj.titles.all(), key=lambda t: (t.tier, t.name))
         payload = {
             "family_name": obj.family.name,
-            "liege_name": edge.liege.name if edge is not None else "",
-            "vassal_names": [vassal.name for vassal in vassals_of(obj)],
-            "titles": obj.titles.select_related("holder").order_by("tier", "name"),
-            "domains": obj.domains.prefetch_related("holdings"),  # noqa: PREFETCH_STRING
+            "liege_name": liege_edge.liege.name if liege_edge is not None else "",
+            "vassal_names": [edge.vassal.name for edge in obj.vassal_edges.all()],
+            "titles": titles,
+            "domains": obj.domains.all(),
             "aspects": [
                 {
                     "definition": facet.definition.name,
                     "option": facet.option.name,
                     "description": facet.option.description,
                 }
-                for facet in obj.aspects.select_related("definition", "option")
+                for facet in obj.aspects.all()
             ],
             "features": [
                 {
@@ -132,7 +140,7 @@ class OrganizationSerializer(serializers.ModelSerializer):
                     "slug": stamped.feature.slug,
                     "description": stamped.feature.description,
                 }
-                for stamped in obj.features.select_related("feature")
+                for stamped in obj.features.all()
             ],
         }
         return HouseDetailSerializer(payload).data

--- a/src/world/societies/tests/test_organization_api.py
+++ b/src/world/societies/tests/test_organization_api.py
@@ -64,6 +64,46 @@ class OrganizationApiTests(TestCase):
         self.assertIn(self.organization.id, ids)
         self.assertNotIn(cov_membership.organization.id, ids)
 
+    def test_house_payload_is_bounded_regardless_of_org_count(self) -> None:
+        """The org list query count doesn't grow with the number of family orgs (2026-07 audit).
+
+        OrganizationSerializer.get_house used to fire ~6 queries per org with a
+        family; the viewset now prefetches the house relations so a page of many
+        houses costs the same as one.
+        """
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+        from evennia.utils.idmapper.models import flush_cache
+
+        from world.roster.factories import FamilyFactory
+
+        staff = AccountFactory(is_staff=True)
+        self.client.force_authenticate(user=staff)
+        url = reverse("societies:organization-list")
+
+        OrganizationFactory(family=FamilyFactory())
+        self.client.get(url)  # warm up (session middleware)
+        # Flush the SharedMemoryModel identity map before each capture — otherwise
+        # a warmed request serves cached relations and undercounts the prefetches.
+        flush_cache()
+        with CaptureQueriesContext(connection) as one_ctx:
+            self.client.get(url)
+        one_org = len(one_ctx.captured_queries)
+
+        # Four more family orgs must not scale the query count.
+        for _ in range(4):
+            OrganizationFactory(family=FamilyFactory())
+        flush_cache()
+        with CaptureQueriesContext(connection) as five_ctx:
+            self.client.get(url)
+        five_orgs = len(five_ctx.captured_queries)
+
+        self.assertEqual(
+            five_orgs,
+            one_org,
+            f"House payload query count scaled with org count: {one_org} -> {five_orgs}",
+        )
+
     def test_staff_sees_all_non_covenant_organizations(self) -> None:
         """Staff users see every non-covenant organization, regardless of membership."""
         staff_account = AccountFactory(is_staff=True)

--- a/src/world/societies/views.py
+++ b/src/world/societies/views.py
@@ -47,9 +47,24 @@ class OrganizationViewSet(viewsets.ReadOnlyModelViewSet):
     Staff see all non-covenant organizations.
     """
 
-    queryset = Organization.objects.prefetch_related(
-        "ranks",  # noqa: PREFETCH_STRING
-    ).order_by("id")
+    # Prefetch the house-payload relations (2026-07 audit): OrganizationSerializer
+    # .get_house serializes titles/domains/aspects/features inline, which fired
+    # ~6 queries per org with a family (~300 on a 50-org page). select_related
+    # the family + prefetch the rest so the payload reads from cache.
+    queryset = (
+        Organization.objects.select_related("family", "society", "org_type")
+        .prefetch_related(
+            "ranks",  # noqa: PREFETCH_STRING
+            "titles__holder",  # noqa: PREFETCH_STRING
+            "domains__holdings",  # noqa: PREFETCH_STRING
+            "aspects__definition",  # noqa: PREFETCH_STRING
+            "aspects__option",  # noqa: PREFETCH_STRING
+            "features__feature",  # noqa: PREFETCH_STRING
+            "fealty__liege",  # noqa: PREFETCH_STRING  — this org's liege edge (get_house)
+            "vassal_edges__vassal",  # noqa: PREFETCH_STRING  — its direct vassals
+        )
+        .order_by("id")
+    )
     serializer_class = OrganizationSerializer
     permission_classes = [IsAuthenticated]
     pagination_class = SocietiesPagination


### PR DESCRIPTION
## What

Fifth of the second audit series — backend query-discipline fixes.

- **Organizations list N+1**: `OrganizationSerializer.get_house` serialized titles/domains/aspects/features/fealty/vassals inline — ~6 queries per org with a family (~300 on a 50-org page). The viewset now `select_related`s `family`/`society`/`org_type` and prefetches every house relation; `get_house` reads the prefetch caches. A new test proves the query count no longer scales with org count (flushing the SharedMemoryModel identity map between captures so the comparison is apples-to-apples).
- **Ritual session list N+1**: `RitualSessionListSerializer.get_my_role` re-ran `RosterEntry.for_account(...).character_ids()` per row on an unpaginated list; the viewset now seeds `my_sheet_ids` into serializer context once.
- **Goals `my-goals` GET write**: it `get_or_create`d a `GoalRevision` — a DB write inside a GET that also stamped a brand-new character with `last_revised_at=now`, locking them out of revising for a week. A missing revision now reads `can_revise=True` with no row written.

**Deferred**: the covenants `member_count`/`legend_total` N+1 — the matview Subquery correlation proved fragile and the covenant list is members-only (small N); left for a dedicated pass rather than shipping brittle SQL.

## Tests

New bounded-query test (societies), read-only-GET test (goals); societies (17) / magic session (105 with goals) / goals (25) suites green. No schema change (gen-api-types produced only the known local drift, reverted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)