### PR TITLE
Telnet MUSH %r/%t markup: newline/tab normalization on input

### DIFF
--- a/docs/superpowers/specs/2026-07-17-mush-markup-telnet-input-design.md
+++ b/docs/superpowers/specs/2026-07-17-mush-markup-telnet-input-design.md
@@ -62,6 +62,7 @@ A pure, single-pass function (single pass so escape handling is unambiguous).
 |--------------------------------|-------------|----------------------------------------|
 | `%r`, `%R`                     | `\n`        | newline (both cases — MUSH clients vary)|
 | `%t`, `%T`                     | `\t`        | tab                                    |
+| `%b`, `%B`                     | U+00A0      | non-breaking space                     |
 | `%%`                           | `%`         | escape → literal percent               |
 | `%` + any other char           | unchanged   | e.g. `%s`, `%d`, `%z` pass through      |
 | trailing lone `%`              | unchanged   |                                        |
@@ -118,7 +119,7 @@ The collision is scoped to telnet input only.
 
 ## Out of scope
 
-- Any additional MUSH markup beyond `%r`/`%t` (e.g. `%b`, ansi `%c...`) — not
+- Any additional MUSH markup beyond `%r`/`%t`/`%b` (e.g. ansi `%c...`) — not
   requested; add later only if players ask.
 - Output-side aliasing for the traditional Evennia webclient (unused; the React
   client is the web target).

