### PR TITLE
reset_room_feature_strategies restores empty import-time snapshot — wipes at-ready registrations, breaks main CI shard-2

### DIFF
--- a/src/world/companions/apps.py
+++ b/src/world/companions/apps.py
@@ -14,4 +14,5 @@ class CompanionsConfig(AppConfig):
         register_room_feature_strategy(
             RoomFeatureServiceStrategy.STABLES,
             handle_stables_progression,
+            as_default=True,
         )

--- a/src/world/magic/apps.py
+++ b/src/world/magic/apps.py
@@ -23,6 +23,7 @@ class MagicConfig(AppConfig):
         register_room_feature_strategy(
             RoomFeatureServiceStrategy.SANCTUM,
             handle_progression,
+            as_default=True,
         )
 
         # Register Make an Entrance as a reaction-window kind (#904) —

--- a/src/world/room_features/apps.py
+++ b/src/world/room_features/apps.py
@@ -38,6 +38,7 @@ class RoomFeaturesConfig(AppConfig):
         register_room_feature_strategy(
             RoomFeatureServiceStrategy.COMMAND_CENTER,
             handle_command_center_progression,
+            as_default=True,
         )
 
         # Civic-hub readers (#1450) are likewise generic — home app is here.
@@ -49,10 +50,12 @@ class RoomFeaturesConfig(AppConfig):
         register_room_feature_strategy(
             RoomFeatureServiceStrategy.NOTICE_BOARD,
             handle_notice_board_progression,
+            as_default=True,
         )
         register_room_feature_strategy(
             RoomFeatureServiceStrategy.TOWN_CRIER,
             handle_town_crier_progression,
+            as_default=True,
         )
 
         # #675 feature kinds — generic; home app is here.
@@ -66,18 +69,22 @@ class RoomFeaturesConfig(AppConfig):
         register_room_feature_strategy(
             RoomFeatureServiceStrategy.LIBRARY,
             handle_library_progression,
+            as_default=True,
         )
         register_room_feature_strategy(
             RoomFeatureServiceStrategy.TRAINING_ROOM,
             handle_training_room_progression,
+            as_default=True,
         )
         register_room_feature_strategy(
             RoomFeatureServiceStrategy.SIEGE_DECK,
             handle_siege_deck_progression,
+            as_default=True,
         )
         register_room_feature_strategy(
             RoomFeatureServiceStrategy.CAPTAINS_QUARTERS,
             handle_captains_quarters_progression,
+            as_default=True,
         )
 
         # Owner-upgradeable social hub (#1694) — generic; home app is here.
@@ -88,6 +95,7 @@ class RoomFeaturesConfig(AppConfig):
         register_room_feature_strategy(
             RoomFeatureServiceStrategy.SOCIAL_HUB,
             handle_social_hub_progression,
+            as_default=True,
         )
 
         # #2179 — Vault room feature (secure storage + access list).
@@ -98,6 +106,7 @@ class RoomFeaturesConfig(AppConfig):
         register_room_feature_strategy(
             RoomFeatureServiceStrategy.VAULT,
             handle_vault_progression,
+            as_default=True,
         )
 
         # #1825 — Workshop of Iniquity (criminal-projects gate; frame jobs).
@@ -108,6 +117,7 @@ class RoomFeaturesConfig(AppConfig):
         register_room_feature_strategy(
             RoomFeatureServiceStrategy.WORKSHOP_OF_INIQUITY,
             handle_workshop_of_iniquity_progression,
+            as_default=True,
         )
 
         # #1862 — Brig room feature (ship holding cell for captured characters).
@@ -118,6 +128,7 @@ class RoomFeaturesConfig(AppConfig):
         register_room_feature_strategy(
             RoomFeatureServiceStrategy.BRIG,
             handle_brig_progression,
+            as_default=True,
         )
 
         # Installable exit/room defenses (#2177) -- independent of

