### PR TITLE
Bound the covenant list query count (member_count / legend_total / storylines N+1)

### DIFF
--- a/docs/systems/MODEL_MAP.md
+++ b/docs/systems/MODEL_MAP.md
@@ -6937,6 +6937,7 @@
 - `get_character_legend_total(character: 'ObjectDB') -> 'int' — Fast lookup of a character's total legend from materialized view.`
 - `get_character_role_legend(*, character_sheet: 'CharacterSheet', role: 'CovenantRole', covenant_ids: 'list[int] | None' = None) -> 'int' — Sum the legend this character earned that was credited to covenants where they held ``role``.`
 - `get_covenant_legend_total(covenant: 'Covenant') -> 'int' — Return the covenant's total legend from the materialized view.`
+- `get_covenant_legend_totals(covenant_ids: 'list[int]') -> 'dict[int, int]' — Bulk sibling of ``get_covenant_legend_total`` — one query for a page of covenants.`
 - `get_persona_legend_total(persona: 'Persona') -> 'int' — Per-persona legend lookup from materialized view.`
 - `refresh_legend_views() -> None — Refresh all legend materialized views concurrently.`
 - `spread_deed(deed: 'LegendEntry', spreader_persona: 'Persona', value_added: 'int', *, description: 'str' = '', method: 'str' = '', skill: 'Skill | None' = None, audience_factor: 'Decimal' = Decimal('1.0'), scene: 'Scene | None' = None, societies_reached: 'list[Society] | None' = None) -> 'LegendSpread' — Record a spreading action and add legend value, clamped to capacity.`

--- a/src/world/covenants/serializers.py
+++ b/src/world/covenants/serializers.py
@@ -286,12 +286,20 @@ class CovenantSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
     def get_member_count(self, obj: Covenant) -> int:
+        # Prefer the page aggregate the viewset precomputed (2026-07 audit);
+        # fall back to a direct count for callers outside CovenantViewSet.list.
+        aggregate = self.context.get("covenant_aggregates", {}).get(obj.pk)
+        if aggregate is not None:
+            return aggregate["member_count"]
         return obj.memberships.filter(left_at__isnull=True).count()
 
     def get_is_active(self, obj: Covenant) -> bool:
         return obj.dissolved_at is None
 
     def get_legend_total(self, obj: Covenant) -> int:
+        aggregate = self.context.get("covenant_aggregates", {}).get(obj.pk)
+        if aggregate is not None:
+            return aggregate["legend_total"]
         from world.societies.services import get_covenant_legend_total  # noqa: PLC0415
 
         return get_covenant_legend_total(obj)

--- a/src/world/covenants/tests/test_views.py
+++ b/src/world/covenants/tests/test_views.py
@@ -474,6 +474,66 @@ class CovenantViewTests(CovenantsViewTestCase):
         response = unauthenticated_client.get("/api/covenants/covenants/")
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
+    def test_list_aggregates_member_count_and_legend_without_per_row_queries(self) -> None:
+        """List member_count/legend_total come from one bulk pass, not per row (2026-07 audit).
+
+        The legend matview is Postgres-only (absent in the fast SQLite tier), so
+        this mocks the bulk legend service — that also isolates the member_count
+        aggregate + query-bounding, which need no matview. Adding more covenants
+        must not add per-covenant count/legend queries.
+        """
+        from unittest.mock import patch
+
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+        from evennia.accounts.models import AccountDB
+        from evennia.utils.idmapper.models import flush_cache
+
+        from world.covenants.factories import (
+            CharacterCovenantRoleFactory,
+            CovenantFactory,
+        )
+
+        staff = AccountDB.objects.create_user(
+            username="cov_agg_staff", email="cov_agg_staff@test.com", password="p", is_staff=True
+        )
+        self.client.force_authenticate(user=staff)
+        url = "/api/covenants/covenants/"
+
+        # cov_active_member has one active membership (from setUpTestData).
+        legend_map = {self.cov_active_member.pk: 42}
+
+        def fake_totals(ids: list[int]) -> dict[int, int]:
+            return {pk: legend_map.get(pk, 0) for pk in ids}
+
+        with patch("world.societies.services.get_covenant_legend_totals", side_effect=fake_totals):
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            rows = {row["id"]: row for row in response.data["results"]}
+            self.assertEqual(rows[self.cov_active_member.pk]["member_count"], 1)
+            self.assertEqual(rows[self.cov_active_member.pk]["legend_total"], 42)
+            self.assertEqual(rows[self.cov_no_membership.pk]["member_count"], 0)
+            self.assertEqual(rows[self.cov_no_membership.pk]["legend_total"], 0)
+
+            flush_cache()
+            with CaptureQueriesContext(connection) as ctx_before:
+                self.client.get(url)
+            baseline = len(ctx_before.captured_queries)
+
+            # Two more covenants, one with two active members.
+            extra = CovenantFactory(name="ExtraCov")
+            CharacterCovenantRoleFactory(covenant=extra)
+            CharacterCovenantRoleFactory(covenant=extra)
+            CovenantFactory(name="ExtraCov2")
+
+            flush_cache()
+            with CaptureQueriesContext(connection) as ctx_after:
+                after = self.client.get(url)
+            self.assertEqual(after.status_code, status.HTTP_200_OK)
+            self.assertEqual(len(ctx_after.captured_queries), baseline)
+            after_rows = {row["id"]: row for row in after.data["results"]}
+            self.assertEqual(after_rows[extra.pk]["member_count"], 2)
+
 
 class CharacterCovenantRoleSerializerExposureTests(CovenantsViewTestCase):
     """Verify CharacterCovenantRoleSerializer exposes covenant + engaged."""

