### PR TITLE
Navbar is too busy — stack/group navigation items

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -3,7 +3,14 @@ import { Menu } from 'lucide-react';
 import { SiteTitle } from './SiteTitle';
 import { UserNav } from './UserNav';
 import { ModeToggle } from './ModeToggle';
-import { NavigationMenu, NavigationMenuList, NavigationMenuItem } from './ui/navigation-menu';
+import {
+  NavigationMenu,
+  NavigationMenuList,
+  NavigationMenuItem,
+  NavigationMenuTrigger,
+  NavigationMenuContent,
+  NavigationMenuViewport,
+} from './ui/navigation-menu';
 import { Sheet, SheetTrigger, SheetContent } from './ui/sheet';
 import { Button } from './ui/button';
 import { Badge } from './ui/badge';
@@ -14,22 +21,48 @@ import { UnreadNarrativeBadge } from '@/narrative/components/UnreadNarrativeBadg
 import { UnreadMailBadge } from '@/mail/components/UnreadMailBadge';
 import { useRitualSessionInbox } from '@/rituals/queries';
 
-const links = [
-  { to: '/game', label: 'Play' },
-  { to: '/roster', label: 'Roster' },
-  { to: '/scenes', label: 'Scenes' },
-  { to: '/events', label: 'Events' },
-  { to: '/crossover/inbox', label: 'Crossover' },
-  { to: '/codex', label: 'Codex' },
-  { to: '/tidings', label: 'Tidings' },
-  { to: '/threads', label: 'Threads' },
-  { to: '/magic/progression', label: 'Progression' },
-];
+interface NavLink {
+  to: string;
+  label: string;
+  authOnly?: boolean;
+}
 
