### PR TITLE
Paginate the player media library (ADR-0138 follow-up)

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -28090,6 +28090,21 @@ export interface components {
       previous?: string | null;
       results: components['schemas']['PlayerMail'][];
     };
+    PaginatedPlayerMediaList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['PlayerMedia'][];
+    };
     PaginatedPlayerReportDetailList: {
       /** @example 123 */
       count: number;
@@ -57943,7 +57958,12 @@ export interface operations {
   };
   roster_media_list: {
     parameters: {
-      query?: never;
+      query?: {
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        /** @description Number of results to return per page. */
+        page_size?: number;
+      };
       header?: never;
       path?: never;
       cookie?: never;
@@ -57955,7 +57975,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['PlayerMedia'][];
+          'application/json': components['schemas']['PaginatedPlayerMediaList'];
         };
       };
     };

--- a/frontend/src/roster/api.ts
+++ b/frontend/src/roster/api.ts
@@ -8,6 +8,7 @@ import type {
 } from './types';
 import type { PaginatedResponse } from '@/shared/types';
 import { apiFetch } from '@/evennia_replacements/api';
+import { fetchAllPages } from '@/lib/pagination';
 
 export async function fetchRosterEntry(id: RosterEntryData['id']): Promise<RosterEntryData> {
   const res = await apiFetch(`/api/roster/entries/${id}/`);
@@ -42,11 +43,9 @@ export async function fetchRosters(): Promise<RosterData[]> {
 }
 
 export async function fetchPlayerMedia(): Promise<PlayerMedia[]> {
-  const res = await apiFetch('/api/roster/media/');
-  if (!res.ok) {
-    throw new Error('Failed to load media');
-  }
-  return res.json();
+  // The endpoint is paginated (ADR-0138); the gallery grid shows the full
+  // library, so walk every page.
+  return fetchAllPages<PlayerMedia>('/api/roster/media/', 'Failed to load media');
 }
 
 export async function uploadPlayerMedia(form: FormData): Promise<PlayerMedia> {

--- a/src/schema.json
+++ b/src/schema.json
@@ -25620,6 +25620,19 @@ paths:
     get:
       operationId: roster_media_list
       description: API viewset for managing player media.
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
       tags:
       - roster
       security:
@@ -25629,9 +25642,7 @@ paths:
           content:
             application/json:
               schema:
-                type: array
-                items:
-                  $ref: '#/components/schemas/PlayerMedia'
+                $ref: '#/components/schemas/PaginatedPlayerMediaList'
           description: ''
     post:
       operationId: roster_media_create
@@ -49914,6 +49925,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/PlayerMail'
+    PaginatedPlayerMediaList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/PlayerMedia'
     PaginatedPlayerReportDetailList:
       type: object
       required:

--- a/src/world/roster/tests/test_permissions.py
+++ b/src/world/roster/tests/test_permissions.py
@@ -256,19 +256,19 @@ class QuerysetPermissionsTestCase(APITestCase):
         """Users should only see their own media when authenticated."""
         url = reverse("roster:media-list")
 
-        # User1 should only see their own media
+        # User1 should only see their own media (paginated envelope, ADR-0138)
         self.client.force_authenticate(user=self.user1)
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 1
-        assert response.data[0]["id"] == self.user1_media.id
+        assert len(response.data["results"]) == 1
+        assert response.data["results"][0]["id"] == self.user1_media.id
 
         # User2 should only see their own media
         self.client.force_authenticate(user=self.user2)
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 1
-        assert response.data[0]["id"] == self.user2_media.id
+        assert len(response.data["results"]) == 1
+        assert response.data["results"][0]["id"] == self.user2_media.id
 
     def test_staff_sees_all_media(self):
         """Staff should see all media."""
@@ -277,7 +277,7 @@ class QuerysetPermissionsTestCase(APITestCase):
         self.client.force_authenticate(user=self.staff)
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 2  # Both users' media
+        assert len(response.data["results"]) == 2  # Both users' media
 
     def test_unauthenticated_sees_no_media(self):
         """Unauthenticated users should see no media in list (no player_data)."""
@@ -285,4 +285,4 @@ class QuerysetPermissionsTestCase(APITestCase):
 
         response = self.client.get(url)
         assert response.status_code == status.HTTP_200_OK
-        assert len(response.data) == 0  # No media for unauthenticated users
+        assert len(response.data["results"]) == 0  # No media for unauthenticated users

--- a/src/world/roster/tests/test_viewset.py
+++ b/src/world/roster/tests/test_viewset.py
@@ -211,8 +211,10 @@ class TestPlayerMediaViewSet(TestCase):
         url = "/api/roster/media/"
         response = self.client.get(url)
         assert response.status_code == 200
-        assert len(response.data) == 1
-        media_data = response.data[0]
+        # Paginated envelope (ADR-0138).
+        assert response.data["count"] == 1
+        assert len(response.data["results"]) == 1
+        media_data = response.data["results"][0]
         expected_fields = [
             "id",
             "cloudinary_public_id",
@@ -228,6 +230,24 @@ class TestPlayerMediaViewSet(TestCase):
             assert field in media_data
         assert media_data["id"] == self.media.id
         assert media_data["created_by"] is None
+
+    def test_list_media_is_paginated(self):
+        """A player's media library is paginated (ADR-0138); the FE walks pages."""
+        # setUp made 1; add two more for this player (3 total).
+        PlayerMediaFactory(player_data=self.player)
+        PlayerMediaFactory(player_data=self.player)
+
+        url = "/api/roster/media/"
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response.data["count"] == 3
+        assert response.data["next"] is None
+        assert len(response.data["results"]) == 3
+
+        # A small page splits the library and hands back a next link.
+        response = self.client.get(f"{url}?page_size=2")
+        assert len(response.data["results"]) == 2
+        assert response.data["next"] is not None
 
     @patch("world.roster.views.media_views.CloudinaryGalleryService.upload_image")
     def test_create_media(self, mock_upload):

--- a/src/world/roster/views/media_views.py
+++ b/src/world/roster/views/media_views.py
@@ -24,8 +24,10 @@ from world.roster.services import CloudinaryGalleryService
 class PlayerMediaViewSet(viewsets.ModelViewSet):
     """API viewset for managing player media."""
 
-    pagination_class = None  # 2026-07 audit: opt out of default paginator (ADR-0138)
-
+    # Paginated via the project default (ADR-0138): a player's whole uploaded
+    # image library grows over time. PlayerMedia.Meta.ordering (-uploaded_date)
+    # gives stable page boundaries; the frontend gallery loads every page via
+    # fetchAllPages since the grid shows the full set.
     serializer_class = PlayerMediaSerializer
     permission_classes = [ReadOnlyOrOwner]
 


### PR DESCRIPTION
## What

Second of the deferred pagination follow-ups. A player's uploaded media library (`/api/roster/media/`) grows over time — character portraits, gallery images — so it opted out of the ADR-0138 default. This removes the opt-out so it inherits the default paginator (`PlayerMedia.Meta.ordering = -uploaded_date` gives stable page boundaries).

## Frontend

The gallery grid shows the whole library, so `fetchPlayerMedia` now walks every page via the existing `fetchAllPages` helper (from the first-series #2422). The backend is bounded per request while the UI is unchanged — `fetchPlayerMedia` still returns `PlayerMedia[]`, so `PlayerMediaPage` needs no change. It's the only list consumer; the POST / associate-tenure / detail paths are single-item and unaffected.

`TenureGallery` deliberately **keeps** its opt-out — a character has a handful of gallery *containers* (returned filtered by `?tenure=`), not a growing list. Not everything should paginate.

## Tests

Existing media-list tests updated to read the paginated envelope; added one asserting a small `?page_size=` splits the library and returns a `next` link. Backend (34 roster) + frontend (17 roster) suites green; `pnpm build` clean. api-types regenerated (`PaginatedPlayerMediaList`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)