### PR TITLE
Combat write-path audit findings (for Tehom): dispatches ignore success:false, unreconciled local locks, stale available-actions

### DIFF
--- a/docs/audits/2026-07-10-webclient-rp-ux-audit.md
+++ b/docs/audits/2026-07-10-webclient-rp-ux-audit.md
@@ -193,8 +193,10 @@ Resolving this split is **#2156**, the structural core of the slate.
 - Typed verbs silently become prose: the composer's `KNOWN_COMMANDS` whitelist
   (pose/say/emit/whisper/tt) absorbs `intimidate Bob` into pose text with no signal.
 - `PersonaContextMenu` silently omits prerequisite-unmet actions (panel shows reason
-  tooltips) and reads available-actions from cache only — empty menu until the action panel
-  has been opened once.
+  tooltips). [FIXED prior to #2423] It used to read available-actions from cache only
+  (empty menu until the action panel had been opened once) — it now fetches directly via
+  its own query (#2158, landed in #2215), and #2423 repointed that fetch onto the shared
+  `useAvailableActionsQuery` hook without reintroducing the cache-only gap.
 - Non-GM participants have no round-state visibility in structured scenes (`active_round`
   consumed only by the GM-gated `RoundSettingsDialog`).
 - Parity: Seduce is web-only (no telnet command; #1697 asymmetry).

--- a/docs/roadmap/combat-build-history.md
+++ b/docs/roadmap/combat-build-history.md
@@ -717,8 +717,11 @@ guard wired into `resolve_round`/`declare_action`; duel-state serializers.
 clamps soulfray below any death-risk stage, and never fires a `character_loss` consequence.
 
 **Actions (telnet + web):** `challenge` (social-consent-gated) / `accept` / `decline` /
-`withdraw` / `yield` / `acknowledge_risk`. **Frontend:** `combat/duels/DuelChallengeControls`
-(+ yield / acknowledge controls), reusing the existing combat round UI + dispatch. **Telnet:**
+`withdraw` / `yield` / `acknowledge_risk`. **Frontend (at ship):**
+`combat/duels/DuelChallengeControls` (+ yield / acknowledge controls), reusing the existing
+combat round UI + dispatch — the Accept/Decline prompt for an incoming challenge later moved
+to `DuelChallengeNotifier`'s toast (#2157); the standalone in-panel prompt was superseded and
+deleted, leaving `DuelChallengeControls` scoped to yield/acknowledge-risk only (#2423). **Telnet:**
 the `duel <subverb>` namespace (`CmdDuel`, #1492) routes challenge/accept/decline/withdraw/risk
 through the same `dispatch_player_action` REGISTRY seam; `yield` stays on `combat yield` (#1453).
 

--- a/frontend/src/actions/ActionDeclarationCard.tsx
+++ b/frontend/src/actions/ActionDeclarationCard.tsx
@@ -6,7 +6,7 @@
  *
  * Props:
  * - characterId     — Evennia ObjectDB pk. NOT characterSheetId. Used with
- *                     fetchAvailableActions (scenes/actionQueries).
+ *                     useAvailableActionsQuery (scenes/actionQueries).
  * - characterSheetId — CharacterSheet pk. Used by the applicable-pulls API
  *                      (POST /api/magic/applicable-pulls/). The two IDs are
  *                      different objects; the parent supplies both. Phase 7
@@ -19,9 +19,8 @@
  */
 
 import { useEffect, useMemo, useState } from 'react';
-import { useQuery as useTQQuery } from '@tanstack/react-query';
 import { cn } from '@/lib/utils';
-import { fetchAvailableActions } from '@/scenes/actionQueries';
+import { useAvailableActionsQuery } from '@/scenes/actionQueries';
 import type { PlayerAction } from '@/scenes/actionTypes';
 import { useTechnique, useCharacterResonances } from '@/magic/queries';
 import { ThreadPullPicker } from '@/magic/components/threads/ThreadPullPicker';
@@ -593,11 +592,7 @@ export function ActionDeclarationCard({
   onCastPositionChange,
 }: ActionDeclarationCardProps) {
   // Fetch available techniques for this character.
-  const { data, isLoading } = useTQQuery({
-    queryKey: ['available-actions', characterId],
-    queryFn: () => fetchAvailableActions(characterId),
-    enabled: characterId > 0,
-  });
+  const { data, isLoading } = useAvailableActionsQuery(characterId);
 
   // Fetch technique detail for I/C chip and cost preview.
   const {

--- a/frontend/src/actions/__tests__/ActionDeclarationCard.test.tsx
+++ b/frontend/src/actions/__tests__/ActionDeclarationCard.test.tsx
@@ -24,9 +24,24 @@ import type { ActionContext } from '../types';
 // Module mocks
 // ---------------------------------------------------------------------------
 
-vi.mock('@/scenes/actionQueries', () => ({
-  fetchAvailableActions: vi.fn(),
-}));
+vi.mock('@/scenes/actionQueries', async () => {
+  const { useQuery } = await import('@tanstack/react-query');
+  const fetchAvailableActions = vi.fn();
+  return {
+    fetchAvailableActions,
+    useAvailableActionsQuery: (
+      characterId: number | null,
+      options: { enabled?: boolean; staleTime?: number; refetchInterval?: number } = {}
+    ) =>
+      useQuery({
+        queryKey: ['available-actions', characterId ?? 0],
+        queryFn: () => fetchAvailableActions(characterId),
+        enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
+        staleTime: options.staleTime,
+        refetchInterval: options.refetchInterval,
+      }),
+  };
+});
 
 // Mock the entire magic queries module to control useTechnique, useApplicablePulls,
 // useThreads, and useCharacterResonances synchronously.

--- a/frontend/src/actions/__tests__/ActionDeclarationCard.test.tsx
+++ b/frontend/src/actions/__tests__/ActionDeclarationCard.test.tsx
@@ -37,7 +37,7 @@ vi.mock('@/scenes/actionQueries', async () => {
         queryKey: ['available-actions', characterId ?? 0],
         queryFn: () => fetchAvailableActions(characterId),
         enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
-        staleTime: options.staleTime,
+        staleTime: options.staleTime ?? 10_000,
         refetchInterval: options.refetchInterval,
       }),
   };

--- a/frontend/src/battles/components/BattleMapCanvas.tsx
+++ b/frontend/src/battles/components/BattleMapCanvas.tsx
@@ -10,8 +10,8 @@
  * module-level `nodeTypes`, `Background` + `Controls`.
  */
 
-import { useCallback, useEffect, useMemo } from 'react';
-import { type Node, useNodesState } from '@xyflow/react';
+import { useCallback, useMemo } from 'react';
+import type { Node, NodeChange } from '@xyflow/react';
 
 import {
   centeredNodePosition,
@@ -78,11 +78,18 @@ export function BattleMapCanvas({ detail, selectedPlaceId, onSelectPlace }: Batt
     });
   }, [detail, selectedPlaceId, onSelectPlace]);
 
-  const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
-
-  useEffect(() => {
-    setNodes(computedNodes);
-  }, [computedNodes, setNodes]);
+  // Places never move interactively (read-only map — `nodesDraggable={false}`
+  // below, Decision 1 in the header doc), so there's no mutable node state to
+  // own: `computedNodes` is passed straight through as a controlled prop
+  // (`areas/components/TacticalMap.tsx`'s memo-direct pattern), which also
+  // fixes first paint — a `useNodesState([])` seed + mirroring `useEffect`
+  // rendered an empty canvas for one frame before the effect caught up
+  // (#2423). `MapCanvasShell.onNodesChange` is a required prop, so this is a
+  // no-op: React Flow's internal dimension/selection bookkeeping (used for
+  // its own measurement pass) doesn't need to round-trip back into our node
+  // list, since selection here is driven by `selectedPlaceId` and dragging
+  // is disabled.
+  const onNodesChange = useCallback((_changes: NodeChange[]) => {}, []);
 
   const onNodeClick = useCallback(
     (_event: React.MouseEvent, node: Node) => {
@@ -97,7 +104,7 @@ export function BattleMapCanvas({ detail, selectedPlaceId, onSelectPlace }: Batt
   return (
     <MapCanvasShell
       testId="battle-map-canvas"
-      nodes={nodes}
+      nodes={computedNodes}
       edges={[]}
       nodeTypes={nodeTypes}
       onNodesChange={onNodesChange}

--- a/frontend/src/battles/components/StagingPanel.test.tsx
+++ b/frontend/src/battles/components/StagingPanel.test.tsx
@@ -42,7 +42,7 @@ vi.mock('@/scenes/actionQueries', async () => {
         queryKey: ['available-actions', characterId ?? 0],
         queryFn: () => fetchAvailableActions(characterId),
         enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
-        staleTime: options.staleTime,
+        staleTime: options.staleTime ?? 10_000,
         refetchInterval: options.refetchInterval,
       }),
   };

--- a/frontend/src/battles/components/StagingPanel.test.tsx
+++ b/frontend/src/battles/components/StagingPanel.test.tsx
@@ -29,9 +29,24 @@ vi.mock('@/scenes/queries', async () => {
   };
 });
 
-vi.mock('@/scenes/actionQueries', () => ({
-  fetchAvailableActions: vi.fn(),
-}));
+vi.mock('@/scenes/actionQueries', async () => {
+  const { useQuery } = await import('@tanstack/react-query');
+  const fetchAvailableActions = vi.fn();
+  return {
+    fetchAvailableActions,
+    useAvailableActionsQuery: (
+      characterId: number | null,
+      options: { enabled?: boolean; staleTime?: number; refetchInterval?: number } = {}
+    ) =>
+      useQuery({
+        queryKey: ['available-actions', characterId ?? 0],
+        queryFn: () => fetchAvailableActions(characterId),
+        enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
+        staleTime: options.staleTime,
+        refetchInterval: options.refetchInterval,
+      }),
+  };
+});
 
 vi.mock('@/roster/queries', () => ({
   useMyRosterEntriesQuery: vi.fn(() => ({

--- a/frontend/src/battles/components/StagingPanel.tsx
+++ b/frontend/src/battles/components/StagingPanel.tsx
@@ -41,6 +41,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { useDispatchPlayerAction } from '@/combat/queries';
+import { isDispatchFailure } from '@/combat/types';
 import { fetchAvailableActions } from '@/scenes/actionQueries';
 import { fetchScene, sceneKeys } from '@/scenes/queries';
 import type { SceneDetail, ScenePersona } from '@/scenes/types';
@@ -122,11 +123,6 @@ export function StagingPanel({ sceneId, battle, detail }: Props) {
   // (`postDispatchAction`, `frontend/src/combat/api.ts:383-397`) marks a
   // real transport/structural error. Both render with the same error styling.
   const [feedback, setFeedback] = useState<{ text: string; error: boolean } | null>(null);
-
-  /** `result.success === false` is the honest-failure wire signal (#2010 review). */
-  function isDispatchFailure(result: { success?: boolean | null }): boolean {
-    return result.success === false;
-  }
 
   function invalidateBattleQueries() {
     queryClient.invalidateQueries({ queryKey: battleKeys.forScene(sceneId) });

--- a/frontend/src/battles/components/StagingPanel.tsx
+++ b/frontend/src/battles/components/StagingPanel.tsx
@@ -42,7 +42,7 @@ import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { useDispatchPlayerAction } from '@/combat/queries';
 import { isDispatchFailure } from '@/combat/types';
-import { fetchAvailableActions } from '@/scenes/actionQueries';
+import { useAvailableActionsQuery } from '@/scenes/actionQueries';
 import { fetchScene, sceneKeys } from '@/scenes/queries';
 import type { SceneDetail, ScenePersona } from '@/scenes/types';
 import type { PlayerAction } from '@/scenes/actionTypes';
@@ -91,11 +91,7 @@ export function StagingPanel({ sceneId, battle, detail }: Props) {
   // ---------------------------------------------------------------------------
   // Available actions -> the four staging refs
   // ---------------------------------------------------------------------------
-  const { data: actionsData } = useQuery({
-    queryKey: ['available-actions', characterId],
-    queryFn: () => fetchAvailableActions(characterId!),
-    enabled: characterId !== null,
-  });
+  const { data: actionsData } = useAvailableActionsQuery(characterId);
   const availableActions: PlayerAction[] = actionsData?.results ?? [];
 
   const findAction = (registryKey: string): PlayerAction | null =>

--- a/frontend/src/battles/components/__tests__/BattleMapCanvas.test.tsx
+++ b/frontend/src/battles/components/__tests__/BattleMapCanvas.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * Tests for BattleMapCanvas (#2423 finding 7) — place nodes must be present
+ * on FIRST render. The original implementation seeded `useNodesState([])`
+ * and mirrored `computedNodes` in via a post-render `useEffect`, so the very
+ * first commit showed an empty React Flow canvas until that passive effect
+ * flushed.
+ *
+ * `@/map-canvas/MapCanvasShell` is mocked to a trivial stub that renders the
+ * `nodes` prop directly — this isolates BattleMapCanvas's own render/effect
+ * behavior from React Flow's internal Zustand-store sync (itself driven by a
+ * `useLayoutEffect` in `@xyflow/react`'s `StoreUpdater`, which every
+ * consumer of the shell — old or new — needs regardless of this fix, and
+ * which `@testing-library/react`'s `act()`-wrapped `render()` would flush
+ * away either way). What's actually under test here is whether
+ * BattleMapCanvas hands the shell populated nodes on mount, or seeds it
+ * empty and corrects itself a render later.
+ */
+
+import { act } from 'react';
+import { flushSync } from 'react-dom';
+import { createRoot } from 'react-dom/client';
+import { describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import type { Node } from '@xyflow/react';
+
+import { BattleMapCanvas } from '../BattleMapCanvas';
+import type { BattleDetail } from '../../types';
+
+vi.mock('@/map-canvas/MapCanvasShell', () => ({
+  MapCanvasShell: ({
+    testId,
+    nodes,
+    emptyState,
+  }: {
+    testId: string;
+    nodes: Node[];
+    emptyState?: React.ReactNode;
+  }) => {
+    if (emptyState) {
+      return <>{emptyState}</>;
+    }
+    return (
+      <div data-testid={testId}>
+        {nodes.map((node) => (
+          <div key={node.id} data-testid="battle-place-node" data-place-id={node.id} />
+        ))}
+      </div>
+    );
+  },
+}));
+
+const MOCK_DETAIL: BattleDetail = {
+  id: 42,
+  name: 'Siege of the Gate',
+  outcome: null,
+  risk_level: 'high',
+  is_paused: false,
+  round: null,
+  sides: [
+    {
+      id: 1,
+      role: 'attacker',
+      victory_points: 8,
+      victory_threshold: 10,
+      posture: 'aggressive',
+      covenant_id: 1,
+      covenant_name: 'Iron Vanguard',
+    },
+  ],
+  places: [
+    {
+      id: 1,
+      name: 'The Ford',
+      terrain_type: 'flooded',
+      movement_cost: 2,
+      x: 10.5,
+      y: -3.0,
+      footprint_radius: 2.0,
+      controlled_by_id: 1,
+      encounter_scene_id: null,
+      encounter_roster: null,
+      vehicle: null,
+      fortifications: [],
+    },
+    {
+      id: 2,
+      name: 'The Bridge',
+      terrain_type: 'open',
+      movement_cost: 1,
+      x: -5.0,
+      y: 4.0,
+      footprint_radius: 1.5,
+      controlled_by_id: null,
+      encounter_scene_id: null,
+      encounter_roster: null,
+      vehicle: null,
+      fortifications: [],
+    },
+  ],
+  units: [],
+  participants: [],
+} as unknown as BattleDetail;
+
+describe('BattleMapCanvas', () => {
+  it('renders place nodes synchronously on first render (no effect flush)', () => {
+    // `@testing-library/react`'s `render()` wraps the mount in `act()`,
+    // which drains ALL pending effects (layout AND passive) to a stable
+    // fixed point before returning — that would flush away the exact bug
+    // this test guards against (nodes seeded empty, corrected a render
+    // later by a passive `useEffect`). `flushSync` forces the initial commit
+    // to happen synchronously (so we can read the DOM immediately) without
+    // draining the passive-effect queue the way `act()` does — so reading
+    // the DOM right after `flushSync` returns reflects the true first
+    // commit, before any `useEffect` has had a chance to run.
+    const container = document.createElement('div');
+    document.body.appendChild(container);
+    const root = createRoot(container);
+
+    flushSync(() => {
+      root.render(
+        <BattleMapCanvas detail={MOCK_DETAIL} selectedPlaceId={null} onSelectPlace={vi.fn()} />
+      );
+    });
+
+    const renderedNodeCount = container.querySelectorAll(
+      '[data-testid="battle-place-node"]'
+    ).length;
+
+    // Flush/unmount inside act() so no pending effect leaks a warning (or a
+    // state update) into a later test.
+    act(() => {
+      root.unmount();
+    });
+    document.body.removeChild(container);
+
+    expect(renderedNodeCount).toBe(MOCK_DETAIL.places.length);
+  });
+
+  it('renders the empty state when there are no places', () => {
+    render(
+      <BattleMapCanvas
+        detail={{ ...MOCK_DETAIL, places: [] }}
+        selectedPlaceId={null}
+        onSelectPlace={vi.fn()}
+      />
+    );
+
+    expect(screen.getByTestId('battle-map-canvas-empty')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/battles/queries.ts
+++ b/frontend/src/battles/queries.ts
@@ -37,6 +37,8 @@ export function useBattleDetailQuery(battleId: number | null | undefined) {
     queryKey: battleKeys.detail(battleId ?? 0),
     queryFn: () => fetchBattleDetail(battleId!),
     enabled: battleId != null,
+    // Staging is multi-GM: poll so another GM's changes appear without a reload (#2423).
+    refetchInterval: 10_000,
     staleTime: 15_000,
   });
 }

--- a/frontend/src/combat/CombatTurnPanel.tsx
+++ b/frontend/src/combat/CombatTurnPanel.tsx
@@ -32,7 +32,6 @@ import { RoundFlow } from './sections/RoundFlow';
 import { EncounterOutcomeBanner } from './components/EncounterOutcomeBanner';
 import { ForcedEscapeBanner } from './components/ForcedEscapeBanner';
 import { OutcomeRoulette } from './OutcomeRoulette';
-import type { OutcomeDisplayRow } from './api';
 import type { components } from '@/generated/api';
 import type { CastPosition, PositionTargetShape } from '@/actions/types';
 
@@ -363,7 +362,7 @@ export function CombatTurnPanel({
           {!collapsed.outcomeRoulette && (
             <div className="border-t border-border px-3 py-2">
               <OutcomeRoulette
-                outcomeDisplay={latestOutcome.outcome_display as unknown as OutcomeDisplayRow[]}
+                outcomeDisplay={latestOutcome.outcome_display}
                 modifiers={latestOutcome.modifiers}
                 modifierTotal={latestOutcome.modifier_total}
                 summary={latestOutcome.summary}

--- a/frontend/src/combat/DuelChallengeNotifier.tsx
+++ b/frontend/src/combat/DuelChallengeNotifier.tsx
@@ -8,11 +8,13 @@
  * buttons — the first time a new challenge id appears in the poll. A `Set` of
  * already-toasted ids prevents the 15s poll from re-firing the same toast.
  *
- * Accept/Decline await the dispatch (mirroring DuelChallengeControls' mutateAsync
- * + try/catch pattern) — the toast only dismisses on success; on failure it stays
- * open with an inline error and the buttons remain clickable to retry, so a failed
- * dispatch is never silently lost (the id was already added to toastedIds when the
- * toast first fired, so a dismissed-on-error toast would otherwise never resurface).
+ * Accept/Decline await the dispatch (mutateAsync + try/catch, plus an
+ * `isDispatchFailure(result)` check since the endpoint resolves HTTP 200 with
+ * `success: false` for a business-rule rejection — #2423) — the toast only
+ * dismisses on a genuine success; on failure it stays open with an inline error
+ * and the buttons remain clickable to retry, so a failed dispatch is never
+ * silently lost (the id was already added to toastedIds when the toast first
+ * fired, so a dismissed-on-error toast would otherwise never resurface).
  *
  * Right-character dispatch (#2166): `useDuelChallengeInbox` is already account-wide
  * (server-scoped to `request.user.played_character_sheet_ids`, not the active
@@ -39,6 +41,7 @@ import type { MyRosterEntry } from '@/roster/types';
 import { useDuelChallengeInbox, useDispatchPlayerAction } from './queries';
 import type { DuelChallenge } from './api';
 import { registryRef } from './duels/DuelChallengeControls';
+import { isDispatchFailure } from '@/combat/types';
 
 interface ToastBodyProps {
   toastId: string | number;
@@ -62,7 +65,11 @@ function DuelChallengeToastBody({
     setIsPending(true);
     setError(null);
     try {
-      await mutateAsync(registryRef(action, { challenge_id: challenge.id }));
+      const result = await mutateAsync(registryRef(action, { challenge_id: challenge.id }));
+      if (isDispatchFailure(result)) {
+        setError(result.message ?? 'Failed to respond to the challenge');
+        return;
+      }
       toast.dismiss(toastId);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to respond to the challenge');

--- a/frontend/src/combat/__tests__/ActiveState.test.tsx
+++ b/frontend/src/combat/__tests__/ActiveState.test.tsx
@@ -66,7 +66,7 @@ function makeEncounter(clashes: ClashState[] = []): EncounterDetail {
       },
     ],
     current_round_actions: [],
-    clashes: clashes as unknown as EncounterDetail['clashes'],
+    clashes,
     engagement_locks: [],
     created_at: '2026-01-01T00:00:00Z',
     outcome: '',

--- a/frontend/src/combat/__tests__/CombatTurnPanel.test.tsx
+++ b/frontend/src/combat/__tests__/CombatTurnPanel.test.tsx
@@ -45,7 +45,6 @@ vi.mock('@/combat/queries', () => ({
     all: ['combat'],
     encounter: (id: number) => ['combat', 'encounter', id],
     combos: (id: number) => ['combat', 'combos', id],
-    availableActions: (id: number) => ['combat', 'available-actions', id],
     consequenceOutcomes: (params: Record<string, unknown>) => [
       'combat',
       'consequence-outcomes',

--- a/frontend/src/combat/__tests__/DuelChallengeNotifier.test.tsx
+++ b/frontend/src/combat/__tests__/DuelChallengeNotifier.test.tsx
@@ -176,4 +176,19 @@ describe('DuelChallengeNotifier', () => {
     expect(toastDismissMock).not.toHaveBeenCalled();
     expect(getByTestId('duel-toast-accept-btn')).not.toBeDisabled();
   });
+
+  it('shows an inline error and does not dismiss the toast when the dispatch resolves success:false (#2423)', async () => {
+    mockUseDuelChallengeInbox.mockReturnValue({ data: [challenge(5)], isLoading: false });
+    mockMutateAsync.mockResolvedValue({ success: false, message: 'Challenge already expired.' });
+    render(<DuelChallengeNotifier />);
+
+    const renderFn = toastCustomMock.mock.calls[0][0] as (id: string | number) => JSX.Element;
+    const { getByTestId } = render(renderFn('toast-1'));
+    fireEvent.click(getByTestId('duel-toast-accept-btn'));
+
+    await waitFor(() => {
+      expect(getByTestId('duel-toast-error')).toHaveTextContent('Challenge already expired.');
+    });
+    expect(toastDismissMock).not.toHaveBeenCalled();
+  });
 });

--- a/frontend/src/combat/__tests__/RoundFlow.test.tsx
+++ b/frontend/src/combat/__tests__/RoundFlow.test.tsx
@@ -290,7 +290,7 @@ describe('SurgeBeats', () => {
   it('renders a surge beat narration line', () => {
     const encounter = makeEncounter([], [], 1, {
       escalation_curve_name: 'Standard Dramatic Escalation',
-      surge_beats: [{ narration: "Kira's power surges with sudden, dramatic force." }],
+      surge_beats: [{ id: 1, narration: "Kira's power surges with sudden, dramatic force." }],
     });
     mockedUseEndEncounter.mockReturnValue({ mutate: vi.fn(), isPending: false });
 

--- a/frontend/src/combat/__tests__/YourTurn.test.tsx
+++ b/frontend/src/combat/__tests__/YourTurn.test.tsx
@@ -1806,3 +1806,50 @@ describe('YourTurn — server is_ready lock (#2423)', () => {
     mockActionDeclarationCard.mockImplementation(defaultCardImpl);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Round-advance round-scoped state reset (#2423 finding 4)
+// ---------------------------------------------------------------------------
+
+describe('YourTurn — round-advance clash reset (#2423 finding 4)', () => {
+  it('does not carry a round-N clash selection into the round-N+1 submit', async () => {
+    setupMocks();
+    const clashAction = makePlayerAction(42, 'The Great Clash');
+
+    const { rerender } = render(
+      <YourTurn {...defaultProps({ roundNumber: 1, availableActions: [clashAction] })} />,
+      { wrapper: createWrapper() }
+    );
+
+    // Select the clash in round 1 — no submit yet.
+    await userEvent.click(screen.getByTestId('clash-commit-btn-42'));
+    expect(screen.getByTestId('clash-strain-slider-42')).toBeInTheDocument();
+
+    // Advance to round 2 (same clash action still offered by the server).
+    // Deliberately reuses the SAME wrapper/QueryClientProvider instance (RTL's
+    // `rerender` re-wraps with the original `wrapper` automatically) so the
+    // component does NOT remount — only its props change — otherwise a fresh
+    // mount would trivially reset all local state and mask the bug (#2423).
+    rerender(<YourTurn {...defaultProps({ roundNumber: 2, availableActions: [clashAction] })} />);
+
+    // The round-N selection must not have survived the reset — no strain
+    // slider, no selected styling on the commit button.
+    await waitFor(() => {
+      expect(screen.queryByTestId('clash-strain-slider-42')).not.toBeInTheDocument();
+    });
+
+    // Submit round 2 with nothing declared.
+    await userEvent.click(screen.getByTestId('submit-declarations-btn'));
+    await waitFor(() => {
+      expect(screen.getByTestId('ready-badge')).toBeInTheDocument();
+    });
+
+    // The dispatched jobs must NOT include a clash contribution carried over
+    // from round 1's stale `selectedClashRef` — this is the exact bug (#2423).
+    const calls = mockMutateAsync.mock.calls as Array<
+      [{ ref: Record<string, unknown>; kwargs: Record<string, unknown> }]
+    >;
+    const staleClashCall = calls.find((c) => c[0].ref.clash_id === 42);
+    expect(staleClashCall).toBeUndefined();
+  });
+});

--- a/frontend/src/combat/__tests__/YourTurn.test.tsx
+++ b/frontend/src/combat/__tests__/YourTurn.test.tsx
@@ -155,9 +155,14 @@ function createWrapper() {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false, gcTime: 0 } },
   });
-  return function Wrapper({ children }: { children: ReactNode }) {
+  function Wrapper({ children }: { children: ReactNode }) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
-  };
+  }
+  // Exposes the QueryClient instance so tests can spy on invalidateQueries
+  // (#2423) — attaching to the function keeps every existing
+  // `{ wrapper: createWrapper() }` call site unaffected.
+  Wrapper.queryClient = queryClient;
+  return Wrapper;
 }
 
 const mockedUseAvailableCombos = combatQueries.useAvailableCombos as ReturnType<typeof vi.fn>;
@@ -1692,7 +1697,7 @@ describe('YourTurn — server is_ready lock (#2423)', () => {
     expect(screen.getByTestId('action-card-focused')).toHaveAttribute('data-readonly', 'true');
   });
 
-  it('does not show ready badge and surfaces the rejection when a dispatch job resolves success:false', async () => {
+  it('skips the ready badge and encounter invalidation when a job resolves success:false', async () => {
     setupMocks();
 
     // Override the focused card stub so selecting a technique emits techniqueId=99.
@@ -1728,7 +1733,10 @@ describe('YourTurn — server is_ready lock (#2423)', () => {
       message: 'Rejected.',
     });
 
-    render(<YourTurn {...defaultProps()} />, { wrapper: createWrapper() });
+    const wrapper = createWrapper();
+    const invalidateSpy = vi.spyOn(wrapper.queryClient, 'invalidateQueries');
+
+    render(<YourTurn {...defaultProps()} />, { wrapper });
 
     await userEvent.click(screen.getByTestId('card-select-technique-focused'));
     await userEvent.click(screen.getByTestId('submit-declarations-btn'));
@@ -1739,6 +1747,61 @@ describe('YourTurn — server is_ready lock (#2423)', () => {
     // ready-badge should NOT appear — submission did not complete successfully.
     expect(screen.queryByTestId('ready-badge')).not.toBeInTheDocument();
     expect(screen.getByTestId('submit-declarations-btn')).not.toBeDisabled();
+
+    // The honest-failure result must short-circuit before any invalidation —
+    // a rejected dispatch must not refresh the encounter as if it succeeded.
+    expect(invalidateSpy).not.toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: combatQueries.combatKeys.encounter(1) })
+    );
+
+    mockActionDeclarationCard.mockImplementation(defaultCardImpl);
+  });
+
+  it('invalidates the encounter query once every dispatch job succeeds', async () => {
+    setupMocks();
+
+    // Override the focused card stub so selecting a technique emits techniqueId=7.
+    mockActionDeclarationCard.mockImplementation(({ actionContext, onContextChange, readOnly }) => {
+      const slot = actionContext.slot as string;
+      return (
+        <div data-testid={`action-card-${slot}`} data-readonly={String(readOnly ?? false)}>
+          ActionCard [{slot}]
+          <button
+            type="button"
+            data-testid={`card-select-technique-${slot}`}
+            onClick={() =>
+              onContextChange({
+                slot,
+                effort: 'MEDIUM',
+                strainCommitment: 0,
+                techniqueId: 7,
+              })
+            }
+          >
+            select technique
+          </button>
+        </div>
+      );
+    });
+
+    // beforeEach already sets mockMutateAsync's default resolved value to a
+    // successful, non-deferred-looking result — no override needed here.
+
+    const wrapper = createWrapper();
+    const invalidateSpy = vi.spyOn(wrapper.queryClient, 'invalidateQueries');
+
+    render(<YourTurn {...defaultProps({ encounterId: 1 })} />, { wrapper });
+
+    await userEvent.click(screen.getByTestId('card-select-technique-focused'));
+    await userEvent.click(screen.getByTestId('submit-declarations-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ready-badge')).toBeInTheDocument();
+    });
+
+    expect(invalidateSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ queryKey: combatQueries.combatKeys.encounter(1) })
+    );
 
     mockActionDeclarationCard.mockImplementation(defaultCardImpl);
   });

--- a/frontend/src/combat/__tests__/YourTurn.test.tsx
+++ b/frontend/src/combat/__tests__/YourTurn.test.tsx
@@ -1658,3 +1658,88 @@ describe('YourTurn — cast-position mount-reset guard (#2206 review finding)', 
     expect(onCastPositionChange).not.toHaveBeenCalledWith({});
   });
 });
+
+// ---------------------------------------------------------------------------
+// Task 5 — lock derives from server is_ready; submit checks results (#2423)
+// ---------------------------------------------------------------------------
+
+describe('YourTurn — server is_ready lock (#2423)', () => {
+  it('locks the panel and shows the ready badge from server is_ready on fresh mount', () => {
+    // Simulates the tab-remount scenario: Radix unmounts YourTurn on Map tab
+    // switch, then remounts it — local `submitted` state resets to false, but
+    // the server already has this participant's round action marked ready.
+    setupMocks();
+    const encounter = makeEncounter({
+      status: 'declaring',
+      participants: [makeSelfParticipant(5)],
+      current_round_actions: [
+        {
+          participant: 5,
+          participant_name: 'Hero',
+          maneuver: null,
+          is_ready: true,
+          focused_ally_target: null,
+        },
+      ],
+    });
+
+    render(<YourTurn {...defaultProps({ encounter })} />, { wrapper: createWrapper() });
+
+    // Fresh local state (no click on submit) — ready-badge still renders
+    // because it derives from ownRoundAction.is_ready, not local `submitted`.
+    expect(screen.getByTestId('ready-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('submit-declarations-btn')).toBeDisabled();
+    expect(screen.getByTestId('action-card-focused')).toHaveAttribute('data-readonly', 'true');
+  });
+
+  it('does not show ready badge and surfaces the rejection when a dispatch job resolves success:false', async () => {
+    setupMocks();
+
+    // Override the focused card stub so selecting a technique emits techniqueId=99.
+    mockActionDeclarationCard.mockImplementation(({ actionContext, onContextChange, readOnly }) => {
+      const slot = actionContext.slot as string;
+      return (
+        <div data-testid={`action-card-${slot}`} data-readonly={String(readOnly ?? false)}>
+          ActionCard [{slot}]
+          <button
+            type="button"
+            data-testid={`card-select-technique-${slot}`}
+            onClick={() =>
+              onContextChange({
+                slot,
+                effort: 'MEDIUM',
+                strainCommitment: 0,
+                techniqueId: 99,
+              })
+            }
+          >
+            select technique
+          </button>
+        </div>
+      );
+    });
+
+    // The dispatch endpoint always resolves 200 — a business-rule rejection
+    // surfaces as success:false, not a thrown error.
+    mockMutateAsync.mockResolvedValueOnce({
+      backend: 'COMBAT',
+      deferred: false,
+      success: false,
+      message: 'Rejected.',
+    });
+
+    render(<YourTurn {...defaultProps()} />, { wrapper: createWrapper() });
+
+    await userEvent.click(screen.getByTestId('card-select-technique-focused'));
+    await userEvent.click(screen.getByTestId('submit-declarations-btn'));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Rejected.');
+
+    // ready-badge should NOT appear — submission did not complete successfully.
+    expect(screen.queryByTestId('ready-badge')).not.toBeInTheDocument();
+    expect(screen.getByTestId('submit-declarations-btn')).not.toBeDisabled();
+
+    mockActionDeclarationCard.mockImplementation(defaultCardImpl);
+  });
+});

--- a/frontend/src/combat/__tests__/isDispatchFailure.test.ts
+++ b/frontend/src/combat/__tests__/isDispatchFailure.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from 'vitest';
+import { isDispatchFailure } from '../types';
+
+describe('isDispatchFailure', () => {
+  it('is true only for success === false', () => {
+    expect(isDispatchFailure({ success: false })).toBe(true);
+    expect(isDispatchFailure({ success: true })).toBe(false);
+    expect(isDispatchFailure({ success: null })).toBe(false);
+    expect(isDispatchFailure({})).toBe(false);
+  });
+});

--- a/frontend/src/combat/api.ts
+++ b/frontend/src/combat/api.ts
@@ -32,14 +32,10 @@ export type DuelChallengeRole = 'incoming' | 'outgoing';
 
 /**
  * A single row in the outcome_display roulette wheel.
- * The backend serializes OutcomeDisplay dataclass as plain dicts.
+ * The backend annotates get_outcome_display with @extend_schema_field
+ * (OutcomeDisplayRowSerializer), so this is a direct re-export (#2423).
  */
-export interface OutcomeDisplayRow {
-  label: string;
-  tier_name: string;
-  weight: number;
-  is_selected: boolean;
-}
+export type OutcomeDisplayRow = components['schemas']['OutcomeDisplayRow'];
 
 // ---------------------------------------------------------------------------
 // Encounter

--- a/frontend/src/combat/components/CombatTacticalMap.test.tsx
+++ b/frontend/src/combat/components/CombatTacticalMap.test.tsx
@@ -30,7 +30,7 @@ vi.mock('@/scenes/actionQueries', async () => {
         queryKey: ['available-actions', characterId ?? 0],
         queryFn: () => fetchAvailableActions(characterId),
         enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
-        staleTime: options.staleTime,
+        staleTime: options.staleTime ?? 10_000,
         refetchInterval: options.refetchInterval,
       }),
   };

--- a/frontend/src/combat/components/CombatTacticalMap.test.tsx
+++ b/frontend/src/combat/components/CombatTacticalMap.test.tsx
@@ -17,9 +17,24 @@ vi.mock('../queries', async () => {
   };
 });
 
-vi.mock('@/scenes/actionQueries', () => ({
-  fetchAvailableActions: vi.fn(),
-}));
+vi.mock('@/scenes/actionQueries', async () => {
+  const { useQuery } = await import('@tanstack/react-query');
+  const fetchAvailableActions = vi.fn();
+  return {
+    fetchAvailableActions,
+    useAvailableActionsQuery: (
+      characterId: number | null,
+      options: { enabled?: boolean; staleTime?: number; refetchInterval?: number } = {}
+    ) =>
+      useQuery({
+        queryKey: ['available-actions', characterId ?? 0],
+        queryFn: () => fetchAvailableActions(characterId),
+        enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
+        staleTime: options.staleTime,
+        refetchInterval: options.refetchInterval,
+      }),
+  };
+});
 
 vi.mock('sonner', () => ({
   toast: {

--- a/frontend/src/combat/components/CombatTacticalMap.test.tsx
+++ b/frontend/src/combat/components/CombatTacticalMap.test.tsx
@@ -1,7 +1,8 @@
-import { render, screen, within } from '@testing-library/react';
+import { render, screen, within, fireEvent } from '@testing-library/react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, expect, it, vi, beforeEach } from 'vitest';
 import type { ReactNode } from 'react';
+import type { PlayerAction } from '@/scenes/actionTypes';
 
 // ---------------------------------------------------------------------------
 // Mocks — must come before importing the component under test
@@ -20,8 +21,16 @@ vi.mock('@/scenes/actionQueries', () => ({
   fetchAvailableActions: vi.fn(),
 }));
 
-import { useCombatEncounter, useDispatchPlayerAction } from '../queries';
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { combatKeys, useCombatEncounter, useDispatchPlayerAction } from '../queries';
 import { fetchAvailableActions } from '@/scenes/actionQueries';
+import { toast } from 'sonner';
 import { CombatTacticalMap } from './CombatTacticalMap';
 import type { EncounterDetail } from '../types';
 
@@ -35,6 +44,43 @@ function createWrapper() {
   });
   return function Wrapper({ children }: { children: ReactNode }) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+// Exposes the QueryClient (unlike createWrapper above) so a test can spy on
+// invalidateQueries — #2423: the move dispatch must refresh the encounter on
+// a genuine success and must not on a success:false rejection.
+function createWrapperWithClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { Wrapper, queryClient };
+}
+
+function makeMoveAction(positionId: number, displayName: string): PlayerAction {
+  return {
+    backend: 'registry',
+    display_name: displayName,
+    description: '',
+    difficulty: null,
+    prerequisite_met: true,
+    prerequisite_reasons: [],
+    check_type: { id: 1, name: 'Standard' },
+    action_template: null,
+    ref: {
+      backend: 'registry',
+      challenge_instance_id: null,
+      approach_id: null,
+      technique_id: null,
+      registry_key: 'move_to_position',
+      position_id: positionId,
+    },
+    target_spec: null,
+    enhancements: [],
+    strain: null,
   };
 }
 
@@ -203,5 +249,107 @@ describe('CombatTacticalMap', () => {
     const node = screen.getByTestId('tactical-map-node-101');
     expect(within(node).getByAltText('Aerande')).toBeInTheDocument();
     expect(within(node).getByAltText('Rival Knight')).toBeInTheDocument();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Dispatch contract (#2423) — the endpoint resolves HTTP 200 + success:false
+  // for a business-rule rejection, so a resolved promise is not itself proof
+  // of success.
+  // ---------------------------------------------------------------------------
+
+  function renderWithMoveAction(mockMutateAsync: ReturnType<typeof vi.fn>) {
+    vi.mocked(useDispatchPlayerAction).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDispatchPlayerAction>);
+
+    const moveAction = makeMoveAction(102, 'Move to Center');
+    vi.mocked(fetchAvailableActions).mockResolvedValue({
+      count: 1,
+      next: null,
+      previous: null,
+      results: [moveAction],
+    });
+
+    vi.mocked(useCombatEncounter).mockReturnValue({
+      data: makeEncounter({
+        participants: [],
+        opponents: [],
+        position_nodes: [
+          {
+            id: 101,
+            name: 'North Wall',
+            kind: 'feature',
+            elevation_anchor_id: null,
+            layout_x: null,
+            layout_y: null,
+            rampart_element: null,
+            rampart_integrity: null,
+            rampart_max_integrity: null,
+            rampart_crack_state: null,
+          },
+          {
+            id: 102,
+            name: 'Center',
+            kind: 'primary',
+            elevation_anchor_id: null,
+            layout_x: null,
+            layout_y: null,
+            rampart_element: null,
+            rampart_integrity: null,
+            rampart_max_integrity: null,
+            rampart_crack_state: null,
+          },
+        ],
+        position_edges: [
+          {
+            position_a_id: 101,
+            position_b_id: 102,
+            is_passable: true,
+            blocks_flight: false,
+            gating_challenge_name: null,
+          },
+        ],
+      }),
+      isLoading: false,
+      isError: false,
+    } as unknown as ReturnType<typeof useCombatEncounter>);
+
+    const { Wrapper, queryClient } = createWrapperWithClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    render(<CombatTacticalMap encounterId={7} characterId={10} />, { wrapper: Wrapper });
+
+    return { invalidateSpy };
+  }
+
+  it('toasts and skips encounter invalidation on a success:false move', async () => {
+    const mockMutateAsync = vi.fn(() =>
+      Promise.resolve({ backend: 'registry', deferred: false, success: false, message: 'Blocked.' })
+    );
+    const { invalidateSpy } = renderWithMoveAction(mockMutateAsync);
+
+    const centerNode = await screen.findByTestId('tactical-map-node-102');
+    fireEvent.click(centerNode);
+
+    await vi.waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Blocked.');
+    });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: combatKeys.encounter(7) });
+  });
+
+  it('invalidates the encounter query on a success:true move', async () => {
+    const mockMutateAsync = vi.fn(() =>
+      Promise.resolve({ backend: 'registry', deferred: false, success: true })
+    );
+    const { invalidateSpy } = renderWithMoveAction(mockMutateAsync);
+
+    const centerNode = await screen.findByTestId('tactical-map-node-102');
+    fireEvent.click(centerNode);
+
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: combatKeys.encounter(7) });
+    });
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/combat/components/CombatTacticalMap.tsx
+++ b/frontend/src/combat/components/CombatTacticalMap.tsx
@@ -10,11 +10,11 @@
  */
 
 import { useMemo } from 'react';
-import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { combatKeys, useCombatEncounter, useDispatchPlayerAction } from '../queries';
 import { isDispatchFailure } from '../types';
-import { fetchAvailableActions } from '@/scenes/actionQueries';
+import { useAvailableActionsQuery } from '@/scenes/actionQueries';
 import { TacticalMap } from '@/areas/components/TacticalMap';
 import type { OccupantSummary } from '@/areas/components/PositionMapNode';
 import type { PlayerAction } from '@/scenes/actionTypes';
@@ -47,10 +47,8 @@ export function CombatTacticalMap({
 }: CombatTacticalMapProps) {
   const { data: encounter } = useCombatEncounter(encounterId);
 
-  const { data: actionsData } = useQuery({
-    queryKey: ['available-actions', characterId],
-    queryFn: () => fetchAvailableActions(characterId),
-    enabled: characterId > 0,
+  const { data: actionsData } = useAvailableActionsQuery(characterId, {
+    refetchInterval: 10_000,
   });
 
   const availableActions: PlayerAction[] = actionsData?.results ?? [];

--- a/frontend/src/combat/components/CombatTacticalMap.tsx
+++ b/frontend/src/combat/components/CombatTacticalMap.tsx
@@ -10,8 +10,10 @@
  */
 
 import { useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
-import { useCombatEncounter, useDispatchPlayerAction } from '../queries';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import { combatKeys, useCombatEncounter, useDispatchPlayerAction } from '../queries';
+import { isDispatchFailure } from '../types';
 import { fetchAvailableActions } from '@/scenes/actionQueries';
 import { TacticalMap } from '@/areas/components/TacticalMap';
 import type { OccupantSummary } from '@/areas/components/PositionMapNode';
@@ -59,6 +61,7 @@ export function CombatTacticalMap({
   );
 
   const { mutateAsync: dispatchAction } = useDispatchPlayerAction(characterId);
+  const queryClient = useQueryClient();
 
   const occupantsByPosition = useMemo(() => {
     const map = new Map<number, OccupantSummary[]>();
@@ -96,7 +99,19 @@ export function CombatTacticalMap({
   }
 
   const handleDispatchMove = (action: PlayerAction) => {
-    dispatchAction({ ref: action.ref, kwargs: {} }).catch(() => {});
+    dispatchAction({ ref: action.ref, kwargs: {} })
+      .then((result) => {
+        if (isDispatchFailure(result)) {
+          toast.error(result.message ?? 'Move rejected.');
+          return;
+        }
+        queryClient
+          .invalidateQueries({ queryKey: combatKeys.encounter(encounterId) })
+          .catch(() => {});
+      })
+      .catch((err: unknown) => {
+        toast.error(err instanceof Error ? err.message : 'Move failed.');
+      });
   };
 
   // Only hand TacticalMap a defined onPickPosition while a position-shaped

--- a/frontend/src/combat/components/MovementActions.test.tsx
+++ b/frontend/src/combat/components/MovementActions.test.tsx
@@ -4,6 +4,15 @@ import { vi } from 'vitest';
 import { MovementActions } from './MovementActions';
 import type { PlayerAction } from '@/scenes/actionTypes';
 
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { toast } from 'sonner';
+
 function makeMoveAction(positionId: number, displayName: string): PlayerAction {
   return {
     backend: 'registry',
@@ -68,5 +77,59 @@ describe('MovementActions', () => {
       <MovementActions actions={[]} isLocked={false} dispatchAction={dispatchAction} />
     );
     expect(container.firstChild).toBeNull();
+  });
+
+  // ---------------------------------------------------------------------------
+  // Dispatch contract (#2423) — the endpoint resolves HTTP 200 + success:false
+  // for a business-rule rejection, so a resolved promise is not itself proof
+  // of success.
+  // ---------------------------------------------------------------------------
+
+  it('shows a toast and does not call onDispatched when the dispatch resolves success:false', async () => {
+    vi.clearAllMocks();
+    const action = makeMoveAction(5, 'Move to Balcony');
+    const dispatchAction = vi.fn(() =>
+      Promise.resolve({ backend: 'registry', deferred: false, success: false, message: 'Blocked.' })
+    );
+    const onDispatched = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <MovementActions
+        actions={[action]}
+        isLocked={false}
+        dispatchAction={dispatchAction}
+        onDispatched={onDispatched}
+      />
+    );
+
+    await user.click(screen.getByTestId('move-btn-5'));
+
+    expect(toast.error).toHaveBeenCalledWith('Blocked.');
+    expect(onDispatched).not.toHaveBeenCalled();
+  });
+
+  it('calls onDispatched when the dispatch resolves success:true', async () => {
+    vi.clearAllMocks();
+    const action = makeMoveAction(5, 'Move to Balcony');
+    const dispatchAction = vi.fn(() =>
+      Promise.resolve({ backend: 'registry', deferred: false, success: true })
+    );
+    const onDispatched = vi.fn();
+    const user = userEvent.setup();
+
+    render(
+      <MovementActions
+        actions={[action]}
+        isLocked={false}
+        dispatchAction={dispatchAction}
+        onDispatched={onDispatched}
+      />
+    );
+
+    await user.click(screen.getByTestId('move-btn-5'));
+
+    expect(onDispatched).toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/combat/components/MovementActions.test.tsx
+++ b/frontend/src/combat/components/MovementActions.test.tsx
@@ -52,7 +52,7 @@ describe('MovementActions', () => {
 
   it('click dispatches with the action ref and empty kwargs', async () => {
     const action = makeMoveAction(5, 'Move to Balcony');
-    const dispatchAction = vi.fn(() => Promise.resolve());
+    const dispatchAction = vi.fn(() => Promise.resolve({ success: true }));
     const user = userEvent.setup();
 
     render(<MovementActions actions={[action]} isLocked={false} dispatchAction={dispatchAction} />);
@@ -85,7 +85,7 @@ describe('MovementActions', () => {
   // of success.
   // ---------------------------------------------------------------------------
 
-  it('shows a toast and does not call onDispatched when the dispatch resolves success:false', async () => {
+  it('shows a toast and skips onDispatched on success:false', async () => {
     vi.clearAllMocks();
     const action = makeMoveAction(5, 'Move to Balcony');
     const dispatchAction = vi.fn(() =>

--- a/frontend/src/combat/components/MovementActions.test.tsx
+++ b/frontend/src/combat/components/MovementActions.test.tsx
@@ -3,6 +3,7 @@ import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { MovementActions } from './MovementActions';
 import type { PlayerAction } from '@/scenes/actionTypes';
+import type { DispatchResult } from '@/combat/types';
 
 vi.mock('sonner', () => ({
   toast: {
@@ -12,6 +13,11 @@ vi.mock('sonner', () => ({
 }));
 
 import { toast } from 'sonner';
+
+/** Successful dispatch resolution — the full wire shape the tightened prop type requires. */
+function okDispatch(): Promise<DispatchResult> {
+  return Promise.resolve({ backend: 'registry', deferred: false, success: true });
+}
 
 function makeMoveAction(positionId: number, displayName: string): PlayerAction {
   return {
@@ -40,7 +46,7 @@ function makeMoveAction(positionId: number, displayName: string): PlayerAction {
 describe('MovementActions', () => {
   it('renders one button per action', () => {
     const actions = [makeMoveAction(1, 'Move to North Wall'), makeMoveAction(2, 'Move to Center')];
-    const dispatchAction = vi.fn(() => Promise.resolve());
+    const dispatchAction = vi.fn(okDispatch);
 
     render(<MovementActions actions={actions} isLocked={false} dispatchAction={dispatchAction} />);
 
@@ -52,7 +58,7 @@ describe('MovementActions', () => {
 
   it('click dispatches with the action ref and empty kwargs', async () => {
     const action = makeMoveAction(5, 'Move to Balcony');
-    const dispatchAction = vi.fn(() => Promise.resolve({ success: true }));
+    const dispatchAction = vi.fn(okDispatch);
     const user = userEvent.setup();
 
     render(<MovementActions actions={[action]} isLocked={false} dispatchAction={dispatchAction} />);
@@ -64,7 +70,7 @@ describe('MovementActions', () => {
 
   it('buttons are disabled when isLocked is true', () => {
     const actions = [makeMoveAction(3, 'Move to Gate')];
-    const dispatchAction = vi.fn(() => Promise.resolve());
+    const dispatchAction = vi.fn(okDispatch);
 
     render(<MovementActions actions={actions} isLocked={true} dispatchAction={dispatchAction} />);
 
@@ -72,7 +78,7 @@ describe('MovementActions', () => {
   });
 
   it('renders nothing when actions array is empty', () => {
-    const dispatchAction = vi.fn(() => Promise.resolve());
+    const dispatchAction = vi.fn(okDispatch);
     const { container } = render(
       <MovementActions actions={[]} isLocked={false} dispatchAction={dispatchAction} />
     );

--- a/frontend/src/combat/components/MovementActions.tsx
+++ b/frontend/src/combat/components/MovementActions.tsx
@@ -15,7 +15,7 @@ import { isDispatchFailure, type DispatchActionRequest, type DispatchResult } fr
 export interface MovementActionsProps {
   actions: PlayerAction[];
   isLocked: boolean;
-  dispatchAction: (params: DispatchActionRequest) => Promise<unknown>;
+  dispatchAction: (params: DispatchActionRequest) => Promise<DispatchResult>;
   /** Fires after a successful move dispatch — callers invalidate the encounter so the
    *  move shows before the next poll. */
   onDispatched?: () => void;
@@ -43,8 +43,8 @@ export function MovementActions({
             onClick={() => {
               dispatchAction({ ref: action.ref, kwargs: {} })
                 .then((result) => {
-                  if (isDispatchFailure(result as DispatchResult)) {
-                    toast.error((result as DispatchResult).message ?? 'Move rejected.');
+                  if (isDispatchFailure(result)) {
+                    toast.error(result.message ?? 'Move rejected.');
                     return;
                   }
                   onDispatched?.();

--- a/frontend/src/combat/components/MovementActions.tsx
+++ b/frontend/src/combat/components/MovementActions.tsx
@@ -7,17 +7,26 @@
  * dispatchAction function.
  */
 
+import { toast } from 'sonner';
 import { cn } from '@/lib/utils';
 import type { PlayerAction } from '@/scenes/actionTypes';
-import type { DispatchActionRequest } from '@/combat/types';
+import { isDispatchFailure, type DispatchActionRequest, type DispatchResult } from '@/combat/types';
 
 export interface MovementActionsProps {
   actions: PlayerAction[];
   isLocked: boolean;
   dispatchAction: (params: DispatchActionRequest) => Promise<unknown>;
+  /** Fires after a successful move dispatch — callers invalidate the encounter so the
+   *  move shows before the next poll. */
+  onDispatched?: () => void;
 }
 
-export function MovementActions({ actions, isLocked, dispatchAction }: MovementActionsProps) {
+export function MovementActions({
+  actions,
+  isLocked,
+  dispatchAction,
+  onDispatched,
+}: MovementActionsProps) {
   if (actions.length === 0) return null;
 
   return (
@@ -32,7 +41,17 @@ export function MovementActions({ actions, isLocked, dispatchAction }: MovementA
             disabled={isLocked}
             data-testid={`move-btn-${positionId ?? 'unknown'}`}
             onClick={() => {
-              dispatchAction({ ref: action.ref, kwargs: {} }).catch(() => {});
+              dispatchAction({ ref: action.ref, kwargs: {} })
+                .then((result) => {
+                  if (isDispatchFailure(result as DispatchResult)) {
+                    toast.error((result as DispatchResult).message ?? 'Move rejected.');
+                    return;
+                  }
+                  onDispatched?.();
+                })
+                .catch((err: unknown) => {
+                  toast.error(err instanceof Error ? err.message : 'Move failed.');
+                });
             }}
             className={cn(
               'w-full rounded border px-3 py-1.5 text-left text-xs font-medium transition-colors',

--- a/frontend/src/combat/duels/DuelChallengeControls.tsx
+++ b/frontend/src/combat/duels/DuelChallengeControls.tsx
@@ -1,27 +1,28 @@
 /**
  * DuelChallengeControls — duel-specific affordances for the combat rail.
  *
- * Three independent components surfaced by CombatTurnPanel when relevant:
+ * Two independent components surfaced by CombatTurnPanel when relevant, plus the
+ * shared `registryRef` dispatch helper:
  *
- * 1. DuelChallengeControls — Accept/Decline prompt for an incoming pending challenge.
- *    Driven by the GET /api/combat/duel-challenges/ inbox (#1180): the caller fetches
- *    the inbox, finds the incoming challenge for this character, and passes
- *    `hasPendingIncomingChallenge`, `challengerName`, and the specific `challengeId`.
- *    Dispatches registry actions 'accept' / 'decline' (threading `challenge_id`) via
- *    useDispatchPlayerAction.
- *
- * 2. DuelYieldControls — Yield button shown while an active duel is in progress.
+ * 1. DuelYieldControls — Yield button shown while an active duel is in progress.
  *    Dispatches registry action 'yield'. Guards on `isActiveDuel` (caller derives
  *    this from encounter.encounter_type === 'duel' && encounter.status !== 'completed').
  *
- * 3. DuelAcknowledgeRiskBanner — Full-width warning shown when the encounter is
+ * 2. DuelAcknowledgeRiskBanner — Full-width warning shown when the encounter is
  *    lethal (encounter.is_lethal) and the character has not yet acknowledged risk.
  *    Dispatches registry action 'acknowledge_risk'. Caller derives `showBanner`
  *    from encounter.is_lethal (backend sets this; acknowledgement state is opaque
  *    to the frontend; the backend removes this action from availability once acked).
  *
- * All three components dispatch through useDispatchPlayerAction (the same hook
- * used by YourTurn for combat actions).
+ * Both components dispatch through useDispatchPlayerAction (the same hook used by
+ * YourTurn for combat actions), and both check `isDispatchFailure(result)` before
+ * flipping confirmed local state — the dispatch endpoint resolves HTTP 200 with
+ * `success: false` for a business-rule rejection (#2423).
+ *
+ * The Accept/Decline prompt for an incoming pending challenge (formerly
+ * DuelChallengeControls here) lives in DuelChallengeNotifier's toast body since
+ * #2157 — the standalone in-panel prompt was superseded and was deleted (#2423).
+ * `registryRef` is re-exported from here for that caller.
  *
  * Part of #568 — Duels feature, Task 14. Inbox wiring + challenge_id threading: #1180.
  */
@@ -29,6 +30,7 @@
 import { useState } from 'react';
 import { cn } from '@/lib/utils';
 import { useDispatchPlayerAction } from '@/combat/queries';
+import { isDispatchFailure } from '@/combat/types';
 
 // ---------------------------------------------------------------------------
 // Dispatch helper — registry-backend action with no extra kwargs
@@ -42,136 +44,6 @@ export function registryRef(key: string, kwargs: Record<string, unknown> = {}) {
     },
     kwargs,
   };
-}
-
-// ---------------------------------------------------------------------------
-// DuelChallengeControls — Accept / Decline prompt
-// ---------------------------------------------------------------------------
-
-export interface DuelChallengeControlsProps {
-  /** The character performing the action (used by useDispatchPlayerAction). */
-  characterId: number;
-  /** True when this character has a PENDING incoming DuelChallenge. */
-  hasPendingIncomingChallenge: boolean;
-  /** Display name of the challenger — shown in the prompt. */
-  challengerName: string | null;
-  /**
-   * The specific PENDING challenge this prompt acts on. Threaded into the action
-   * kwargs as `challenge_id` so accept/decline target the intended challenge when
-   * a PC has more than one pending (#1180). Null when unknown (back-compat).
-   */
-  challengeId?: number | null;
-  /**
-   * Called after a successful accept/decline so the caller can refresh caches
-   * (e.g. invalidate the inbox + the scene's active-encounter list).
-   */
-  onResolved?: () => void;
-}
-
-/**
- * Accept/Decline prompt for an incoming duel challenge.
- *
- * Renders null when `hasPendingIncomingChallenge` is false.
- * Dispatches the 'accept' or 'decline' registry action (threading `challenge_id`)
- * on click. The caller supplies the availability + identity from the
- * GET /api/combat/duel-challenges/ inbox (#1180).
- */
-export function DuelChallengeControls({
-  characterId,
-  hasPendingIncomingChallenge,
-  challengerName,
-  challengeId = null,
-  onResolved,
-}: DuelChallengeControlsProps) {
-  const { mutateAsync, isPending } = useDispatchPlayerAction(characterId);
-  const [error, setError] = useState<string | null>(null);
-
-  if (!hasPendingIncomingChallenge) return null;
-
-  const challengeKwargs: Record<string, unknown> =
-    challengeId != null ? { challenge_id: challengeId } : {};
-
-  async function handleAccept() {
-    setError(null);
-    try {
-      await mutateAsync(registryRef('accept', challengeKwargs));
-      onResolved?.();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to accept challenge');
-    }
-  }
-
-  async function handleDecline() {
-    setError(null);
-    try {
-      await mutateAsync(registryRef('decline', challengeKwargs));
-      onResolved?.();
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to decline challenge');
-    }
-  }
-
-  return (
-    <div
-      className="space-y-2 rounded-md border border-amber-500/50 bg-amber-500/10 p-3"
-      data-testid="duel-challenge-prompt"
-    >
-      <p className="text-xs font-semibold uppercase tracking-wide text-amber-300">Duel Challenge</p>
-      <p className="text-sm text-foreground">
-        {challengerName ? (
-          <>
-            <span className="font-semibold">{challengerName}</span> has challenged you to a duel.
-          </>
-        ) : (
-          'You have received a duel challenge.'
-        )}
-      </p>
-
-      <div className="flex gap-2">
-        <button
-          type="button"
-          disabled={isPending}
-          onClick={() => {
-            handleAccept().catch(() => {});
-          }}
-          data-testid="duel-accept-btn"
-          className={cn(
-            'flex-1 rounded-md border px-3 py-1.5 text-sm font-semibold transition-colors',
-            'disabled:cursor-not-allowed disabled:opacity-50',
-            isPending
-              ? 'border-border bg-muted text-muted-foreground'
-              : 'border-emerald-500/60 bg-emerald-500/10 text-emerald-300 hover:bg-emerald-500/20'
-          )}
-        >
-          {isPending ? 'Dispatching…' : 'Accept'}
-        </button>
-
-        <button
-          type="button"
-          disabled={isPending}
-          onClick={() => {
-            handleDecline().catch(() => {});
-          }}
-          data-testid="duel-decline-btn"
-          className={cn(
-            'flex-1 rounded-md border px-3 py-1.5 text-sm font-semibold transition-colors',
-            'disabled:cursor-not-allowed disabled:opacity-50',
-            isPending
-              ? 'border-border bg-muted text-muted-foreground'
-              : 'border-destructive/60 bg-destructive/10 text-destructive hover:bg-destructive/20'
-          )}
-        >
-          {isPending ? 'Dispatching…' : 'Decline'}
-        </button>
-      </div>
-
-      {error !== null && (
-        <p role="alert" className="text-sm text-destructive" data-testid="duel-challenge-error">
-          {error}
-        </p>
-      )}
-    </div>
-  );
 }
 
 // ---------------------------------------------------------------------------
@@ -205,7 +77,11 @@ export function DuelYieldControls({ characterId, isActiveDuel }: DuelYieldContro
   async function handleYield() {
     setError(null);
     try {
-      await mutateAsync(registryRef('yield'));
+      const result = await mutateAsync(registryRef('yield'));
+      if (isDispatchFailure(result)) {
+        setError(result.message ?? 'Failed to yield');
+        return;
+      }
       setYielded(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to yield');
@@ -287,7 +163,11 @@ export function DuelAcknowledgeRiskBanner({
   async function handleAcknowledge() {
     setError(null);
     try {
-      await mutateAsync(registryRef('acknowledge_risk'));
+      const result = await mutateAsync(registryRef('acknowledge_risk'));
+      if (isDispatchFailure(result)) {
+        setError(result.message ?? 'Failed to acknowledge risk');
+        return;
+      }
       setAcknowledged(true);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to acknowledge risk');

--- a/frontend/src/combat/duels/__tests__/DuelChallengeControls.test.tsx
+++ b/frontend/src/combat/duels/__tests__/DuelChallengeControls.test.tsx
@@ -1,14 +1,15 @@
 /**
- * Tests for DuelChallengeControls — Task 14.
+ * Tests for DuelYieldControls / DuelAcknowledgeRiskBanner — Task 14 (#2423 follow-up).
  *
  * Covers:
- * - Pending-challenge accept/decline prompt renders and dispatches correctly.
  * - Yield button visible only in an active duel (encounter_type==='duel').
  * - AcknowledgeRisk banner visible when is_lethal and no acknowledgement yet.
- * - No duel controls rendered when there is no pending challenge and no active duel.
+ * - Both honor the dispatch contract: a resolved `{success: false}` result must
+ *   NOT flip confirmed/acknowledged state and must surface the server message (#2423).
  *
  * Note: the outgoing "challenge a co-located character" affordance (challenge button)
- * is deferred to a follow-up and is not tested here.
+ * is deferred to a follow-up and is not tested here. The former Accept/Decline prompt
+ * (DuelChallengeControls) was deleted (#2423) — that UI now lives in DuelChallengeNotifier.
  */
 
 import { render, screen, waitFor } from '@testing-library/react';
@@ -30,12 +31,8 @@ vi.mock('@/combat/queries', () => ({
 }));
 
 import * as combatQueries from '@/combat/queries';
-import {
-  DuelChallengeControls,
-  DuelYieldControls,
-  DuelAcknowledgeRiskBanner,
-} from '../DuelChallengeControls';
-import type { DuelChallengeControlsProps, DuelYieldControlsProps } from '../DuelChallengeControls';
+import { DuelYieldControls, DuelAcknowledgeRiskBanner } from '../DuelChallengeControls';
+import type { DuelYieldControlsProps } from '../DuelChallengeControls';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -70,156 +67,6 @@ function setupMocks() {
 beforeEach(() => {
   vi.clearAllMocks();
   mockMutateAsync.mockResolvedValue({ backend: 'registry', deferred: false });
-});
-
-// ---------------------------------------------------------------------------
-// DuelChallengeControls — accept/decline prompt
-// ---------------------------------------------------------------------------
-
-describe('DuelChallengeControls — pending challenge prompt', () => {
-  function defaultChallengeProps(
-    overrides?: Partial<DuelChallengeControlsProps>
-  ): DuelChallengeControlsProps {
-    return {
-      characterId: 10,
-      hasPendingIncomingChallenge: true,
-      challengerName: 'Rival Knight',
-      challengeId: 42,
-      ...overrides,
-    };
-  }
-
-  it('renders accept and decline buttons when there is a pending incoming challenge', () => {
-    setupMocks();
-
-    render(<DuelChallengeControls {...defaultChallengeProps()} />, { wrapper: createWrapper() });
-
-    expect(screen.getByTestId('duel-accept-btn')).toBeInTheDocument();
-    expect(screen.getByTestId('duel-decline-btn')).toBeInTheDocument();
-  });
-
-  it('shows the challenger name in the prompt', () => {
-    setupMocks();
-
-    render(<DuelChallengeControls {...defaultChallengeProps({ challengerName: 'Baron Vex' })} />, {
-      wrapper: createWrapper(),
-    });
-
-    expect(screen.getByTestId('duel-challenge-prompt')).toHaveTextContent('Baron Vex');
-  });
-
-  it('dispatches accept action with the threaded challenge_id and calls onResolved', async () => {
-    setupMocks();
-    const onResolved = vi.fn();
-
-    render(<DuelChallengeControls {...defaultChallengeProps({ onResolved })} />, {
-      wrapper: createWrapper(),
-    });
-
-    await userEvent.click(screen.getByTestId('duel-accept-btn'));
-
-    expect(mockMutateAsync).toHaveBeenCalledWith({
-      ref: {
-        backend: 'registry',
-        registry_key: 'accept',
-      },
-      kwargs: { challenge_id: 42 },
-    });
-    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
-  });
-
-  it('dispatches decline action with the threaded challenge_id and calls onResolved', async () => {
-    setupMocks();
-    const onResolved = vi.fn();
-
-    render(<DuelChallengeControls {...defaultChallengeProps({ onResolved })} />, {
-      wrapper: createWrapper(),
-    });
-
-    await userEvent.click(screen.getByTestId('duel-decline-btn'));
-
-    expect(mockMutateAsync).toHaveBeenCalledWith({
-      ref: {
-        backend: 'registry',
-        registry_key: 'decline',
-      },
-      kwargs: { challenge_id: 42 },
-    });
-    await waitFor(() => expect(onResolved).toHaveBeenCalledTimes(1));
-  });
-
-  it('omits challenge_id from kwargs when no challengeId is provided (back-compat)', async () => {
-    setupMocks();
-
-    render(<DuelChallengeControls {...defaultChallengeProps({ challengeId: null })} />, {
-      wrapper: createWrapper(),
-    });
-
-    await userEvent.click(screen.getByTestId('duel-accept-btn'));
-
-    expect(mockMutateAsync).toHaveBeenCalledWith({
-      ref: {
-        backend: 'registry',
-        registry_key: 'accept',
-      },
-      kwargs: {},
-    });
-  });
-
-  it('does not call onResolved when the dispatch fails', async () => {
-    setupMocks();
-    mockMutateAsync.mockRejectedValueOnce(new Error('Challenge already expired'));
-    const onResolved = vi.fn();
-
-    render(<DuelChallengeControls {...defaultChallengeProps({ onResolved })} />, {
-      wrapper: createWrapper(),
-    });
-
-    await userEvent.click(screen.getByTestId('duel-accept-btn'));
-
-    await screen.findByRole('alert');
-    expect(onResolved).not.toHaveBeenCalled();
-  });
-
-  it('does not render the challenge prompt when there is no pending challenge', () => {
-    setupMocks();
-
-    render(
-      <DuelChallengeControls
-        characterId={10}
-        hasPendingIncomingChallenge={false}
-        challengerName={null}
-      />,
-      { wrapper: createWrapper() }
-    );
-
-    expect(screen.queryByTestId('duel-challenge-prompt')).not.toBeInTheDocument();
-    expect(screen.queryByTestId('duel-accept-btn')).not.toBeInTheDocument();
-  });
-
-  it('shows an error message when accept dispatch fails', async () => {
-    setupMocks();
-    mockMutateAsync.mockRejectedValueOnce(new Error('Challenge already expired'));
-
-    render(<DuelChallengeControls {...defaultChallengeProps()} />, { wrapper: createWrapper() });
-
-    await userEvent.click(screen.getByTestId('duel-accept-btn'));
-
-    const alert = await screen.findByRole('alert');
-    expect(alert).toHaveTextContent('Challenge already expired');
-  });
-
-  it('buttons are disabled while a dispatch is pending', () => {
-    mockedUseDispatchPlayerAction.mockReturnValue({
-      mutateAsync: mockMutateAsync,
-      isPending: true,
-    });
-
-    render(<DuelChallengeControls {...defaultChallengeProps()} />, { wrapper: createWrapper() });
-
-    expect(screen.getByTestId('duel-accept-btn')).toBeDisabled();
-    expect(screen.getByTestId('duel-decline-btn')).toBeDisabled();
-  });
 });
 
 // ---------------------------------------------------------------------------
@@ -293,6 +140,19 @@ describe('DuelYieldControls — yield button', () => {
     expect(alert).toHaveTextContent('Not in a duel');
   });
 
+  it('does not show the confirmed state when the dispatch resolves success:false (#2423)', async () => {
+    setupMocks();
+    mockMutateAsync.mockResolvedValueOnce({ success: false, message: 'Not your turn.' });
+
+    render(<DuelYieldControls {...defaultYieldProps()} />, { wrapper: createWrapper() });
+
+    await userEvent.click(screen.getByTestId('duel-yield-btn'));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Not your turn.');
+    expect(screen.queryByTestId('duel-yield-confirmed')).not.toBeInTheDocument();
+  });
+
   it('yield button is disabled while a dispatch is pending', () => {
     mockedUseDispatchPlayerAction.mockReturnValue({
       mutateAsync: mockMutateAsync,
@@ -347,5 +207,20 @@ describe('DuelAcknowledgeRiskBanner', () => {
       },
       kwargs: {},
     });
+  });
+
+  it('keeps the banner visible when the dispatch resolves success:false (#2423)', async () => {
+    setupMocks();
+    mockMutateAsync.mockResolvedValueOnce({ success: false, message: 'Not your turn.' });
+
+    render(<DuelAcknowledgeRiskBanner characterId={10} showBanner={true} />, {
+      wrapper: createWrapper(),
+    });
+
+    await userEvent.click(screen.getByTestId('duel-acknowledge-risk-btn'));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Not your turn.');
+    expect(screen.getByTestId('duel-acknowledge-risk-banner')).toBeInTheDocument();
   });
 });

--- a/frontend/src/combat/modals/DeepLinkModalHost.tsx
+++ b/frontend/src/combat/modals/DeepLinkModalHost.tsx
@@ -28,7 +28,6 @@ import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { closeDeepLink } from '@/store/deepLinkModalSlice';
 import { useCombatEncounter } from '@/combat/queries';
 import { ClashCard } from '@/combat/sections/ActiveState';
-import type { ClashState } from '@/combat/types';
 import { ConditionDetailModal } from './ConditionDetailModal';
 
 export interface DeepLinkModalHostProps {
@@ -89,9 +88,9 @@ function renderContent(
       return <ConditionDetailModal id={id} />;
 
     case 'clash': {
-      // EncounterDetail.clashes is typed opaquely in the generated schema —
-      // cast to the concrete ClashState[] (same as ActiveState does).
-      const clashes = (encounter?.clashes ?? []) as unknown as ClashState[];
+      // clashes is correctly typed in the generated schema (get_clashes is
+      // annotated with @extend_schema_field(ClashStateSerializer), #2423).
+      const clashes = encounter?.clashes ?? [];
       const clash = clashes.find((c) => c.id === id);
       if (!clash) return <UnavailableContent label={`Clash #${id}`} />;
       const opponentName = encounter?.opponents.find((o) => o.id === clash.npc_opponent)?.name;

--- a/frontend/src/combat/queries.ts
+++ b/frontend/src/combat/queries.ts
@@ -40,7 +40,7 @@ export const combatKeys = {
  * Invalidate every consequence-outcome query (all character/encounter variants),
  * so the "Last Outcome" panel refetches after a round-affecting mutation (#866).
  */
-function invalidateConsequenceOutcomes(qc: QueryClient): void {
+export function invalidateConsequenceOutcomes(qc: QueryClient): void {
   qc.invalidateQueries({ queryKey: [...combatKeys.all, 'consequence-outcomes'] }).catch(() => {});
 }
 

--- a/frontend/src/combat/queries.ts
+++ b/frontend/src/combat/queries.ts
@@ -8,7 +8,7 @@
 import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query';
 import * as api from './api';
 import type { DispatchActionRequest, DispatchResult, EncounterListItem } from './types';
-import { fetchAvailableActions } from '@/scenes/actionQueries';
+import { availableActionsKeys, useAvailableActionsQuery } from '@/scenes/actionQueries';
 import type { PlayerAction } from '@/scenes/actionTypes';
 
 // ---------------------------------------------------------------------------
@@ -24,11 +24,6 @@ export const combatKeys = {
     [...combatKeys.all, 'encounters-for-scene', sceneId] as const,
 
   combos: (encounterId: number) => [...combatKeys.all, 'combos', encounterId] as const,
-
-  availableActionsAll: () => [...combatKeys.all, 'available-actions'] as const,
-
-  availableActions: (characterId: number) =>
-    [...combatKeys.availableActionsAll(), characterId] as const,
 
   outcomeDetails: (ids: number[]) => [...combatKeys.all, 'outcome-details', ids] as const,
 
@@ -204,35 +199,21 @@ export function useUpgradeCombo(encounterId: number) {
 // ---------------------------------------------------------------------------
 
 /**
- * Fetch COMBAT-backend PlayerActions for the character.
- *
- * Wraps GET /api/actions/characters/{characterId}/available/ and filters
- * results where ref.backend === 'combat'. Clash contribution actions appear
- * here too with ref.clash_id !== null.
- *
- * Disabled when characterId <= 0.
+ * COMBAT-backend PlayerActions for the character. Thin filter over the shared
+ * useAvailableActionsQuery; polls at 10s to match useCombatEncounter's
+ * declaration-phase contract (#2423 finding 6) so round advances and clash
+ * spawns reach the technique list within one poll period.
  */
 export function useAvailableActions(characterId: number): {
   data: PlayerAction[];
   isLoading: boolean;
   isError: boolean;
 } {
-  const result = useQuery({
-    queryKey: combatKeys.availableActions(characterId),
-    queryFn: () => fetchAvailableActions(characterId),
-    enabled: characterId > 0,
-    staleTime: 10_000,
-  });
-
+  const result = useAvailableActionsQuery(characterId, { refetchInterval: 10_000 });
   const combatActions = (result.data?.results ?? []).filter(
     (a: PlayerAction) => a.ref.backend === 'combat'
   );
-
-  return {
-    data: combatActions,
-    isLoading: result.isLoading,
-    isError: result.isError,
-  };
+  return { data: combatActions, isLoading: result.isLoading, isError: result.isError };
 }
 
 // ---------------------------------------------------------------------------
@@ -332,7 +313,7 @@ export function useEndEncounter(encounterId: number) {
     onSuccess: (data) => {
       qc.invalidateQueries({ queryKey: combatKeys.encounter(encounterId) }).catch(() => {});
       // Terminal event: every character's action list for this fight is now stale.
-      qc.invalidateQueries({ queryKey: combatKeys.availableActionsAll() }).catch(() => {});
+      qc.invalidateQueries({ queryKey: availableActionsKeys.all }).catch(() => {});
       invalidateConsequenceOutcomes(qc);
       if (typeof data.scene === 'number') {
         qc.invalidateQueries({ queryKey: combatKeys.encountersForScene(data.scene) }).catch(

--- a/frontend/src/combat/sections/ActiveState.tsx
+++ b/frontend/src/combat/sections/ActiveState.tsx
@@ -19,8 +19,7 @@
  */
 
 import { cn } from '@/lib/utils';
-import type { EncounterDetail } from '../types';
-import type { ClashState } from '../types';
+import type { ClashState, EncounterDetail } from '../types';
 
 // ---------------------------------------------------------------------------
 // Props
@@ -157,10 +156,9 @@ export function ClashCard({ clash, opponentName }: ClashCardProps) {
 // ---------------------------------------------------------------------------
 
 export function ActiveState({ encounter, collapsed = false, onToggleCollapse }: ActiveStateProps) {
-  // The generated schema types clashes as {[key: string]: unknown}[] —
-  // we cast to our local ClashState[] since ClashStateSerializer produces
-  // exactly that shape.
-  const clashes = encounter.clashes as unknown as ClashState[];
+  // clashes is correctly typed in the generated schema (get_clashes is
+  // annotated with @extend_schema_field(ClashStateSerializer), #2423).
+  const clashes = encounter.clashes;
 
   // Build a quick opponent lookup by id.
   const opponentById = new Map(encounter.opponents.map((o) => [o.id, o.name]));

--- a/frontend/src/combat/sections/RoundFlow.tsx
+++ b/frontend/src/combat/sections/RoundFlow.tsx
@@ -114,9 +114,9 @@ function SurgeBeats({ encounter }: { encounter: EncounterDetail }) {
   }
   return (
     <div className="space-y-1" data-testid="surge-beats">
-      {beats.map((beat, index) => (
+      {beats.map((beat) => (
         <p
-          key={index}
+          key={beat.id}
           className="rounded border border-rose-500/40 bg-rose-500/10 px-2 py-1 text-xs font-semibold italic text-rose-300"
           data-testid="surge-beat-line"
         >

--- a/frontend/src/combat/sections/YourTurn.tsx
+++ b/frontend/src/combat/sections/YourTurn.tsx
@@ -552,7 +552,12 @@ export function YourTurn({
   // existing call site (~60 across this file and child-component props)
   // compiles unchanged. Defined inside the component (not module level) so it
   // closes over `setRoundState`; `setRoundState` from `useState` is stable, so
-  // the `useMemo([])` deps below are correct.
+  // the `useMemo([])` deps below are correct. `makeFieldSetter` itself is a
+  // fresh function object every render, but that's harmless: it's a pure
+  // factory (no closure over per-render values besides the stable
+  // `setRoundState`) and nothing holds a reference to it by identity across
+  // renders — only the memoized setters it returns are read, and those never
+  // need to change.
   function makeFieldSetter<K extends keyof RoundScopedState>(key: K) {
     return (value: SetStateAction<RoundScopedState[K]>) => {
       setRoundState((prev) => ({

--- a/frontend/src/combat/sections/YourTurn.tsx
+++ b/frontend/src/combat/sections/YourTurn.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/components/ui/select';
 import {
   combatKeys,
+  invalidateConsequenceOutcomes,
   useAvailableCombos,
   useCoverMutation,
   useDispatchPlayerAction,
@@ -45,9 +46,11 @@ import {
   useGuardMutation,
   useUpgradeCombo,
 } from '../queries';
+import { isDispatchFailure } from '../types';
 import type {
   AvailableCombo,
   DispatchActionRequest,
+  DispatchResult,
   EncounterDetail,
   Participant,
   PositionNode,
@@ -640,6 +643,13 @@ export function YourTurn({
     return (match as RoundActionTyped) ?? null;
   })();
 
+  // Server-derived ready lock (#2423): CombatRail's Radix tabs unmount inactive
+  // TabsContent, so switching to the Map tab and back remounts this component
+  // and resets local `submitted` to false — even though the server already has
+  // this participant's round action marked ready. Deriving the lock from
+  // ownRoundAction.is_ready (not just local state) survives that remount.
+  const serverReady = ownRoundAction?.is_ready === true;
+
   const participants: Participant[] = encounter?.participants ?? [];
 
   // All active participants except self count as allies until covenant sides land (mirrors backend serializers.py note).
@@ -775,7 +785,7 @@ export function YourTurn({
   // ---------------------------------------------------------------------------
 
   async function handleSubmit() {
-    if (submitted || dispatchPending) return;
+    if (submitted || serverReady || dispatchPending) return;
 
     setSubmitError(null);
 
@@ -835,9 +845,23 @@ export function YourTurn({
 
     try {
       for (const job of dispatchJobs) {
-        await job();
+        const result = (await job()) as DispatchResult | undefined;
+        // The dispatch endpoint always resolves 200 for a business-rule
+        // rejection (only a structural ref error is a 400) — success:false
+        // must be checked explicitly, or an honest-failure job would silently
+        // flip the local `submitted`/ready state (#2423).
+        if (result !== undefined && isDispatchFailure(result)) {
+          setSubmitError(result.message ?? 'Submit failed. Try again.');
+          return;
+        }
       }
       setSubmitted(true);
+      // Refresh the encounter (carries the server's is_ready) and the "Last
+      // Outcome" panel now that every declared job succeeded (#2423).
+      queryClient
+        .invalidateQueries({ queryKey: combatKeys.encounter(encounterId) })
+        .catch(() => {});
+      invalidateConsequenceOutcomes(queryClient);
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Submit failed. Try again.';
       setSubmitError(message);
@@ -910,12 +934,12 @@ export function YourTurn({
   // Render
   // ---------------------------------------------------------------------------
 
-  const isLocked = readOnly || submitted;
+  const isLocked = readOnly || submitted || serverReady;
 
   return (
     <div className="space-y-4" data-testid="your-turn-section">
       {/* Submitted / ready badge */}
-      {submitted && (
+      {(submitted || serverReady) && (
         <div
           className="rounded-md border border-emerald-500/40 bg-emerald-500/10 px-3 py-2 text-center text-sm font-medium text-emerald-300"
           data-testid="ready-badge"

--- a/frontend/src/combat/sections/YourTurn.tsx
+++ b/frontend/src/combat/sections/YourTurn.tsx
@@ -12,7 +12,8 @@
  * Phase 7 of the unified-combat-ui plan.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { SetStateAction } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 import { cn } from '@/lib/utils';
 import { ActionDeclarationCard } from '@/actions/ActionDeclarationCard';
@@ -175,6 +176,59 @@ function initialContext(slot: ActionSlot): ActionContext {
     slot,
     effort: 'MEDIUM',
     strainCommitment: 0,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Round-scoped state (#2423 finding 4) — consolidated into one object so a
+// round advance resets it WHOLESALE, making "forgot to reset one atom" bugs
+// structurally impossible (previously selectedClashRef/strainByClash/
+// focusedContext/passiveContexts/submitError survived a round advance and
+// leaked a stale clash selection into the next round's submit).
+// ---------------------------------------------------------------------------
+
+interface RoundScopedState {
+  focusedContext: ActionContext;
+  passiveContexts: Partial<Record<ActionSlot, ActionContext>>;
+  selectedClashRef: PlayerAction['ref'] | null;
+  strainByClash: Record<number, number>;
+  submitted: boolean;
+  submitError: string | null;
+  pullDialogOpen: boolean;
+  selectedPull: PullSelection | null;
+  soulfrayAccepted: boolean;
+  furyTierId: number | null;
+  furyAnchorId: number | null;
+  coverAllyId: string;
+  maneuverError: string | null;
+  guardAllyId: string;
+  guardTechniqueId: string;
+  guardDestination: string;
+}
+
+/** Everything a new round must wipe — reset WHOLESALE so a missed atom is impossible (#2423). */
+function initialRoundState(): RoundScopedState {
+  return {
+    focusedContext: initialContext('focused'),
+    passiveContexts: {
+      'passive-physical': initialContext('passive-physical'),
+      'passive-social': initialContext('passive-social'),
+      'passive-mental': initialContext('passive-mental'),
+    },
+    selectedClashRef: null,
+    strainByClash: {},
+    submitted: false,
+    submitError: null,
+    pullDialogOpen: false,
+    selectedPull: null,
+    soulfrayAccepted: false,
+    furyTierId: null,
+    furyAnchorId: null,
+    coverAllyId: '',
+    maneuverError: null,
+    guardAllyId: GUARD_ANYONE_VALUE,
+    guardTechniqueId: GUARD_NO_TECHNIQUE_VALUE,
+    guardDestination: GUARD_DESTINATION_AWAY,
   };
 }
 
@@ -470,63 +524,68 @@ export function YourTurn({
   const strainMax = availableStrain ?? 10;
   const queryClient = useQueryClient();
   // ---------------------------------------------------------------------------
-  // Slot state
+  // Round-scoped state (#2423 finding 4) — consolidated into one object,
+  // reset WHOLESALE on round advance (see initialRoundState above).
   // ---------------------------------------------------------------------------
 
-  const [focusedContext, setFocusedContext] = useState<ActionContext>(() =>
-    initialContext('focused')
-  );
-  const [passiveContexts, setPassiveContexts] = useState<
-    Partial<Record<ActionSlot, ActionContext>>
-  >(() => ({
-    'passive-physical': initialContext('passive-physical'),
-    'passive-social': initialContext('passive-social'),
-    'passive-mental': initialContext('passive-mental'),
-  }));
+  const [roundState, setRoundState] = useState<RoundScopedState>(initialRoundState);
+  const {
+    focusedContext,
+    passiveContexts,
+    selectedClashRef,
+    strainByClash,
+    submitted,
+    submitError,
+    pullDialogOpen,
+    selectedPull,
+    soulfrayAccepted,
+    furyTierId,
+    furyAnchorId,
+    coverAllyId,
+    maneuverError,
+    guardAllyId,
+    guardTechniqueId,
+    guardDestination,
+  } = roundState;
 
-  // ---------------------------------------------------------------------------
-  // Clash selection state
-  // ---------------------------------------------------------------------------
-
-  // Currently-selected clash ref (for the focused slot target).
-  const [selectedClashRef, setSelectedClashRef] = useState<PlayerAction['ref'] | null>(null);
-  // Per-clash strain commitment. Keyed on clash_id.
-  const [strainByClash, setStrainByClash] = useState<Record<number, number>>({});
-
-  // ---------------------------------------------------------------------------
-  // Submit state
-  // ---------------------------------------------------------------------------
-
-  const [submitted, setSubmitted] = useState(false);
-  const [submitError, setSubmitError] = useState<string | null>(null);
-  const [pullDialogOpen, setPullDialogOpen] = useState(false);
-  // Inline pull selection — populated when the player selects a pull via the
-  // ThreadPullDialog. Sent in kwargs of the focused/clash dispatch on submit.
-  const [selectedPull, setSelectedPull] = useState<PullSelection | null>(null);
-
-  // Soulfray + fury declaration state for combat-cast focused actions (#1543).
-  const [soulfrayAccepted, setSoulfrayAccepted] = useState(false);
-  const [furyTierId, setFuryTierId] = useState<number | null>(null);
-  const [furyAnchorId, setFuryAnchorId] = useState<number | null>(null);
-
-  // Cover picker state — selected ally participant PK (string for Select compatibility).
-  const [coverAllyId, setCoverAllyId] = useState<string>('');
-  const [maneuverError, setManeuverError] = useState<string | null>(null);
-
-  // Guard (Interpose) picker state (#2207) — ward defaults to "anyone hit this
-  // round"; protective technique defaults to "none" (mundane interpose).
-  const [guardAllyId, setGuardAllyId] = useState<string>(GUARD_ANYONE_VALUE);
-  const [guardTechniqueId, setGuardTechniqueId] = useState<string>(GUARD_NO_TECHNIQUE_VALUE);
-  // Redirect destination picker state (#2210) — only shown/consulted when the
-  // selected guard technique is REDIRECT-flavored; "away" is the default and
-  // universal fallback (same default the backend applies when the kwargs are
-  // omitted entirely).
-  const [guardDestination, setGuardDestination] = useState<string>(GUARD_DESTINATION_AWAY);
+  // Per-field setter preserving React.SetStateAction semantics so every
+  // existing call site (~60 across this file and child-component props)
+  // compiles unchanged. Defined inside the component (not module level) so it
+  // closes over `setRoundState`; `setRoundState` from `useState` is stable, so
+  // the `useMemo([])` deps below are correct.
+  function makeFieldSetter<K extends keyof RoundScopedState>(key: K) {
+    return (value: SetStateAction<RoundScopedState[K]>) => {
+      setRoundState((prev) => ({
+        ...prev,
+        [key]:
+          typeof value === 'function'
+            ? (value as (p: RoundScopedState[K]) => RoundScopedState[K])(prev[key])
+            : value,
+      }));
+    };
+  }
+  const setFocusedContext = useMemo(() => makeFieldSetter('focusedContext'), []);
+  const setPassiveContexts = useMemo(() => makeFieldSetter('passiveContexts'), []);
+  const setSelectedClashRef = useMemo(() => makeFieldSetter('selectedClashRef'), []);
+  const setStrainByClash = useMemo(() => makeFieldSetter('strainByClash'), []);
+  const setSubmitted = useMemo(() => makeFieldSetter('submitted'), []);
+  const setSubmitError = useMemo(() => makeFieldSetter('submitError'), []);
+  const setPullDialogOpen = useMemo(() => makeFieldSetter('pullDialogOpen'), []);
+  const setSelectedPull = useMemo(() => makeFieldSetter('selectedPull'), []);
+  const setSoulfrayAccepted = useMemo(() => makeFieldSetter('soulfrayAccepted'), []);
+  const setFuryTierId = useMemo(() => makeFieldSetter('furyTierId'), []);
+  const setFuryAnchorId = useMemo(() => makeFieldSetter('furyAnchorId'), []);
+  const setCoverAllyId = useMemo(() => makeFieldSetter('coverAllyId'), []);
+  const setManeuverError = useMemo(() => makeFieldSetter('maneuverError'), []);
+  const setGuardAllyId = useMemo(() => makeFieldSetter('guardAllyId'), []);
+  const setGuardTechniqueId = useMemo(() => makeFieldSetter('guardTechniqueId'), []);
+  const setGuardDestination = useMemo(() => makeFieldSetter('guardDestination'), []);
 
   // Cast-time position selection for the focused technique (#2206). Controlled
   // by the caller when castPositionProp/onCastPositionChangeProp are supplied
   // (CombatRail lifts this above the rail tabs so the tactical-map tab
   // shares it); falls back to local state otherwise (e.g. standalone tests).
+  // NOT part of RoundScopedState — stays lifted/controlled exactly as before.
   const [localCastPosition, setLocalCastPosition] = useState<CastPosition>({});
   const castPosition = castPositionProp ?? localCastPosition;
   const setCastPosition = onCastPositionChangeProp ?? setLocalCastPosition;
@@ -542,23 +601,15 @@ export function YourTurn({
   const roundResetMounted = useRef(false);
   const techniqueResetMounted = useRef(false);
 
-  // Reset submitted, pull selection, and pull dialog when round advances.
+  // Reset every round-scoped atom WHOLESALE when round advances (#2423) — a
+  // single `setRoundState(initialRoundState())` makes "forgot to reset one
+  // field" bugs structurally impossible.
   useEffect(() => {
     if (!roundResetMounted.current) {
       roundResetMounted.current = true;
       return;
     }
-    setSubmitted(false);
-    setPullDialogOpen(false);
-    setSelectedPull(null);
-    setSoulfrayAccepted(false);
-    setFuryTierId(null);
-    setFuryAnchorId(null);
-    setCoverAllyId('');
-    setGuardAllyId(GUARD_ANYONE_VALUE);
-    setGuardTechniqueId(GUARD_NO_TECHNIQUE_VALUE);
-    setGuardDestination(GUARD_DESTINATION_AWAY);
-    setManeuverError(null);
+    setRoundState(initialRoundState());
     setCastPosition({});
   }, [roundNumber, setCastPosition]);
 

--- a/frontend/src/combat/sections/YourTurn.tsx
+++ b/frontend/src/combat/sections/YourTurn.tsx
@@ -182,9 +182,9 @@ function initialContext(slot: ActionSlot): ActionContext {
 // Dispatch-job builders (extracted from handleSubmit to flatten its branching)
 // ---------------------------------------------------------------------------
 
-type DispatchFn = (params: DispatchActionRequest) => Promise<unknown>;
+type DispatchFn = (params: DispatchActionRequest) => Promise<DispatchResult>;
 
-type DispatchJob = () => Promise<unknown>;
+type DispatchJob = () => Promise<DispatchResult>;
 
 /**
  * Build the focused-slot dispatch job (if a technique is selected). Threads the
@@ -845,12 +845,12 @@ export function YourTurn({
 
     try {
       for (const job of dispatchJobs) {
-        const result = (await job()) as DispatchResult | undefined;
+        const result = await job();
         // The dispatch endpoint always resolves 200 for a business-rule
         // rejection (only a structural ref error is a 400) — success:false
         // must be checked explicitly, or an honest-failure job would silently
         // flip the local `submitted`/ready state (#2423).
-        if (result !== undefined && isDispatchFailure(result)) {
+        if (isDispatchFailure(result)) {
           setSubmitError(result.message ?? 'Submit failed. Try again.');
           return;
         }

--- a/frontend/src/combat/sections/YourTurn.tsx
+++ b/frontend/src/combat/sections/YourTurn.tsx
@@ -13,6 +13,7 @@
  */
 
 import { useEffect, useRef, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import { cn } from '@/lib/utils';
 import { ActionDeclarationCard } from '@/actions/ActionDeclarationCard';
 import type {
@@ -36,6 +37,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import {
+  combatKeys,
   useAvailableCombos,
   useCoverMutation,
   useDispatchPlayerAction,
@@ -463,6 +465,7 @@ export function YourTurn({
   onPositionShapeChange,
 }: YourTurnProps) {
   const strainMax = availableStrain ?? 10;
+  const queryClient = useQueryClient();
   // ---------------------------------------------------------------------------
   // Slot state
   // ---------------------------------------------------------------------------
@@ -1009,7 +1012,16 @@ export function YourTurn({
       )}
 
       {/* Move-to-position actions (#532) — shown when adjacent open positions exist */}
-      <MovementActions actions={moveActions} isLocked={isLocked} dispatchAction={dispatchAction} />
+      <MovementActions
+        actions={moveActions}
+        isLocked={isLocked}
+        dispatchAction={dispatchAction}
+        onDispatched={() => {
+          queryClient
+            .invalidateQueries({ queryKey: combatKeys.encounter(encounterId) })
+            .catch(() => {});
+        }}
+      />
 
       {/* Passive slots — only non-focused-category slots */}
       {visiblePassiveSlots.length > 0 && (

--- a/frontend/src/combat/types.ts
+++ b/frontend/src/combat/types.ts
@@ -68,34 +68,17 @@ export interface RoundActionTyped extends RoundAction {
 }
 
 // ---------------------------------------------------------------------------
-// Local type for ClashState (from ClashStateSerializer, Phase 8)
+// ClashState (from ClashStateSerializer, Phase 8)
 //
-// EncounterDetail.clashes is typed as {[key: string]: unknown}[] in the
-// generated schema because ClashStateSerializer is a SerializerMethodField
-// result. We declare the concrete shape here.
+// clashes is now correctly typed in the generated schema (the backend
+// annotates get_clashes with @extend_schema_field, and get_contributors
+// with its own ClashContributorSerializer), so these are direct re-exports
+// of the generated components (#2423).
 // ---------------------------------------------------------------------------
 
-export interface ClashContributor {
-  character_id: number | null;
-  character_name: string;
-  action_slot: string;
-  progress_delta: number;
-  anima: number;
-}
+export type ClashContributor = components['schemas']['ClashContributor'];
 
-export interface ClashState {
-  id: number;
-  flavor: 'CLASH' | 'LOCK' | 'WARD' | 'BREAK';
-  status: 'ACTIVE' | 'RESOLVED';
-  progress: number;
-  pc_win_threshold: number;
-  npc_win_threshold: number | null;
-  npc_opponent: number;
-  /** Per-PC contribution rollup (Phase 7). */
-  contributors: ClashContributor[];
-  /** "PC" / "NPC" / "EVEN" — Phase 7. */
-  side_favored: 'PC' | 'NPC' | 'EVEN';
-}
+export type ClashState = components['schemas']['ClashState'];
 
 // ---------------------------------------------------------------------------
 // Local types for available-combos

--- a/frontend/src/combat/types.ts
+++ b/frontend/src/combat/types.ts
@@ -43,6 +43,8 @@ export type RoundAction = Record<string, unknown>;
 export type SurgeBeat = Record<string, unknown>;
 
 export interface SurgeBeatTyped extends SurgeBeat {
+  /** DramaticSurgeRecord pk — the stable list key (#2423). */
+  id: number;
   narration: string;
   trigger_kind?: string;
   amount?: number;

--- a/frontend/src/combat/types.ts
+++ b/frontend/src/combat/types.ts
@@ -159,3 +159,13 @@ export interface DispatchResult {
    */
   data?: Record<string, unknown> | null;
 }
+
+/**
+ * `result.success === false` is the honest-failure wire signal (#2010 review):
+ * the dispatch endpoint always resolves HTTP 200 for a business-rule rejection
+ * (only a structural ref error is a 400), so every write path must check this
+ * before flipping confirmed local state (#2423).
+ */
+export function isDispatchFailure(result: Pick<DispatchResult, 'success'>): boolean {
+  return result.success === false;
+}

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -20819,11 +20819,11 @@ export interface components {
     ClashState: {
       readonly id: number;
       flavor: components['schemas']['FlavorEnum'];
-      status?: components['schemas']['ClashStateStatusEnum'];
-      progress?: number;
+      status: components['schemas']['ClashStateStatusEnum'];
+      progress: number;
       pc_win_threshold: number;
       /** @description Set iff flavor=CLASH; null otherwise. */
-      npc_win_threshold?: number | null;
+      npc_win_threshold: number | null;
       npc_opponent: number;
       readonly contributors: components['schemas']['ClashContributor'][];
       /**

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -20793,6 +20793,53 @@ export interface components {
       readonly seat_domain_name: string;
       readonly templates: components['schemas']['HouseTemplateOption'][];
     };
+    /**
+     * @description Schema-only shape of get_contributors rows on ClashStateSerializer.
+     *
+     *     Never instantiated for serialization — exists so drf-spectacular emits a
+     *     concrete component instead of {[key: string]: unknown} (#2423). Mirrors
+     *     the frontend ``ClashContributor`` interface (combat/types.ts).
+     */
+    ClashContributor: {
+      character_id: number | null;
+      character_name: string;
+      action_slot: string;
+      progress_delta: number;
+      anima: number;
+    };
+    /**
+     * @description Compact read serializer for an active Clash, surfaced on EncounterDetail.
+     *
+     *     Exposes the fields needed by the frontend ActiveState rail section:
+     *     - id, flavor, status, progress, pc_win_threshold, npc_win_threshold
+     *     - npc_opponent_id (for labelling the clash target)
+     *     - contributors: per-PC contribution rollup (latest round)
+     *     - side_favored: "PC" / "NPC" / "EVEN" computed from progress vs thresholds.
+     */
+    ClashState: {
+      readonly id: number;
+      flavor: components['schemas']['FlavorEnum'];
+      status?: components['schemas']['ClashStateStatusEnum'];
+      progress?: number;
+      pc_win_threshold: number;
+      /** @description Set iff flavor=CLASH; null otherwise. */
+      npc_win_threshold?: number | null;
+      npc_opponent: number;
+      readonly contributors: components['schemas']['ClashContributor'][];
+      /**
+       * @description PC / NPC / EVEN — computed from current progress vs thresholds.
+       *
+       *     Heuristic: a side is "favored" when progress is past 75% of that side's
+       *     win threshold. Else "EVEN."
+       */
+      readonly side_favored: string;
+    };
+    /**
+     * @description * `ACTIVE` - Active
+     *     * `RESOLVED` - Resolved
+     * @enum {string}
+     */
+    ClashStateStatusEnum: 'ACTIVE' | 'RESOLVED';
     /** @description Request serializer for staff clock adjustment. */
     ClockAdjustRequest: {
       /** Format: date-time */
@@ -21164,26 +21211,7 @@ export interface components {
       readonly selected_consequence: number | null;
       readonly modifier_total: number;
       readonly summary: string;
-      /**
-       * @description Recompute the roulette from pool + selected_consequence on read.
-       *
-       *     When pool is not None, reads pool entries and parent entries from the
-       *     prefetch cache (populated by the ViewSet's _POOL_ENTRIES_PREFETCH /
-       *     _PARENT_ENTRIES_PREFETCH Prefetch objects) so no additional queries are
-       *     issued per row.  Mirrors the pool-walk logic of
-       *     resolve_pool_consequences() but operates on already-fetched data.
-       *
-       *     When pool is None (challenge-based resolution), reconstructs the
-       *     consequence list from the authored ApproachConsequence and
-       *     ChallengeTemplateConsequence links via the challenge_record.  Uses
-       *     prefetch caches populated by the ViewSet's challenge-link Prefetch
-       *     objects.
-       *
-       *     Returns a list of plain dicts matching OutcomeDisplay's fields.
-       */
-      readonly outcome_display: {
-        [key: string]: unknown;
-      }[];
+      readonly outcome_display: components['schemas']['OutcomeDisplayRow'][];
       readonly modifiers: components['schemas']['ConsequenceOutcomeModifier'][];
       readonly combat_interaction_id: number;
       readonly challenge_record_id: number;
@@ -22331,21 +22359,7 @@ export interface components {
       readonly is_participant: boolean;
       /** @description Check whether the requesting user is GM of the linked scene. */
       readonly is_gm: boolean;
-      /**
-       * @description Return active Clash records for this encounter.
-       *
-       *     Phase 8, Task 8.4 — exposes clash state to the frontend ActiveState
-       *     rail section. Returns only ACTIVE clashes so resolved ones don't litter
-       *     the UI after the clash is done.
-       *
-       *     Uses the ``clashes_cached`` prefetch-to-attr set on the viewset's
-       *     ``_base_queryset`` so no extra query fires during detail serialization.
-       *     Falls back to a direct filter for callers that don't use the viewset
-       *     (e.g. unit tests that call the serializer directly).
-       */
-      readonly clashes: {
-        [key: string]: unknown;
-      }[];
+      readonly clashes: components['schemas']['ClashState'][];
       /**
        * @description Return active EngagementLock records for this encounter (#2020).
        *
@@ -23132,6 +23146,14 @@ export interface components {
       amenity: number;
       affinities: components['schemas']['FixtureAffinity'][];
     };
+    /**
+     * @description * `CLASH` - Clash
+     *     * `LOCK` - Lock
+     *     * `WARD` - Ward
+     *     * `BREAK` - Break
+     * @enum {string}
+     */
+    FlavorEnum: 'CLASH' | 'LOCK' | 'WARD' | 'BREAK';
     /** @description Cheap RoomPanel resolver: which building, and what the viewer may do. */
     ForRoomResult: {
       building_id: number | null;
@@ -26382,6 +26404,18 @@ export interface components {
       strain_committed?: number | null;
       power?: number | null;
       progress_delta?: number | null;
+    };
+    /**
+     * @description Schema-only shape of get_outcome_display rows (world.checks.types.OutcomeDisplay).
+     *
+     *     Never instantiated for serialization — exists so drf-spectacular emits a
+     *     concrete component instead of {[key: string]: unknown} (#2423).
+     */
+    OutcomeDisplayRow: {
+      label: string;
+      tier_name: string;
+      weight: number;
+      is_selected: boolean;
     };
     /** @description Read serializer for Outfit — nests slot rows. */
     OutfitRead: {

--- a/frontend/src/scenes/actionQueries.ts
+++ b/frontend/src/scenes/actionQueries.ts
@@ -33,6 +33,45 @@ export async function fetchAvailableActions(characterId: number): Promise<Player
   return res.json() as Promise<PlayerActionsResponse>;
 }
 
+/**
+ * Single source of truth for the available-actions cache (#2423 finding 5).
+ * The key is intentionally UN-namespaced (`['available-actions', id]`) rather
+ * than nested under a system prefix (e.g. `['combat', ...]`) because the
+ * endpoint is an actions-registry surface shared by scenes/combat/battles —
+ * every consumer must land on the same cache entry so a single invalidation
+ * (e.g. useEndEncounter) reaches every mounted rail/panel.
+ */
+export const availableActionsKeys = {
+  all: ['available-actions'] as const,
+  forCharacter: (characterId: number) => [...availableActionsKeys.all, characterId] as const,
+};
+
+export interface AvailableActionsOptions {
+  enabled?: boolean;
+  staleTime?: number;
+  refetchInterval?: number;
+}
+
+/**
+ * Shared TanStack Query hook for the unified available-actions endpoint
+ * (#2423 finding 5). Every consumer of GET
+ * /api/actions/characters/<characterId>/available/ should go through this
+ * hook rather than an inline `useQuery` — that's what keeps them all on the
+ * one `availableActionsKeys` cache entry.
+ */
+export function useAvailableActionsQuery(
+  characterId: number | null,
+  options: AvailableActionsOptions = {}
+) {
+  return useQuery({
+    queryKey: availableActionsKeys.forCharacter(characterId ?? 0),
+    queryFn: () => fetchAvailableActions(characterId!),
+    enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
+    staleTime: options.staleTime ?? 10_000,
+    refetchInterval: options.refetchInterval,
+  });
+}
+
 /** The treat-condition action key — a backend registry key, not a UI string. */
 export const TREAT_CONDITION_ACTION_KEY = 'treat_condition';
 

--- a/frontend/src/scenes/components/ActionAttachment.test.tsx
+++ b/frontend/src/scenes/components/ActionAttachment.test.tsx
@@ -5,10 +5,25 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import type { PlayerActionsResponse } from '../actionTypes';
 
-vi.mock('../actionQueries', () => ({
-  fetchAvailableActions: vi.fn(),
-  createActionRequest: vi.fn(),
-}));
+vi.mock('../actionQueries', async () => {
+  const { useQuery } = await import('@tanstack/react-query');
+  const fetchAvailableActions = vi.fn();
+  return {
+    fetchAvailableActions,
+    createActionRequest: vi.fn(),
+    useAvailableActionsQuery: (
+      characterId: number | null,
+      options: { enabled?: boolean; staleTime?: number; refetchInterval?: number } = {}
+    ) =>
+      useQuery({
+        queryKey: ['available-actions', characterId ?? 0],
+        queryFn: () => fetchAvailableActions(characterId),
+        enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
+        staleTime: options.staleTime,
+        refetchInterval: options.refetchInterval,
+      }),
+  };
+});
 
 // Mock the roster query — component resolves active character → characterId
 vi.mock('@/roster/queries', () => ({

--- a/frontend/src/scenes/components/ActionAttachment.test.tsx
+++ b/frontend/src/scenes/components/ActionAttachment.test.tsx
@@ -19,7 +19,7 @@ vi.mock('../actionQueries', async () => {
         queryKey: ['available-actions', characterId ?? 0],
         queryFn: () => fetchAvailableActions(characterId),
         enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
-        staleTime: options.staleTime,
+        staleTime: options.staleTime ?? 10_000,
         refetchInterval: options.refetchInterval,
       }),
   };

--- a/frontend/src/scenes/components/ActionAttachment.tsx
+++ b/frontend/src/scenes/components/ActionAttachment.tsx
@@ -1,10 +1,9 @@
 import { useState, useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
 import { Zap, X, Loader2 } from 'lucide-react';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
-import { fetchAvailableActions } from '../actionQueries';
+import { useAvailableActionsQuery } from '../actionQueries';
 import type { ActionAttachmentInfo, PlayerAction } from '../actionTypes';
 
 interface ActionAttachmentProps {
@@ -32,10 +31,8 @@ export function ActionAttachment({
     [myRosterEntries, activeCharacterName]
   );
 
-  const { data, isLoading } = useQuery({
-    queryKey: ['available-actions', characterId],
-    queryFn: () => fetchAvailableActions(characterId!),
-    enabled: open && characterId !== null,
+  const { data, isLoading } = useAvailableActionsQuery(characterId, {
+    enabled: open,
     staleTime: 30_000,
   });
 

--- a/frontend/src/scenes/components/ActionPanel.test.tsx
+++ b/frontend/src/scenes/components/ActionPanel.test.tsx
@@ -9,9 +9,11 @@ vi.mock('../actionQueries', async (importOriginal) => {
   // Keep the real toastDispositionMessage (it only depends on 'sonner', mocked
   // below) so this test exercises the shared helper's actual wiring/logic.
   const actual = await importOriginal<typeof import('../actionQueries')>();
+  const { useQuery } = await import('@tanstack/react-query');
+  const fetchAvailableActions = vi.fn();
   return {
     ...actual,
-    fetchAvailableActions: vi.fn(),
+    fetchAvailableActions,
     createActionRequest: vi.fn(),
     castTechnique: vi.fn(),
     fetchCastableTechniques: vi.fn(),
@@ -19,6 +21,20 @@ vi.mock('../actionQueries', async (importOriginal) => {
       data: [],
       isLoading: false,
     })),
+    // Override with a version that calls the mocked fetchAvailableActions
+    // above — the real useAvailableActionsQuery's internal call binds to
+    // the actual module's own fetchAvailableActions, not this mock's export.
+    useAvailableActionsQuery: (
+      characterId: number | null,
+      options: { enabled?: boolean; staleTime?: number; refetchInterval?: number } = {}
+    ) =>
+      useQuery({
+        queryKey: ['available-actions', characterId ?? 0],
+        queryFn: () => fetchAvailableActions(characterId),
+        enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
+        staleTime: options.staleTime,
+        refetchInterval: options.refetchInterval,
+      }),
   };
 });
 

--- a/frontend/src/scenes/components/ActionPanel.test.tsx
+++ b/frontend/src/scenes/components/ActionPanel.test.tsx
@@ -32,7 +32,7 @@ vi.mock('../actionQueries', async (importOriginal) => {
         queryKey: ['available-actions', characterId ?? 0],
         queryFn: () => fetchAvailableActions(characterId),
         enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
-        staleTime: options.staleTime,
+        staleTime: options.staleTime ?? 10_000,
         refetchInterval: options.refetchInterval,
       }),
   };

--- a/frontend/src/scenes/components/ActionPanel.tsx
+++ b/frontend/src/scenes/components/ActionPanel.tsx
@@ -14,10 +14,10 @@ import { useAppSelector } from '@/store/hooks';
 import { actingPersonaId } from '@/roster/persona';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import {
-  fetchAvailableActions,
   createActionRequest,
   castTechnique,
   useCastableTechniques,
+  useAvailableActionsQuery,
   toastDispositionMessage,
 } from '../actionQueries';
 import { fetchScene, sceneKeys } from '../queries';
@@ -111,11 +111,7 @@ export function ActionPanel({ sceneId }: Props) {
   const characterId = activeEntry?.character_id ?? null;
   const initiatorPersonaId = actingPersonaId(activeEntry);
 
-  const { data, isLoading } = useQuery({
-    queryKey: ['available-actions', characterId],
-    queryFn: () => fetchAvailableActions(characterId!),
-    enabled: open && characterId !== null,
-  });
+  const { data, isLoading } = useAvailableActionsQuery(characterId, { enabled: open });
 
   // Scene participants — used as candidates when a targeted action is selected.
   const { data: scene } = useQuery<SceneDetail>({

--- a/frontend/src/scenes/components/PersonaContextMenu.test.tsx
+++ b/frontend/src/scenes/components/PersonaContextMenu.test.tsx
@@ -51,7 +51,8 @@ vi.mock('sonner', () => ({
 
 import { PersonaContextMenu } from './PersonaContextMenu';
 import { createActionRequest, fetchAvailableActions } from '../actionQueries';
-import { useDispatchPlayerAction } from '@/combat/queries';
+import { useDispatchPlayerAction, combatKeys } from '@/combat/queries';
+import { toast } from 'sonner';
 
 function makeAction(
   overrides: Partial<PlayerActionsResponse['results'][0]> = {}
@@ -310,6 +311,51 @@ describe('PersonaContextMenu', () => {
     expect(mockMutateAsync).toHaveBeenCalledWith({
       ref: { backend: 'registry', registry_key: 'challenge' },
       kwargs: { target: 10 },
+    });
+  });
+
+  // #2423: the dispatch endpoint resolves HTTP 200 + success:false for a
+  // business-rule rejection — a resolved promise is not itself proof of success.
+  it('shows a toast and does not invalidate duel challenges when the challenge dispatch resolves success:false', async () => {
+    const user = userEvent.setup();
+    const mockMutateAsync = vi.fn(() =>
+      Promise.resolve({ backend: 'registry', deferred: false, success: false, message: 'No.' })
+    );
+    vi.mocked(useDispatchPlayerAction).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDispatchPlayerAction>);
+
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false, gcTime: 0 } },
+    });
+    queryClient.setQueryData(['available-actions', 42], MOCK_ACTIONS);
+    queryClient.setQueryData(['scene', '1'], {
+      id: 1,
+      personas: [{ id: 10, name: 'Alice', character_sheet: 99 }],
+    });
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    render(
+      <PersonaContextMenu personaId={10} personaName="Alice" sceneId="1">
+        <span>Alice</span>
+      </PersonaContextMenu>,
+      {
+        wrapper: ({ children }: { children: ReactNode }) => (
+          <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+        ),
+      }
+    );
+
+    await user.click(screen.getByRole('button'));
+    const challengeItem = await screen.findByTestId('challenge-to-duel-item');
+    await user.click(challengeItem);
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('No.');
+    });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({
+      queryKey: combatKeys.duelChallengesAll(),
     });
   });
 

--- a/frontend/src/scenes/components/PersonaContextMenu.test.tsx
+++ b/frontend/src/scenes/components/PersonaContextMenu.test.tsx
@@ -5,10 +5,25 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import type { PlayerActionsResponse } from '../actionTypes';
 
-vi.mock('../actionQueries', () => ({
-  fetchAvailableActions: vi.fn(),
-  createActionRequest: vi.fn(),
-}));
+vi.mock('../actionQueries', async () => {
+  const { useQuery } = await import('@tanstack/react-query');
+  const fetchAvailableActions = vi.fn();
+  return {
+    fetchAvailableActions,
+    createActionRequest: vi.fn(),
+    useAvailableActionsQuery: (
+      characterId: number | null,
+      options: { enabled?: boolean; staleTime?: number; refetchInterval?: number } = {}
+    ) =>
+      useQuery({
+        queryKey: ['available-actions', characterId ?? 0],
+        queryFn: () => fetchAvailableActions(characterId),
+        enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
+        staleTime: options.staleTime,
+        refetchInterval: options.refetchInterval,
+      }),
+  };
+});
 
 // Mock the roster query — component resolves active character → characterId
 vi.mock('@/roster/queries', () => ({

--- a/frontend/src/scenes/components/PersonaContextMenu.test.tsx
+++ b/frontend/src/scenes/components/PersonaContextMenu.test.tsx
@@ -19,7 +19,7 @@ vi.mock('../actionQueries', async () => {
         queryKey: ['available-actions', characterId ?? 0],
         queryFn: () => fetchAvailableActions(characterId),
         enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
-        staleTime: options.staleTime,
+        staleTime: options.staleTime ?? 10_000,
         refetchInterval: options.refetchInterval,
       }),
   };

--- a/frontend/src/scenes/components/PersonaContextMenu.test.tsx
+++ b/frontend/src/scenes/components/PersonaContextMenu.test.tsx
@@ -316,7 +316,7 @@ describe('PersonaContextMenu', () => {
 
   // #2423: the dispatch endpoint resolves HTTP 200 + success:false for a
   // business-rule rejection — a resolved promise is not itself proof of success.
-  it('shows a toast and does not invalidate duel challenges when the challenge dispatch resolves success:false', async () => {
+  it('toasts and skips duel-challenge invalidation on success:false', async () => {
     const user = userEvent.setup();
     const mockMutateAsync = vi.fn(() =>
       Promise.resolve({ backend: 'registry', deferred: false, success: false, message: 'No.' })

--- a/frontend/src/scenes/components/PersonaContextMenu.tsx
+++ b/frontend/src/scenes/components/PersonaContextMenu.tsx
@@ -15,6 +15,7 @@ import { Ban, HeartPulse, Swords, VolumeX, Zap, ScrollText, Eye } from 'lucide-r
 import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { useDispatchPlayerAction, combatKeys } from '@/combat/queries';
+import { isDispatchFailure } from '@/combat/types';
 import {
   Dialog,
   DialogContent,
@@ -210,7 +211,13 @@ export function PersonaContextMenu({
       ref: { backend: 'registry', registry_key: 'challenge' },
       kwargs: { target: personaId },
     })
-      .then(() => queryClient.invalidateQueries({ queryKey: combatKeys.duelChallengesAll() }))
+      .then((result) => {
+        if (isDispatchFailure(result)) {
+          toast.error(result.message ?? 'Could not send the challenge.');
+          return;
+        }
+        queryClient.invalidateQueries({ queryKey: combatKeys.duelChallengesAll() }).catch(() => {});
+      })
       .catch(() => {});
   }
 

--- a/frontend/src/scenes/components/PersonaContextMenu.tsx
+++ b/frontend/src/scenes/components/PersonaContextMenu.tsx
@@ -1,5 +1,5 @@
 import { type ReactNode, useMemo, useState } from 'react';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -28,7 +28,7 @@ import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { useCreateBlock, useCreateMute } from '@/social/queries';
 import { toast } from 'sonner';
-import { createActionRequest, fetchAvailableActions } from '../actionQueries';
+import { createActionRequest, useAvailableActionsQuery } from '../actionQueries';
 import type { ActionAttachmentInfo, PlayerAction } from '../actionTypes';
 import type { SceneDetail } from '../types';
 import { WhisperReceiverPicker } from './WhisperReceiverPicker';
@@ -78,7 +78,7 @@ export function PersonaContextMenu({
   const queryClient = useQueryClient();
 
   // Resolve the active character name to its numeric ObjectDB pk to look up
-  // the correct cache key (which ActionAttachment populates as ['available-actions', characterId]).
+  // the correct cache key (the shared availableActionsKeys.forCharacter(characterId)).
   const activeCharacterName = useAppSelector((state) => state.game.active);
   const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
   const characterId = useMemo(
@@ -89,11 +89,7 @@ export function PersonaContextMenu({
   // Fetch directly (mirrors ActionPanel.tsx) rather than reading the cache
   // opportunistically — the menu must populate even if ActionPanel/ActionAttachment
   // hasn't been opened yet this session (#2158).
-  const { data } = useQuery({
-    queryKey: ['available-actions', characterId],
-    queryFn: () => fetchAvailableActions(characterId!),
-    enabled: characterId !== null,
-  });
+  const { data } = useAvailableActionsQuery(characterId);
 
   // #907: present scene personas (excluding the target) are the extra-listener
   // pool. Read from the already-loaded scene cache; empty if not yet present.

--- a/frontend/src/scenes/components/SceneHeader.tsx
+++ b/frontend/src/scenes/components/SceneHeader.tsx
@@ -1,11 +1,11 @@
 import { useState, useEffect, useMemo } from 'react';
 import { useForm } from 'react-hook-form';
-import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { useDispatchPlayerAction } from '@/combat/queries';
 import { SceneDetail, updateScene, finishScene } from '../queries';
-import { fetchAvailableActions } from '../actionQueries';
+import { useAvailableActionsQuery } from '../actionQueries';
 import type { PlayerAction } from '../actionTypes';
 import type { SceneRoundState } from '../types';
 import { Button } from '@/components/ui/button';
@@ -41,11 +41,7 @@ function GrantSceneGMControl() {
     [myRosterEntries, activeCharacterName]
   );
 
-  const { data: actionsData } = useQuery({
-    queryKey: ['available-actions', characterId],
-    queryFn: () => fetchAvailableActions(characterId!),
-    enabled: characterId !== null,
-  });
+  const { data: actionsData } = useAvailableActionsQuery(characterId);
   const availableActions: PlayerAction[] = actionsData?.results ?? [];
   const grantAction =
     availableActions.find(

--- a/frontend/src/scenes/components/SceneTacticalMap.test.tsx
+++ b/frontend/src/scenes/components/SceneTacticalMap.test.tsx
@@ -50,9 +50,17 @@ vi.mock('@/combat/queries', () => ({
   })),
 }));
 
-import { fetchScene } from '../queries';
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { fetchScene, sceneKeys } from '../queries';
 import { fetchAvailableActions } from '../actionQueries';
 import { useDispatchPlayerAction } from '@/combat/queries';
+import { toast } from 'sonner';
 import { SceneTacticalMap } from './SceneTacticalMap';
 
 // ---------------------------------------------------------------------------
@@ -66,6 +74,19 @@ function createWrapper() {
   return function Wrapper({ children }: { children: ReactNode }) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
   };
+}
+
+// Exposes the QueryClient (unlike createWrapper above) so a test can spy on
+// invalidateQueries — #2423: dispatches must refresh the scene's position
+// data on a genuine success and must not on a success:false rejection.
+function createWrapperWithClient() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+  return { Wrapper, queryClient };
 }
 
 const MOCK_SCENE = {
@@ -223,5 +244,73 @@ describe('SceneTacticalMap', () => {
     const northWallNode = screen.getByTestId('tactical-map-node-101');
     fireEvent.click(northWallNode);
     expect(mockMutateAsync).toHaveBeenCalledWith({ ref: takeAction.ref, kwargs: {} });
+  });
+
+  // ---------------------------------------------------------------------------
+  // Dispatch contract (#2423) — the endpoint resolves HTTP 200 + success:false
+  // for a business-rule rejection, so a resolved promise is not itself proof
+  // of success.
+  // ---------------------------------------------------------------------------
+
+  it('shows a toast and does not invalidate scene positions when the move dispatch resolves success:false', async () => {
+    const mockMutateAsync = vi.fn(() =>
+      Promise.resolve({ backend: 'registry', deferred: false, success: false, message: 'Blocked.' })
+    );
+    vi.mocked(useDispatchPlayerAction).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDispatchPlayerAction>);
+
+    const moveAction = makeMoveAction('move_to_position', 102, 'Move to Center');
+    vi.mocked(fetchAvailableActions).mockResolvedValue({
+      count: 1,
+      next: null,
+      previous: null,
+      results: [moveAction],
+    });
+
+    const { Wrapper, queryClient } = createWrapperWithClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    render(<SceneTacticalMap sceneId="10" />, { wrapper: Wrapper });
+
+    const centerNode = await screen.findByTestId('tactical-map-node-102');
+    fireEvent.click(centerNode);
+
+    await vi.waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith('Blocked.');
+    });
+    expect(invalidateSpy).not.toHaveBeenCalledWith({ queryKey: sceneKeys.detail('10') });
+  });
+
+  it('invalidates the scene query when the move dispatch resolves success:true', async () => {
+    const mockMutateAsync = vi.fn(() =>
+      Promise.resolve({ backend: 'registry', deferred: false, success: true })
+    );
+    vi.mocked(useDispatchPlayerAction).mockReturnValue({
+      mutateAsync: mockMutateAsync,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDispatchPlayerAction>);
+
+    const moveAction = makeMoveAction('move_to_position', 102, 'Move to Center');
+    vi.mocked(fetchAvailableActions).mockResolvedValue({
+      count: 1,
+      next: null,
+      previous: null,
+      results: [moveAction],
+    });
+
+    const { Wrapper, queryClient } = createWrapperWithClient();
+    const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+
+    render(<SceneTacticalMap sceneId="10" />, { wrapper: Wrapper });
+
+    const centerNode = await screen.findByTestId('tactical-map-node-102');
+    fireEvent.click(centerNode);
+
+    await vi.waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({ queryKey: sceneKeys.detail('10') });
+    });
+    expect(toast.error).not.toHaveBeenCalled();
   });
 });

--- a/frontend/src/scenes/components/SceneTacticalMap.test.tsx
+++ b/frontend/src/scenes/components/SceneTacticalMap.test.tsx
@@ -17,10 +17,25 @@ vi.mock('../queries', async () => {
   };
 });
 
-vi.mock('../actionQueries', () => ({
-  fetchAvailableActions: vi.fn(),
-  createActionRequest: vi.fn(),
-}));
+vi.mock('../actionQueries', async () => {
+  const { useQuery } = await import('@tanstack/react-query');
+  const fetchAvailableActions = vi.fn();
+  return {
+    fetchAvailableActions,
+    createActionRequest: vi.fn(),
+    useAvailableActionsQuery: (
+      characterId: number | null,
+      options: { enabled?: boolean; staleTime?: number; refetchInterval?: number } = {}
+    ) =>
+      useQuery({
+        queryKey: ['available-actions', characterId ?? 0],
+        queryFn: () => fetchAvailableActions(characterId),
+        enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
+        staleTime: options.staleTime,
+        refetchInterval: options.refetchInterval,
+      }),
+  };
+});
 
 vi.mock('@/roster/queries', () => ({
   useMyRosterEntriesQuery: vi.fn(() => ({

--- a/frontend/src/scenes/components/SceneTacticalMap.test.tsx
+++ b/frontend/src/scenes/components/SceneTacticalMap.test.tsx
@@ -252,7 +252,7 @@ describe('SceneTacticalMap', () => {
   // of success.
   // ---------------------------------------------------------------------------
 
-  it('shows a toast and does not invalidate scene positions when the move dispatch resolves success:false', async () => {
+  it('toasts and skips scene invalidation on a success:false move', async () => {
     const mockMutateAsync = vi.fn(() =>
       Promise.resolve({ backend: 'registry', deferred: false, success: false, message: 'Blocked.' })
     );

--- a/frontend/src/scenes/components/SceneTacticalMap.test.tsx
+++ b/frontend/src/scenes/components/SceneTacticalMap.test.tsx
@@ -31,7 +31,7 @@ vi.mock('../actionQueries', async () => {
         queryKey: ['available-actions', characterId ?? 0],
         queryFn: () => fetchAvailableActions(characterId),
         enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
-        staleTime: options.staleTime,
+        staleTime: options.staleTime ?? 10_000,
         refetchInterval: options.refetchInterval,
       }),
   };

--- a/frontend/src/scenes/components/SceneTacticalMap.tsx
+++ b/frontend/src/scenes/components/SceneTacticalMap.tsx
@@ -10,10 +10,12 @@
  */
 
 import { useMemo } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
 import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { useDispatchPlayerAction } from '@/combat/queries';
+import { isDispatchFailure } from '@/combat/types';
 import { TacticalMap } from '@/areas/components/TacticalMap';
 import type { OccupantSummary } from '@/areas/components/PositionMapNode';
 import { fetchScene, sceneKeys } from '../queries';
@@ -70,6 +72,7 @@ export function SceneTacticalMap({ sceneId }: Props) {
   // Dispatch
   // ---------------------------------------------------------------------------
   const { mutateAsync: dispatchAction, isPending } = useDispatchPlayerAction(characterId ?? 0);
+  const queryClient = useQueryClient();
 
   // ---------------------------------------------------------------------------
   // Derived data — build memos before any conditional return (rules of hooks)
@@ -102,7 +105,17 @@ export function SceneTacticalMap({ sceneId }: Props) {
   if (!scene || positionNodes.length === 0) return null;
 
   const handleDispatchMove = (action: PlayerAction) => {
-    dispatchAction({ ref: action.ref, kwargs: {} }).catch(() => {});
+    dispatchAction({ ref: action.ref, kwargs: {} })
+      .then((result) => {
+        if (isDispatchFailure(result)) {
+          toast.error(result.message ?? 'Move rejected.');
+          return;
+        }
+        queryClient.invalidateQueries({ queryKey: sceneKeys.detail(sceneId) }).catch(() => {});
+      })
+      .catch((err: unknown) => {
+        toast.error(err instanceof Error ? err.message : 'Move failed.');
+      });
   };
 
   // ---------------------------------------------------------------------------
@@ -128,7 +141,19 @@ export function SceneTacticalMap({ sceneId }: Props) {
           type="button"
           data-testid="set-the-stage-btn"
           onClick={() => {
-            dispatchAction({ ref: setTheStageAction.ref, kwargs: {} }).catch(() => {});
+            dispatchAction({ ref: setTheStageAction.ref, kwargs: {} })
+              .then((result) => {
+                if (isDispatchFailure(result)) {
+                  toast.error(result.message ?? 'Could not set the stage.');
+                  return;
+                }
+                queryClient
+                  .invalidateQueries({ queryKey: sceneKeys.detail(sceneId) })
+                  .catch(() => {});
+              })
+              .catch((err: unknown) => {
+                toast.error(err instanceof Error ? err.message : 'Failed to set the stage.');
+              });
           }}
           disabled={isPending}
           className="w-full rounded border border-blue-500/40 bg-blue-500/5 px-3 py-1.5 text-left text-xs font-medium text-blue-300 transition-colors hover:bg-blue-500/10 disabled:cursor-not-allowed disabled:opacity-50"

--- a/frontend/src/scenes/components/SceneTacticalMap.tsx
+++ b/frontend/src/scenes/components/SceneTacticalMap.tsx
@@ -19,7 +19,7 @@ import { isDispatchFailure } from '@/combat/types';
 import { TacticalMap } from '@/areas/components/TacticalMap';
 import type { OccupantSummary } from '@/areas/components/PositionMapNode';
 import { fetchScene, sceneKeys } from '../queries';
-import { fetchAvailableActions } from '../actionQueries';
+import { useAvailableActionsQuery } from '../actionQueries';
 import type { SceneDetail } from '../types';
 import type { PlayerAction } from '../actionTypes';
 
@@ -49,10 +49,8 @@ export function SceneTacticalMap({ sceneId }: Props) {
   // ---------------------------------------------------------------------------
   // Available actions — move_to_position/take_position + set_the_stage
   // ---------------------------------------------------------------------------
-  const { data: actionsData } = useQuery({
-    queryKey: ['available-actions', characterId],
-    queryFn: () => fetchAvailableActions(characterId!),
-    enabled: characterId !== null,
+  const { data: actionsData } = useAvailableActionsQuery(characterId, {
+    refetchInterval: 10_000,
   });
 
   const availableActions: PlayerAction[] = actionsData?.results ?? [];

--- a/frontend/src/scenes/pages/__tests__/SceneDetailPage.test.tsx
+++ b/frontend/src/scenes/pages/__tests__/SceneDetailPage.test.tsx
@@ -87,7 +87,7 @@ vi.mock('../../actionQueries', async () => {
         queryKey: ['available-actions', characterId ?? 0],
         queryFn: () => fetchAvailableActions(),
         enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
-        staleTime: options.staleTime,
+        staleTime: options.staleTime ?? 10_000,
         refetchInterval: options.refetchInterval,
       }),
   };

--- a/frontend/src/scenes/pages/__tests__/SceneDetailPage.test.tsx
+++ b/frontend/src/scenes/pages/__tests__/SceneDetailPage.test.tsx
@@ -65,15 +65,33 @@ vi.mock('@tanstack/react-query', async (importOriginal) => {
 // Mock action queries (used by ConsentPrompt + ActionPanel)
 // ---------------------------------------------------------------------------
 
-vi.mock('../../actionQueries', () => ({
-  fetchPendingRequests: vi.fn(() =>
+vi.mock('../../actionQueries', async () => {
+  const { useQuery } = await import('@tanstack/react-query');
+  const fetchAvailableActions = vi.fn(() =>
     Promise.resolve({ count: 0, next: null, previous: null, results: [] })
-  ),
-  createActionRequest: vi.fn(),
-  respondToRequest: vi.fn(),
-  fetchActionPanelData: vi.fn(() => Promise.resolve({ techniques: [], pending_requests: [] })),
-  fetchPlaces: vi.fn(() => Promise.resolve({ results: [] })),
-}));
+  );
+  return {
+    fetchPendingRequests: vi.fn(() =>
+      Promise.resolve({ count: 0, next: null, previous: null, results: [] })
+    ),
+    createActionRequest: vi.fn(),
+    respondToRequest: vi.fn(),
+    fetchActionPanelData: vi.fn(() => Promise.resolve({ techniques: [], pending_requests: [] })),
+    fetchPlaces: vi.fn(() => Promise.resolve({ results: [] })),
+    fetchAvailableActions,
+    useAvailableActionsQuery: (
+      characterId: number | null,
+      options: { enabled?: boolean; staleTime?: number; refetchInterval?: number } = {}
+    ) =>
+      useQuery({
+        queryKey: ['available-actions', characterId ?? 0],
+        queryFn: () => fetchAvailableActions(),
+        enabled: (options.enabled ?? true) && characterId !== null && characterId > 0,
+        staleTime: options.staleTime,
+        refetchInterval: options.refetchInterval,
+      }),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Mock roster queries — SceneDetailPage uses useMyRosterEntriesQuery to

--- a/src/schema.json
+++ b/src/schema.json
@@ -35636,6 +35636,94 @@ components:
       - seat_domain_name
       - templates
       - tier
+    ClashContributor:
+      type: object
+      description: |-
+        Schema-only shape of get_contributors rows on ClashStateSerializer.
+
+        Never instantiated for serialization — exists so drf-spectacular emits a
+        concrete component instead of {[key: string]: unknown} (#2423). Mirrors
+        the frontend ``ClashContributor`` interface (combat/types.ts).
+      properties:
+        character_id:
+          type: integer
+          nullable: true
+        character_name:
+          type: string
+        action_slot:
+          type: string
+        progress_delta:
+          type: integer
+        anima:
+          type: integer
+      required:
+      - action_slot
+      - anima
+      - character_id
+      - character_name
+      - progress_delta
+    ClashState:
+      type: object
+      description: |-
+        Compact read serializer for an active Clash, surfaced on EncounterDetail.
+
+        Exposes the fields needed by the frontend ActiveState rail section:
+        - id, flavor, status, progress, pc_win_threshold, npc_win_threshold
+        - npc_opponent_id (for labelling the clash target)
+        - contributors: per-PC contribution rollup (latest round)
+        - side_favored: "PC" / "NPC" / "EVEN" computed from progress vs thresholds.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        flavor:
+          $ref: '#/components/schemas/FlavorEnum'
+        status:
+          $ref: '#/components/schemas/ClashStateStatusEnum'
+        progress:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        pc_win_threshold:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+        npc_win_threshold:
+          type: integer
+          maximum: 2147483647
+          minimum: -2147483648
+          nullable: true
+          description: Set iff flavor=CLASH; null otherwise.
+        npc_opponent:
+          type: integer
+        contributors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ClashContributor'
+          readOnly: true
+        side_favored:
+          type: string
+          description: |-
+            PC / NPC / EVEN — computed from current progress vs thresholds.
+
+            Heuristic: a side is "favored" when progress is past 75% of that side's
+            win threshold. Else "EVEN."
+          readOnly: true
+      required:
+      - contributors
+      - flavor
+      - id
+      - npc_opponent
+      - pc_win_threshold
+      - side_favored
+    ClashStateStatusEnum:
+      enum:
+      - ACTIVE
+      - RESOLVED
+      type: string
+      description: |-
+        * `ACTIVE` - Active
+        * `RESOLVED` - Resolved
     ClockAdjustRequest:
       type: object
       description: Request serializer for staff clock adjustment.
@@ -36510,24 +36598,7 @@ components:
         outcome_display:
           type: array
           items:
-            type: object
-            additionalProperties: {}
-          description: |-
-            Recompute the roulette from pool + selected_consequence on read.
-
-            When pool is not None, reads pool entries and parent entries from the
-            prefetch cache (populated by the ViewSet's _POOL_ENTRIES_PREFETCH /
-            _PARENT_ENTRIES_PREFETCH Prefetch objects) so no additional queries are
-            issued per row.  Mirrors the pool-walk logic of
-            resolve_pool_consequences() but operates on already-fetched data.
-
-            When pool is None (challenge-based resolution), reconstructs the
-            consequence list from the authored ApproachConsequence and
-            ChallengeTemplateConsequence links via the challenge_record.  Uses
-            prefetch caches populated by the ViewSet's challenge-link Prefetch
-            objects.
-
-            Returns a list of plain dicts matching OutcomeDisplay's fields.
+            $ref: '#/components/schemas/OutcomeDisplayRow'
           readOnly: true
         modifiers:
           type: array
@@ -38935,19 +39006,7 @@ components:
         clashes:
           type: array
           items:
-            type: object
-            additionalProperties: {}
-          description: |-
-            Return active Clash records for this encounter.
-
-            Phase 8, Task 8.4 — exposes clash state to the frontend ActiveState
-            rail section. Returns only ACTIVE clashes so resolved ones don't litter
-            the UI after the clash is done.
-
-            Uses the ``clashes_cached`` prefetch-to-attr set on the viewset's
-            ``_base_queryset`` so no extra query fires during detail serialization.
-            Falls back to a direct filter for callers that don't use the viewset
-            (e.g. unit tests that call the serializer directly).
+            $ref: '#/components/schemas/ClashState'
           readOnly: true
         engagement_locks:
           type: array
@@ -40574,6 +40633,18 @@ components:
       - description
       - id
       - name
+    FlavorEnum:
+      enum:
+      - CLASH
+      - LOCK
+      - WARD
+      - BREAK
+      type: string
+      description: |-
+        * `CLASH` - Clash
+        * `LOCK` - Lock
+        * `WARD` - Ward
+        * `BREAK` - Break
     ForRoomResult:
       type: object
       description: 'Cheap RoomPanel resolver: which building, and what the viewer
@@ -47235,6 +47306,27 @@ components:
       required:
       - action_interaction_id
       - effects
+    OutcomeDisplayRow:
+      type: object
+      description: |-
+        Schema-only shape of get_outcome_display rows (world.checks.types.OutcomeDisplay).
+
+        Never instantiated for serialization — exists so drf-spectacular emits a
+        concrete component instead of {[key: string]: unknown} (#2423).
+      properties:
+        label:
+          type: string
+        tier_name:
+          type: string
+        weight:
+          type: integer
+        is_selected:
+          type: boolean
+      required:
+      - is_selected
+      - label
+      - tier_name
+      - weight
     OutfitRead:
       type: object
       description: Read serializer for Outfit — nests slot rows.

--- a/src/schema.json
+++ b/src/schema.json
@@ -35714,8 +35714,11 @@ components:
       - flavor
       - id
       - npc_opponent
+      - npc_win_threshold
       - pc_win_threshold
+      - progress
       - side_favored
+      - status
     ClashStateStatusEnum:
       enum:
       - ACTIVE

--- a/src/world/checks/serializers.py
+++ b/src/world/checks/serializers.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from dataclasses import asdict
 
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from world.checks.outcome_models import ConsequenceOutcome, ConsequenceOutcomeModifier
@@ -16,6 +17,19 @@ class ConsequenceOutcomeModifierSerializer(serializers.ModelSerializer):
     class Meta:
         model = ConsequenceOutcomeModifier
         fields = ["source_kind", "source_label", "value"]
+
+
+class OutcomeDisplayRowSerializer(serializers.Serializer):
+    """Schema-only shape of get_outcome_display rows (world.checks.types.OutcomeDisplay).
+
+    Never instantiated for serialization — exists so drf-spectacular emits a
+    concrete component instead of {[key: string]: unknown} (#2423).
+    """
+
+    label = serializers.CharField()
+    tier_name = serializers.CharField()
+    weight = serializers.IntegerField()
+    is_selected = serializers.BooleanField()
 
 
 class ConsequenceOutcomeSerializer(serializers.ModelSerializer):
@@ -57,6 +71,7 @@ class ConsequenceOutcomeSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = fields
 
+    @extend_schema_field(OutcomeDisplayRowSerializer(many=True))
     def get_outcome_display(self, obj: ConsequenceOutcome) -> list[dict]:
         """Recompute the roulette from pool + selected_consequence on read.
 

--- a/src/world/combat/serializers.py
+++ b/src/world/combat/serializers.py
@@ -574,6 +574,18 @@ class ClashStateSerializer(serializers.ModelSerializer):
             "contributors",
             "side_favored",
         ]
+        # This serializer is read-only (constructed directly for output, never bound
+        # to request data — see get_clashes below), but ModelSerializer infers
+        # `required=False` from the model's `default=`/`null=True` on `status`,
+        # `progress`, and `npc_win_threshold`. Every response always includes them
+        # (drf-spectacular otherwise marks them optional, which surfaces as `?` on
+        # the generated frontend type even though the field is never actually
+        # missing — #2423 follow-up, caught by dropping the `as unknown as` casts).
+        extra_kwargs = {
+            "status": {"required": True},
+            "progress": {"required": True},
+            "npc_win_threshold": {"required": True},
+        }
 
     @extend_schema_field(ClashContributorSerializer(many=True))
     def get_contributors(self, obj: Clash) -> list[dict[str, object]]:

--- a/src/world/combat/serializers.py
+++ b/src/world/combat/serializers.py
@@ -533,6 +533,21 @@ class RoundActionSerializer(serializers.ModelSerializer):
 # ---------------------------------------------------------------------------
 
 
+class ClashContributorSerializer(serializers.Serializer):
+    """Schema-only shape of get_contributors rows on ClashStateSerializer.
+
+    Never instantiated for serialization — exists so drf-spectacular emits a
+    concrete component instead of {[key: string]: unknown} (#2423). Mirrors
+    the frontend ``ClashContributor`` interface (combat/types.ts).
+    """
+
+    character_id = serializers.IntegerField(allow_null=True)
+    character_name = serializers.CharField()
+    action_slot = serializers.CharField()
+    progress_delta = serializers.IntegerField()
+    anima = serializers.IntegerField()
+
+
 class ClashStateSerializer(serializers.ModelSerializer):
     """Compact read serializer for an active Clash, surfaced on EncounterDetail.
 
@@ -560,6 +575,7 @@ class ClashStateSerializer(serializers.ModelSerializer):
             "side_favored",
         ]
 
+    @extend_schema_field(ClashContributorSerializer(many=True))
     def get_contributors(self, obj: Clash) -> list[dict[str, object]]:
         """Per-PC contribution rollup across all rounds of the clash.
 
@@ -1038,6 +1054,7 @@ class EncounterDetailSerializer(serializers.ModelSerializer):
             return ""
         return _render_surge_narration(curve, character_name)
 
+    @extend_schema_field(ClashStateSerializer(many=True))
     def get_clashes(self, obj: CombatEncounter) -> list[dict[str, Any]]:
         """Return active Clash records for this encounter.
 

--- a/src/world/combat/serializers.py
+++ b/src/world/combat/serializers.py
@@ -1010,7 +1010,10 @@ class EncounterDetailSerializer(serializers.ModelSerializer):
 
         beats: list[dict[str, Any]] = []
         for record in records:
-            beat: dict[str, Any] = {"narration": self._render_surge_beat_narration(record)}
+            beat: dict[str, Any] = {
+                "id": record.pk,
+                "narration": self._render_surge_beat_narration(record),
+            }
             character_id = record.participant.character_sheet.character_id
             if is_gm_or_staff or character_id in viewer_character_ids:
                 beat["trigger_kind"] = record.trigger_kind

--- a/src/world/combat/tests/test_escalation_serializer_fields.py
+++ b/src/world/combat/tests/test_escalation_serializer_fields.py
@@ -21,7 +21,7 @@ from world.combat.factories import (
     CombatParticipantFactory,
     EscalationCurveFactory,
 )
-from world.combat.models import CombatParticipant
+from world.combat.models import CombatParticipant, DramaticSurgeRecord
 from world.combat.serializers import ParticipantSerializer
 from world.mechanics.constants import EngagementType
 from world.mechanics.services import begin_engagement, end_engagement
@@ -286,6 +286,10 @@ class SurgeBeatsSerializerFieldTests(TestCase):
             amount=4,
             trigger_kind=SurgeTriggerKind.HIGH_STAKES,
         )
+        self.surge_record = DramaticSurgeRecord.objects.get(
+            encounter=self.encounter,
+            participant=self.participant,
+        )
 
     def _get_detail(self, account: object) -> dict:
         client = APIClient()
@@ -297,6 +301,7 @@ class SurgeBeatsSerializerFieldTests(TestCase):
     def test_owner_sees_full_provenance(self) -> None:
         data = self._get_detail(self.account)
         beat = data["surge_beats"][0]
+        self.assertEqual(beat["id"], self.surge_record.pk)
         self.assertEqual(beat["narration"], f"{self.character.db_key}'s power surges.")
         self.assertEqual(beat["trigger_kind"], SurgeTriggerKind.HIGH_STAKES)
         self.assertEqual(beat["amount"], 4)
@@ -304,6 +309,7 @@ class SurgeBeatsSerializerFieldTests(TestCase):
     def test_other_viewer_sees_only_generic_line(self) -> None:
         data = self._get_detail(self.other_account)
         beat = data["surge_beats"][0]
+        self.assertEqual(beat["id"], self.surge_record.pk)
         self.assertIn("narration", beat)
         self.assertNotIn("trigger_kind", beat)
         self.assertNotIn("amount", beat)


### PR DESCRIPTION
Closes #2423

## Summary

Fixes all 10 combat write-path audit findings from #2423 (all re-verified against current code before implementation), plus three same-pattern gaps found during verification (PersonaContextMenu.handleChallenge, SceneTacticalMap move + set_the_stage dispatches).

**Dispatch contract (findings 1, 2, 10):** shared `isDispatchFailure` exported beside `DispatchResult`; every duel/movement/challenge write path now checks `success:false` before flipping confirmed UI state (no more phantom yields, permanently-hidden lethal-risk banners, or silently vanishing challenge toasts); movement dispatches surface rejections and invalidate the encounter on success; the production-dead `DuelChallengeControls` Accept/Decline prompt (superseded by the #2157 notifier toast) is deleted.

**Server-truth locks (findings 3, 4):** YourTurn's submit lock derives from `ownRoundAction.is_ready` (tab-switch remount can no longer re-arm Submit); submit checks each job's result, and invalidates encounter + consequence outcomes on success; the ~16 round-scoped state atoms are consolidated into one object reset wholesale on round advance — the missed-atom class (stale clash refs riding into the next round) is now structurally impossible.

**Cache/freshness (findings 5, 6, 7):** one shared `useAvailableActionsQuery` + key factory replaces 9 call sites across 2 key namespaces (endEncounter invalidation now reaches all consumers; rail mounts no longer double-fetch); combat consumers poll at 10s matching the encounter contract; BattleMapCanvas renders nodes on first paint (memo-direct, mirror dropped) and battle detail polls at 10s for multi-GM staging.

**Typing (findings 8, 9):** surge beats carry their record pk and RoundFlow keys on it; `outcome_display`/`clashes` get `@extend_schema_field` (+ nested `ClashContributor`, + required-marking on read-only ClashState fields that the production build's stricter tsc pass exposed) — schema + api.d.ts regenerated in-branch, all `as unknown as` casts removed.

**Reviewer notes:** `side_favored` widens from a local `'PC'|'NPC'|'EVEN'` union to generated `string` (drf-spectacular can't infer method-field literals; cheap future fix is a ChoiceField-backed schema annotation — deliberately not filed per fold-in rule). The two `AlterationResolveDialog` timeouts on full-suite runs are pre-existing in src/magic, untouched by this branch.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2423 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main at 66ae8a2d8 (clean, no conflicts); post-rebase typecheck + scoped combat suite green.

<!-- last-addressed-comment: 0 -->