-/** Nav links visible only to authenticated users (account != null). */
-const authLinks = [
-  { to: '/stories/my-active', label: 'My Stories' },
-  { to: '/books', label: 'Books' },
+interface NavDropdown {
+  type: 'dropdown';
+  label: string;
+  children: NavLink[];
+}
+
+/** Dropdown groups for secondary navigation links. */
+const dropdownGroups: NavDropdown[] = [
+  {
+    type: 'dropdown',
+    label: 'Characters',
+    children: [
+      { to: '/roster', label: 'Roster' },
+      { to: '/magic/progression', label: 'Progression' },
+      { to: '/threads', label: 'Threads' },
+    ],
+  },
+  {
+    type: 'dropdown',
+    label: 'Story',
+    children: [
+      { to: '/scenes', label: 'Scenes' },
+      { to: '/events', label: 'Events' },
+      { to: '/stories/my-active', label: 'My Stories', authOnly: true },
+      { to: '/books', label: 'Books', authOnly: true },
+    ],
+  },
+  {
+    type: 'dropdown',
+    label: 'World',
+    children: [
+      { to: '/crossover/inbox', label: 'Crossover' },
+      { to: '/codex', label: 'Codex' },
+      { to: '/tidings', label: 'Tidings' },
+    ],
+  },
 ];
 
 export function Header() {
@@ -45,21 +78,31 @@ export function Header() {
         <SiteTitle />
         <NavigationMenu className="hidden md:block">
           <NavigationMenuList>
-            {links.map((link) => (
-              <NavigationMenuItem key={link.to}>
-                <Link to={link.to} className={navigationMenuTriggerStyle()}>
-                  {link.label}
-                </Link>
-              </NavigationMenuItem>
-            ))}
-            {account &&
-              authLinks.map((link) => (
-                <NavigationMenuItem key={link.to}>
-                  <Link to={link.to} className={navigationMenuTriggerStyle()}>
-                    {link.label}
-                  </Link>
+            <NavigationMenuItem>
+              <Link to="/game" className={navigationMenuTriggerStyle()}>
+                Play
+              </Link>
+            </NavigationMenuItem>
+            {dropdownGroups.map((group) => {
+              const visibleChildren = group.children.filter((child) => !child.authOnly || account);
+              if (visibleChildren.length === 0) return null;
+              return (
+                <NavigationMenuItem key={group.label}>
+                  <NavigationMenuTrigger>{group.label}</NavigationMenuTrigger>
+                  <NavigationMenuContent>
+                    <ul className="flex flex-col gap-1 p-2">
+                      {visibleChildren.map((child) => (
+                        <li key={child.to}>
+                          <Link to={child.to} className={navigationMenuTriggerStyle()}>
+                            {child.label}
+                          </Link>
+                        </li>
+                      ))}
+                    </ul>
+                  </NavigationMenuContent>
                 </NavigationMenuItem>
-              ))}
+              );
+            })}
             {account && (
               <NavigationMenuItem>
                 <Link to="/rituals/sessions/inbox" className={navigationMenuTriggerStyle()}>
@@ -108,6 +151,7 @@ export function Header() {
               <UserNav />
             </NavigationMenuItem>
           </NavigationMenuList>
+          <NavigationMenuViewport />
         </NavigationMenu>
         <div className="md:hidden">
           <Sheet>
@@ -119,17 +163,27 @@ export function Header() {
             </SheetTrigger>
             <SheetContent side="left" className="p-4">
               <nav className="flex flex-col gap-4">
-                {links.map((link) => (
-                  <Link key={link.to} to={link.to} className="text-lg">
-                    {link.label}
-                  </Link>
-                ))}
-                {account &&
-                  authLinks.map((link) => (
-                    <Link key={link.to} to={link.to} className="text-lg">
-                      {link.label}
-                    </Link>
-                  ))}
+                <Link to="/game" className="text-lg">
+                  Play
+                </Link>
+                {dropdownGroups.map((group) => {
+                  const visibleChildren = group.children.filter(
+                    (child) => !child.authOnly || account
+                  );
+                  if (visibleChildren.length === 0) return null;
+                  return (
+                    <div key={group.label} className="space-y-2">
+                      <p className="text-sm font-semibold text-muted-foreground">{group.label}</p>
+                      <div className="flex flex-col gap-2 pl-2">
+                        {visibleChildren.map((child) => (
+                          <Link key={child.to} to={child.to} className="text-lg">
+                            {child.label}
+                          </Link>
+                        ))}
+                      </div>
+                    </div>
+                  );
+                })}
                 {account && (
                   <Link to="/rituals/sessions/inbox" className="text-lg">
                     Inbox {pendingInvitationCount > 0 ? `(${pendingInvitationCount})` : ''}

--- a/frontend/src/components/__tests__/Header.test.tsx
+++ b/frontend/src/components/__tests__/Header.test.tsx
@@ -3,6 +3,7 @@
  */
 
 import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { describe, it, expect, vi } from 'vitest';
 import type { ReactNode } from 'react';
@@ -12,6 +13,10 @@ import { Header } from '../Header';
 import { authSlice } from '@/store/authSlice';
 import { gameSlice } from '@/store/gameSlice';
 import { rouletteSlice } from '@/store/rouletteSlice';
+
+function setupUser() {
+  return { user: userEvent.setup() };
+}
 
 // Mock the queries that Header uses
 vi.mock('@/staff/queries', () => ({
@@ -51,20 +56,66 @@ function Wrapper({ children }: { children: ReactNode }) {
 }
 
 describe('Header', () => {
-  it('renders navigation links including Threads', () => {
+  it('renders direct nav links and dropdown triggers', () => {
     render(
       <Wrapper>
         <Header />
       </Wrapper>
     );
 
-    // Check for main nav links
+    // Play is a direct link, always visible
     expect(screen.getByRole('link', { name: /play/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /roster/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /scenes/i })).toBeInTheDocument();
-    expect(screen.getByRole('link', { name: /codex/i })).toBeInTheDocument();
 
-    // Check for Threads link specifically (Task 21)
+    // Dropdown group triggers are present as buttons
+    expect(screen.getByRole('button', { name: /characters/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /story/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /world/i })).toBeInTheDocument();
+  });
+
+  it('renders dropdown links when a group is opened', async () => {
+    const { user } = setupUser();
+    render(
+      <Wrapper>
+        <Header />
+      </Wrapper>
+    );
+
+    // Open the Characters dropdown
+    await user.click(screen.getByRole('button', { name: /characters/i }));
+
+    // Links inside the dropdown are now visible
+    expect(screen.getByRole('link', { name: /roster/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /progression/i })).toBeInTheDocument();
     expect(screen.getByRole('link', { name: /threads/i })).toBeInTheDocument();
+  });
+
+  it('renders Story dropdown links when opened', async () => {
+    const { user } = setupUser();
+    render(
+      <Wrapper>
+        <Header />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByRole('button', { name: /story/i }));
+
+    expect(screen.getByRole('link', { name: /scenes/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /events/i })).toBeInTheDocument();
+    // My Stories and Books are auth-only — not logged in, so absent
+  });
+
+  it('renders World dropdown links when opened', async () => {
+    const { user } = setupUser();
+    render(
+      <Wrapper>
+        <Header />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByRole('button', { name: /world/i }));
+
+    expect(screen.getByRole('link', { name: /crossover/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /codex/i })).toBeInTheDocument();
+    expect(screen.getByRole('link', { name: /tidings/i })).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Closes #2406

## Summary

Group the 14+ navbar links into 3 dropdown menus (Characters, Story, World) using the already-exported NavigationMenuTrigger/Content/Viewport primitives. Play, Inbox, Staff, and Story Workload remain as direct links. Mobile Sheet menu uses grouped sub-headers.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2406 (in the issue body)
- Brainstorm/plan: skipped
- Sync-with-main: Clean rebase, no conflicts.

<!-- last-addressed-comment: 0 -->