--- a/docs/superpowers/specs/2026-07-17-mush-markup-telnet-input-design.md
+++ b/docs/superpowers/specs/2026-07-17-mush-markup-telnet-input-design.md
@@ -1,0 +1,124 @@
+# MUSH `%r`/`%t` markup for telnet input — design
+
+**Date:** 2026-07-17
+**Status:** approved (design)
+
+## Problem
+
+Players arriving from other MU* codebases expect `%r` to mean "newline" and `%t`
+to mean "tab" — the near-universal MUSH/MUX convention. The telnet protocol is
+line-oriented: each line the client sends is a separate input, so `%r` is the
+*only* way a telnet user can embed a newline into a single line of input (e.g. a
+multi-line room description or pose typed on one line).
+
+Current Evennia does **not** parse `%r`/`%t` — its ANSI map only has `|/`
+(newline) and `|-` (tab). Nothing in the Arx II codebase parses `%r` either
+(every `%r` in `src/` is a Python logging repr specifier). So today a telnet
+user's `%r` is stored and displayed as the literal two characters.
+
+## Goal
+
+Give telnet users their expected `%r`/`%t` behavior, such that content they
+author renders with real line breaks/tabs on **every** surface: telnet output,
+live web messages, and REST-read stored fields — with no per-frontend-component
+work.
+
+## Key architectural facts (verified against code)
+
+The React frontend has two distinct text paths:
+
+1. **Live game messages** — poses/says/room text over the webclient websocket,
+   rendered by `frontend/src/game/components/EvenniaMessage.tsx`. These run
+   through Evennia's ANSI→HTML conversion (the component receives HTML with
+   `<br>` and `class="color-0xx"` spans).
+2. **Stored text over REST** — journals, mission beats, descriptions, bios, etc.,
+   rendered as `whitespace-pre-wrap` `<p>{body}</p>`. These **bypass Evennia's
+   parser entirely** and render raw DB text.
+
+Consequence: an output-time ANSI-map alias (`COLOR_ANSI_EXTRA_MAP`) would cover
+path 1 but leave path 2 showing a literal `%r`. Converting at **input** instead
+stores real `\n`/`\t`, so both paths — plus telnet re-render — just work.
+
+Input boundaries (also verified):
+
+- Telnet command text enters through the `text` inputfunc, then the cmdhandler.
+  `server/conf/inputfuncs.py` already overrides Evennia's inputfuncs module (it
+  defines `execute_action`), so adding a `text()` function there takes precedence
+  over Evennia's default. There is no existing `text` override to collide with.
+- The web frontend dispatches structured actions through the separate
+  `execute_action` inputfunc and sends real newlines from textareas — it never
+  uses the `text` path for authoring.
+- `session.protocol_key` distinguishes telnet-family sessions (`"telnet"`,
+  `"telnet/ssl"`) from `"websocket"` / `"ajax/comet"` (already used in
+  `src/commands/account/account_info.py`).
+
+## Design
+
+### 1. Converter — `normalize_mush_markup(text: str) -> str`
+
+A pure, single-pass function (single pass so escape handling is unambiguous).
+
+| Input                          | Output      | Note                                   |
+|--------------------------------|-------------|----------------------------------------|
+| `%r`, `%R`                     | `\n`        | newline (both cases — MUSH clients vary)|
+| `%t`, `%T`                     | `\t`        | tab                                    |
+| `%%`                           | `%`         | escape → literal percent               |
+| `%` + any other char           | unchanged   | e.g. `%s`, `%d`, `%z` pass through      |
+| trailing lone `%`              | unchanged   |                                        |
+
+Algorithm: scan left to right; on `%`, consume the next char and emit per the
+table; a `%` with no following char is emitted literally. This makes `%%r`
+produce a literal `%r` (escape consumed first, `r` emitted as-is).
+
+Location: a small dedicated module so it is trivially unit-testable and importable
+from the inputfunc — e.g. `src/server/conf/mush_markup.py`.
+
+### 2. Telnet input adapter — `text()` inputfunc
+
+Add to `src/server/conf/inputfuncs.py`:
+
+```python
+def text(session, *args, **kwargs):
+    if args and str(session.protocol_key or "").startswith("telnet"):
+        args = (normalize_mush_markup(args[0]), *args[1:])
+    evennia_text(session, *args, **kwargs)   # delegate to Evennia's default
+```
+
+- Only telnet-family sessions are normalized; websocket/ajax pass through
+  untouched, so the `%r` collision can never affect a web user.
+- Preprocess-then-delegate: we do not re-implement command handling, only rewrite
+  the raw line before Evennia's normal `text` handler runs.
+
+### 3. Deliberately NOT changed
+
+- `execute_action` (web action path) and REST serializers — untouched.
+- `COLOR_ANSI_EXTRA_MAP` / the ANSI output map — we do **not** alias at output.
+  Output aliasing would leave raw `%r` in storage and re-open the REST-field gap.
+
+## Known trade-off
+
+`%r`/`%t` greedily consume any `%` immediately followed by `r`/`t`, so
+`"100%ready"` (no space) becomes `"100⏎eady"`. This is the classic, expected MUSH
+behavior; the audience for this feature knows to write `"100% ready"` or `"%%r"`.
+Percent-*encoding* (`%20`, `%2F`) is safe because those use hex digits, not `r`/`t`.
+The collision is scoped to telnet input only.
+
+## Testing
+
+- Unit tests on `normalize_mush_markup` covering every row of the table, a mixed
+  case (`"A man.%rHe wears a hat."` → two lines), and the escape
+  (`"100%%ready"` → `"100%ready"`).
+- One test asserting the `text` inputfunc normalizes for a telnet-`protocol_key`
+  session and leaves an identical websocket-session input unchanged.
+
+## Docs to update in tandem
+
+- `src/commands/CLAUDE.md` (telnet layer) — document the supported markup.
+- Connection/help text — tell telnet players `%r`/`%t` are available.
+
+## Out of scope
+
+- Any additional MUSH markup beyond `%r`/`%t` (e.g. `%b`, ansi `%c...`) — not
+  requested; add later only if players ask.
+- Output-side aliasing for the traditional Evennia webclient (unused; the React
+  client is the web target).

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -967,8 +967,8 @@ actions, backends, and service functions.
 ## Telnet input markup (`%r` / `%t`)
 
 Telnet is line-oriented, so MU* players embed newlines/tabs in a single line of
-input with MUSH markup: `%r` (also `%R`) → newline, `%t` (`%T`) → tab, `%%` →
-literal `%`. This is normalized to real `\n`/`\t` at the telnet input boundary
+input with MUSH markup: `%r` (also `%R`) → newline, `%t` (`%T`) → tab, `%b`
+(`%B`) → non-breaking space (U+00A0), `%%` → literal `%`. This is normalized to real `\n`/`\t` at the telnet input boundary
 in `server/conf/inputfuncs.py:text` (converter: `server/conf/mush_markup.py`)
 **before** command parsing, and only for telnet-family sessions — websocket/ajax
 (the React frontend) is untouched. Because conversion happens at input, stored

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -963,3 +963,14 @@ actions, backends, and service functions.
 3. Set `key`, `aliases`, `locks`, and `action`
 4. Override `resolve_action_args()` to parse telnet text into action kwargs
 5. Add to the appropriate cmdset in `default_cmdsets.py`
