### PR TITLE
Material consumption deletes whole ItemInstance stacks: over-consumes (req 1 eats stack of 5) and fans out delete-cascades on every craft

### DIFF
--- a/src/world/items/crafting/cost.py
+++ b/src/world/items/crafting/cost.py
@@ -21,7 +21,7 @@ from typing import TYPE_CHECKING
 from world.items.crafting.constants import PARTIAL_FRACTION, CostConsumption
 from world.items.exceptions import CraftingCostUnaffordable, InsufficientMaterials
 from world.items.models import ItemInstance
-from world.items.services.materials import consume_pks, gather_consumable_pks
+from world.items.services.materials import consume_materials, gather_consumable_pks
 
 if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
@@ -40,12 +40,12 @@ class StagedCost:
     Attributes:
         action_points: AP required by the recipe.
         anima: Anima required by the recipe.
-        material_pks: Primary keys of ``ItemInstance`` rows to consume.
+        material_allocations: ``(ItemInstance, amount)`` tuples to consume.
     """
 
     action_points: int
     anima: int
-    material_pks: list[int] = field(default_factory=list)
+    material_allocations: list[tuple[ItemInstance, int]] = field(default_factory=list)
 
 
 def stage_and_assert_affordable(
@@ -110,7 +110,7 @@ def stage_and_assert_affordable(
     )
 
     try:
-        material_pks = gather_consumable_pks(available=available, requirements=requirements)
+        material_allocations = gather_consumable_pks(available=available, requirements=requirements)
     except InsufficientMaterials as exc:
         msg = "You do not have the required materials."
         raise CraftingCostUnaffordable(msg) from exc
@@ -118,7 +118,7 @@ def stage_and_assert_affordable(
     return StagedCost(
         action_points=ap_cost,
         anima=anima_cost,
-        material_pks=material_pks,
+        material_allocations=material_allocations,
     )
 
 
@@ -181,8 +181,8 @@ def consume_cost(
         deduct_anima(crafter_character, anima_to_spend, lethal=False)
 
     # Consume materials (PARTIAL and FULL both consume ALL materials)
-    materials_consumed = len(staged.material_pks)
-    consume_pks(staged.material_pks)
+    materials_consumed = len(staged.material_allocations)
+    consume_materials(staged.material_allocations)
 
     return {
         "action_points": ap_to_spend,

--- a/src/world/items/services/materials.py
+++ b/src/world/items/services/materials.py
@@ -58,14 +58,16 @@ def gather_consumable_pks(
     *,
     available: Iterable[ItemInstance],
     requirements: Iterable[object],
-) -> list[int]:
-    """Validate that ``available`` satisfies ``requirements`` and return PKs to consume.
+) -> list[tuple[ItemInstance, int]]:
+    """Validate that ``available`` satisfies ``requirements`` and return allocations.
 
     For each requirement, scans ``available`` for instances matching the required
     item template and quality tier, sums their quantities, and greedily records
-    the minimum set of PKs needed to cover the requirement.
+    the minimum set of (instance, amount) pairs needed to cover the requirement
+    exactly — a requirement of 1 against a stack of 5 returns ``[(inst, 1)]``,
+    not the whole stack.
 
-    An instance PK already allocated to a prior requirement is excluded from
+    An instance already allocated to a prior requirement is excluded from
     consideration for later ones (prevents double-spending).
 
     Args:
@@ -75,7 +77,7 @@ def gather_consumable_pks(
             ``min_quality_tier``, and ``quantity``.
 
     Returns:
-        Flat list of ItemInstance PKs to pass to ``consume_pks``.
+        List of ``(ItemInstance, amount)`` tuples to pass to ``consume_materials``.
 
     Raises:
         InsufficientMaterials: On the first unsatisfied requirement.
@@ -84,7 +86,8 @@ def gather_consumable_pks(
     """
     # Materialise available once so we can iterate it multiple times.
     available_list = list(available)
-    consumed_pks: list[int] = []
+    consumed: list[tuple[ItemInstance, int]] = []
+    allocated_pks: set[int] = set()
 
     for req in requirements:
         # Candidates: right template, meets quality tier, not already allocated.
