### PR TITLE
Allowlist species.language in CONTENT_MODELS (#2463 language half)

### DIFF
--- a/src/core_management/content_export.py
+++ b/src/core_management/content_export.py
@@ -93,6 +93,7 @@ CONTENT_MODELS: frozenset[str] = frozenset(
         # skills
         "skills.skill",
         # species
+        "species.language",
         "species.species",
         # tarot
         "tarot.tarotcard",


### PR DESCRIPTION
## What

One-line addition of `species.language` to the content export/import allowlist.

## Why

`species.Language` is `[BUILT]` with `NaturalKeyMixin` but has zero rows anywhere (#2463): `Beginnings.starting_languages` and `Species.starting_languages` are unwired across every realm because the language table cannot ride the lore-repo content pipeline. With the allowlist entry, the lore repo carries `fixtures/species/language.json` (authored there — content lives only in the lore repo) and the six realms' ratified starting-language gates become expressible.

The generic natural-key assertions in `test_content_export.py` cover the new entry; `just test-fast core_management` is green (153 tests, 5 skipped).

Refs #2463 (the form-traits half of that issue remains open — this is the language half only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)