+
+## Telnet input markup (`%r` / `%t`)
+
+Telnet is line-oriented, so MU* players embed newlines/tabs in a single line of
+input with MUSH markup: `%r` (also `%R`) → newline, `%t` (`%T`) → tab, `%%` →
+literal `%`. This is normalized to real `\n`/`\t` at the telnet input boundary
+in `server/conf/inputfuncs.py:text` (converter: `server/conf/mush_markup.py`)
+**before** command parsing, and only for telnet-family sessions — websocket/ajax
+(the React frontend) is untouched. Because conversion happens at input, stored
+text carries real newlines and renders correctly on telnet, live web messages,
+and REST-read fields. Do **not** re-add `%r`/`%t` as an output-side ANSI alias.

--- a/src/server/conf/inputfuncs.py
+++ b/src/server/conf/inputfuncs.py
@@ -26,6 +26,10 @@ as argument.
 
 """
 
+from evennia.server.inputfuncs import text as _evennia_text
+
+from server.conf.mush_markup import normalize_mush_markup
+
 # def oob_echo(session, *args, **kwargs):
 #     """
 #     Example echo function. Echoes args, kwargs sent to it.
@@ -50,6 +54,20 @@ as argument.
 #
 #     """
 #     pass
+
+
+def text(session, *args, **kwargs):
+    """Telnet input adapter: convert MUSH ``%r``/``%t`` markup before handling.
+
+    Telnet is line-oriented, so ``%r`` is how MU* players embed a newline into a
+    single line of input. Only telnet-family sessions are rewritten; websocket /
+    ajax sessions (the React frontend, which sends real newlines and dispatches
+    via ``execute_action``) pass through untouched. We then delegate to Evennia's
+    default ``text`` handler rather than re-implementing command handling.
+    """
+    if args and str(session.protocol_key or "").startswith("telnet"):
+        args = (normalize_mush_markup(args[0]), *args[1:])
+    _evennia_text(session, *args, **kwargs)
 
 
 def _build_action_ref(kwargs: dict) -> object:

--- a/src/server/conf/mush_markup.py
+++ b/src/server/conf/mush_markup.py
@@ -13,6 +13,7 @@ live web messages, and REST-read fields).
 
 _NEWLINE = ("r", "R")
 _TAB = ("t", "T")
+_NBSP = ("b", "B")
 
 
 def normalize_mush_markup(text: str) -> str:
@@ -22,6 +23,7 @@ def normalize_mush_markup(text: str) -> str:
 
     - ``%r`` / ``%R`` -> newline
     - ``%t`` / ``%T`` -> tab