@@ -93,7 +96,7 @@ def gather_consumable_pks(
             for inst in available_list
             if inst.template_id == req.item_template_id
             and meets_quality_tier(inst, req)
-            and inst.pk not in consumed_pks
+            and inst.pk not in allocated_pks
         ]
 
         total_qty = sum(inst.quantity for inst in candidates)
@@ -105,19 +108,34 @@ def gather_consumable_pks(
         for inst in candidates:
             if remaining <= 0:
                 break
-            consumed_pks.append(inst.pk)
-            remaining -= inst.quantity
+            take = min(inst.quantity, remaining)
+            consumed.append((inst, take))
+            allocated_pks.add(inst.pk)
+            remaining -= take
 
-    return consumed_pks
+    return consumed
 
 
-def consume_pks(pks: list[int]) -> None:
-    """Delete ItemInstance rows identified by ``pks``.
+def consume_materials(allocations: list[tuple[ItemInstance, int]]) -> None:
+    """Decrement quantity on each allocated ItemInstance, deleting depleted rows.
+
+    Follows the codebase's canonical SharedMemoryModel mutation pattern (ADR-0008):
+    mutate the Python attribute, then ``.save(update_fields=)`` or ``.delete()``.
+    Never uses ``F("quantity") - n`` with ``.update()`` — that would leave
+    in-memory cached instances stale.
 
     Args:
-        pks: List of ItemInstance primary keys to delete. A no-op for an
-            empty list (avoids a pointless DB round-trip).
+        allocations: List of ``(ItemInstance, amount)`` tuples from
+            ``gather_consumable_pks``. A no-op for an empty list.
     """
-    if not pks:
+    if not allocations:
         return
-    ItemInstance.objects.filter(pk__in=pks).delete()
+    from django.db import transaction  # noqa: PLC0415
+
+    with transaction.atomic():
+        for inst, amount in allocations:
+            inst.quantity -= amount
+            if inst.quantity <= 0:
+                inst.delete()
+            else:
+                inst.save(update_fields=["quantity"])

--- a/src/world/items/tests/test_crafting_cost.py
+++ b/src/world/items/tests/test_crafting_cost.py
@@ -66,7 +66,7 @@ class StageAndAssertAffordableTests(_CraftingCostBase):
         self.assertIsInstance(result, StagedCost)
         self.assertEqual(result.action_points, 0)
         self.assertEqual(result.anima, 0)
-        self.assertEqual(result.material_pks, [])
+        self.assertEqual(result.material_allocations, [])
 
     def test_sufficient_ap_returns_staged_cost(self) -> None:
         self.recipe.action_point_cost = 50
@@ -104,7 +104,7 @@ class StageAndAssertAffordableTests(_CraftingCostBase):
             crafter_character=self.character,
             crafter_character_sheet=self.sheet,
         )
-        self.assertIn(item.pk, result.material_pks)
+        self.assertIn(item.pk, [inst.pk for inst, _ in result.material_allocations])
 
     def test_insufficient_ap_raises(self) -> None:
         self.recipe.action_point_cost = 100
@@ -206,7 +206,7 @@ class ConsumeCostNoneTests(_CraftingCostBase):
         template = ItemTemplateFactory()
         CraftingMaterialRequirementFactory(recipe=self.recipe, item_template=template, quantity=1)
         item = ItemInstanceFactory(template=template, holder_character_sheet=self.sheet, quantity=1)
-        staged = StagedCost(action_points=30, anima=5, material_pks=[item.pk])
+        staged = StagedCost(action_points=30, anima=5, material_allocations=[(item, 1)])
 
         result = consume_cost(
             crafter_character=self.character,
@@ -238,7 +238,7 @@ class ConsumeCostPartialTests(_CraftingCostBase):
 
         # AP cost=7 → ceil(7 * 0.5) = ceil(3.5) = 4
         # Anima cost=3 → ceil(3 * 0.5) = ceil(1.5) = 2
-        staged = StagedCost(action_points=7, anima=3, material_pks=[])
+        staged = StagedCost(action_points=7, anima=3, material_allocations=[])
 
         result = consume_cost(
             crafter_character=self.character,
@@ -266,7 +266,7 @@ class ConsumeCostPartialTests(_CraftingCostBase):
         item2 = ItemInstanceFactory(
             template=template, holder_character_sheet=self.sheet, quantity=1
         )
-        staged = StagedCost(action_points=0, anima=0, material_pks=[item1.pk, item2.pk])
+        staged = StagedCost(action_points=0, anima=0, material_allocations=[(item1, 1), (item2, 1)])
 
         result = consume_cost(
             crafter_character=self.character,
@@ -281,7 +281,7 @@ class ConsumeCostPartialTests(_CraftingCostBase):
 
     def test_partial_zero_cost_is_zero(self) -> None:
         """PARTIAL of 0 AP/Anima should charge 0."""
-        staged = StagedCost(action_points=0, anima=0, material_pks=[])
+        staged = StagedCost(action_points=0, anima=0, material_allocations=[])
 
         result = consume_cost(
             crafter_character=self.character,
@@ -302,7 +302,7 @@ class ConsumeCostFullTests(_CraftingCostBase):
         self.anima.current = 10
         self.anima.save(update_fields=["current"])
 
-        staged = StagedCost(action_points=50, anima=8, material_pks=[])
+        staged = StagedCost(action_points=50, anima=8, material_allocations=[])
 
         result = consume_cost(
             crafter_character=self.character,
@@ -322,7 +322,7 @@ class ConsumeCostFullTests(_CraftingCostBase):
     def test_full_consumes_all_materials(self) -> None:
         template = ItemTemplateFactory()
         item = ItemInstanceFactory(template=template, holder_character_sheet=self.sheet, quantity=1)
-        staged = StagedCost(action_points=0, anima=0, material_pks=[item.pk])
+        staged = StagedCost(action_points=0, anima=0, material_allocations=[(item, 1)])
 
         result = consume_cost(
             crafter_character=self.character,
@@ -338,7 +338,7 @@ class ConsumeCostFullTests(_CraftingCostBase):
     def test_full_returns_summary_dict(self) -> None:
         template = ItemTemplateFactory()
         item = ItemInstanceFactory(template=template, holder_character_sheet=self.sheet, quantity=1)
-        staged = StagedCost(action_points=10, anima=3, material_pks=[item.pk])
+        staged = StagedCost(action_points=10, anima=3, material_allocations=[(item, 1)])
 
         result = consume_cost(
             crafter_character=self.character,
@@ -357,7 +357,7 @@ class ConsumeCostFullTests(_CraftingCostBase):
         self.anima.current = 10
         self.anima.save(update_fields=["current"])
 
-        staged = StagedCost(action_points=0, anima=0, material_pks=[])
+        staged = StagedCost(action_points=0, anima=0, material_allocations=[])
 
         consume_cost(
             crafter_character=self.character,
@@ -378,7 +378,7 @@ class ConsumeCostApPoolCreationTests(_CraftingCostBase):
         # Delete the pool set up in setUp.
         ActionPointPool.objects.filter(character=self.character).delete()
 
-        staged = StagedCost(action_points=10, anima=0, material_pks=[])
+        staged = StagedCost(action_points=10, anima=0, material_allocations=[])
 
         result = consume_cost(
             crafter_character=self.character,
@@ -397,7 +397,7 @@ class ConsumeCostApShortfallTests(_CraftingCostBase):
 
     def test_ap_drained_between_stage_and_consume_raises(self) -> None:
         """If the pool is emptied after staging, consume_cost raises instead of lying."""
-        staged = StagedCost(action_points=50, anima=0, material_pks=[])
+        staged = StagedCost(action_points=50, anima=0, material_allocations=[])
 
         # Simulate a concurrent spend draining the pool below the staged amount.
         self.pool.current = 0
@@ -420,7 +420,7 @@ class ConsumeCostAnimaShortfallTests(_CraftingCostBase):
         ``deduct_anima(lethal=False)`` would clamp to available and leave the consumed
         summary over-reporting; the symmetric guard fails hard like the AP path instead.
         """
-        staged = StagedCost(action_points=0, anima=8, material_pks=[])
+        staged = StagedCost(action_points=0, anima=8, material_allocations=[])
 
         # Simulate a concurrent spend draining anima below the staged amount.
         self.anima.current = 3
@@ -438,7 +438,7 @@ class ConsumeCostAnimaShortfallTests(_CraftingCostBase):
 
     def test_anima_row_deleted_after_staging_raises(self) -> None:
         """A positive anima cost can't be paid when the anima row vanished after staging."""
-        staged = StagedCost(action_points=0, anima=5, material_pks=[])
+        staged = StagedCost(action_points=0, anima=5, material_allocations=[])
         CharacterAnima.objects.filter(character=self.character).delete()
 
         with self.assertRaises(CraftingCostUnaffordable):

--- a/src/world/items/tests/test_crafting_query_counts.py
+++ b/src/world/items/tests/test_crafting_query_counts.py
@@ -31,7 +31,7 @@ rather than discovered in production profiling.
      b. anima sufficiency guard (filter.first) — 1 query (#1243; symmetric with the AP
         path, asserts the staged anima is still affordable before deducting)
      c. deduct_anima → anima GET + unique check + UPDATE — 3 queries
-     d. consume_pks → Django cascade collect (batched IN-lists per FK) + DELETE — ~14 q
+     d. consume_materials → per-instance .save(update_fields) or .delete() — ~2 q
   7. apply_resolution → apply_all_effects — 0 queries for a consequence with no effects
   8. resolve_capped_tier:
      a. CraftingSkillCap.for_skill — 1 query (single ORDER BY + LIMIT, not per-row)
@@ -246,7 +246,14 @@ class CraftAttachFacetQueryCountTests(TestCase):
             # BOTH vendors — the old exact-per-vendor pins broke every time
             # the CI shard groupings changed. The guard's purpose is catching
             # per-row N+1s, and those add ≥3 (3 consequence rows), which blows
-            # past the band. Observed: 92 (warm identity map) / 93 (cold).
+            # past the band. Observed: 74 (cold identity map) / 75 (warm).
+            #
+            # #2454: consume_materials replaced the wholesale DELETE cascade
+            # (14+ cascade-collect queries per material ItemInstance) with a
+            # per-instance .save(update_fields=["quantity"]) — the test setup
+            # uses quantity=2 materials with quantity=1 requirements, so the
+            # common case is now a partial-consume (save, not delete). The band
+            # dropped from 91-94 to 74-76.
             with CaptureQueriesContext(connection) as ctx:
                 result = craft_attach_facet(
                     crafter_account=self.account,
@@ -256,9 +263,9 @@ class CraftAttachFacetQueryCountTests(TestCase):
                 )
             executed = len(ctx.captured_queries)
             self.assertTrue(
-                91 <= executed <= 94,
-                f"{executed} queries executed, expected 92-93 ±1 identity-map "
-                f"wobble (band 91-94). A jump of >=3 means a per-row N+1.",
+                74 <= executed <= 76,
+                f"{executed} queries executed, expected 75 ±1 identity-map "
+                f"wobble (band 74-76). A jump of >=3 means a per-row N+1.",
             )
 
         self.assertTrue(result.attached)

--- a/src/world/items/tests/test_materials_service.py
+++ b/src/world/items/tests/test_materials_service.py
@@ -1,11 +1,12 @@
 """Tests for world.items.services.materials — shared material-consumption helper.
 
 Covers:
-- gather_consumable_pks: sufficient supply returns the expected PKs (no raise)
+- gather_consumable_pks: sufficient supply returns the expected allocations (no raise)
 - gather_consumable_pks: insufficient quantity raises InsufficientMaterials with
   structured requirement + provided_qty attrs
 - gather_consumable_pks: min_quality_tier filtering excludes low-tier instances
-- consume_pks: deletes exactly the requested PKs; other rows are untouched
+- consume_materials: partial consume decrements quantity; full consume deletes row;
+  split across stacks decrements each correctly
 """
 
 from django.test import TestCase
@@ -13,7 +14,11 @@ from django.test import TestCase
 from world.items.exceptions import InsufficientMaterials
 from world.items.factories import ItemInstanceFactory, ItemTemplateFactory, QualityTierFactory
 from world.items.models import ItemInstance
-from world.items.services.materials import consume_pks, gather_consumable_pks, meets_quality_tier
+from world.items.services.materials import (
+    consume_materials,
+    gather_consumable_pks,
+    meets_quality_tier,
+)
 
 # ---------------------------------------------------------------------------
 # Minimal duck-typed requirement for tests
@@ -80,7 +85,7 @@ class MeetsQualityTierTests(TestCase):
 
 
 class GatherConsumablePksSufficientTests(TestCase):
-    """gather_consumable_pks returns PKs without raising when supply is adequate."""
+    """gather_consumable_pks returns allocations without raising when supply is adequate."""
 
     @classmethod
     def setUpTestData(cls) -> None:
@@ -89,41 +94,47 @@ class GatherConsumablePksSufficientTests(TestCase):
         cls.inst2 = ItemInstanceFactory(template=cls.template, quantity=3)
 
     def test_single_requirement_single_instance(self) -> None:
-        """One requirement, one instance with sufficient qty — returns that PK."""
+        """One requirement, one instance with sufficient qty — returns that instance."""
         req = _Req(self.template, 2)
-        pks = gather_consumable_pks(available=[self.inst1], requirements=[req])
-        self.assertIn(self.inst1.pk, pks)
+        allocations = gather_consumable_pks(available=[self.inst1], requirements=[req])
+        self.assertEqual(allocations, [(self.inst1, 2)])
 
     def test_single_requirement_multiple_instances(self) -> None:
-        """Requirement satisfied across multiple instances — all needed PKs returned."""
+        """Requirement satisfied across multiple instances — all needed allocations returned."""
         req = _Req(self.template, 4)
-        pks = gather_consumable_pks(available=[self.inst1, self.inst2], requirements=[req])
-        # Both instances needed (qty 2+3=5 >= 4); at minimum inst1 + inst2 appear.
-        self.assertIn(self.inst1.pk, pks)
-        self.assertIn(self.inst2.pk, pks)
+        allocations = gather_consumable_pks(available=[self.inst1, self.inst2], requirements=[req])
+        # Both instances needed (qty 2+3=5 >= 4); inst1 fully consumed, inst2 partially.
+        self.assertEqual(allocations, [(self.inst1, 2), (self.inst2, 2)])
 
     def test_greedy_prune_stops_early(self) -> None:
-        """Greedy logic stops adding PKs once the running qty is satisfied."""
+        """Greedy logic stops adding allocations once the running qty is satisfied."""
         # inst2 alone (qty=3) satisfies requirement=3; inst1 should NOT be needed.
         req = _Req(self.template, 3)
-        pks = gather_consumable_pks(available=[self.inst2], requirements=[req])
-        self.assertIn(self.inst2.pk, pks)
-        self.assertNotIn(self.inst1.pk, pks)
+        allocations = gather_consumable_pks(available=[self.inst2], requirements=[req])
+        self.assertEqual(allocations, [(self.inst2, 3)])
+
+    def test_partial_consume_takes_only_what_is_needed(self) -> None:
+        """Requirement of 1 against a stack of 5 returns amount=1, not 5."""
+        inst = ItemInstanceFactory(template=self.template, quantity=5)
+        req = _Req(self.template, 1)
+        allocations = gather_consumable_pks(available=[inst], requirements=[req])
+        self.assertEqual(allocations, [(inst, 1)])
 
     def test_empty_requirements_returns_empty(self) -> None:
-        """No requirements → empty pk list, no error."""
-        pks = gather_consumable_pks(available=[self.inst1], requirements=[])
-        self.assertEqual(pks, [])
+        """No requirements → empty allocations list, no error."""
+        allocations = gather_consumable_pks(available=[self.inst1], requirements=[])
+        self.assertEqual(allocations, [])
 
     def test_no_double_count_across_requirements(self) -> None:
-        """The same instance PK cannot be allocated to two requirements simultaneously."""
+        """The same instance cannot be allocated to two requirements simultaneously."""
         template_a = ItemTemplateFactory()
         template_b = ItemTemplateFactory()
         inst_a = ItemInstanceFactory(template=template_a, quantity=1)
         inst_b = ItemInstanceFactory(template=template_b, quantity=1)
         req_a = _Req(template_a, 1)
         req_b = _Req(template_b, 1)
-        pks = gather_consumable_pks(available=[inst_a, inst_b], requirements=[req_a, req_b])
+        allocations = gather_consumable_pks(available=[inst_a, inst_b], requirements=[req_a, req_b])
+        pks = [inst.pk for inst, _ in allocations]
         self.assertIn(inst_a.pk, pks)
         self.assertIn(inst_b.pk, pks)
         # No duplicates.
@@ -203,43 +214,68 @@ class GatherConsumablePksQualityFilterTests(TestCase):
     def test_high_tier_satisfies_low_requirement(self) -> None:
         """High-tier instance satisfies a low min_quality_tier."""
         req = _Req(self.template, 1, min_quality_tier=self.low)
-        pks = gather_consumable_pks(available=[self.high_inst], requirements=[req])
-        self.assertIn(self.high_inst.pk, pks)
+        allocations = gather_consumable_pks(available=[self.high_inst], requirements=[req])
+        self.assertEqual(allocations, [(self.high_inst, 1)])
 
     def test_mixed_only_high_tier_selected(self) -> None:
         """With both tiers available, only high-tier instance is selected for a high req."""
         req = _Req(self.template, 1, min_quality_tier=self.high)
-        pks = gather_consumable_pks(available=[self.low_inst, self.high_inst], requirements=[req])
-        self.assertIn(self.high_inst.pk, pks)
-        self.assertNotIn(self.low_inst.pk, pks)
+        allocations = gather_consumable_pks(
+            available=[self.low_inst, self.high_inst], requirements=[req]
+        )
+        self.assertEqual(allocations, [(self.high_inst, 1)])
 
 
 # ---------------------------------------------------------------------------
-# consume_pks
+# consume_materials
 # ---------------------------------------------------------------------------
 
 
-class ConsumePksTests(TestCase):
-    """consume_pks deletes exactly the given PKs and leaves others untouched."""
+class ConsumeMaterialsTests(TestCase):
+    """consume_materials decrements partial stacks and deletes depleted ones."""
 
-    def test_deletes_targeted_pks(self) -> None:
-        """PKs passed to consume_pks are deleted from the DB."""
+    def test_partial_consume_decrements_quantity(self) -> None:
+        """Consuming 1 from a stack of 5 leaves quantity=4; row survives."""
         template = ItemTemplateFactory()
-        inst = ItemInstanceFactory(template=template)
-        consume_pks([inst.pk])
+        inst = ItemInstanceFactory(template=template, quantity=5)
+        consume_materials([(inst, 1)])
+        inst.refresh_from_db()
+        self.assertEqual(inst.quantity, 4)
+        self.assertTrue(ItemInstance.objects.filter(pk=inst.pk).exists())
+
+    def test_full_consume_deletes_row(self) -> None:
+        """Consuming the full quantity deletes the row."""
+        template = ItemTemplateFactory()
+        inst = ItemInstanceFactory(template=template, quantity=5)
+        consume_materials([(inst, 5)])
         self.assertFalse(ItemInstance.objects.filter(pk=inst.pk).exists())
 
-    def test_leaves_other_pks_intact(self) -> None:
-        """ItemInstance rows NOT in the PK list are unaffected."""
+    def test_split_across_stacks(self) -> None:
+        """A requirement split across two stacks: first depleted, second survives."""
         template = ItemTemplateFactory()
-        to_delete = ItemInstanceFactory(template=template)
-        to_keep = ItemInstanceFactory(template=template)
-        consume_pks([to_delete.pk])
-        self.assertTrue(ItemInstance.objects.filter(pk=to_keep.pk).exists())
+        inst1 = ItemInstanceFactory(template=template, quantity=5)
+        inst2 = ItemInstanceFactory(template=template, quantity=3)
+        consume_materials([(inst1, 5), (inst2, 2)])
+        self.assertFalse(ItemInstance.objects.filter(pk=inst1.pk).exists())
+        inst2.refresh_from_db()
+        self.assertEqual(inst2.quantity, 1)
 
-    def test_empty_pk_list_is_noop(self) -> None:
-        """An empty PK list does not raise and does not delete any rows."""
+    def test_leaves_other_instances_intact(self) -> None:
+        """Instances NOT in the allocations list are unaffected."""
         template = ItemTemplateFactory()
-        inst = ItemInstanceFactory(template=template)
-        consume_pks([])
+        to_consume = ItemInstanceFactory(template=template, quantity=3)
+        to_keep = ItemInstanceFactory(template=template, quantity=2)
+        consume_materials([(to_consume, 3)])
+        self.assertFalse(ItemInstance.objects.filter(pk=to_consume.pk).exists())
+        self.assertTrue(ItemInstance.objects.filter(pk=to_keep.pk).exists())
+        to_keep.refresh_from_db()
+        self.assertEqual(to_keep.quantity, 2)
+
+    def test_empty_allocations_is_noop(self) -> None:
+        """An empty allocations list does not raise and does not modify any rows."""
+        template = ItemTemplateFactory()
+        inst = ItemInstanceFactory(template=template, quantity=1)
+        consume_materials([])
         self.assertTrue(ItemInstance.objects.filter(pk=inst.pk).exists())
+        inst.refresh_from_db()
+        self.assertEqual(inst.quantity, 1)

--- a/src/world/magic/services/ritual_components.py
+++ b/src/world/magic/services/ritual_components.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from world.items.exceptions import InsufficientMaterials
-from world.items.services.materials import consume_pks, gather_consumable_pks
+from world.items.services.materials import consume_materials, gather_consumable_pks
 from world.magic.exceptions import RitualComponentError
 
 if TYPE_CHECKING:
@@ -27,7 +27,7 @@ def _resolve_touchstone_pks(
     performer_sheet: CharacterSheet,
     resonance_context: Resonance | None,
     already_allocated: set[int],
-) -> list[int]:
+) -> list[ItemInstance]:
     """Resolve touchstone-mode requirements against ``available``.
 
     An instance satisfies a requirement when: it's attuned to
@@ -36,12 +36,15 @@ def _resolve_touchstone_pks(
     ``tied_resonance`` matches either ``resonance_context`` (when given) or
     any ``CharacterResonance`` the performer holds (the general case).
 
+    Returns:
+        List of matched ``ItemInstance`` objects (one per requirement).
+
     Raises:
         RitualComponentError: On the first unsatisfied requirement.
     """
     from world.magic.models import CharacterResonance  # noqa: PLC0415
 
