### PR TITLE
Remove HomePageAPIView — dead Evennia-homepage port that leaked account activity

### DIFF
--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -7975,23 +7975,6 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
-  '/api/homepage/': {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    /** @description Return basic game statistics. */
-    get: operations['homepage_retrieve'];
-    put?: never;
-    post?: never;
-    delete?: never;
-    options?: never;
-    head?: never;
-    patch?: never;
-    trace?: never;
-  };
   '/api/interaction-favorites/': {
     parameters: {
       query?: never;
@@ -46842,24 +46825,6 @@ export interface operations {
         content: {
           'application/json': components['schemas']['GroupStoryRequest'];
         };
-      };
-    };
-  };
-  homepage_retrieve: {
-    parameters: {
-      query?: never;
-      header?: never;
-      path?: never;
-      cookie?: never;
-    };
-    requestBody?: never;
-    responses: {
-      /** @description No response body */
-      200: {
-        headers: {
-          [name: string]: unknown;
-        };
-        content?: never;
       };
     };
   };

--- a/src/schema.json
+++ b/src/schema.json
@@ -12800,18 +12800,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/GroupStoryRequest'
           description: ''
-  /api/homepage/:
-    get:
-      operationId: homepage_retrieve
-      description: Return basic game statistics.
-      tags:
-      - homepage
-      security:
-      - cookieAuth: []
-      - {}
-      responses:
-        '200':
-          description: No response body
   /api/interaction-favorites/:
     get:
       operationId: interaction_favorites_list

--- a/src/web/api/urls.py
+++ b/src/web/api/urls.py
@@ -5,7 +5,6 @@ from rest_framework.permissions import AllowAny
 from web.api.views.general_views import (
     CurrentUserAPIView,
     EmailVerificationAPIView,
-    HomePageAPIView,
     LogoutAPIView,
     RegisterAvailabilityAPIView,
     ResendEmailVerificationAPIView,
@@ -19,7 +18,6 @@ from web.api.views.search_views import (
 )
 
 urlpatterns = [
-    path("homepage/", HomePageAPIView.as_view(), name="api-homepage"),
     path("status/", ServerStatusAPIView.as_view(), name="api-status"),
     path("user/", CurrentUserAPIView.as_view(), name="api-current-user"),
     path(

--- a/src/web/api/views/general_views.py
+++ b/src/web/api/views/general_views.py
@@ -4,11 +4,9 @@ from allauth.account.models import EmailAddress
 from django.conf import settings
 from django.contrib.auth import logout
 from django.utils.decorators import method_decorator
-from django.utils.timesince import timesince
 from django.views.decorators.csrf import ensure_csrf_cookie
 from evennia import SESSION_HANDLER
 from evennia.accounts.models import AccountDB
-from evennia.objects.models import ObjectDB
 from evennia.utils import class_from_module
 from rest_framework import status
 from rest_framework.permissions import AllowAny
@@ -18,59 +16,6 @@ from rest_framework.views import APIView
 from web.api.payload_helpers import build_account_payload_context
 from web.api.serializers import AccountPlayerSerializer
 from world.roster.models import RosterEntry
-
-
-class HomePageAPIView(APIView):
-    """Return context for the Evennia home page."""
-
-    permission_classes = [AllowAny]
-
-    def get(self, request, *args, **kwargs):
-        """Return basic game statistics."""
-        recent_accounts = list(AccountDB.objects.get_recently_connected_accounts())
-        account_limit = 4
-        accounts_data = []
-        for account in recent_accounts[:account_limit]:
-            last_login = ""
-            if account.last_login:
-                last_login = timesince(account.last_login)
-            accounts_data.append(
-                {"username": account.username, "last_login": last_login},
-            )
-
-        character_cls = class_from_module(
-            settings.BASE_CHARACTER_TYPECLASS,
-            fallback=settings.FALLBACK_CHARACTER_TYPECLASS,
-        )
-        room_cls = class_from_module(
-            settings.BASE_ROOM_TYPECLASS,
-            fallback=settings.FALLBACK_ROOM_TYPECLASS,
-        )
-        exit_cls = class_from_module(
-            settings.BASE_EXIT_TYPECLASS,
-            fallback=settings.FALLBACK_EXIT_TYPECLASS,
-        )
-
-        num_characters = character_cls.objects.all_family().count()
-        num_rooms = room_cls.objects.all_family().count()
-        num_exits = exit_cls.objects.all_family().count()
-        num_objects = ObjectDB.objects.count()
-
-        context = {
-            "num_accounts_connected": SESSION_HANDLER.account_count(),
-            "num_accounts_registered": AccountDB.objects.count(),
-            "num_accounts_registered_recent": (
-                AccountDB.objects.get_recently_created_accounts().count()
-            ),
-            "num_accounts_connected_recent": len(recent_accounts),
-            "num_characters": num_characters,
-            "num_rooms": num_rooms,
-            "num_exits": num_exits,
-            "num_others": num_objects - num_characters - num_rooms - num_exits,
-            "page_title": "Arx II",
-            "accounts_connected_recent": accounts_data,
-        }
-        return Response(context)
 
 
 class ServerStatusAPIView(APIView):

--- a/src/web/tests/test_api.py
+++ b/src/web/tests/test_api.py
@@ -31,20 +31,6 @@ class WebAPITests(TestCase):
         )
 
     @patch("web.api.views.general_views.SESSION_HANDLER")
-    def test_homepage_api_returns_stats(self, mock_session_handler):
-        mock_session_handler.account_count.return_value = 0
-        url = reverse("api-homepage")
-        response = self.client.get(url)
-        assert response.status_code == 200
-        data = response.json()
-        assert data["page_title"] == "Arx II"
-        assert data["num_accounts_registered"] == 1
-        assert data["num_accounts_connected"] == 0
-        assert data["num_accounts_registered_recent"] == 1
-        assert data["num_accounts_connected_recent"] == 0
-        assert isinstance(data["accounts_connected_recent"], list)
-
-    @patch("web.api.views.general_views.SESSION_HANDLER")
     def test_status_api_returns_counts(self, mock_session_handler):
         mock_session_handler.account_count.return_value = 2
         character = ObjectDBFactory(


### PR DESCRIPTION
## What

The uncalled-routes investigation flagged two supersession candidates. This PR deletes the one that survived verification — and documents why the other stays.

### Deleted: `HomePageAPIView` (`/api/homepage/`)

A PR #51-era port of Evennia's default website homepage stats block (recent accounts, room/exit/object counts) into a React-consumable API. The React homepage never adopted it — zero frontend callers. Worse: it was **`AllowAny` and returned recently-connected account usernames + last-login times to unauthenticated callers**, which sits badly with the player-anonymity philosophy — worth removing on privacy grounds alone. Removed the view, URL registration, test, and schema entries (`class_from_module` kept — `ServerStatusAPIView` still uses it).

### Kept: `OnlineCharacterSearchAPIView` (`/api/characters/online/`)

Flagged as uncalled, but verification found it **alive**: `CmdPage`'s frontend metadata declares it as the `options_endpoint` for the web page-command form's character-search widget, which `CommandForm` fetches at runtime. A frontend-corpus grep can't see that reference because the URL string lives in backend Python. It's also semantically correct for `page` (you page the player of an *online character* — persona search isn't the right replacement). Recorded here so the next dead-code sweep doesn't re-flag it.

## Tests

`web` suite shows the identical 3 pre-existing errors as pristine main (stash-verified), zero new failures. api-types regenerated; frontend build clean. No overlap with #2476 (telnet markup) — disjoint files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)