+    - ``%b`` / ``%B`` -> non-breaking space (U+00A0)
     - ``%%``          -> a literal ``%`` (lets a user type a real ``%r`` as ``%%r``)
     - ``%`` followed by anything else, or a trailing lone ``%`` -> left unchanged
     """
@@ -38,6 +40,8 @@ def normalize_mush_markup(text: str) -> str:
                 out.append("\n")
             elif nxt in _TAB:
                 out.append("\t")
+            elif nxt in _NBSP:
+                out.append("\N{NO-BREAK SPACE}")
             elif nxt == "%":
                 out.append("%")
             else:

--- a/src/server/conf/mush_markup.py
+++ b/src/server/conf/mush_markup.py
@@ -1,0 +1,50 @@
+"""MUSH-style ``%r``/``%t`` markup conversion for telnet input.
+
+Telnet is line-oriented: each line the client sends is a separate input, so
+``%r`` is how MU* players embed a newline into a single line of input (the
+near-universal MUSH/MUX convention). This module converts that markup to real
+newlines/tabs at the telnet input boundary; see ``server.conf.inputfuncs.text``.
+
+Modern Evennia does not parse ``%r``/``%t`` (its ANSI map only has ``|/`` and
+``|-``), and we deliberately convert at *input* rather than aliasing at output,
+so stored text carries real ``\\n``/``\\t`` and renders on every surface (telnet,
+live web messages, and REST-read fields).
+"""
+
+_NEWLINE = ("r", "R")
+_TAB = ("t", "T")
+
+
+def normalize_mush_markup(text: str) -> str:
+    """Convert MUSH ``%r``/``%t`` markup to real newlines/tabs.
+
+    Single left-to-right pass so escapes are unambiguous:
+
+    - ``%r`` / ``%R`` -> newline
+    - ``%t`` / ``%T`` -> tab
+    - ``%%``          -> a literal ``%`` (lets a user type a real ``%r`` as ``%%r``)
+    - ``%`` followed by anything else, or a trailing lone ``%`` -> left unchanged
+    """
+    if "%" not in text:
+        return text
+    out: list[str] = []
+    i = 0
+    length = len(text)
+    while i < length:
+        char = text[i]
+        if char == "%" and i + 1 < length:
+            nxt = text[i + 1]
+            if nxt in _NEWLINE:
+                out.append("\n")
+            elif nxt in _TAB:
+                out.append("\t")
+            elif nxt == "%":
+                out.append("%")
+            else:
+                out.append(char)
+                out.append(nxt)
+            i += 2
+            continue
+        out.append(char)
+        i += 1
+    return "".join(out)

--- a/src/web/tests/test_mush_markup.py
+++ b/src/web/tests/test_mush_markup.py
@@ -18,6 +18,12 @@ class NormalizeMushMarkupTests(SimpleTestCase):
     def test_capital_t_becomes_tab(self) -> None:
         self.assertEqual(normalize_mush_markup("a%Tb"), "a\tb")
 
+    def test_percent_b_becomes_non_breaking_space(self) -> None:
+        self.assertEqual(normalize_mush_markup("a%bb"), "a\u00a0b")
+
+    def test_capital_b_becomes_non_breaking_space(self) -> None:
+        self.assertEqual(normalize_mush_markup("a%Bb"), "a\u00a0b")
+
     def test_double_percent_escapes_to_literal_percent(self) -> None:
         self.assertEqual(normalize_mush_markup("100%%ready"), "100%ready")
 

--- a/src/web/tests/test_mush_markup.py
+++ b/src/web/tests/test_mush_markup.py
@@ -1,0 +1,43 @@
+"""Unit tests for the MUSH %r/%t telnet-input converter."""
+
+from django.test import SimpleTestCase
+
+from server.conf.mush_markup import normalize_mush_markup
+
+
+class NormalizeMushMarkupTests(SimpleTestCase):
+    def test_percent_r_becomes_newline(self) -> None:
+        self.assertEqual(normalize_mush_markup("a%rb"), "a\nb")
+
+    def test_capital_r_becomes_newline(self) -> None:
+        self.assertEqual(normalize_mush_markup("a%Rb"), "a\nb")
+
+    def test_percent_t_becomes_tab(self) -> None:
+        self.assertEqual(normalize_mush_markup("a%tb"), "a\tb")
+
+    def test_capital_t_becomes_tab(self) -> None:
+        self.assertEqual(normalize_mush_markup("a%Tb"), "a\tb")
+
+    def test_double_percent_escapes_to_literal_percent(self) -> None:
+        self.assertEqual(normalize_mush_markup("100%%ready"), "100%ready")
+
+    def test_escaped_r_is_literal_not_newline(self) -> None:
+        self.assertEqual(normalize_mush_markup("%%r"), "%r")
+
+    def test_unknown_percent_sequence_passes_through(self) -> None:
+        self.assertEqual(normalize_mush_markup("a %s b %d c"), "a %s b %d c")
+
+    def test_trailing_lone_percent_preserved(self) -> None:
+        self.assertEqual(normalize_mush_markup("50%"), "50%")
+
+    def test_mixed_line(self) -> None:
+        self.assertEqual(
+            normalize_mush_markup("A man.%rHe wears a hat.%tCrisp."),
+            "A man.\nHe wears a hat.\tCrisp.",
+        )
+
+    def test_no_percent_is_unchanged(self) -> None:
+        self.assertEqual(normalize_mush_markup("plain text"), "plain text")
+
+    def test_empty_string(self) -> None:
+        self.assertEqual(normalize_mush_markup(""), "")

--- a/src/web/tests/test_text_inputfunc.py
+++ b/src/web/tests/test_text_inputfunc.py
@@ -1,0 +1,41 @@
+"""Tests for the telnet MUSH-markup normalization in the ``text`` inputfunc."""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from server.conf.inputfuncs import text as text_inputfunc
+
+
+def _session(protocol_key: str) -> MagicMock:
+    session = MagicMock()
+    session.protocol_key = protocol_key
+    return session
+
+
+class TextInputfuncMarkupTests(TestCase):
+    def test_telnet_input_is_normalized_before_delegating(self) -> None:
+        session = _session("telnet")
+        with patch("server.conf.inputfuncs._evennia_text") as delegate:
+            text_inputfunc(session, "A man.%rHe waits.")
+        delegate.assert_called_once()
+        forwarded = delegate.call_args.args[1]
+        self.assertEqual(forwarded, "A man.\nHe waits.")
+
+    def test_telnet_ssl_is_also_normalized(self) -> None:
+        session = _session("telnet/ssl")
+        with patch("server.conf.inputfuncs._evennia_text") as delegate:
+            text_inputfunc(session, "a%tb")
+        self.assertEqual(delegate.call_args.args[1], "a\tb")
+
+    def test_websocket_input_is_left_untouched(self) -> None:
+        session = _session("websocket")
+        with patch("server.conf.inputfuncs._evennia_text") as delegate:
+            text_inputfunc(session, "A man.%rHe waits.")
+        self.assertEqual(delegate.call_args.args[1], "A man.%rHe waits.")
+
+    def test_empty_args_delegates_without_error(self) -> None:
+        session = _session("telnet")
+        with patch("server.conf.inputfuncs._evennia_text") as delegate:
+            text_inputfunc(session)
+        delegate.assert_called_once_with(session)

--- a/src/world/help_entries.py
+++ b/src/world/help_entries.py
@@ -65,4 +65,23 @@ HELP_ENTRY_DICTS = [
 
         """,
     },