-    matched_pks: list[int] = []
+    matched_instances: list[ItemInstance] = []
     claimed_resonance_ids = set(
         CharacterResonance.objects.filter(character_sheet=performer_sheet).values_list(
             "resonance_id", flat=True
@@ -53,7 +56,7 @@ def _resolve_touchstone_pks(
             inst
             for inst in available
             if inst.pk not in already_allocated
-            and inst.pk not in matched_pks
+            and inst.pk not in {i.pk for i in matched_instances}
             and inst.attuned_to_character_sheet_id == performer_sheet.pk
             and inst.template.tied_resonance_id is not None
             and inst.template.resonance_tier_id is not None
@@ -71,9 +74,9 @@ def _resolve_touchstone_pks(
                 f"(tier >= {req.min_touchstone_tier.name}) that you don't have."
             )
             raise exc
-        matched_pks.append(candidates[0].pk)
+        matched_instances.append(candidates[0])
 
-    return matched_pks
+    return matched_instances
 
 
 def resolve_and_consume_ritual_components(
@@ -113,7 +116,9 @@ def resolve_and_consume_ritual_components(
     touchstone_reqs = [r for r in requirements if r.min_touchstone_tier_id is not None]
 
     try:
-        template_pks = gather_consumable_pks(available=components, requirements=template_reqs)
+        template_allocations = gather_consumable_pks(
+            available=components, requirements=template_reqs
+        )
     except InsufficientMaterials as exc:
         req = exc.requirement
         component_exc = RitualComponentError()
@@ -123,12 +128,14 @@ def resolve_and_consume_ritual_components(
         )
         raise component_exc from exc
 
-    touchstone_pks = _resolve_touchstone_pks(
+    touchstone_instances = _resolve_touchstone_pks(
         available=components,
         requirements=touchstone_reqs,
         performer_sheet=performer_sheet,
         resonance_context=resonance_context,
-        already_allocated=set(template_pks),
+        already_allocated={inst.pk for inst, _ in template_allocations},
     )
 
-    consume_pks(list({*template_pks, *touchstone_pks}))
+    # Touchstones are non-stackable (quantity=1); consuming amount=1 decrements to 0 → delete.
+    all_allocations = [*template_allocations, *((inst, 1) for inst in touchstone_instances)]
+    consume_materials(all_allocations)


### PR DESCRIPTION
Closes #2454

## Summary

Replace wholesale ItemInstance DELETE with per-instance quantity decrement. Fixes over-consumption bug (req 1 eats stack of 5) and eliminates cascade fan-out on the crafting hot path.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2454 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased cleanly on main.

<!-- last-addressed-comment: 0 -->