### PR TITLE
Audit2 S7: derive wardrobe selections live instead of click-time snapshots

### DIFF
--- a/frontend/src/inventory/hooks/useOutfits.ts
+++ b/frontend/src/inventory/hooks/useOutfits.ts
@@ -98,6 +98,11 @@ export function useCreateOutfitSlot() {
     onSuccess: (_slot, variables) => {
       qc.invalidateQueries({ queryKey: outfitKeys.slots(variables.outfit) }).catch(() => {});
       qc.invalidateQueries({ queryKey: outfitKeys.detail(variables.outfit) }).catch(() => {});
+      // Also refresh the list (2026-07 audit): the outfit list rows carry their
+      // slots, and WardrobePage's live-derived editing outfit reads from the
+      // list, so a slot add must invalidate it too or the editor shows stale
+      // slots. `all` matches every ['outfits', <characterSheetId>] list.
+      qc.invalidateQueries({ queryKey: outfitKeys.all }).catch(() => {});
     },
   });
 }
@@ -109,6 +114,8 @@ export function useDeleteOutfitSlot() {
     onSuccess: (_void, variables) => {
       qc.invalidateQueries({ queryKey: outfitKeys.slots(variables.outfitId) }).catch(() => {});
       qc.invalidateQueries({ queryKey: outfitKeys.detail(variables.outfitId) }).catch(() => {});
+      // See useCreateOutfitSlot — keep the list (and its embedded slots) live.
+      qc.invalidateQueries({ queryKey: outfitKeys.all }).catch(() => {});
     },
   });
 }

--- a/frontend/src/inventory/pages/WardrobePage.tsx
+++ b/frontend/src/inventory/pages/WardrobePage.tsx
@@ -56,7 +56,7 @@ import { DeleteOutfitDialog } from '../components/DeleteOutfitDialog';
 import { UndressButton } from '../components/UndressButton';
 import { useEquippedItems, useInventory, inventoryKeys } from '../hooks/useInventory';
 import { useOutfits } from '../hooks/useOutfits';
-import type { ContainerAccessPolicy, ItemInstance, Outfit } from '../types';
+import type { ContainerAccessPolicy, ItemInstance } from '../types';
 
 export function WardrobePage() {
   const activeCharacter = useAppSelector((state) => state.game.active);
@@ -81,9 +81,14 @@ export function WardrobePage() {
 
   const [saveOpen, setSaveOpen] = useState(false);
   const [craftOpen, setCraftOpen] = useState(false);
-  const [editingOutfit, setEditingOutfit] = useState<Outfit | null>(null);
-  const [deletingOutfit, setDeletingOutfit] = useState<Outfit | null>(null);
-  const [detailItem, setDetailItem] = useState<ItemInstance | null>(null);
+  // Selection is held by id, not by a captured object (2026-07 audit): the
+  // detail panel and outfit editor re-derive their live record from the query
+  // caches below, so a mutation that refetches inventory/outfits is reflected
+  // immediately instead of leaving a stale click-time snapshot on screen (e.g.
+  // adding an outfit slot, changing a container's access policy, using a charge).
+  const [editingOutfitId, setEditingOutfitId] = useState<number | null>(null);
+  const [deletingOutfitId, setDeletingOutfitId] = useState<number | null>(null);
+  const [detailItemId, setDetailItemId] = useState<number | null>(null);
   // Item awaiting a recipient/container pick (#1909) — set by the detail
   // panel's Give/Put-in buttons, consumed once the picker dialog confirms.
   const [givingItemId, setGivingItemId] = useState<number | null>(null);
@@ -176,6 +181,15 @@ export function WardrobePage() {
     () => new Set(equippedItems.map((item) => item.id)),
     [equippedItems]
   );
+
+  // Live-derived selections (2026-07 audit) — see the id-state comment above.
+  // Equipped items are hydrated from `inventory`, so `inventoryById` covers
+  // both worn and carried; a null lookup (item left inventory) closes the panel.
+  const detailItem = detailItemId != null ? (inventoryById.get(detailItemId) ?? null) : null;
+  const editingOutfit =
+    editingOutfitId != null ? (outfits.find((o) => o.id === editingOutfitId) ?? null) : null;
+  const deletingOutfit =
+    deletingOutfitId != null ? (outfits.find((o) => o.id === deletingOutfitId) ?? null) : null;
 
   // -------------------------------------------------------------------------
   // Action handlers (websocket)
@@ -328,11 +342,11 @@ export function WardrobePage() {
                 key={outfit.id}
                 outfit={outfit}
                 onWear={() => handleApplyOutfit(outfit.id)}
-                onEdit={() => setEditingOutfit(outfit)}
-                onDelete={() => setDeletingOutfit(outfit)}
+                onEdit={() => setEditingOutfitId(outfit.id)}
+                onDelete={() => setDeletingOutfitId(outfit.id)}
                 onItemClick={(itemId) => {
                   const item = inventoryById.get(itemId);
-                  if (item) setDetailItem(item);
+                  if (item) setDetailItemId(item.id);
                 }}
               />
             ))}