--- a/src/world/room_features/services.py
+++ b/src/world/room_features/services.py
@@ -52,23 +52,36 @@ def _default_strategy_not_registered(
 
 ROOM_FEATURE_STRATEGIES: dict[str, RoomFeatureStrategyHandler] = {}
 
-# Snapshot of the default (empty) registry so tests can reset between
-# cases — mirrors npc_services.effects.reset_offer_effect_handlers.
-_DEFAULT_STRATEGIES: dict[str, RoomFeatureStrategyHandler] = dict(ROOM_FEATURE_STRATEGIES)
+# The at-ready baseline: registrations made with ``as_default=True`` (every
+# ``AppConfig.ready()`` call site) land here too, so ``reset`` restores the
+# fully-wired registry — never the empty import-time state (#2490: an
+# import-time snapshot let a tearDown reset wipe sanctum's registration for
+# the rest of the CI shard process).
+_DEFAULT_STRATEGIES: dict[str, RoomFeatureStrategyHandler] = {}
 
 
-def register_room_feature_strategy(strategy_key: str, handler: RoomFeatureStrategyHandler) -> None:
+def register_room_feature_strategy(
+    strategy_key: str,
+    handler: RoomFeatureStrategyHandler,
+    *,
+    as_default: bool = False,
+) -> None:
     """Register/override the strategy handler for ``strategy_key``.
 
-    Each feature's home app calls this at app-ready time. Sanctum's
+    Each feature's home app calls this at app-ready time with
+    ``as_default=True`` so the registration survives test resets. Sanctum's
     ``world.magic`` registers ``RoomFeatureServiceStrategy.SANCTUM`` →
-    ``world.magic.services.sanctum.handle_progression``.
+    ``world.magic.services.sanctum.handle_progression``. Tests wiring a mock
+    override omit ``as_default`` and pair with
+    :func:`reset_room_feature_strategies` in tearDown.
     """
     ROOM_FEATURE_STRATEGIES[strategy_key] = handler
+    if as_default:
+        _DEFAULT_STRATEGIES[strategy_key] = handler
 
 
 def reset_room_feature_strategies() -> None:
-    """Restore the empty baseline. Test-only escape hatch."""
+    """Restore the at-ready baseline registrations. Test-only escape hatch."""
     ROOM_FEATURE_STRATEGIES.clear()
     ROOM_FEATURE_STRATEGIES.update(_DEFAULT_STRATEGIES)
 

--- a/src/world/room_features/tests/test_room_features.py
+++ b/src/world/room_features/tests/test_room_features.py
@@ -29,6 +29,7 @@ from world.room_features.models import (
 )
 from world.room_features.seeds import SANCTUM_KIND_NAME, ensure_sanctum_kind
 from world.room_features.services import (
+    ROOM_FEATURE_STRATEGIES,
     can_modify_room_features,
     complete_room_feature_progression,
     register_room_feature_strategy,
@@ -116,6 +117,9 @@ class StrategyRegistryTests(TestCase):
 
     def test_unregistered_strategy_raises(self) -> None:
         details = RoomFeatureProgressionDetailsFactory()
+        # Every enum member has an at-ready handler, so simulate a kind whose
+        # home app forgot to register; tearDown's reset restores the baseline.
+        ROOM_FEATURE_STRATEGIES.pop(details.target_feature_kind.service_strategy, None)
         with self.assertRaises(NotImplementedError):
             complete_room_feature_progression(details.project, outcome_tier=None)
 
@@ -124,16 +128,20 @@ class StrategyRegistryTests(TestCase):
         with self.assertRaises(RuntimeError):
             complete_room_feature_progression(project, outcome_tier=None)
 
-    def test_reset_clears_overrides(self) -> None:
-        register_room_feature_strategy(RoomFeatureServiceStrategy.SANCTUM, MagicMock())
+    def test_reset_restores_app_ready_baseline(self) -> None:
+        """#2490: reset drops test overrides but keeps at-ready registrations.
+
+        The old reset restored an import-time (empty) snapshot, so any
+        tearDown reset wiped sanctum's registration for the rest of the test
+        process and broke world.magic's registration test downstream in the
+        same CI shard.
+        """
+        override = MagicMock()
+        register_room_feature_strategy(RoomFeatureServiceStrategy.SANCTUM, override)
         reset_room_feature_strategies()
-        details = RoomFeatureProgressionDetailsFactory(
-            target_feature_kind=RoomFeatureKindFactory(
-                service_strategy=RoomFeatureServiceStrategy.SANCTUM
-            ),
-        )
-        with self.assertRaises(NotImplementedError):
-            complete_room_feature_progression(details.project, outcome_tier=None)
+        self.assertIn(RoomFeatureServiceStrategy.SANCTUM, ROOM_FEATURE_STRATEGIES)
+        self.assertIsNot(ROOM_FEATURE_STRATEGIES[RoomFeatureServiceStrategy.SANCTUM], override)
+        self.assertIn(RoomFeatureServiceStrategy.COMMAND_CENTER, ROOM_FEATURE_STRATEGIES)
 
 
 class PermissionGateTests(TestCase):


### PR DESCRIPTION
Closes #2490

## Summary

Fixes the main-CI shard-2 breakage (red since b26628059; last green a4dd351bc). `reset_room_feature_strategies()` restored a snapshot taken at module import — i.e. `{}`, before any `AppConfig.ready()` registration — so `world.room_features`' `StrategyRegistryTests.tearDown` wiped every at-ready registration (11 room_features + companions' STABLES + magic's SANCTUM) for the remainder of the shard-2 test process, and `world.magic`'s `test_strategy_registered_at_ready` failed downstream with `SANCTUM not found in {}`. The first red commit is frontend-only, confirming no commit content caused it — the 2026-07-17 shard rebalance simply made the latent ordering land deterministically.

Fix: `register_room_feature_strategy` gains `as_default: bool = False`; every apps.py ready-time call site passes `as_default=True`, recording into the `_DEFAULT_STRATEGIES` baseline that reset now restores. Test overrides (no flag) still vanish on reset.

Notable: `test_unregistered_strategy_raises` only ever passed BECAUSE of the bug (its factory kind defaults to SANCTUM, which is registered at ready — a prior tearDown's empty reset masked that); it now pops the key explicitly. `test_reset_clears_overrides` is reframed as `test_reset_restores_app_ready_baseline`, the direct regression test for this bug. The sibling lazy-snapshot pattern in `npc_services.effects.reset_offer_effect_handlers` is subtly capturable mid-test but not failing today — deliberately left alone.

Verified: `world.room_features` + `world.companions` + `world.magic.tests.test_sanctum` in one process (the poison chain): 291/291 OK. Design phase skipped: CI-breakage hotfix; the issue body carries the full diagnosis.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2490 (in the issue body)
- Brainstorm/plan: skipped (CI-breakage hotfix; diagnosis in issue body)
- Sync-with-main: Branched from origin/main head 66ae8a2d8; no sync needed.

<!-- last-addressed-comment: 0 -->