### PR TITLE
Paginate the ResonanceGrant audit ledger (ADR-0138 follow-up)

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -28225,6 +28225,21 @@ export interface components {
       previous?: string | null;
       results: components['schemas']['RelationshipUpdate'][];
     };
+    PaginatedResonanceGrantList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['ResonanceGrant'][];
+    };
     PaginatedRiskCalibrationList: {
       /** @example 123 */
       count: number;
@@ -49850,6 +49865,10 @@ export interface operations {
       query?: {
         granted_after?: string;
         granted_before?: string;
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        /** @description Number of results to return per page. */
+        page_size?: number;
         resonance?: number;
         /**
          * @description Discriminator. Identifies which source_* FK is populated.
@@ -49908,7 +49927,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['ResonanceGrant'][];
+          'application/json': components['schemas']['PaginatedResonanceGrantList'];
         };
       };
     };

--- a/src/schema.json
+++ b/src/schema.json
@@ -16310,6 +16310,18 @@ paths:
         schema:
           type: string
           format: date-time
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
       - in: query
         name: resonance
         schema:
@@ -16371,9 +16383,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/ResonanceGrant'
+                $ref: '#/components/schemas/PaginatedResonanceGrantList'
           description: ''
   /api/magic/resonance-grants/{id}/:
     get:
@@ -50121,6 +50131,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RelationshipUpdate'
+    PaginatedResonanceGrantList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ResonanceGrant'
     PaginatedRiskCalibrationList:
       type: object
       required:

--- a/src/world/magic/tests/test_gain_views.py
+++ b/src/world/magic/tests/test_gain_views.py
@@ -250,6 +250,37 @@ class ResonanceGrantListTests(APITestCase):
         results = data["results"] if isinstance(data, dict) and "results" in data else data
         self.assertEqual(len(results), 1)
 
+    def test_ledger_is_paginated(self) -> None:
+        """The audit ledger is paginated (ADR-0138) — it grows a row per grant.
+
+        The old endpoint returned every row in one response; a character with a
+        long resonance history would have shipped hundreds of rows at once.
+        """
+        from world.magic.constants import GainSource
+        from world.magic.services.resonance import grant_resonance
+
+        account, sheet, resonance = self._account_with_grant()
+        # Two more ledger rows (3 total for this account).
+        grant_resonance(sheet, resonance, 1, source=GainSource.STAFF_GRANT)
+        grant_resonance(sheet, resonance, 1, source=GainSource.STAFF_GRANT)
+        self.client.force_authenticate(user=account)
+
+        # Default page: the paginated envelope is present with all 3 rows.
+        response = self.client.get("/api/magic/resonance-grants/")
+        self.assertEqual(response.status_code, 200)
+        data = response.json()
+        self.assertIn("count", data)
+        self.assertIn("results", data)
+        self.assertEqual(data["count"], 3)
+        self.assertEqual(len(data["results"]), 3)
+        self.assertIsNone(data["next"])
+
+        # A small page_size actually splits it and hands back a next link.
+        response = self.client.get("/api/magic/resonance-grants/?page_size=2")
+        data = response.json()
+        self.assertEqual(len(data["results"]), 2)
+        self.assertIsNotNone(data["next"])
+
     def test_user_does_not_see_others_grants(self) -> None:
         # Set up two accounts, each with a grant
         alice_account, _, _ = self._account_with_grant()

--- a/src/world/magic/views.py
+++ b/src/world/magic/views.py
@@ -1298,8 +1298,10 @@ class ResonanceGrantViewSet(
     Filter params: source, resonance (PK), granted_after, granted_before.
     """
 
-    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
-
+    # Paginated via the project default (ADR-0138): this audit ledger accrues a
+    # row every time a character earns resonance (poses, scene entries, style
+    # endorsements, dramatic moments, …), so it grows without bound over a
+    # character's life — a timeline surface that must be served in pages.
     serializer_class = ResonanceGrantSerializer
     permission_classes = [IsAuthenticated]
     filter_backends = [DjangoFilterBackend]


### PR DESCRIPTION
## What

First of the deferred pagination follow-ups from ADR-0138.

`ResonanceGrant` is a per-character **audit ledger** — a row is written every time a character earns resonance (pose / scene-entry / style endorsements, dramatic moments, room residence, entry flourishes, …). So `/api/magic/resonance-grants/` grows **without bound** over a character's life. It opted out of the ADR-0138 default (to keep that PR behavior-preserving); this change removes the opt-out so it inherits the default paginator — the newest-first timeline is now served in pages of 50 (with a `?page_size=` override) instead of every row in one response.

## No frontend impact

The endpoint has **no frontend consumer yet** (it's a built-but-not-wired read endpoint — the only references are in generated types), so the sole externally-visible change is the response envelope. This is hardening the endpoint *before* any UI bakes in a bare-array assumption — the right time to do it.

## Tests

The existing view tests were already written to accept either shape (`data["results"] if … else data`), so they keep passing; I added a test asserting the paginated envelope is present (`count`/`results`/`next`) and that a small `?page_size=` actually splits the ledger and returns a `next` link. api-types regenerated (`PaginatedResonanceGrantList`); frontend build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)