--- a/src/world/covenants/views.py
+++ b/src/world/covenants/views.py
@@ -290,8 +290,18 @@ class CovenantViewSet(viewsets.ReadOnlyModelViewSet):
     filter_backends = [DjangoFilterBackend]
     filterset_class = CovenantFilter
 
+    # Page aggregates (member_count / legend_total keyed by covenant pk) that
+    # ``list`` precomputes for ``get_serializer_context``; None on non-list
+    # actions so the serializer falls back to its per-object path. DRF builds a
+    # fresh viewset instance per request, so this never leaks across requests.
+    _page_aggregates: dict[int, dict[str, int]] | None = None
+
     def get_queryset(self) -> QuerySet[Covenant]:
-        qs = Covenant.objects.all().order_by("-formed_at")
+        # prefetch storylines (2026-07 audit): CovenantSerializer.storylines is a
+        # many-relation that otherwise fires one query per covenant on the list.
+        qs = Covenant.objects.prefetch_related(
+            "storylines",  # noqa: PREFETCH_STRING
+        ).order_by("-formed_at")
         if self.request.user.is_staff:
             return qs
         return qs.filter(
@@ -299,6 +309,56 @@ class CovenantViewSet(viewsets.ReadOnlyModelViewSet):
             memberships__character_sheet__roster_entry__tenures__end_date__isnull=True,
             memberships__character_sheet__roster_entry__tenures__player_data__account=self.request.user,
         ).distinct()
