### PR TITLE
Paginate list endpoints by default; explicit opt-out (ADR-0138)

### DIFF
--- a/django_notes.md
+++ b/django_notes.md
@@ -113,7 +113,21 @@ class StoryFilter(django_filters.FilterSet):
 
 ### Pagination
 
-**Create custom pagination classes for consistent API responses:**
+**List endpoints are paginated by default (ADR-0138).**
+`REST_FRAMEWORK["DEFAULT_PAGINATION_CLASS"]` is `web.api.pagination.DefaultPagination`
+(PageNumber, `page_size=50`), so a new ViewSet is paginated **without doing
+anything** — you can no longer leak an unbounded list by forgetting
+`pagination_class`. Opt out **explicitly** only when the result set is
+intrinsically small (a lookup table, a per-scene queue, one character's
+sanctums):
+
+```python
+class SpeakerQueueViewSet(viewsets.ReadOnlyModelViewSet):
+    pagination_class = None  # intrinsically small — bare array is fine
+```
+
+**Custom pagination classes** (a different `page_size`, extra metadata) still
+apply per-ViewSet:
 
 ```python
 class StandardResultsSetPagination(PageNumberPagination):

--- a/docs/adr/0138-paginate-list-endpoints-by-default-with-explicit-opt-out.md
+++ b/docs/adr/0138-paginate-list-endpoints-by-default-with-explicit-opt-out.md
@@ -1,0 +1,37 @@
+# Paginate list endpoints by default; opt out explicitly
+
+`REST_FRAMEWORK["DEFAULT_PAGINATION_CLASS"]` is now set to
+`web.api.pagination.DefaultPagination` (PageNumber, `page_size=50`,
+`?page_size=` override capped at 200), so **every list endpoint is paginated
+unless it declares `pagination_class = None`**. Before this, no default was
+set: a ViewSet that forgot `pagination_class` silently shipped an *unbounded*
+bare array — 43 of ~202 viewset classes were in exactly that state, one HTTP
+request from returning every row in the table. Pagination-by-default makes the
+safe posture the *default* posture: a new ViewSet can no longer leak an
+unbounded list by omission, and the ~40 pre-existing bare-array endpoints keep
+their exact current shape via an explicit `= None` that now *documents* the
+choice instead of leaving it to chance.
+
+**Behavior-preserving by construction.** This change flips zero existing
+endpoints: every currently-unpaginated viewset got an explicit `= None`, and
+the generated OpenAPI schema (`src/schema.json`) is byte-identical to before —
+verified by regenerating it and confirming no response shape changed
+array→paginated or paginated→array. So no frontend consumer breaks. Genuinely
+paginating the ~13 can-grow lists that today opt out (media galleries, market
+listings, the ResonanceGrant audit ledger, endorsement ledgers, …) is
+deliberately **out of scope here** — each needs its own frontend-consumer
+rewire and testing, and lands as a focused follow-up PR. This ADR is only about
+the *default* and the opt-out convention.
+
+`DefaultPagination` lives in `web/api/` (the API-infrastructure home, alongside
+the shared exception handler) — **not** reusing `world.stories.pagination
+.StandardResultsSetPagination`, because a project-wide setting must not depend
+on a specific game app.
+
+**Rejected: targeted gap-fill without a global default** — add pagination
+case-by-case only where a list is known to grow. Closes today's gap but leaves
+the trap armed: the *next* viewset authored without `pagination_class` ships
+unbounded again. The whole value here is making omission safe, which only a
+default delivers. **Rejected: `page_size=20`** (the `StandardResultsSetPagination`
+value) — 50 is the modal per-endpoint `page_size` already in the codebase, so it
+minimizes surprise for the endpoints that inherit the default going forward.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -89,6 +89,7 @@ treat those names as hints to confirm, not gospel.
 - [0083 — CI/test databases build schema from model state; migration replay runs nightly only](0083-ci-schema-from-models.md)
 - [0084 — SQLite fast tier restores a cached schema template instead of rebuilding per run](0084-sqlite-test-schema-template-cache.md)
 - [0137 — CI shards balanced by measured runtime; oversized apps split via generated module labels](0137-ci-shards-balanced-by-measured-runtime-with-generated-splits.md) (extends ADR-0083's CI pipeline)
+- [0138 — Paginate list endpoints by default; opt out explicitly](0138-paginate-list-endpoints-by-default-with-explicit-opt-out.md)
 
 ### Game-design tenets
 - [0023 — PvP is structurally non-lethal](0023-pvp-is-structurally-non-lethal.md)

--- a/src/server/conf/settings.py
+++ b/src/server/conf/settings.py
@@ -358,6 +358,10 @@ REST_FRAMEWORK = {
         "rest_framework.authentication.SessionAuthentication",
     ],
     "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+    # Paginate every list endpoint by default (2026-07 audit) — a ViewSet must
+    # explicitly `pagination_class = None` to return a bare array. See ADR-0138
+    # and web/api/pagination.py.
+    "DEFAULT_PAGINATION_CLASS": "web.api.pagination.DefaultPagination",
 }
 
 SPECTACULAR_SETTINGS = {

--- a/src/web/api/pagination.py
+++ b/src/web/api/pagination.py
@@ -1,0 +1,23 @@
+"""Project-wide default pagination.
+
+Wired as ``REST_FRAMEWORK["DEFAULT_PAGINATION_CLASS"]`` so every list endpoint
+is paginated unless it explicitly opts out with ``pagination_class = None``
+(2026-07 audit). Pagination-by-default is the safe posture: a new ViewSet can
+no longer accidentally ship an unbounded list. Endpoints whose result set is
+intrinsically small (a scene's speaker queue, one character's sanctums) opt out
+so their response stays a bare array.
+"""
+
+from rest_framework.pagination import PageNumberPagination
+
+
+class DefaultPagination(PageNumberPagination):
+    """PageNumber pagination with an opt-in ``?page_size=`` override.
+
+    ``page_size=50`` matches the most common per-endpoint convention already in
+    use across the codebase; ``max_page_size`` caps a client asking for more.
+    """
+
+    page_size = 50
+    page_size_query_param = "page_size"
+    max_page_size = 200

--- a/src/world/achievements/views.py
+++ b/src/world/achievements/views.py
@@ -29,6 +29,8 @@ class AchievementViewSet(ReadOnlyModelViewSet):
     have been earned by the requesting user's characters.
     """
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     permission_classes = [IsAuthenticated]
     filter_backends = [DjangoFilterBackend, SearchFilter]
     search_fields = ["name", "description"]
@@ -83,6 +85,8 @@ class CharacterTitleViewSet(ReadOnlyModelViewSet):
     Titles are cosmetic and public — a character shows them off — so any authenticated user can
     read any character's titles. Filter by ``character_sheet`` (== character ObjectDB pk).
     """
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     serializer_class = CharacterTitleSerializer
     permission_classes = [IsAuthenticated]

--- a/src/world/character_creation/views.py
+++ b/src/world/character_creation/views.py
@@ -92,6 +92,8 @@ logger = logging.getLogger(__name__)
 class StartingAreaViewSet(viewsets.ReadOnlyModelViewSet):
     """ViewSet for listing starting areas."""
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     serializer_class = StartingAreaSerializer
     permission_classes = [IsAuthenticated]
 
@@ -107,6 +109,8 @@ class BeginningsViewSet(viewsets.ReadOnlyModelViewSet):
     Filter by starting_area to get options available for a specific starting area.
     Results are filtered by user trust level.
     """
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     serializer_class = BeginningsSerializer
     permission_classes = [IsAuthenticated]
@@ -152,6 +156,8 @@ class SpeciesViewSet(viewsets.ReadOnlyModelViewSet):
     Returns all species with their parent hierarchy.
     """
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     queryset = Species.objects.select_related("parent").prefetch_related(
         Prefetch(
             "stat_bonuses",
@@ -172,6 +178,8 @@ class FamilyViewSet(viewsets.ReadOnlyModelViewSet):
     Filter by area_id to get families available for a starting area's realm.
     """
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     queryset = Family.objects.filter(is_playable=True)
     serializer_class = FamilySerializer
     permission_classes = [IsAuthenticated]
@@ -182,6 +190,8 @@ class FamilyViewSet(viewsets.ReadOnlyModelViewSet):
 class GenderViewSet(viewsets.ReadOnlyModelViewSet):
     """ViewSet for listing gender options."""
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     queryset = Gender.objects.all()
     serializer_class = GenderSerializer
     permission_classes = [IsAuthenticated]
@@ -191,6 +201,8 @@ class GenderViewSet(viewsets.ReadOnlyModelViewSet):
 
 class PronounsViewSet(viewsets.ReadOnlyModelViewSet):
     """ViewSet for listing pronoun sets."""
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     queryset = Pronouns.objects.all()
     serializer_class = PronounsSerializer
@@ -205,6 +217,8 @@ class CGPointBudgetViewSet(viewsets.ReadOnlyModelViewSet):
 
     Returns the active budget configuration for character creation.
     """
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     serializer_class = CGPointBudgetSerializer
     permission_classes = [IsAuthenticated]
@@ -221,6 +235,8 @@ class PathViewSet(viewsets.ReadOnlyModelViewSet):
     Only returns active Prospect-stage paths.
     Uses Prefetch with to_attr to avoid SharedMemoryModel cache pollution.
     """
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     serializer_class = PathSerializer
     permission_classes = [IsAuthenticated]
@@ -259,6 +275,8 @@ class TraditionViewSet(viewsets.ReadOnlyModelViewSet):
     Query params:
         beginning_id: Filter by beginning (required)
     """
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     serializer_class = TraditionSerializer
     permission_classes = [IsAuthenticated]
@@ -502,6 +520,8 @@ class CharacterDraftViewSet(viewsets.ModelViewSet):
     Each user can have at most one draft. The queryset is filtered
     to only return the current user's draft.
     """
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     serializer_class = CharacterDraftSerializer
     permission_classes = [IsAuthenticated]

--- a/src/world/character_sheets/views.py
+++ b/src/world/character_sheets/views.py
@@ -24,6 +24,8 @@ class CharacterSheetViewSet(RetrieveModelMixin, GenericViewSet):
     the original creator or staff.
     """
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     serializer_class = CharacterSheetSerializer
     permission_classes = [IsAuthenticated]
     filter_backends = []

--- a/src/world/conditions/views.py
+++ b/src/world/conditions/views.py
@@ -404,6 +404,8 @@ class ConditionInstanceViewSet(mixins.RetrieveModelMixin, viewsets.GenericViewSe
     so retrieving them yields 404 (queryset-scoped, like the list view).
     """
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     serializer_class = ConditionInstanceSerializer
     permission_classes = [IsAuthenticated]
 

--- a/src/world/distinctions/views.py
+++ b/src/world/distinctions/views.py
@@ -45,6 +45,8 @@ class DistinctionCategoryViewSet(viewsets.ReadOnlyModelViewSet):
     Read-only endpoint for retrieving distinction categories.
     """
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     queryset = DistinctionCategory.objects.all()
     serializer_class = DistinctionCategorySerializer
     permission_classes = [IsAuthenticated]
@@ -62,6 +64,8 @@ class DistinctionViewSet(viewsets.ReadOnlyModelViewSet):
     - exclude_variants: Exclude variant distinctions (show only parents/standalone)
     - draft_id: Add lock status based on draft's existing distinctions
     """
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     permission_classes = [IsAuthenticated]
     filter_backends = [DjangoFilterBackend]

--- a/src/world/forms/views.py
+++ b/src/world/forms/views.py
@@ -38,6 +38,8 @@ from world.roster.selectors import puppeted_sheet_for
 class FormTraitViewSet(viewsets.ReadOnlyModelViewSet):
     """ViewSet for browsing form trait definitions."""
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     queryset = FormTrait.objects.all()
     serializer_class = FormTraitSerializer
     permission_classes = [IsAuthenticated]
@@ -45,6 +47,8 @@ class FormTraitViewSet(viewsets.ReadOnlyModelViewSet):
 
 class CharacterFormViewSet(viewsets.ReadOnlyModelViewSet):
     """ViewSet for viewing a character's forms."""
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     serializer_class = CharacterFormSerializer
     permission_classes = [IsAuthenticated]
@@ -81,6 +85,8 @@ class CharacterFormViewSet(viewsets.ReadOnlyModelViewSet):
 class HeightBandViewSet(viewsets.ReadOnlyModelViewSet):
     """ViewSet for browsing height bands in character creation."""
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     serializer_class = HeightBandSerializer
     permission_classes = [IsAuthenticated]
 
@@ -93,6 +99,8 @@ class HeightBandViewSet(viewsets.ReadOnlyModelViewSet):
 
 class BuildViewSet(viewsets.ReadOnlyModelViewSet):
     """ViewSet for browsing builds in character creation."""
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     serializer_class = BuildSerializer
     permission_classes = [IsAuthenticated]

--- a/src/world/goals/views.py
+++ b/src/world/goals/views.py
@@ -41,6 +41,8 @@ class GoalDomainViewSet(viewsets.ReadOnlyModelViewSet):
     Goal domains are ModifierTarget entries with category='goal'.
     """
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     queryset = get_goal_domains_queryset()
     serializer_class = GoalDomainSerializer
     permission_classes = [IsAuthenticated]

--- a/src/world/items/market/views.py
+++ b/src/world/items/market/views.py
@@ -26,6 +26,8 @@ class MarketSquareFilterSet(django_filters.FilterSet):
 class MarketSquareViewSet(viewsets.ReadOnlyModelViewSet):
     """Browse market squares with their stalls and live listings."""
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     queryset = MarketSquare.objects.prefetch_related(
         "stalls__stock_listings__template",  # noqa: PREFETCH_STRING — no to_attr on SharedMemoryModel (leak)
         "stalls__ware_listings__item_instance",  # noqa: PREFETCH_STRING
@@ -48,6 +50,8 @@ class ServiceOfferFilterSet(django_filters.FilterSet):
 
 class ServiceOfferViewSet(viewsets.ReadOnlyModelViewSet):
     """The shop directory: standing craft-as-service offers (visit to use)."""
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     queryset = (
         CraftingServiceOffer.objects.filter(is_active=True)

--- a/src/world/items/views.py
+++ b/src/world/items/views.py
@@ -1402,6 +1402,8 @@ class FashionJudgementViewSet(
     duplicate judging are rejected with HTTP 400 (friendly message).
     """
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     queryset = FashionPresentation.objects.none()
     serializer_class = FashionJudgementSerializer
     permission_classes = [IsAuthenticated]

--- a/src/world/magic/views.py
+++ b/src/world/magic/views.py
@@ -509,6 +509,8 @@ class CharacterAuraViewSet(viewsets.ModelViewSet):
     to disambiguate when the user has alts.
     """
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     serializer_class = CharacterAuraSerializer
     permission_classes = [IsAuthenticated]
     filter_backends = [DjangoFilterBackend]
@@ -534,6 +536,8 @@ class CharacterResonanceViewSet(viewsets.ModelViewSet):
     picker for rituals) should pass ``?character_sheet=<pk>`` so the
     result is unambiguous when the user has alts.
     """
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     serializer_class = CharacterResonanceSerializer
     permission_classes = [IsAuthenticated]
@@ -565,6 +569,8 @@ class CharacterGiftViewSet(viewsets.ModelViewSet):
     of whether they are actively puppeting them right now. Pass
     ``?character=<pk>`` to narrow to a single character.
     """
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     serializer_class = CharacterGiftSerializer
     permission_classes = [IsAuthenticated]
@@ -611,6 +617,8 @@ class CharacterAnimaViewSet(viewsets.ModelViewSet):
     regardless of whether they are actively puppeting them right now.
     Pass ``?character=<pk>`` to narrow to a single character.
     """
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     serializer_class = CharacterAnimaSerializer
     permission_classes = [IsAuthenticated]
@@ -1170,6 +1178,8 @@ class PoseEndorsementViewSet(
     DELETE /api/magic/pose-endorsements/<pk>/ — retract an unsettled endorsement.
     """
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     queryset = PoseEndorsement.objects.select_related(
         "endorser_sheet",
         "endorsee_sheet",
@@ -1215,6 +1225,8 @@ class SceneEntryEndorsementViewSet(
     GET  /api/magic/scene-entry-endorsements/<pk>/ — retrieve an endorsement.
     """
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     queryset = SceneEntryEndorsement.objects.select_related(
         "endorser_sheet",
         "endorsee_sheet",
@@ -1248,6 +1260,8 @@ class StylePresentationEndorsementViewSet(
     POST /api/magic/style-presentation-endorsements/ — create an endorsement.
     GET  /api/magic/style-presentation-endorsements/<pk>/ — retrieve an endorsement.
     """
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     queryset = StylePresentationEndorsement.objects.select_related(
         "endorser_sheet",
@@ -1283,6 +1297,8 @@ class ResonanceGrantViewSet(
 
     Filter params: source, resonance (PK), granted_after, granted_before.
     """
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     serializer_class = ResonanceGrantSerializer
     permission_classes = [IsAuthenticated]

--- a/src/world/magic/views_sanctum.py
+++ b/src/world/magic/views_sanctum.py
@@ -78,6 +78,8 @@ class SanctumViewSet(PuppetActorMixin, viewsets.ReadOnlyModelViewSet):
     contract is preserved (#1497).
     """
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     serializer_class = SanctumDetailsSerializer
     permission_classes = [IsAuthenticated]
     lookup_field = "feature_instance_id"

--- a/src/world/mechanics/views.py
+++ b/src/world/mechanics/views.py
@@ -73,6 +73,8 @@ class ModifierTargetViewSet(viewsets.ReadOnlyModelViewSet):
 class CharacterModifierViewSet(viewsets.ReadOnlyModelViewSet):
     """List and retrieve character modifiers."""
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     queryset = CharacterModifier.objects.select_related(
         "character",
         "character__character",

--- a/src/world/progression/views.py
+++ b/src/world/progression/views.py
@@ -238,6 +238,8 @@ class VoteViewSet(
     GET /votes/budget/ — Return current vote budget
     """
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     serializer_class = WeeklyVoteSerializer
     permission_classes = [IsAuthenticated]
 
@@ -318,6 +320,8 @@ class RandomSceneViewSet(mixins.ListModelMixin, viewsets.GenericViewSet):
     POST /random-scenes/<id>/claim/ — Claim a target
     POST /random-scenes/<id>/reroll/ — Reroll a target
     """
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     serializer_class = RandomSceneTargetSerializer
     permission_classes = [IsAuthenticated]

--- a/src/world/roster/views/family_views.py
+++ b/src/world/roster/views/family_views.py
@@ -41,6 +41,8 @@ def _viewer_entry(request: Request) -> object:
 class FamilyViewSet(viewsets.ReadOnlyModelViewSet):
     """Families list/detail + the viewer-aware tree and CG slot browser."""
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     queryset = Family.objects.filter(is_playable=True).order_by("family_type", "name")
     serializer_class = FamilySerializer
     permission_classes = [IsAuthenticated]

--- a/src/world/roster/views/media_views.py
+++ b/src/world/roster/views/media_views.py
@@ -24,6 +24,8 @@ from world.roster.services import CloudinaryGalleryService
 class PlayerMediaViewSet(viewsets.ModelViewSet):
     """API viewset for managing player media."""
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     serializer_class = PlayerMediaSerializer
     permission_classes = [ReadOnlyOrOwner]
 
@@ -118,6 +120,8 @@ class PlayerMediaViewSet(viewsets.ModelViewSet):
 
 class TenureGalleryViewSet(viewsets.ModelViewSet):
     """API viewset for managing tenure galleries."""
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     serializer_class = TenureGallerySerializer
     permission_classes = [ReadOnlyOrOwner]

--- a/src/world/roster/views/roster_views.py
+++ b/src/world/roster/views/roster_views.py
@@ -13,6 +13,8 @@ from world.roster.serializers import RosterListSerializer
 class RosterViewSet(viewsets.ReadOnlyModelViewSet):
     """API viewset for listing rosters."""
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     queryset = Roster.objects.filter(is_active=True).order_by("sort_order", "name")
     serializer_class = RosterListSerializer
     permission_classes = [AllowAny]

--- a/src/world/scenes/reaction_views.py
+++ b/src/world/scenes/reaction_views.py
@@ -44,6 +44,8 @@ class ReactionWindowViewSet(viewsets.GenericViewSet):
     reaction — kudos-style kinds need no pre-existing window row.
     """
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     queryset = ReactionWindow.objects.all()
     serializer_class = WindowReactInputSerializer
     permission_classes = [IsAuthenticated]

--- a/src/world/scenes/speaker_queue_views.py
+++ b/src/world/scenes/speaker_queue_views.py
@@ -62,6 +62,8 @@ class SpeakerQueueSerializer(serializers.ModelSerializer):
 class SpeakerQueueViewSet(viewsets.ReadOnlyModelViewSet):
     """Read-only ViewSet with action endpoints for speaker queue mutations."""
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     serializer_class = SpeakerQueueSerializer
     permission_classes = [IsAuthenticated]
     filter_backends = [DjangoFilterBackend]

--- a/src/world/travel/views.py
+++ b/src/world/travel/views.py
@@ -17,6 +17,8 @@ from world.travel.serializers import (
 class TravelHubViewSet(viewsets.ReadOnlyModelViewSet):
     """List active travel hubs — public infrastructure (no per-char filtering)."""
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     serializer_class = TravelHubSerializer
     permission_classes = [IsAuthenticated]
     queryset = TravelHub.objects.filter(is_active=True)
@@ -25,6 +27,8 @@ class TravelHubViewSet(viewsets.ReadOnlyModelViewSet):
 class TravelMethodViewSet(viewsets.ReadOnlyModelViewSet):
     """List all travel methods."""
 
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
+
     serializer_class = TravelMethodSerializer
     permission_classes = [IsAuthenticated]
     queryset = TravelMethod.objects.all()
@@ -32,6 +36,8 @@ class TravelMethodViewSet(viewsets.ReadOnlyModelViewSet):
 
 class VoyageViewSet(viewsets.ReadOnlyModelViewSet):
     """List voyages the requesting user's personas participate in."""
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     serializer_class = VoyageSerializer
     permission_classes = [IsAuthenticated]
@@ -57,6 +63,8 @@ class VoyageViewSet(viewsets.ReadOnlyModelViewSet):
 
 class VoyageInviteViewSet(viewsets.ReadOnlyModelViewSet):
     """List PENDING voyage invites targeting the requesting user's personas."""
+
+    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
 
     serializer_class = VoyageInviteSerializer
     permission_classes = [IsAuthenticated]


### PR DESCRIPTION
## What

The `DEFAULT_PAGINATION_CLASS` audit item — done as the **safe core** of the split you chose: set the global default + preserve every existing endpoint's behavior with an explicit opt-out. Genuinely paginating the can-grow lists is deferred to focused follow-ups (see below).

Before this, DRF had **no default pagination**, so 43 of ~202 viewset classes set no `pagination_class` and silently returned **unbounded bare arrays** — one request from returning every row in the table. Now `REST_FRAMEWORK["DEFAULT_PAGINATION_CLASS"]` = new `web.api.pagination.DefaultPagination` (PageNumber, `page_size=50`, `?page_size=` capped at 200), so a new ViewSet **can't leak an unbounded list by omission**.

## Behavior-preserving by construction

Every currently-unpaginated viewset got an explicit `pagination_class = None`, so **`src/schema.json` is byte-identical to before** — I verified by regenerating the schema and confirming **zero** endpoints flipped array↔paginated (`added: 0, removed: 0`). No frontend consumer changes, nothing breaks. The 4 `player_submissions` viewsets that inherit pagination from `_SubmissionViewSetMixin` were correctly left untouched (the zero-diff check caught my first pass over-opting-them-out).

## Deliberately out of scope (follow-ups)

Actually paginating the ~13 lists that *can* grow but opt out today — media galleries (`PlayerMedia`/`TenureGallery`), `MarketSquare`/`ServiceOffer`, the `ResonanceGrant` audit ledger, the endorsement ledgers, `Distinction`, fashion judgements, voyages, votes — each needs its own frontend-consumer rewire (`.results` + a page control) and testing, so each lands as a focused follow-up PR.

## Docs

ADR-0138 + README index + `django_notes.md` pagination standard (the opt-out convention). `DefaultPagination` lives in `web/api/` (API infra), not the story-app `StandardResultsSetPagination`, so a project-wide setting doesn't depend on a game app.

## Tests

No new failures — the pre-existing local matview/codex-seed errors (travel, distinctions, character_creation `setUpClass`) reproduce identically on pristine main (stash-verified); CI's Postgres tier is their gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)