### PR TITLE
Audit admin FK widgets: default <select> will crash on large in-game tables

### DIFF
--- a/src/evennia_extensions/admin.py
+++ b/src/evennia_extensions/admin.py
@@ -25,6 +25,7 @@ logger = logging.getLogger(__name__)
 
 @admin.register(PlayerData)
 class PlayerDataAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["account"]
     list_display: ClassVar[list[str]] = [
         "account",
         "display_name",
@@ -58,6 +59,7 @@ class PlayerDataAdmin(admin.ModelAdmin):
 
 @admin.register(PlayerAllowList)
 class PlayerAllowListAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["allowed_player", "owner"]
     list_display: ClassVar[list[str]] = [
         "owner",
         "allowed_player",
@@ -74,6 +76,7 @@ class PlayerAllowListAdmin(admin.ModelAdmin):
 
 @admin.register(PlayerMedia)
 class PlayerMediaAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["player_data"]
     list_display: ClassVar[list[str]] = [
         "player_data",
         "media_type",
@@ -88,6 +91,7 @@ class PlayerMediaAdmin(admin.ModelAdmin):
 
 @admin.register(ObjectDisplayData)
 class ObjectDisplayDataAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["object"]
     list_display: ClassVar[list[str]] = [
         "object",
         "longname",
@@ -106,6 +110,7 @@ class ObjectDisplayDataAdmin(admin.ModelAdmin):
 
 @admin.register(Artist)
 class ArtistAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["player_data"]
     list_display: ClassVar[list[str]] = ["name", "player_data", "accepting_commissions"]
     list_filter: ClassVar[list[str]] = ["accepting_commissions"]
     search_fields: ClassVar[list[str]] = ["name", "player_data__account__username"]
@@ -119,6 +124,7 @@ with contextlib.suppress(admin.sites.NotRegistered):
 
 @admin.register(EmailAddress)
 class EmailAddressAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["user"]
     list_display = [
         "email",
         "user",
@@ -238,7 +244,7 @@ class RoomProfileAdmin(admin.ModelAdmin):
     list_display: ClassVar[list[str]] = ["objectdb", "area", "size", "is_outdoor", "is_public"]
     list_filter: ClassVar[list[str]] = ["area__level", "is_outdoor", "is_public", "size"]
     search_fields: ClassVar[list[str]] = ["objectdb__db_key"]
-    autocomplete_fields: ClassVar[list[str]] = ["area"]
+    autocomplete_fields: ClassVar[list[str]] = ["area", "objectdb"]
 
 
 @admin.register(RoomSizeTier)

--- a/src/web/admin/apps.py
+++ b/src/web/admin/apps.py
@@ -10,3 +10,57 @@ class AdminConfig(AppConfig):
     name = "web.admin"
     label = "web_admin"  # Avoid conflict with django.contrib.admin
     verbose_name = "Admin Customizations"
+
+    def ready(self):
+        """Import checks module and patch Evennia/Django admin classes.
+
+        Evennia and Django built-in admin classes (ObjectAdmin, AccountAdmin,
+        ScriptAdmin, TagAdmin, GroupAdmin) live in site-packages and can't be
+        edited directly. We monkey-patch ``autocomplete_fields`` onto them
+        for FKs to large tables, so the system check passes and the admin
+        pages render efficiently.
+        """
+        # Lazy imports are required in ready() to avoid circular import issues.
+        from web.admin import checks  # noqa: F401, PLC0415
+
+        _patch_external_admins()
+
+
+def _patch_external_admins():
+    """Add autocomplete_fields to Evennia/Django built-in admin classes.
+
+    These classes live in site-packages and can't be edited directly. The
+    fields listed below all point to large-table models (ObjectDB, AccountDB,
+    ScriptDB, CharacterSheet, PlayerData, Scene, ItemInstance) that would
+    crash the browser with a default ``<select>`` widget.
+
+    Reverse relations (OneToOneRel, ManyToManyRel) can't use
+    ``autocomplete_fields`` or ``raw_id_fields`` — those are exempted via
+    ``large_table_widget_exempt`` so the system check passes without error.
+    """
+    # Lazy imports are required here because these admin classes import models
+    # that may not be fully loaded at AppConfig.ready() time.
+    from django.contrib.auth.admin import GroupAdmin  # noqa: PLC0415
+    from evennia.web.admin.accounts import AccountAdmin  # noqa: PLC0415
+    from evennia.web.admin.objects import ObjectAdmin  # noqa: PLC0415
+    from evennia.web.admin.scripts import ScriptAdmin  # noqa: PLC0415
+    from evennia.web.admin.tags import TagAdmin  # noqa: PLC0415
+
+    # Evennia's ObjectDB admin
+    # item_instance and sheet_data are reverse OneToOneRel — can't use autocomplete
+    ObjectAdmin.autocomplete_fields = ()
+    ObjectAdmin.large_table_widget_exempt = ["item_instance", "sheet_data"]
+
+    # Evennia's AccountDB admin
+    # participated_scenes is a reverse ManyToManyRel; player_data is reverse OneToOneRel
+    AccountAdmin.autocomplete_fields = ()
+    AccountAdmin.large_table_widget_exempt = ["participated_scenes", "player_data"]
+
+    # Evennia's ScriptDB admin
+    ScriptAdmin.autocomplete_fields = ("db_account",)
+
+    # Evennia's Tag admin
+    TagAdmin.autocomplete_fields = ("accountdb", "objectdb", "scriptdb")
+
+    # Django's built-in Group admin — Group.user points to User (AccountDB)
+    GroupAdmin.autocomplete_fields = ("user",)

--- a/src/web/admin/checks.py
+++ b/src/web/admin/checks.py
@@ -1,0 +1,141 @@
+"""Django system check: flag FK/M2M fields to large tables without autocomplete/raw_id.
+
+Prevents the failure mode where a default ``<select>`` widget renders every row
+of a large table (ObjectDB, AccountDB, CharacterSheet, etc.) as an ``<option>``,
+crashing or hanging the browser on admin pages with thousands of rows.
+
+See issue #2435 for the full audit and design.
+"""
+
+from django.apps import apps
+from django.contrib import admin
+from django.core.checks import Error, register
+
+# Evennia base models — always large in production. Stored as string labels
+# so the check resolves them lazily (avoiding import-order issues).
+EVENNIA_LARGE_TABLE_LABELS = {
+    "objects.ObjectDB",
+    "accounts.AccountDB",
+    "scripts.ScriptDB",
+}
+
+# Arx-specific large tables. Staff add models here as the game grows.
+# Grouped by domain for readability.
+LARGE_TABLE_MODELS = {
+    # Character identity
+    "character_sheets.CharacterSheet",
+    # Scenes / roleplay
+    "scenes.Scene",
+    "scenes.Persona",
+    "scenes.Interaction",
+    "scenes.Place",
+    # Roster
+    "roster.RosterEntry",
+    "roster.RosterTenure",
+    "evennia_extensions.PlayerData",
+    # Items
+    "items.ItemInstance",
+    # Magic (per-character links)
+    "magic.CharacterGift",
+    "magic.CharacterTechnique",
+    "magic.CharacterTradition",
+}
+
+
+def _get_protected_fields(admin_cls):
+    """Get the set of field names protected by autocomplete_fields or raw_id_fields.
+
+    Args:
+        admin_cls: A ModelAdmin instance.
+
+    Returns:
+        A set of field name strings that are already protected.
+    """
+    protected: set[str] = set()
+    if hasattr(admin_cls, "autocomplete_fields"):
+        protected.update(admin_cls.autocomplete_fields)
+    if hasattr(admin_cls, "raw_id_fields"):
+        protected.update(admin_cls.raw_id_fields)
+    return protected
+
+
+def _get_exempt_fields(admin_cls):
+    """Get the set of field names exempted from the check.
+
+    Args:
+        admin_cls: A ModelAdmin instance.
+
+    Returns:
+        A set of field name strings that are exempted.
+    """
+    if hasattr(admin_cls, "large_table_widget_exempt"):
+        return set(admin_cls.large_table_widget_exempt)
+    return set()
+
+
+def _is_large_table(model):
+    """Check if a model is a large table that should not use a default ``<select>``.
+
+    Args:
+        model: A Django model class.
+
+    Returns:
+        True if the model is an Evennia base model (or subclass thereof) or
+        is listed in ``LARGE_TABLE_MODELS``.
+    """
+    meta = model._meta  # noqa: SLF001
+    label = f"{meta.app_label}.{model.__name__}"
+
+    # Evennia base models: use issubclass() to catch typeclass subclasses
+    # (e.g., Room, Character, Exit all inherit from ObjectDB). FKs declared
+    # against base ObjectDB return ObjectDB as related_model; FKs declared
+    # against a typeclass return the typeclass. issubclass catches both.
+    for evennia_label in EVENNIA_LARGE_TABLE_LABELS:
+        parts = evennia_label.split(".")
+        try:
+            evennia_cls = apps.get_model(parts[0], parts[1])
+        except LookupError:
+            continue
+        if evennia_cls and issubclass(model, evennia_cls):
+            return True
+
+    return label in LARGE_TABLE_MODELS
+
+
+@register()
+def check_admin_fk_widgets(app_configs, **kwargs):  # noqa: ARG001
+    """Flag FK/M2M fields to large tables without autocomplete_fields or raw_id_fields.
+
+    Iterates every registered ModelAdmin and checks whether any FK, OneToOne,
+    or M2M field points to a large-table model without being listed in
+    ``autocomplete_fields`` or ``raw_id_fields``. Emits ``web_admin.W001``
+    errors for each violation.
+
+    A ModelAdmin can exempt a specific field by listing it in
+    ``large_table_widget_exempt`` (with a code comment explaining why).
+    """
+    errors = []
+    for model, admin_cls in admin.site._registry.items():  # noqa: SLF001
+        exempt = _get_exempt_fields(admin_cls)
+        protected = _get_protected_fields(admin_cls)
+        for field in model._meta.get_fields():  # noqa: SLF001
+            if not field.is_relation or field.name in exempt or field.name in protected:
+                continue
+            if field.many_to_one or field.one_to_one or field.many_to_many:
+                target = field.related_model
+                if target and _is_large_table(target):
+                    errors.append(
+                        Error(
+                            f"{type(admin_cls).__name__}.{field.name} is a FK/M2M to "
+                            f"large table {target.__name__} but is not in "
+                            f"autocomplete_fields or raw_id_fields.",
+                            hint=(
+                                "Add the field to autocomplete_fields (preferred) "
+                                "or raw_id_fields. If a default <select> is "
+                                "intentional, add the field name to "
+                                "large_table_widget_exempt with a comment."
+                            ),
+                            id="web_admin.W001",
+                        )
+                    )
+    return errors

--- a/src/web/admin/tests/test_admin_checks.py
+++ b/src/web/admin/tests/test_admin_checks.py
@@ -1,0 +1,110 @@
+"""Tests for the admin FK widget system check (#2435)."""
+
+from django.contrib import admin
+from django.test import TestCase
+
+from web.admin.checks import (
+    _is_large_table,
+    check_admin_fk_widgets,
+)
+
+
+class IsLargeTableTest(TestCase):
+    """Test the _is_large_table predicate."""
+
+    def test_objectdb_is_large_table(self):
+        """ObjectDB is auto-detected as a large table via issubclass."""
+        from evennia.objects.models import ObjectDB
+
+        self.assertTrue(_is_large_table(ObjectDB))
+
+    def test_accountdb_is_large_table(self):
+        """AccountDB is auto-detected as a large table via issubclass."""
+        from evennia.accounts.models import AccountDB
+
+        self.assertTrue(_is_large_table(AccountDB))
+
+    def test_scriptdb_is_large_table(self):
+        """ScriptDB is auto-detected as a large table via issubclass."""
+        from evennia.scripts.models import ScriptDB
+
+        self.assertTrue(_is_large_table(ScriptDB))
+
+    def test_character_sheet_is_large_table(self):
+        """CharacterSheet is in the explicit registry."""
+        from world.character_sheets.models import CharacterSheet
+
+        self.assertTrue(_is_large_table(CharacterSheet))
+
+    def test_persona_is_large_table(self):
+        """Persona is in the explicit registry."""
+        from world.scenes.models import Persona
+
+        self.assertTrue(_is_large_table(Persona))
+
+    def test_roster_entry_is_large_table(self):
+        """RosterEntry is in the explicit registry."""
+        from world.roster.models import RosterEntry
+
+        self.assertTrue(_is_large_table(RosterEntry))
+
+    def test_small_lookup_table_is_not_large(self):
+        """A small lookup table (e.g., Gender) is not flagged."""
+        from world.character_sheets.models import Gender
+
+        self.assertFalse(_is_large_table(Gender))
+
+    def test_objectdb_subclass_is_large_table(self):
+        """A typeclass subclass of ObjectDB is caught via issubclass."""
+        from evennia.objects.models import ObjectDB
+
+        from typeclasses.rooms import Room
+
+        self.assertTrue(_is_large_table(Room))
+        self.assertTrue(issubclass(Room, ObjectDB))
+
+
+class CheckAdminFkWidgetsTest(TestCase):
+    """Test the system check against registered ModelAdmins."""
+
+    def test_check_runs_without_crashing(self):
+        """The check should run against all registered admins and return a list."""
+        errors = check_admin_fk_widgets(None)
+        self.assertIsInstance(errors, list)
+
+    def test_check_returns_errors_with_correct_id(self):
+        """Any errors returned should use the web_admin.W001 check id."""
+        errors = check_admin_fk_widgets(None)
+        for error in errors:
+            self.assertEqual(error.id, "web_admin.W001")
+
+    def test_exempt_field_suppresses_error(self):
+        """A field listed in large_table_widget_exempt should not appear in errors."""
+
+        class FakeAdmin:
+            """Minimal stand-in to test the exempt logic."""
+
+            autocomplete_fields = []
+            raw_id_fields = []
+            large_table_widget_exempt = ["test_field"]
+            __name__ = "FakeAdmin"
+
+        # Register a dummy model + admin, check, then unregister
+        # We can't easily register a dummy model, so instead verify the logic
+        # by checking that the exempt set is respected in the filter.
+        # This is tested implicitly: if any real admin uses large_table_widget_exempt,
+        # those fields won't appear in the error list.
+        errors = check_admin_fk_widgets(None)
+        exempt_fields: set[str] = set()
+        for admin_cls in admin.site._registry.values():
+            if hasattr(admin_cls, "large_table_widget_exempt"):
+                exempt_fields.update(admin_cls.large_table_widget_exempt)
+        for error in errors:
+            # The error message contains "field_name but is not in"
+            # Check that no exempt field appears in any error message
+            for exempt_field in exempt_fields:
+                self.assertNotIn(
+                    f".{exempt_field} ",
+                    str(error),
+                    f"Exempt field '{exempt_field}' appeared in error: {error}",
+                )

--- a/src/world/agriculture/admin.py
+++ b/src/world/agriculture/admin.py
@@ -52,6 +52,7 @@ class FoodConfigAdmin(admin.ModelAdmin):
 
 @admin.register(FoodTransfer)
 class FoodTransferAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["acting_persona"]
     list_display = ["source_domain", "target_domain", "amount", "acting_persona", "created_at"]
     readonly_fields = ["created_at"]
     search_fields = ["source_domain__name", "target_domain__name"]

--- a/src/world/battles/admin.py
+++ b/src/world/battles/admin.py
@@ -40,6 +40,7 @@ from world.battles.models import (
 
 @admin.register(Battle)
 class BattleAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["scene"]
     list_display = ("name", "outcome", "round_limit", "risk_level", "created_at")
     list_filter = ("outcome", "risk_level")
     search_fields = ("name",)
@@ -85,6 +86,7 @@ class BattleRoundAdmin(admin.ModelAdmin):
 
 @admin.register(BattleParticipant)
 class BattleParticipantAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character_sheet"]
     list_display = ("battle", "character_sheet", "side", "place", "status")
     list_filter = ("status",)
 

--- a/src/world/boundaries/admin.py
+++ b/src/world/boundaries/admin.py
@@ -19,6 +19,8 @@ class ContentThemeAdmin(admin.ModelAdmin):
 class PlayerBoundaryAdmin(admin.ModelAdmin):
     """Admin interface for PlayerBoundary."""
 
+    autocomplete_fields = ["excluded_tenures", "visible_to_tenures"]
+
     list_display = ["owner", "kind", "theme", "visibility_mode", "created_at"]
     list_filter = ["kind", "visibility_mode", "theme"]
     search_fields = ["owner__account__username"]
@@ -28,6 +30,8 @@ class PlayerBoundaryAdmin(admin.ModelAdmin):
 @admin.register(TreasuredSubject)
 class TreasuredSubjectAdmin(admin.ModelAdmin):
     """Admin interface for TreasuredSubject."""
+
+    autocomplete_fields = ["excluded_tenures", "visible_to_tenures"]
 
     list_display = ["owner", "subject_kind", "subject_label", "created_at"]
     list_filter = ["subject_kind"]

--- a/src/world/captivity/admin.py
+++ b/src/world/captivity/admin.py
@@ -7,6 +7,7 @@ from world.captivity.models import Captivity
 
 @admin.register(Captivity)
 class CaptivityAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["holding_room", "return_location"]
     list_display = (
         "captive",
         "status",

--- a/src/world/character_creation/admin.py
+++ b/src/world/character_creation/admin.py
@@ -18,6 +18,7 @@ from world.codex.models import BeginningsCodexGrant
 
 @admin.register(StartingArea)
 class StartingAreaAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["default_starting_room"]
     list_display = [
         "name",
         "realm",
@@ -61,6 +62,8 @@ class BeginningTraditionInline(admin.TabularInline):
 @admin.register(Beginnings)
 class BeginningsAdmin(admin.ModelAdmin):
     """Admin for Beginnings - worldbuilding paths in character creation."""
+
+    autocomplete_fields = ["starting_room_override"]
 
     list_display = [
         "name",
@@ -122,6 +125,7 @@ class BeginningsAdmin(admin.ModelAdmin):
 
 @admin.register(CharacterDraft)
 class CharacterDraftAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["account"]
     list_display = [
         "__str__",
         "account",
@@ -187,6 +191,7 @@ class DraftApplicationCommentInline(admin.TabularInline):
 
 @admin.register(DraftApplication)
 class DraftApplicationAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["player_account", "reviewer"]
     list_display = ["__str__", "status", "submitted_at", "reviewer", "reviewed_at", "expires_at"]
     list_filter = ["status"]
     search_fields = ["draft__account__username", "draft__draft_data"]

--- a/src/world/character_sheets/admin.py
+++ b/src/world/character_sheets/admin.py
@@ -12,6 +12,9 @@ from world.character_sheets.models import (
 class ProfileAdmin(admin.ModelAdmin):
     """Admin for the narrative bio Profile (#1270)."""
 
+    # owning_sheet is a reverse OneToOneRel — can't use autocomplete_fields/raw_id_fields
+    large_table_widget_exempt = ["owning_sheet"]
+
     list_display = ["__str__", "concept"]
     search_fields = ["concept", "real_concept"]
     raw_id_fields = ("heritage", "origin_realm", "family", "tarot_card")
@@ -51,6 +54,9 @@ class PronounsAdmin(admin.ModelAdmin):
 
 @admin.register(CharacterSheet)
 class CharacterSheetAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["active_persona", "character", "created_by"]
+    # roster_entry is a reverse OneToOneRel — can't use autocomplete_fields/raw_id_fields
+    large_table_widget_exempt = ["roster_entry"]
     list_display = [
         "character",
         "age",

--- a/src/world/clues/admin.py
+++ b/src/world/clues/admin.py
@@ -13,6 +13,8 @@ from world.clues.models import (
 class ClueAdmin(admin.ModelAdmin):
     """Authoring surface for clues — add/remove/rename freely (data, not code)."""
 
+    autocomplete_fields = ["target_persona", "target_persona_linked"]
+
     list_display = ["name", "target_kind", "get_active_target_name", "resolution_mode"]
     list_filter = ["target_kind", "resolution_mode"]
     search_fields = ["name", "description"]
@@ -25,6 +27,8 @@ class ClueAdmin(admin.ModelAdmin):
 @admin.register(CharacterClue)
 class CharacterClueAdmin(admin.ModelAdmin):
     """Read-only debugging view of who holds which clues."""
+
+    autocomplete_fields = ["roster_entry"]
 
     list_display = ["roster_entry", "clue", "found_at"]
     list_filter = ["clue__target_kind"]

--- a/src/world/codex/admin.py
+++ b/src/world/codex/admin.py
@@ -150,6 +150,8 @@ class CharacterCodexKnowledgeAdmin(admin.ModelAdmin):
 class CodexTeachingOfferAdmin(admin.ModelAdmin):
     """Admin interface for CodexTeachingOffer."""
 
+    autocomplete_fields = ["excluded_tenures", "visible_to_tenures"]
+
     list_display = ["teacher", "entry", "banked_ap", "gold_cost", "visibility_mode"]
     list_filter = ["visibility_mode", "entry__subject__category"]
     search_fields = ["teacher__roster_entry__character__db_key", "entry__name", "pitch"]

--- a/src/world/combat/admin.py
+++ b/src/world/combat/admin.py
@@ -51,6 +51,7 @@ class CombatParticipantInline(admin.TabularInline):
 
 @admin.register(CombatEncounter)
 class CombatEncounterAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["duel_winner", "room", "scene"]
     list_display = [
         "id",
         "encounter_type",
@@ -78,6 +79,7 @@ class BossPhaseInline(admin.TabularInline):
 
 @admin.register(CombatOpponent)
 class CombatOpponentAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["objectdb", "persona", "summoned_by"]
     list_display = [
         "name",
         "persona",
@@ -93,6 +95,7 @@ class CombatOpponentAdmin(admin.ModelAdmin):
 
 @admin.register(CombatParticipant)
 class CombatParticipantAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character_sheet"]
     list_display = ["character_sheet", "encounter", "covenant_role"]
 
 
@@ -143,6 +146,7 @@ class BossPhaseAdmin(admin.ModelAdmin):
 
 @admin.register(CombatRoundAction)
 class CombatRoundActionAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["fury_anchor", "interaction", "item_instance", "redirect_object_target"]
     list_display = [
         "participant",
         "round_number",
@@ -190,6 +194,7 @@ class ComboSlotAdmin(admin.ModelAdmin):
 
 @admin.register(ComboLearning)
 class ComboLearningAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character_sheet"]
     list_display = ["character_sheet", "combo", "learned_via", "learned_at", "use_count"]
     list_filter = ["learned_via"]
 
@@ -333,6 +338,7 @@ class ClashRoundAdmin(admin.ModelAdmin):
 
 @admin.register(StrainConfig)
 class StrainConfigAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["updated_by"]
     list_display = [
         "pk",
         "conversion_base",
@@ -344,6 +350,7 @@ class StrainConfigAdmin(admin.ModelAdmin):
 
 @admin.register(ClashConfig)
 class ClashConfigAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["updated_by"]
     list_display = [
         "pk",
         "affinity_tilt_coefficient",
@@ -429,6 +436,7 @@ class StakesLevelRequirementAdmin(admin.ModelAdmin):
 
 @admin.register(EncounterScalingConfig)
 class EncounterScalingConfigAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["updated_by"]
     list_display = [
         "pk",
         "baseline_party_size",

--- a/src/world/companions/admin.py
+++ b/src/world/companions/admin.py
@@ -38,7 +38,7 @@ class CompanionAdmin(admin.ModelAdmin):
     list_display = ["name", "archetype", "owner", "bonded_at", "released_at"]
     list_filter = ["archetype__domain"]
     search_fields = ["name"]
-    autocomplete_fields = ["owner", "archetype", "granting_gift"]
+    autocomplete_fields = ["archetype", "granting_gift", "objectdb", "owner", "ridden_by"]
 
 
 @admin.register(CompanionDeployment)

--- a/src/world/conditions/admin.py
+++ b/src/world/conditions/admin.py
@@ -267,11 +267,12 @@ class ConditionInstanceAdmin(admin.ModelAdmin):
         "source_description",
     ]
     autocomplete_fields = [
-        "target",
         "condition",
         "current_stage",
+        "detected_by",
         "source_character",
         "source_technique",
+        "target",
     ]
     readonly_fields = ["applied_at"]
 

--- a/src/world/covenants/admin.py
+++ b/src/world/covenants/admin.py
@@ -22,6 +22,7 @@ class CovenantRoleAdmin(admin.ModelAdmin):
 
 @admin.register(Covenant)
 class CovenantAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["leader"]
     list_display = ("name", "covenant_type", "level", "formed_at", "dissolved_at")
     list_filter = ("covenant_type",)
     search_fields = ("name",)

--- a/src/world/distinctions/admin.py
+++ b/src/world/distinctions/admin.py
@@ -156,7 +156,7 @@ class CharacterDistinctionAdmin(admin.ModelAdmin):
     list_filter = ["origin", "is_temporary", "distinction__category"]
     list_select_related = ["character", "distinction", "distinction__category"]
     search_fields = ["character__db_key", "distinction__name"]
-    autocomplete_fields = ["distinction"]
+    autocomplete_fields = ["character", "distinction"]
     readonly_fields = ["created_at", "updated_at"]
 
 
@@ -171,7 +171,7 @@ class CharacterDistinctionOtherAdmin(admin.ModelAdmin):
     ]
     list_filter = ["status", "parent_distinction"]
     search_fields = ["character__db_key", "freeform_text"]
-    autocomplete_fields = ["parent_distinction", "staff_mapped_distinction"]
+    autocomplete_fields = ["character", "parent_distinction", "staff_mapped_distinction"]
     readonly_fields = ["created_at"]
     actions = ["mark_approved"]
 

--- a/src/world/dreams/admin.py
+++ b/src/world/dreams/admin.py
@@ -7,6 +7,7 @@ from world.dreams.models import DreamReflection
 
 @admin.register(DreamReflection)
 class DreamReflectionAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["descent_target", "dream_room", "waking_room"]
     list_display = ("waking_room", "dream_room", "descent_target", "is_active")
     list_filter = ("is_active",)
     search_fields = ("waking_room__db_key", "dream_room__db_key")

--- a/src/world/fatigue/admin.py
+++ b/src/world/fatigue/admin.py
@@ -5,6 +5,7 @@ from world.fatigue.models import FatiguePool
 
 @admin.register(FatiguePool)
 class FatiguePoolAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character_sheet"]
     list_display = [
         "character_sheet",
         "physical_current",

--- a/src/world/forms/admin.py
+++ b/src/world/forms/admin.py
@@ -165,6 +165,7 @@ class CharacterFormValueInline(admin.TabularInline):
 
 @admin.register(CharacterForm)
 class CharacterFormAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character"]
     list_display = ["character", "name", "form_type", "is_player_created", "created_at"]
     list_filter = ["form_type", "is_player_created"]
     search_fields = ["character__db_key", "name"]
@@ -173,6 +174,7 @@ class CharacterFormAdmin(admin.ModelAdmin):
 
 @admin.register(CharacterFormState)
 class CharacterFormStateAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["applied_kit_instance", "character"]
     list_display = ["character", "active_form"]
     search_fields = ["character__db_key"]
 
@@ -226,6 +228,7 @@ class ActiveAlternateSelfAdmin(admin.ModelAdmin):
 
 @admin.register(TemporaryFormChange)
 class TemporaryFormChangeAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character"]
     list_display = [
         "character",
         "trait",

--- a/src/world/game_clock/admin.py
+++ b/src/world/game_clock/admin.py
@@ -25,6 +25,8 @@ class GameClockAdmin(admin.ModelAdmin):
 class GameClockHistoryAdmin(admin.ModelAdmin):
     """Admin for clock change audit log."""
 
+    autocomplete_fields = ["changed_by"]
+
     list_display = [
         "changed_at",
         "changed_by",

--- a/src/world/instances/admin.py
+++ b/src/world/instances/admin.py
@@ -5,6 +5,7 @@ from world.instances.models import InstancedRoom
 
 @admin.register(InstancedRoom)
 class InstancedRoomAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["owner", "return_location", "room"]
     list_display = ["room", "owner", "status", "source_key", "created_at"]
     list_filter = ["status"]
     search_fields = ["room__db_key", "source_key"]

--- a/src/world/items/admin.py
+++ b/src/world/items/admin.py
@@ -173,6 +173,12 @@ class ItemStyleInline(admin.TabularInline):
 
 @admin.register(ItemInstance)
 class ItemInstanceAdmin(admin.ModelAdmin):
+    autocomplete_fields = [
+        "attuned_to_character_sheet",
+        "contained_in",
+        "designer_character_sheet",
+        "designer_persona_display",
+    ]
     list_display = [
         "display_name",
         "template",

--- a/src/world/journals/admin.py
+++ b/src/world/journals/admin.py
@@ -22,6 +22,7 @@ class JournalEntryAdmin(admin.ModelAdmin):
 
 @admin.register(WeeklyJournalXP)
 class WeeklyJournalXPAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character_sheet"]
     list_display = [
         "character_sheet",
         "posts_this_week",

--- a/src/world/magic/admin.py
+++ b/src/world/magic/admin.py
@@ -212,7 +212,7 @@ class TechniqueAdmin(admin.ModelAdmin):
     filter_horizontal = ["restrictions", "target_prerequisites"]
     search_fields = ["name", "description"]
     readonly_fields = ["get_tier"]
-    autocomplete_fields = ["gift", "style", "effect_type"]
+    autocomplete_fields = ["creator", "effect_type", "gift", "style"]
     list_select_related = ["gift", "style", "effect_type"]
     inlines = [TechniqueCapabilityGrantInline, TechniqueRemovedConditionInline]
 
@@ -223,6 +223,7 @@ class TechniqueAdmin(admin.ModelAdmin):
 
 @admin.register(CharacterAura)
 class CharacterAuraAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character"]
     list_display = ["character", "celestial", "primal", "abyssal", "get_dominant"]
     list_filter = ["updated_at"]
     search_fields = ["character__db_key"]
@@ -263,7 +264,7 @@ class CharacterResonanceAdmin(admin.ModelAdmin):
         "claimed_at",
     ]
     search_fields = ["character_sheet__character__db_key", "resonance__name"]
-    autocomplete_fields = ["resonance"]
+    autocomplete_fields = ["character_sheet", "resonance"]
     list_select_related = [
         "character_sheet",
         "character_sheet__character",
@@ -275,6 +276,7 @@ class CharacterResonanceAdmin(admin.ModelAdmin):
 
 @admin.register(Gift)
 class GiftAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["creator"]
     list_display = ["name"]
     search_fields = ["name", "description"]
     filter_horizontal = ["resonances"]
@@ -282,6 +284,7 @@ class GiftAdmin(admin.ModelAdmin):
 
 @admin.register(CharacterGift)
 class CharacterGiftAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character"]
     list_display = ["character", "gift", "acquired_at"]
     list_filter = ["gift"]
     search_fields = ["character__character__db_key", "gift__name"]
@@ -322,6 +325,7 @@ class CharacterTraditionAdmin(admin.ModelAdmin):
 
 @admin.register(CharacterTechnique)
 class CharacterTechniqueAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character"]
     list_display = ["character", "technique", "acquired_at"]
     list_filter = ["technique__gift", "technique__style"]
     search_fields = ["character__character__db_key", "technique__name"]
@@ -330,6 +334,7 @@ class CharacterTechniqueAdmin(admin.ModelAdmin):
 
 @admin.register(CharacterAnima)
 class CharacterAnimaAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character"]
     list_display = ["character", "current", "maximum", "last_recovery"]
     list_filter = ["last_recovery"]
     search_fields = ["character__db_key"]
@@ -344,6 +349,7 @@ class AnimaRitualPerformanceInline(admin.TabularInline):
 
 @admin.register(AnimaRitualPerformance)
 class AnimaRitualPerformanceAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["scene", "target_character"]
     list_display = [
         "ritual",
         "target_character",
@@ -368,6 +374,7 @@ class MotifResonanceInline(admin.TabularInline):
 
 @admin.register(Motif)
 class MotifAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character"]
     list_display = ["__str__", "character"]
     search_fields = ["character__character__db_key", "description"]
     inlines = [MotifResonanceInline]
@@ -494,6 +501,8 @@ class StandingCapBandAdmin(admin.ModelAdmin):
 class ResonanceGainConfigAdmin(admin.ModelAdmin):
     """Singleton tuning config — one row per environment."""
 
+    autocomplete_fields = ["updated_by"]
+
     list_display = (
         "pk",
         "weekly_pot_per_character",
@@ -515,6 +524,8 @@ class ResonanceGainConfigAdmin(admin.ModelAdmin):
 @admin.register(ResonanceEnvironmentConfig)
 class ResonanceEnvironmentConfigAdmin(admin.ModelAdmin):
     """Singleton tuning config for the resonance-environment primitive."""
+
+    autocomplete_fields = ["updated_by"]
 
     list_display = (
         "pk",
@@ -631,7 +642,7 @@ class RitualAdmin(admin.ModelAdmin):
     ]
     list_filter = ["execution_kind", "hedge_accessible", "glimpse_eligible"]
     search_fields = ["name", "description"]
-    autocomplete_fields = ["flow", "site_property"]
+    autocomplete_fields = ["author_account", "flow", "site_property"]
     inlines = [RitualComponentRequirementInline, RitualCheckConfigInline]
     # Dispatch fields (execution_kind / service_function_path / flow)
     # determine WHICH code runs when a ritual is performed. Exposing them
@@ -730,6 +741,7 @@ class ThreadWeavingTeachingOfferAdmin(admin.ModelAdmin):
 
 @admin.register(ResonanceGrant)
 class ResonanceGrantAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character_sheet", "source_staff_account"]
     list_display = (
         "id",
         "character_sheet",
@@ -764,6 +776,7 @@ class ResonanceGrantAdmin(admin.ModelAdmin):
 
 @admin.register(PoseEndorsement)
 class PoseEndorsementAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["endorsee_sheet", "endorser_sheet", "interaction", "persona_snapshot"]
     list_display = (
         "id",
         "endorser_sheet",
@@ -784,6 +797,13 @@ class PoseEndorsementAdmin(admin.ModelAdmin):
 
 @admin.register(SceneEntryEndorsement)
 class SceneEntryEndorsementAdmin(admin.ModelAdmin):
+    autocomplete_fields = [
+        "endorsee_sheet",
+        "endorser_sheet",
+        "entry_interaction",
+        "persona_snapshot",
+        "scene",
+    ]
     list_display = (
         "id",
         "endorser_sheet",
@@ -839,6 +859,8 @@ class RelationshipBondPullTuningAdmin(admin.ModelAdmin):
 class SoulTetherConfigAdmin(admin.ModelAdmin):
     """Singleton tuning config for the Soul Tether bond mechanic — one row per environment."""
 
+    autocomplete_fields = ["updated_by"]
+
     list_display = (
         "pk",
         "anima_cost_per_unit",
@@ -880,6 +902,7 @@ class DramaticMomentTypeAdmin(admin.ModelAdmin):
 
 @admin.register(DramaticMomentTag)
 class DramaticMomentTagAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character_sheet", "interaction", "scene", "tagged_by"]
     list_display = ("id", "character_sheet", "moment_type", "scene", "tagged_by", "tagged_at")
     list_filter = ("moment_type",)
     readonly_fields = tuple(f.name for f in DramaticMomentTag._meta.fields)  # noqa: SLF001
@@ -893,6 +916,7 @@ class DramaticMomentTagAdmin(admin.ModelAdmin):
 
 @admin.register(DramaticMomentSuggestion)
 class DramaticMomentSuggestionAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character_sheet", "interaction", "resolved_by", "scene"]
     list_display = (
         "id",
         "character_sheet",
@@ -925,6 +949,7 @@ class GiftUnlockAdmin(admin.ModelAdmin):
 
 @admin.register(CharacterGiftUnlock)
 class CharacterGiftUnlockAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character", "teacher"]
     list_display = ["character", "unlock", "xp_spent", "teacher", "acquired_at"]
     search_fields = ["character__name"]
     readonly_fields = ["acquired_at"]
@@ -932,6 +957,7 @@ class CharacterGiftUnlockAdmin(admin.ModelAdmin):
 
 @admin.register(TechniqueTeachingOffer)
 class TechniqueTeachingOfferAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["teacher"]
     list_display = [
         "teacher",
         "technique",
@@ -1111,6 +1137,8 @@ class FallRedemptionConfigAdmin(admin.ModelAdmin):
 @admin.register(FallRedemptionRecord)
 class FallRedemptionRecordAdmin(admin.ModelAdmin):
     """Read-only admin for Fall/Redemption conversion audit records."""
+
+    autocomplete_fields = ["character_sheet", "scene"]
 
     list_display = (
         "character_sheet",

--- a/src/world/mechanics/admin.py
+++ b/src/world/mechanics/admin.py
@@ -129,6 +129,7 @@ class PropertyCategoryAdmin(admin.ModelAdmin):
 
 @admin.register(Property)
 class PropertyAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["personas"]
     list_display = ["name", "category"]
     list_filter = ["category"]
     search_fields = ["name"]
@@ -272,6 +273,7 @@ class SituationInstanceAdmin(admin.ModelAdmin):
 
 @admin.register(ChallengeInstance)
 class ChallengeInstanceAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["target_object"]
     list_display = ["template", "location", "is_active", "is_revealed"]
     list_filter = ["is_active", "is_revealed"]
     raw_id_fields = ["location", "situation_instance"]
@@ -291,6 +293,7 @@ class ContextConsequencePoolAdmin(admin.ModelAdmin):
 
 @admin.register(CharacterEngagement)
 class CharacterEngagementAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character"]
     list_display = ("character", "engagement_type", "escalation_level", "started_at")
     list_filter = ("engagement_type",)
     readonly_fields = ("started_at",)

--- a/src/world/player_submissions/admin.py
+++ b/src/world/player_submissions/admin.py
@@ -14,6 +14,8 @@ from world.player_submissions.models import (
 class SystemErrorReportAdmin(admin.ModelAdmin):
     """Auto-captured runtime errors (#1164) — the staff queue's system-error lane."""
 
+    autocomplete_fields = ["actor_persona"]
+
     list_display = ["exception_type", "label", "occurrence_count", "last_seen", "status"]
     list_filter = ["status", "exception_type", "last_seen"]
     search_fields = ["label", "exception_type", "message", "traceback"]
@@ -22,6 +24,7 @@ class SystemErrorReportAdmin(admin.ModelAdmin):
 
 @admin.register(PlayerFeedback)
 class PlayerFeedbackAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["location", "reporter_account", "reporter_persona"]
     list_display = ["id", "reporter_account", "reporter_persona", "status", "created_at"]
     list_filter = ["status", "created_at"]
     search_fields = ["description"]
@@ -30,6 +33,7 @@ class PlayerFeedbackAdmin(admin.ModelAdmin):
 
 @admin.register(BugReport)
 class BugReportAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["location", "reporter_account", "reporter_persona"]
     list_display = ["id", "reporter_account", "reporter_persona", "status", "created_at"]
     list_filter = ["status", "created_at"]
     search_fields = ["description"]
@@ -38,6 +42,15 @@ class BugReportAdmin(admin.ModelAdmin):
 
 @admin.register(PlayerReport)
 class PlayerReportAdmin(admin.ModelAdmin):
+    autocomplete_fields = [
+        "interaction",
+        "location",
+        "reported_account",
+        "reported_persona",
+        "reporter_account",
+        "reporter_persona",
+        "scene",
+    ]
     list_display = [
         "id",
         "reporter_account",

--- a/src/world/progression/admin/kudos_admin.py
+++ b/src/world/progression/admin/kudos_admin.py
@@ -45,6 +45,8 @@ class KudosClaimCategoryAdmin(admin.ModelAdmin):
 class KudosPointsDataAdmin(admin.ModelAdmin):
     """Admin interface for KudosPointsData."""
 
+    autocomplete_fields = ["account"]
+
     list_display = ["account", "current_available", "total_earned", "total_claimed"]
     list_filter = ["updated_date"]
     search_fields = ["account__username"]

--- a/src/world/progression/admin/rewards_admin.py
+++ b/src/world/progression/admin/rewards_admin.py
@@ -16,6 +16,8 @@ from world.progression.models import (
 class ExperiencePointsDataAdmin(admin.ModelAdmin):
     """Admin interface for ExperiencePointsData."""
 
+    autocomplete_fields = ["account"]
+
     list_display = ["account", "current_available", "total_earned", "total_spent"]
     list_filter = ["updated_date"]
     search_fields = ["account__username"]
@@ -31,6 +33,8 @@ class ExperiencePointsDataAdmin(admin.ModelAdmin):
 class XPTransactionAdmin(admin.ModelAdmin):
     """Admin interface for XPTransaction."""
 
+    autocomplete_fields = ["account", "character", "gm"]
+
     list_display = ["account", "amount", "reason", "description", "transaction_date"]
     list_filter = ["reason", "transaction_date"]
     search_fields = ["account__username", "description"]
@@ -41,6 +45,8 @@ class XPTransactionAdmin(admin.ModelAdmin):
 class DevelopmentPointsAdmin(admin.ModelAdmin):
     """Admin interface for DevelopmentPoints."""
 
+    autocomplete_fields = ["character_sheet"]
+
     list_display = ["character_sheet", "trait", "total_earned"]
     list_filter = ["trait__trait_type", "updated_date"]
     search_fields = ["character_sheet__character__db_key", "trait__name"]
@@ -50,6 +56,8 @@ class DevelopmentPointsAdmin(admin.ModelAdmin):
 @admin.register(DevelopmentTransaction)
 class DevelopmentTransactionAdmin(admin.ModelAdmin):
     """Admin interface for DevelopmentTransaction."""
+
+    autocomplete_fields = ["character_sheet", "gm", "scene"]
 
     list_display = [
         "character_sheet",

--- a/src/world/progression/admin/unlocks_admin.py
+++ b/src/world/progression/admin/unlocks_admin.py
@@ -265,6 +265,8 @@ class TierRequirementAdmin(admin.ModelAdmin):
 class CharacterUnlockAdmin(admin.ModelAdmin):
     """Admin interface for CharacterUnlock."""
 
+    autocomplete_fields = ["character"]
+
     list_display = [
         "character",
         "character_class",

--- a/src/world/relationships/admin.py
+++ b/src/world/relationships/admin.py
@@ -127,6 +127,7 @@ class RelationshipTrackProgressAdmin(admin.ModelAdmin):
 
 @admin.register(RelationshipUpdate)
 class RelationshipUpdateAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["author", "linked_interaction", "linked_scene"]
     list_display = ["title", "relationship", "track", "points_earned", "visibility", "created_at"]
     list_filter = ["visibility", "is_first_impression", "track"]
     search_fields = ["title"]
@@ -136,6 +137,7 @@ class RelationshipUpdateAdmin(admin.ModelAdmin):
 
 @admin.register(RelationshipDevelopment)
 class RelationshipDevelopmentAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["author", "linked_scene"]
     list_display = [
         "title",
         "relationship",
@@ -153,6 +155,7 @@ class RelationshipDevelopmentAdmin(admin.ModelAdmin):
 
 @admin.register(RelationshipCapstone)
 class RelationshipCapstoneAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["author", "linked_scene"]
     list_display = ["title", "relationship", "track", "points", "visibility", "created_at"]
     list_filter = ["visibility", "track"]
     search_fields = ["title"]
@@ -162,6 +165,7 @@ class RelationshipCapstoneAdmin(admin.ModelAdmin):
 
 @admin.register(RelationshipChange)
 class RelationshipChangeAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["author"]
     list_display = [
         "title",
         "relationship",
@@ -179,6 +183,7 @@ class RelationshipChangeAdmin(admin.ModelAdmin):
 
 @admin.register(WriteupComplaint)
 class WriteupComplaintAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["complainant"]
     list_display = [
         "writeup_ref",
         "author_sheet_col",
@@ -219,6 +224,8 @@ class WriteupComplaintAdmin(admin.ModelAdmin):
 @admin.register(BondCombatConfig)
 class BondCombatConfigAdmin(admin.ModelAdmin):
     """Singleton tuning config for relationship bond combat bonuses (#2021)."""
+
+    autocomplete_fields = ["updated_by"]
 
     list_display = (
         "pk",

--- a/src/world/room_features/admin.py
+++ b/src/world/room_features/admin.py
@@ -47,12 +47,14 @@ class RoomFeatureProgressionDetailsAdmin(admin.ModelAdmin):
 
 @admin.register(Trap)
 class TrapAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["created_by_sheet", "detected_by"]
     list_display = ("name", "room_profile", "is_armed", "is_hidden")
     list_filter = ("is_armed", "is_hidden")
 
 
 @admin.register(VaultDetails)
 class VaultDetailsAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["founder_persona"]
     list_display = ("feature_instance", "founder_persona", "max_items")
     readonly_fields = ("feature_instance", "founder_persona", "max_items")
 
@@ -65,6 +67,7 @@ class BrigDetailsAdmin(admin.ModelAdmin):
 
 @admin.register(VaultAccessEntry)
 class VaultAccessEntryAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["added_by", "holder_persona"]
     list_display = (
         "vault_details",
         "holder_type",

--- a/src/world/roster/admin.py
+++ b/src/world/roster/admin.py
@@ -23,6 +23,7 @@ from world.roster.models import (
 
 @admin.register(Family)
 class FamilyAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["created_by"]
     list_display = ["name", "family_type", "is_playable", "created_by_cg"]
     list_filter = ["family_type", "is_playable", "created_by_cg"]
     search_fields = ["name", "description"]
@@ -46,6 +47,8 @@ class FamilyMembershipInline(admin.TabularInline):
 @admin.register(Kinsperson)
 class KinspersonAdmin(admin.ModelAdmin):
     """Staff authoring surface for the kinship graph (#2062)."""
+
+    autocomplete_fields = ["created_by"]
 
     list_display = [
         "display_name",
@@ -100,7 +103,7 @@ class RosterEntryAdmin(admin.ModelAdmin):
     readonly_fields = ["joined_roster", "created_date", "updated_date"]
 
     # Use autocomplete for CharacterSheet (could be many) and profile_picture
-    autocomplete_fields = ["character_sheet", "profile_picture"]
+    autocomplete_fields = ["character_sheet", "created_by_account", "profile_picture"]
     # Roster is a lookup table with few entries, keep default widget
 
     fieldsets = (

--- a/src/world/scenes/admin.py
+++ b/src/world/scenes/admin.py
@@ -19,6 +19,14 @@ from world.scenes.place_models import InteractionReceiver, Place, PlacePresence
 class BlockContactFlagAdmin(admin.ModelAdmin):
     """Staff review of blocked-player contact attempts (#1278)."""
 
+    autocomplete_fields = [
+        "blocked_account",
+        "blocker_account",
+        "initiator_persona",
+        "scene",
+        "target_persona",
+    ]
+
     list_display = [
         "created_at",
         "blocked_account",
@@ -51,6 +59,7 @@ class SceneParticipationInline(admin.TabularInline):
 
 @admin.register(Scene)
 class SceneAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["location", "participants"]
     list_display = [
         "name",
         "location",
@@ -72,6 +81,7 @@ class SceneAdmin(admin.ModelAdmin):
 
 @admin.register(Persona)
 class PersonaAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character_sheet", "interactions_targeted"]
     list_display = ["name", "character_sheet", "persona_type", "created_at"]
     list_filter = ["persona_type", "created_at"]
     search_fields = ["name", "character__db_key"]
@@ -86,6 +96,7 @@ class InteractionReceiverInlineForInteraction(admin.TabularInline):
 
 @admin.register(Interaction)
 class InteractionAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["persona", "place", "scene", "target_personas", "writer_account"]
     list_display = ["persona", "mode", "visibility", "scene", "place", "timestamp"]
     list_filter = ["mode", "visibility"]
     search_fields = ["content"]
@@ -94,11 +105,13 @@ class InteractionAdmin(admin.ModelAdmin):
 
 @admin.register(InteractionFavorite)
 class InteractionFavoriteAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["interaction", "roster_entry"]
     list_display = ["interaction", "roster_entry", "created_at"]
 
 
 @admin.register(InteractionReaction)
 class InteractionReactionAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["account", "interaction"]
     list_display = ["interaction", "account", "emoji", "created_at"]
     list_filter = ["emoji"]
 
@@ -112,12 +125,14 @@ class ReactionEmojiAdmin(admin.ModelAdmin):
 
 @admin.register(PersonaDiscovery)
 class PersonaDiscoveryAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["discovered_by", "linked_to", "persona"]
     list_display = ["persona", "linked_to", "discovered_by", "discovered_at"]
     list_filter = ["discovered_at"]
 
 
 @admin.register(SceneSummaryRevision)
 class SceneSummaryRevisionAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["persona", "scene"]
     list_display = ["scene", "persona", "action", "timestamp"]
     list_filter = ["action"]
 
@@ -129,6 +144,7 @@ class PlacePresenceInline(admin.TabularInline):
 
 @admin.register(Place)
 class PlaceAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["room"]
     list_display = ["name", "room", "status", "created_at"]
     list_filter = ["status"]
     search_fields = ["name"]

--- a/src/world/secrets/admin.py
+++ b/src/world/secrets/admin.py
@@ -12,6 +12,7 @@ class SecretCategoryAdmin(admin.ModelAdmin):
 
 @admin.register(Secret)
 class SecretAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["scene"]
     list_display = ["__str__", "level", "category", "provenance", "created_date"]
     list_filter = ["level", "provenance", "category"]
     search_fields = ["content", "consequences"]

--- a/src/world/skills/admin.py
+++ b/src/world/skills/admin.py
@@ -52,6 +52,8 @@ class SpecializationAdmin(admin.ModelAdmin):
 class CharacterSkillValueAdmin(admin.ModelAdmin):
     """Admin for character skill values."""
 
+    autocomplete_fields = ["character"]
+
     list_display = [
         "character",
         "skill",
@@ -72,6 +74,8 @@ class CharacterSkillValueAdmin(admin.ModelAdmin):
 @admin.register(CharacterSpecializationValue)
 class CharacterSpecializationValueAdmin(admin.ModelAdmin):
     """Admin for character specialization values."""
+
+    autocomplete_fields = ["character"]
 
     list_display = [
         "character",

--- a/src/world/societies/admin.py
+++ b/src/world/societies/admin.py
@@ -375,6 +375,8 @@ class LegendEntryAdmin(admin.ModelAdmin):
     Manages legendary deeds and their spread instances.
     """
 
+    autocomplete_fields = ["linked_items"]
+
     list_display = [
         "title",
         "persona",
@@ -573,6 +575,8 @@ class FameReactionLineAdmin(admin.ModelAdmin):
 class FameReactionCooldownAdmin(admin.ModelAdmin):
     """#881 — re-fire throttle rows (operational visibility only)."""
 
+    autocomplete_fields = ["persona"]
+
     list_display = ("persona", "room", "available_at")
 
 
@@ -672,6 +676,8 @@ class HouseClaimAdmin(admin.ModelAdmin):
     Approval is the staff greenlight only; the house materializes at CG
     finalization, so approving here never creates rows by itself.
     """
+
+    autocomplete_fields = ["reviewed_by"]
 
     list_display = ("house_name", "title", "template", "status", "created_at", "reviewed_by")
     list_select_related = ("title", "template", "reviewed_by")

--- a/src/world/stories/admin.py
+++ b/src/world/stories/admin.py
@@ -70,6 +70,7 @@ class StoryProtectedSubjectInline(admin.TabularInline):
 
 @admin.register(Story)
 class StoryAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character_sheet", "owners"]
     list_display = [
         "title",
         "status",
@@ -118,6 +119,7 @@ class StoryAdmin(admin.ModelAdmin):
 
 @admin.register(StoryParticipation)
 class StoryParticipationAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character"]
     list_display = [
         "character",
         "story",
@@ -290,6 +292,7 @@ class TrustCategoryFeedbackRatingInline(admin.TabularInline):
 
 @admin.register(StoryFeedback)
 class StoryFeedbackAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["reviewed_player", "reviewer"]
     list_display = [
         "story",
         "reviewed_player",
@@ -342,6 +345,7 @@ class StoryFeedbackAdmin(admin.ModelAdmin):
 
 @admin.register(TrustCategory)
 class TrustCategoryAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["created_by"]
     list_display = ["display_name", "name", "is_active", "created_at"]
     list_filter = ["is_active", "created_at"]
     search_fields = ["name", "display_name", "description"]
@@ -409,6 +413,7 @@ class PlayerTrustLevelAdmin(admin.ModelAdmin):
 
 @admin.register(StoryTrustRequirement)
 class StoryTrustRequirementAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["created_by"]
     list_display = [
         "story",
         "trust_category",
@@ -455,6 +460,7 @@ class EraAdmin(admin.ModelAdmin):
 
 @admin.register(BeatCompletion)
 class BeatCompletionAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character_sheet", "roster_entry"]
     list_display = ("beat", "character_sheet", "outcome", "era", "recorded_at")
     list_filter = ("outcome",)
     search_fields = ("beat__internal_description", "character_sheet__name")
@@ -478,6 +484,7 @@ class CrossoverInviteAdmin(admin.ModelAdmin):
 
 @admin.register(EpisodeResolution)
 class EpisodeResolutionAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character_sheet"]
     list_display = (
         "episode",
         "character_sheet",
@@ -494,6 +501,7 @@ class EpisodeResolutionAdmin(admin.ModelAdmin):
 
 @admin.register(StoryProgress)
 class StoryProgressAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character_sheet"]
     list_display = (
         "story",
         "character_sheet",
@@ -525,6 +533,7 @@ class GlobalStoryProgressAdmin(admin.ModelAdmin):
 
 @admin.register(AggregateBeatContribution)
 class AggregateBeatContributionAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character_sheet", "roster_entry"]
     list_display = ("beat", "character_sheet", "points", "era", "recorded_at")
     list_filter = ("era",)
     search_fields = ("beat__internal_description", "source_note")

--- a/src/world/traits/admin.py
+++ b/src/world/traits/admin.py
@@ -37,6 +37,7 @@ class TraitAdmin(admin.ModelAdmin):
 
 @admin.register(CharacterTraitValue)
 class CharacterTraitValueAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character"]
     list_display = ["character", "trait", "value", "display_value"]
     list_filter = ["trait__trait_type", "trait__category"]
     search_fields = ["character__db_key", "trait__name"]

--- a/src/world/vitals/admin.py
+++ b/src/world/vitals/admin.py
@@ -5,6 +5,7 @@ from world.vitals.models import CharacterVitals, VitalsConsequenceConfig
 
 @admin.register(CharacterVitals)
 class CharacterVitalsAdmin(admin.ModelAdmin):
+    autocomplete_fields = ["character_sheet", "died_in_scene"]
     list_display = ["character_sheet", "health", "max_health", "life_state", "died_at"]
     list_filter = ["life_state"]
     search_fields = ["character_sheet__character__db_key"]


### PR DESCRIPTION
Closes #2435

## Summary

Audit all admin classes for FK/M2M fields pointing to large tables (ObjectDB, AccountDB, CharacterSheet, Persona, Scene, etc.) and switch them from default <select> dropdowns to autocomplete_fields (or raw_id_fields where autocomplete isn't supported). Add a Django system check (web_admin.W001) that prevents future regressions by erroring when a new admin class introduces an unguarded FK to a large table.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2435 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Clean rebase, no conflicts

<!-- last-addressed-comment: 0 -->