+
+    @staticmethod
+    def _covenant_aggregates(covenant_ids: list[int]) -> dict[int, dict[str, int]]:
+        """Bulk member_count + legend_total for a page of covenants (2026-07 audit).
+
+        CovenantSerializer computed both per row — a ``.count()`` and a matview
+        ``values_list`` each — so a page cost ~2 queries per covenant. This runs
+        two total queries for the whole page instead. Kept as a plain
+        bulk-fetch (correlated matview Subqueries proved fragile on the covenant
+        pk); the members-only list keeps the page small regardless.
+        """
+        from django.db.models import Count  # noqa: PLC0415
+
+        from world.societies.services import get_covenant_legend_totals  # noqa: PLC0415
+
+        if not covenant_ids:
+            return {}
+        counts = dict(
+            CharacterCovenantRole.objects.filter(covenant_id__in=covenant_ids, left_at__isnull=True)
+            .values("covenant_id")
+            .annotate(c=Count("id"))
+            .values_list("covenant_id", "c")
+        )
+        totals = get_covenant_legend_totals(covenant_ids)
+        return {
+            pk: {"member_count": counts.get(pk, 0), "legend_total": totals.get(pk, 0)}
+            for pk in covenant_ids
+        }
+
+    def get_serializer_context(self) -> dict:
+        context = super().get_serializer_context()
+        aggregates = self._page_aggregates
+        if aggregates is not None:
+            context["covenant_aggregates"] = aggregates
+        return context
+
+    def list(self, request: Request, *args: object, **kwargs: object) -> Response:
+        # NOTE: intentionally no docstring — drf-spectacular would publish it as
+        # the list endpoint's description, replacing the class docstring. Mirrors
+        # DRF's default list() but stashes the page's aggregates first so
+        # get_serializer_context can hand them to the serializer, avoiding the
+        # per-row member_count/legend_total queries.
+        queryset = self.filter_queryset(self.get_queryset())
+        page = self.paginate_queryset(queryset)
+        covenants = page if page is not None else list(queryset)
+        self._page_aggregates = self._covenant_aggregates([c.pk for c in covenants])
+        serializer = self.get_serializer(covenants, many=True)
+        if page is not None:
+            return self.get_paginated_response(serializer.data)
+        return Response(serializer.data)
 
     @action(detail=True, methods=["GET"])
     def powers(self, request: Request, pk: int | None = None) -> Response:

--- a/src/world/societies/services.py
+++ b/src/world/societies/services.py
@@ -471,6 +471,28 @@ def get_covenant_legend_total(covenant: Covenant) -> int:
     return result[0] if result else 0
 
 
+def get_covenant_legend_totals(covenant_ids: list[int]) -> dict[int, int]:
+    """Bulk sibling of ``get_covenant_legend_total`` — one query for a page of covenants.
+
+    Args:
+        covenant_ids: Covenant pks to look up.
+
+    Returns:
+        ``{covenant_id: legend_total}``. Covenants with no view row are absent
+        (callers default to 0).
+
+    Note: Like the single-covenant version, uses ``values_list`` to bypass the
+    SharedMemoryModel identity-map cache, which would otherwise return stale
+    totals after a view refresh.
+    """
+    if not covenant_ids:
+        return {}
+    rows = CovenantLegendSummary.objects.filter(pk__in=covenant_ids).values_list(
+        "pk", "legend_total"
+    )
+    return dict(rows)
+
+
 def get_character_role_legend(
     *,
     character_sheet: CharacterSheet,


### PR DESCRIPTION
## What

Closes the covenants N+1 I deliberately deferred in audit2 S5 — done here as its own pass, with a **bulk-fetch-in-context** approach instead of the correlated matview Subquery that proved fragile on the covenant pk last time.

`CovenantSerializer` computed `member_count` (a `.count()`) and `legend_total` (a matview `values_list`) **per row**, and `storylines` is a many-relation queried per row — so a covenant page cost ~3 queries per covenant.

- `CovenantViewSet.list()` precomputes the page's member counts (one grouped `CharacterCovenantRole` query) and legend totals (one matview query via the new bulk `get_covenant_legend_totals` service) into serializer context. The serializer reads them, **falling back to the per-object path** for retrieve / standalone serialization.
- `get_queryset` prefetches `storylines`.
- New `world.societies.services.get_covenant_legend_totals(ids)` — bulk sibling of `get_covenant_legend_total`, same `values_list`-bypasses-idmapper contract.
- Page aggregates ride a class-attribute default (plain attribute access, no `getattr` — keeps the noqa ratchet where it is).

## Tests

New bounded-query test asserts the list query count doesn't grow with covenant count and that the aggregates are correct. It **mocks the bulk legend service** so it runs in the fast SQLite tier — the legend matview (`societies_covenantlegendsummary`) is Postgres-only. The 7 other covenant-view tests that serialize `legend_total` fail **identically on pristine main** (matview absent locally, verified by stash-diff); CI's Postgres tier is their gate. `MODEL_MAP.md` regenerated (clean 1-line addition).

## Note

No conflict with the in-flight audit-2 PRs — none of them touch covenants (S5 reused only societies/goals/magic). CI will queue behind the ongoing GitHub Actions recovery like #2438/#2439.

🤖 Generated with [Claude Code](https://claude.com/claude-code)