@@ -352,7 +366,7 @@ export function WardrobePage() {
             equipped={equippedDisplay}
             onItemClick={(itemId) => {
               const item = inventoryById.get(itemId);
-              if (item) setDetailItem(item);
+              if (item) setDetailItemId(item.id);
             }}
           />
           <div className="space-y-2">
@@ -360,7 +374,7 @@ export function WardrobePage() {
               <p className="italic text-muted-foreground">Nothing equipped right now.</p>
             ) : (
               equippedItems.map((item) => (
-                <ItemCard key={item.id} item={item} onClick={() => setDetailItem(item)} />
+                <ItemCard key={item.id} item={item} onClick={() => setDetailItemId(item.id)} />
               ))
             )}
           </div>
@@ -376,7 +390,7 @@ export function WardrobePage() {
         ) : (
           <div className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
             {inventory.map((item) => (
-              <ItemCard key={item.id} item={item} onClick={() => setDetailItem(item)} />
+              <ItemCard key={item.id} item={item} onClick={() => setDetailItemId(item.id)} />
             ))}
           </div>
         )}
@@ -386,7 +400,7 @@ export function WardrobePage() {
         item={detailItem}
         open={detailItem !== null}
         onOpenChange={(open) => {
-          if (!open) setDetailItem(null);
+          if (!open) setDetailItemId(null);
         }}
         isEquipped={detailItem ? equippedItemIds.has(detailItem.id) : false}
         characterId={characterId}
@@ -430,7 +444,7 @@ export function WardrobePage() {
         <EditOutfitDialog
           open={editingOutfit !== null}
           onOpenChange={(open) => {
-            if (!open) setEditingOutfit(null);
+            if (!open) setEditingOutfitId(null);
           }}
           outfit={editingOutfit}
           carriedItems={inventory}
@@ -441,7 +455,7 @@ export function WardrobePage() {
         <DeleteOutfitDialog
           open={deletingOutfit !== null}
           onOpenChange={(open) => {
-            if (!open) setDeletingOutfit(null);
+            if (!open) setDeletingOutfitId(null);
           }}
           outfit={deletingOutfit}
         />

--- a/frontend/src/inventory/pages/__tests__/WardrobePage.test.tsx
+++ b/frontend/src/inventory/pages/__tests__/WardrobePage.test.tsx
@@ -9,6 +9,9 @@
 import { screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { Provider } from 'react-redux';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
 
 import { renderWithProviders } from '@/test/utils/renderWithProviders';
 import { store } from '@/store/store';
@@ -502,6 +505,61 @@ describe('WardrobePage', () => {
         target_id: 1044,
         policy: 'owner_only',
       });
+    });
+  });
+
+  describe('live-derived selection (2026-07 audit)', () => {
+    // renderWithProviders wraps the element directly, so RTL's `rerender`
+    // drops the providers. Re-apply them so the mounted WardrobePage instance
+    // (and its open-panel state) survives the re-render.
+    function rerenderWrapped(rerender: (ui: React.ReactElement) => void) {
+      rerender(
+        <Provider store={store}>
+          <QueryClientProvider client={new QueryClient()}>
+            <MemoryRouter>
+              <WardrobePage />
+            </MemoryRouter>
+          </QueryClientProvider>
+        </Provider>
+      );
+    }
+
+    it('reflects fresh inventory in the open detail panel instead of a click-time snapshot', async () => {
+      const user = userEvent.setup();
+      setupHooks({ inventory: [makeItem(11, 'Silk Tunic')] });
+      const { rerender } = renderWithProviders(<WardrobePage />);
+
+      await user.click(screen.getAllByText('Silk Tunic')[0]);
+      // Panel heading shows the selected item's live display_name.
+      expect(screen.getByRole('heading', { name: 'Silk Tunic' })).toBeInTheDocument();
+
+      // Simulate a mutation refetch: same item id, renamed. The panel must
+      // re-derive from the refreshed query, not the object captured on click.
+      vi.mocked(inventoryHooks.useInventory).mockReturnValue(
+        stubQuery([makeItem(11, 'Silk Tunic (mended)')]) as unknown as ReturnType<
+          typeof inventoryHooks.useInventory
+        >
+      );
+      rerenderWrapped(rerender);
+
+      expect(screen.getByRole('heading', { name: 'Silk Tunic (mended)' })).toBeInTheDocument();
+    });
+
+    it('closes the detail panel when the selected item leaves inventory', async () => {
+      const user = userEvent.setup();
+      setupHooks({ inventory: [makeItem(11, 'Silk Tunic')] });
+      const { rerender } = renderWithProviders(<WardrobePage />);
+
+      await user.click(screen.getAllByText('Silk Tunic')[0]);
+      expect(screen.getByRole('heading', { name: 'Silk Tunic' })).toBeInTheDocument();
+
+      // Item dropped/given → gone from the refreshed inventory.
+      vi.mocked(inventoryHooks.useInventory).mockReturnValue(
+        stubQuery([]) as unknown as ReturnType<typeof inventoryHooks.useInventory>
+      );
+      rerenderWrapped(rerender);
+
+      expect(screen.queryByRole('heading', { name: 'Silk Tunic' })).not.toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
## What

Seventh of the second audit series — a real staleness bug in the wardrobe UI.

`WardrobePage` held the selected item and the editing/deleting outfit as **captured objects** (`setDetailItem(item)`, `setEditingOutfit(outfit)`). After a mutation refetched inventory/outfits, those `useState` snapshots went stale, so the open panel/editor kept rendering click-time data:
- Adding an outfit slot didn't show up in the open editor (`EditOutfitDialog` reads `outfit.slots` from the prop, which was the frozen snapshot).
- A container access-policy change, a spent charge, or a renamed item didn't reflect in the detail panel until the user reselected.

### Fix

- `WardrobePage` now stores `detailItemId` / `editingOutfitId` / `deletingOutfitId` and **re-derives the live record each render** from the inventory map + outfits list. A selection that leaves the list resolves to `null` (panel closes cleanly) instead of rendering a ghost.
- `useCreateOutfitSlot` / `useDeleteOutfitSlot` now also invalidate the outfit **list** (`outfitKeys.all`), not just the per-outfit detail — the list rows carry their slots and the live-derived editing outfit reads from the list, so a slot change has to refresh it too.

The audit flagged `EditOutfitDialog` / `ItemDetailPanel` themselves, but both already read live from their props (the dialog re-seeds via `useEffect`; the panel keys `ItemContent` by id). The staleness was entirely the parent's captured-object state, so the fix belongs there — no change to those two components.

## Tests

Two new `WardrobePage` regression cases (open panel reflects a renamed item after a refetch; panel closes when the item leaves inventory). Full inventory suite **149 green**; `tsc` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)