### PR TITLE
Install zellij in the devcontainer + persistent-session guide

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -72,7 +72,7 @@ RUN cd /tmp/mise && ~/.local/bin/mise trust \
 # GH_TOKEN is provided via dev.env.
 USER root
 RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
- && apt-get install -y --no-install-recommends gh shellcheck \
+ && apt-get install -y --no-install-recommends gh shellcheck tmux \
       # Playwright Chromium runtime dependencies (not the browser itself —
       # that's downloaded at runtime via `npx playwright install chromium`).
       # Without these libs, Chromium launches but crashes on first navigation.
@@ -99,3 +99,14 @@ RUN ~/.local/bin/mise exec -C /tmp/mise -- npm install -g @anthropic-ai/claude-c
 # never needs get/dl.polytoken.dev — only the model-provider host
 # (api.code.umans.ai) is allowlisted in init-firewall.sh.
 RUN curl -fsS https://get.polytoken.dev | bash
+
+# Terminal multiplexer for long-lived agent sessions. `just dc-shell` attaches
+# over `docker exec`, which has NO reattach mechanism: a dropped host
+# connection permanently orphans every TUI running in that shell. Running
+# claude/polytoken inside a zellij session makes them reattachable
+# (`zellij attach`). Pinned static musl binary into ~/.local/bin; tmux (apt,
+# above) is the fallback multiplexer. See docs/devcontainer-setup.md
+# "Persistent sessions".
+ARG ZELLIJ_VERSION=0.44.3
+RUN curl -fsSL "https://github.com/zellij-org/zellij/releases/download/v${ZELLIJ_VERSION}/zellij-x86_64-unknown-linux-musl.tar.gz" \
+    | tar -xz -C /home/vscode/.local/bin zellij

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -123,6 +123,42 @@ where you run Claude Code:
 claude --dangerously-skip-permissions
 ```
 
+### Persistent sessions (zellij)
+
+A plain `dc-shell` rides on `docker exec`, which has **no reattach mechanism**: if
+the PowerShell window closes or the connection drops, every TUI in that shell
+(Claude Code, polytoken) is permanently orphaned — still running, but with no way
+to see its screen again. Run agents inside a zellij session instead, and a dropped
+connection costs nothing:
+
+```powershell
+just dc-attach            # attach to (or create) the session named "main"
+just dc-attach lore       # separate named session per workstream
+```
+
+Inside the session, run `claude` as usual. The bindings that matter (the status
+bar at the bottom shows the rest):
+
+- `Ctrl-o d` — detach; everything keeps running. Reattach later with the same
+  `just dc-attach <name>`.
+- `Ctrl-t n` / `Ctrl-t 1..9` — new tab / switch tabs, for several agents in one
+  session.
+- `zellij ls` (from any container shell) — list sessions.
+
+Prefer one named session (or tab) per workstream — `just dc-attach 2450-maps` —
+so reattaching after a disconnect is self-describing.
+
+**Recovery ladder** when things die anyway: zellij survives a lost host
+connection; `claude --resume <session-id>` (run in a fresh shell) survives a dead
+zellij session; pushed branches and PRs survive a dead container. If a Claude
+process is orphaned outside zellij, confirm it is idle (no tests/subagents in
+flight), `kill` it, then resume it inside `just dc-attach`.
+
+`tmux` is also installed as a fallback multiplexer. Use one or the other for a
+given session, never nested. A TUI that dies mid-screen can leave the host
+terminal spewing mouse-escape garbage on every mouse move — that is cosmetic;
+fix it with `reset`, not by killing processes.
+
 **Run the test suite from the host (without entering the container):**
 
 ```powershell

--- a/justfile
+++ b/justfile
@@ -426,6 +426,13 @@ dc-build:
 dc-shell:
     devcontainer exec --workspace-folder . bash
 
+# Reattaches to <name> if it exists, creates it otherwise. Detach on purpose
+# with Ctrl-o d; agents inside keep running. See docs/devcontainer-setup.md
+# "Persistent sessions".
+# Like dc-shell, but in a persistent zellij session that survives disconnects
+dc-attach name="main":
+    devcontainer exec --workspace-folder . zellij attach --create {{name}}
+
 # Re-copy polytoken-compatible skills (compatibility: polytoken or
 # polytoken-only) into .polytoken/skills/ after editing a bridged skill.
 # post-create.sh runs this at container creation; this recipe is for picking up


### PR DESCRIPTION
## Why

`just dc-shell` rides on `docker exec`, which has **no reattach mechanism**. When the host connection drops, every TUI in that shell (Claude Code, polytoken) is permanently orphaned — still running, but its screen is unrecoverable. This happened for real on 2026-07-18: six concurrent Claude sessions went headless at once.

## What

- **Dockerfile**: bake `zellij` 0.44.3 (pinned static musl binary → `~/.local/bin`, same pattern as the polytoken installer) and `tmux` (apt, as fallback) into the image at build time — network is open during build, so no runtime firewall changes are needed.
- **justfile**: new `just dc-attach [name]` recipe — like `dc-shell`, but attaches to (or creates) a named zellij session that survives disconnects. Defaults to `main`.
- **docs/devcontainer-setup.md**: "Persistent sessions (zellij)" section in the Path B daily workflow — why, the two bindings that matter, one-session-per-workstream naming, the recovery ladder (zellij attach → `claude --resume` → GitHub), and the stale-terminal-mode `reset` fix.

Takes effect on the next `just dc-build`; until then the same binaries are already installed in the running container's home volume, so the workflow works today.

No app code touched — docs + devcontainer tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)