### PR TITLE
No visible 'Create a Character' link on homepage or roster page

### DIFF
--- a/frontend/src/evennia_replacements/HomePage.tsx
+++ b/frontend/src/evennia_replacements/HomePage.tsx
@@ -12,9 +12,14 @@ import { StatsCard } from './StatsCard';
 import { RecentConnected } from './RecentConnected';
 import { NewsTeaser } from './NewsTeaser';
 import { useStatusQuery } from './queries';
+import { useAccount } from '@/store/hooks';
 
 export function HomePage() {
   const { data, isLoading } = useStatusQuery();
+  const account = useAccount();
+  const hasCharacters = (account?.available_characters?.length ?? 0) > 0;
+  const heroDestination = account && !hasCharacters ? '/characters/create' : '/game';
+  const heroLabel = account && !hasCharacters ? 'Create a character' : 'Play in the browser';
 
   return (
     <>
@@ -29,7 +34,7 @@ export function HomePage() {
           </p>
         </div>
         <Button asChild size="lg">
-          <Link to="/game">Play in the browser</Link>
+          <Link to={heroDestination}>{heroLabel}</Link>
         </Button>
         <StatusBlock />
       </section>

--- a/frontend/src/roster/pages/RosterListPage.tsx
+++ b/frontend/src/roster/pages/RosterListPage.tsx
@@ -23,9 +23,12 @@ import {
 } from '@/components/ui/select';
 import { Gender, GENDER_LABELS } from '@/world/character_sheets/types';
 import { useDebouncedValue } from '@/hooks/useDebouncedValue';
+import { Link } from 'react-router-dom';
+import { useAccount } from '@/store/hooks';
 
 export function RosterListPage() {
   const { data: rosters, isLoading: rostersLoading } = useRostersQuery();
+  const account = useAccount();
   const [activeRoster, setActiveRoster] = useState<string>('');
   const [page, setPage] = useState(1);
   const [name, setName] = useState('');
@@ -59,6 +62,14 @@ export function RosterListPage() {
 
   return (
     <div className="container mx-auto space-y-4 p-4">
+      <div className="flex items-center justify-between">
+        <h1 className="text-2xl font-bold">Roster</h1>
+        {account?.can_create_characters && (
+          <Button asChild>
+            <Link to="/characters/create">Create a character</Link>
+          </Button>
+        )}
+      </div>
       <Tabs
         value={activeRoster}
         onValueChange={(v: string) => {


### PR DESCRIPTION
Closes #2403

## Summary

Make the homepage hero button context-aware (logged-in zero-character users go to /characters/create instead of /game) and add a 'Create a character' CTA to the roster page for users with can_create_characters.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2403 (in the issue body)
- Brainstorm/plan: skipped
- Sync-with-main: Clean rebase, no conflicts.

<!-- last-addressed-comment: 0 -->