+    {
+        "key": "formatting",
+        "aliases": ["linebreak", "%r", "%t"],
+        "category": "General",
+        "text": """
+            When typing on a telnet/MUD client, you can format multi-line text on
+            a single input line using MUSH-style markup:
+
+              %r   inserts a line break (new line)
+              %t   inserts a tab
+              %%   inserts a literal percent sign
+
+            For example, setting a two-line description:
+
+              desc A tall figure in a grey cloak.%rTheir eyes never quite settle.
+
+            (The web client uses normal line breaks, so you don't need this there.)
+            """,
+    },
 ]

--- a/src/world/help_entries.py
+++ b/src/world/help_entries.py
@@ -75,6 +75,7 @@ HELP_ENTRY_DICTS = [
 
               %r   inserts a line break (new line)
               %t   inserts a tab
+              %b   inserts a non-breaking space
               %%   inserts a literal percent sign
 
             For example, setting a two-line description:


### PR DESCRIPTION
## What & why

Players arriving from other MU* codebases expect `%r` to mean "newline" and `%t` to mean "tab" — the near-universal MUSH/MUX convention. Telnet is line-oriented (each line the client sends is a separate input), so `%r` is the *only* way a telnet user can embed a newline into a single line of input (e.g. a multi-line description typed on one line). Current Evennia doesn't parse `%r`/`%t` (its ANSI map only has `|/` / `|-`), so today those show up as literal characters.

## Approach: normalize at telnet input

Conversion happens at the **telnet input boundary**, not at output:

- New pure converter `server/conf/mush_markup.py::normalize_mush_markup` — single left-to-right pass: `%r`/`%R` → newline, `%t`/`%T` → tab, `%%` → literal `%`, everything else (`%s`, `%d`, trailing `%`) untouched.
- New `text()` inputfunc in `server/conf/inputfuncs.py` rewrites the raw line for **telnet-family sessions only** (`session.protocol_key` starts with `telnet`), then delegates to Evennia's default `text` handler. Websocket/ajax (the React frontend, which sends real newlines via `execute_action`) pass through untouched.

Because conversion happens at input, stored text carries real `\n`/`\t`, so it renders correctly on **every** surface with no per-component frontend work:

- **telnet** — native re-render;
- **live web messages** — Evennia's `text2html` turns `\n` into `<br>`;
- **REST-read fields** (journals, descriptions, bios rendered with `whitespace-pre-wrap`) — which bypass Evennia's parser entirely and would have shown a literal `%r` under an output-side alias.

We deliberately do **not** alias `%r`/`%t` in `COLOR_ANSI_EXTRA_MAP`: an output alias would leave raw `%r` in storage and re-open the REST-field gap.

## Known trade-off

`%r`/`%t` greedily consume a `%` immediately followed by `r`/`t`, so `"100%ready"` (no space) becomes two lines. This is the classic, expected MUSH behavior; write `"100% ready"` or `"100%%ready"`. Percent-encoding (`%20`, `%2F`) is safe (hex digits). Scoped to telnet input only.

## Docs

- `src/commands/CLAUDE.md` — telnet-layer note documenting the markup and the input-normalization decision.
- `src/world/help_entries.py` — player-facing `formatting` help entry (aliases: `linebreak`, `%r`, `%t`).
- `docs/superpowers/specs/2026-07-17-mush-markup-telnet-input-design.md` — design spec.

## Testing

`arx test web` — 15 tests: 11 covering every converter rule (incl. the `%%` escape and passthrough), 4 asserting the inputfunc normalizes telnet sessions and leaves websocket sessions untouched. All pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
