### PR TITLE
Content load silently skips ~350 rows every run: conditions fixture family predates NK schema; loader has no strict/health mode

### DIFF
--- a/docs/adr/0143-canonical-capability-vocabulary-is-the-27-name-union.md
+++ b/docs/adr/0143-canonical-capability-vocabulary-is-the-27-name-union.md
@@ -1,0 +1,27 @@
+# Canonical capability vocabulary is the 27-name union of wired + affordance sets
+
+Two `CapabilityType` lists had grown independently and never reconciled: the 9 names
+live combat/foundational code already wires by string literal (`endurance`,
+`melee_attack`, `ranged_attack`, `awareness`, `movement`, `limb_use`, `defense`,
+`support`, `leadership` — `world/conditions/constants.py`'s `FoundationalCapability`
+plus `world/seeds/game_content/{magic,battles,covenant_roles}.py`), and the 19-name
+affordance matrix ratified in `docs/architecture/capability-challenge-content.md`
+(`generation`, `force`, `projection`, `manipulation`, `barrier`, `traversal`,
+`movement`, `precision`, `suppression`, `transmutation`, `communication`,
+`perception`, `intimidation`, `persuasion`, `deception`, `charm`, `inspiration`,
+`analysis`, `exploitation`). TehomCD ruled (2026-07-18, #2503 spec phase 0) that the
+canonical vocabulary is their union, deduped on the shared `movement` entry, for 27
+names total. Rejected: picking one set (either orphans the live combat/foundational
+consumers or discards the already-approved affordance design) and letting vocabulary
+grow freely per-feature (the uncurated-sprawl failure mode this repo's
+Anti-Reinvention rule exists to prevent). `awareness` (foundational passive
+sense-gate, `innate_baseline=1`, zeroed by Unconscious) and `perception` (active,
+supernormal sensing, `innate_baseline=0`, granted by techniques) are deliberately
+kept as distinct terms, not merged. The old `stealth` name gets no successor in this
+vocabulary — a capability is added only when a real consumer needs it, per the
+curated-not-invented pattern used elsewhere for GM checks and gift/technique content.
+
+> Status: accepted · Source: issue #2503 spec phase 0 (ruling 2026-07-18) ·
+> Related: `docs/architecture/capability-challenge-content.md` (19-name affordance
+> matrix), `docs/architecture/property-capability-action.md` (capability design
+> principles), `world/conditions/constants.py` (`FoundationalCapability`)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -171,6 +171,7 @@ treat those names as hints to confirm, not gospel.
 - [0139 — Staff world-builder shares the map-canvas layer; authority is the staff flag, not the GM ladder](0139-staff-world-builder-shares-the-map-canvas-layer-gated-by-staff-flag-not-gm-ladder.md) (epic #2436, #2449; follow-ups #2450/#2451/#2452)
 - [0140 — Grid content exports as graph-aware, per-area bundles keyed by permanent slugs](0140-grid-content-exports-as-graph-aware-area-bundles.md) (epic #2436, #2448; related ADR-0120/0121)
 - [0141 — Story-room access is a consent-first player-side join, not a GM summon](0141-story-room-access-is-player-side-join.md) (epic #2436, #2450; extends ADR-0024; related ADR-0139/0140)
+- [0143 — Canonical capability vocabulary is the 27-name union of wired + affordance sets](0143-canonical-capability-vocabulary-is-the-27-name-union.md) (#2503 spec phase 0; related `docs/architecture/capability-challenge-content.md`)
 
 ### Gift & resonance economy
 - [0050 — Gifts are Major or Minor; species abilities are a species-granted Minor Gift](0050-gifts-are-major-or-minor-species-abilities-are-minor-gifts.md)

--- a/docs/dev-commands.md
+++ b/docs/dev-commands.md
@@ -36,6 +36,27 @@ force a rebuild after a model change. A plain `arx manage migrate` (with no
 a deploy pipeline must invoke them explicitly or lookups like the
 `social_engagement` KudosSourceCategory row will be missing.
 
+## Content Pipeline
+
+Loads/exports the private lore-repo content checkout (`CONTENT_REPO_PATH` in
+`src/.env`). See `docs/systems/INDEX.md`'s "Content-repo load" entry and
+`docs/evennia-quirks.md` (#946) for the upsert-not-`loaddata` rationale.
+
+- `just load-content` — build fixtures from the content checkout, then load them
+  (`tools/build_content_fixtures.py --load`; clones the checkout first if
+  `CONTENT_REPO_URL` is set and it doesn't exist yet).
+- `uv run python tools/build_content_fixtures.py --load --strict` — same load, but
+  exits `7` if any skipped row isn't covered by
+  `<content_root>/fixtures/KNOWN_DRIFT.txt` (#2501). A health report (per-source
+  skip counts, known-drift count, unexpected entries) always prints after the load
+  summary, `--strict` or not.
+- `just check-content` (`--check`) — validate content files + report remaining
+  `PLACEHOLDER` slots; writes nothing.
+- `just export-content` / `just check-export` — export authored content from the DB
+  to the content repo's `fixtures/` dir (`--check` for a dry run).
+- `just push-content` / `just check-push` — commit and push exported fixtures to the
+  content repo's origin `main` (`--check` for a dry run).
+
 ## Server Management
 
 - `arx start` — Start the Evennia server (**PREFERRED** for running the server)

--- a/docs/evennia-quirks.md
+++ b/docs/evennia-quirks.md
@@ -64,6 +64,10 @@ cache mid-deserialization.
   natural fields.
 - Don't build cache-flush workarounds; upsert is the standing answer (the
   identity map is load-bearing — see the `sharedmemory-model` skill).
+- **Silent skips now have a gate (#2501):** `tools/build_content_fixtures.py --load
+  --strict` exits 7 when a skip isn't covered by `fixtures/KNOWN_DRIFT.txt`, and a
+  per-source health report always prints after the load summary — see
+  `docs/systems/INDEX.md`'s "Strict-mode health gate" entry.
 
 **Grid bundles follow the same upsert discipline, sequenced after content
 fixtures (#2436/#2448):** `core_management.grid_import.load_grid_bundles()`

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -5169,6 +5169,21 @@ Admin-hosted, superuser-only HTMX dashboards for difficulty tuning/simulation an
   and the `--check`/admin-preview surfaces (warn) share. `world.seeds.character_creation.
   ensure_canonical_fallback_room()` houses the canonical fallback starting room in a
   reserved AUTHORED area (`slug="arx"`) for exactly this reason.
+- **Strict-mode health gate (#2501):** `tools/build_content_fixtures.py --load --strict`
+  exits `7` if any `world_result.skipped` entry isn't covered by
+  `<content_root>/fixtures/KNOWN_DRIFT.txt` (one substring pattern per line, `#`-comment
+  and blank lines ignored; absent file = no known drift). `core_management.content_health`
+  (`group_skips`, `load_known_drift`, `partition_skips`, `render_health_report`) is the
+  pure-python layer this rides — import-safe without Django, same convention as
+  `content_fixtures.py`. A health report (per-source skip counts, known-drift count, and
+  every unexpected skip verbatim) always prints after the load summary, `--strict` or not,
+  so a silent-skip regression (the #2501 root cause — 350 rows dropped with no signal) is
+  visible even on a plain `--load`. `--strict` requires `--load`.
+  `CONTENT_MODELS` (`core_management/content_export.py`) also gained
+  `mechanics.application`, `mechanics.prerequisite`, `mechanics.property`, and
+  `mechanics.propertycategory` — the loader was already dynamic (any `NaturalKeyMixin`
+  model can be fixture-loaded); this only widens the **export** allowlist to cover the
+  Capabilities & Challenges catalog.
 - **Permissions:** every view superuser-only (`web.admin.tuning.views.superuser_required`,
   mirroring `game_setup_views.py`'s gate).
 - **Source:** `src/web/admin/tuning/`, `src/web/admin/content_load_views.py`,

--- a/docs/systems/checks.md
+++ b/docs/systems/checks.md
@@ -49,6 +49,16 @@ result.chart_name     # str: chart name or "No Chart Found"
 | `CheckTypeTrait` | Weighted trait contribution to a check type | `check_type` (FK CheckType), `trait` (FK Trait), `weight` (Decimal, default 1.0) |
 | `CheckTypeAspect` | Weighted aspect relevance for a check type | `check_type` (FK CheckType), `aspect` (FK Aspect), `weight` (Decimal, default 1.0) |
 
+**Rule: a `CheckType.name` must never be duplicated across categories.** The DB
+constraint is only `unique_together = ["name", "category"]`, but several call sites
+look a `CheckType` up by bare name with no category filter — e.g.
+`CheckType.objects.get(name="Stealth")` (`world/npc_services/guard_services.py:83`)
+and `CheckType.objects.get_or_create(name=ENDURANCE_CHECK_NAME, ...)`
+(`world/vitals/services.py:255`). A second same-named `CheckType` in a different
+category makes those lookups raise `MultipleObjectsReturned` (or silently return the
+wrong row for `get_or_create`) — treat every `CheckType.name` as globally unique in
+practice, even though the schema doesn't enforce it (#2501 content-pipeline audit).
+
 ---
 
 ## Key Methods

--- a/src/core_management/content_export.py
+++ b/src/core_management/content_export.py
@@ -101,8 +101,12 @@ CONTENT_MODELS: frozenset[str] = frozenset(
         "magic.tradition",
         "magic.traditiongiftgrant",
         # mechanics
+        "mechanics.application",
         "mechanics.modifiercategory",
         "mechanics.modifiertarget",
+        "mechanics.prerequisite",
+        "mechanics.property",
+        "mechanics.propertycategory",
         # realms
         "realms.realm",
         # skills

--- a/src/core_management/content_health.py
+++ b/src/core_management/content_health.py
@@ -1,0 +1,93 @@
+"""Content-load health helpers (#2501): group, allowlist, and report skips.
+
+``load_world_content`` (``core_management.content_fixtures``) records each
+skipped row as a string in ``WorldLoadResult.skipped``, formatted
+``"{source_path}: {Model} could not be loaded: ..."``. Those skips scroll past
+silently today. This module is the pure-python layer a later task wires into
+the CLI: group skips by source file, load a ``KNOWN_DRIFT.txt`` allowlist of
+substring patterns for expected/pre-existing drift, partition skips into known
+vs. unexpected, and render a human-readable health report.
+
+Import-safe without Django configured (same convention as
+``content_fixtures.py``): no Django imports at module scope, so tooling and
+tests can import this module standalone.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+KNOWN_DRIFT_FILENAME = "KNOWN_DRIFT.txt"
+UNKNOWN_SOURCE = "<unknown>"
+
+
+def group_skips(skipped: list[str]) -> dict[str, list[str]]:
+    """Group skip messages by their source-path prefix (text before ``": "``).
+
+    A skip message missing the ``": "`` separator groups under
+    ``"<unknown>"``. Insertion order is preserved for both the group keys and
+    the messages within each group.
+    """
+    grouped: dict[str, list[str]] = {}
+    for message in skipped:
+        source, sep, _rest = message.partition(": ")
+        key = source if sep else UNKNOWN_SOURCE
+        grouped.setdefault(key, []).append(message)
+    return grouped
+
+
+def load_known_drift(content_root: Path) -> list[str]:
+    """Read ``<content_root>/fixtures/KNOWN_DRIFT.txt`` into a pattern list.
+
+    One substring pattern per line; blank lines and ``#``-comment lines are
+    stripped. Returns ``[]`` when the file is absent.
+    """
+    drift_path = content_root / "fixtures" / KNOWN_DRIFT_FILENAME
+    if not drift_path.is_file():
+        return []
+
+    patterns: list[str] = []
+    for raw_line in drift_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        patterns.append(line)
+    return patterns
+
+
+def partition_skips(skipped: list[str], patterns: list[str]) -> tuple[list[str], list[str]]:
+    """Split ``skipped`` into ``(known, unexpected)`` by substring match.
+
+    A skip is "known" when any pattern in ``patterns`` is a substring of it.
+    Order is preserved within each list.
+    """
+    known: list[str] = []
+    unexpected: list[str] = []
+    for message in skipped:
+        if any(pattern in message for pattern in patterns):
+            known.append(message)
+        else:
+            unexpected.append(message)
+    return known, unexpected
+
+
+def render_health_report(skipped: list[str], patterns: list[str]) -> tuple[list[str], bool]:
+    """Render human-readable report lines for ``skipped`` plus a health verdict.
+
+    Lines cover per-source skip counts, the total known-drift count, and each
+    unexpected skip verbatim. ``healthy`` is ``True`` iff there are no
+    unexpected skips (an empty ``skipped`` list is healthy).
+    """
+    grouped = group_skips(skipped)
+    known, unexpected = partition_skips(skipped, patterns)
+
+    lines: list[str] = []
+    for source, messages in grouped.items():
+        lines.append(f"{source}: {len(messages)} skipped")
+    lines.append(f"known drift: {len(known)}")
+
+    if unexpected:
+        lines.append(f"unexpected: {len(unexpected)}")
+        lines.extend(unexpected)
+
+    return lines, not unexpected

--- a/src/core_management/content_health.py
+++ b/src/core_management/content_health.py
@@ -1,12 +1,17 @@
 """Content-load health helpers (#2501): group, allowlist, and report skips.
 
 ``load_world_content`` (``core_management.content_fixtures``) records each
-skipped row as a string in ``WorldLoadResult.skipped``, formatted
-``"{source_path}: {Model} could not be loaded: ..."``. Those skips scroll past
-silently today. This module is the pure-python layer a later task wires into
-the CLI: group skips by source file, load a ``KNOWN_DRIFT.txt`` allowlist of
-substring patterns for expected/pre-existing drift, partition skips into known
-vs. unexpected, and render a human-readable health report.
+skipped row as a string in ``WorldLoadResult.skipped``. Most read
+``"{source_path}: {Model} could not be loaded: ..."``, but not all: a stale
+model reads ``"{source_path}: stale model {model!r} (renamed or removed) —
+skipped."``, and a model missing ``NaturalKeyMixin`` reads
+``"{location}: model {Model} lacks NaturalKeyMixin — ..."`` where ``location``
+falls back to ``model._meta.label`` (not a source path) when the failure
+isn't tied to one file. Those skips scroll past silently today. This module
+is the pure-python layer a later task wires into the CLI: group skips by
+source file, load a ``KNOWN_DRIFT.txt`` allowlist of substring patterns for
+expected/pre-existing drift, partition skips into known vs. unexpected, and
+render a human-readable health report.
 
 Import-safe without Django configured (same convention as
 ``content_fixtures.py``): no Django imports at module scope, so tooling and

--- a/src/core_management/tests/test_content_health.py
+++ b/src/core_management/tests/test_content_health.py
@@ -1,0 +1,137 @@
+"""Content-load health helpers (#2501): skip grouping, KNOWN_DRIFT allowlist, verdict."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from tempfile import TemporaryDirectory
+
+from django.test import SimpleTestCase
+
+from core_management.content_health import (
+    group_skips,
+    load_known_drift,
+    partition_skips,
+    render_health_report,
+)
+
+
+class GroupSkipsTests(SimpleTestCase):
+    def test_groups_by_source_prefix(self) -> None:
+        skipped = [
+            "gifts/foo.md: Gift could not be loaded: bad category",
+            "gifts/foo.md: Technique could not be loaded: bad rank",
+            "gifts/bar.md: Gift could not be loaded: missing name",
+        ]
+
+        grouped = group_skips(skipped)
+
+        self.assertEqual(
+            grouped,
+            {
+                "gifts/foo.md": [
+                    "gifts/foo.md: Gift could not be loaded: bad category",
+                    "gifts/foo.md: Technique could not be loaded: bad rank",
+                ],
+                "gifts/bar.md": ["gifts/bar.md: Gift could not be loaded: missing name"],
+            },
+        )
+
+    def test_missing_separator_groups_under_unknown(self) -> None:
+        skipped = ["no separator here at all"]
+
+        grouped = group_skips(skipped)
+
+        self.assertEqual(grouped, {"<unknown>": ["no separator here at all"]})
+
+    def test_empty_list_yields_empty_dict(self) -> None:
+        self.assertEqual(group_skips([]), {})
+
+
+class LoadKnownDriftTests(SimpleTestCase):
+    def test_absent_file_returns_empty_list(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            patterns = load_known_drift(Path(temp_dir))
+
+        self.assertEqual(patterns, [])
+
+    def test_strips_blank_lines_and_comments(self) -> None:
+        with TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            fixtures_dir = root / "fixtures"
+            fixtures_dir.mkdir(parents=True)
+            content = (
+                "# stale drift entries\n\nbad category\n  # another comment\nmissing name  \n\n"
+            )
+            (fixtures_dir / "KNOWN_DRIFT.txt").write_text(content, encoding="utf-8")
+
+            patterns = load_known_drift(root)
+
+        self.assertEqual(patterns, ["bad category", "missing name"])
+
+
+class PartitionSkipsTests(SimpleTestCase):
+    def test_partitions_known_vs_unexpected_by_substring(self) -> None:
+        skipped = [
+            "gifts/foo.md: Gift could not be loaded: bad category",
+            "gifts/bar.md: Gift could not be loaded: missing name",
+            "gifts/baz.md: Gift could not be loaded: totally new failure",
+        ]
+        patterns = ["bad category", "missing name"]
+
+        known, unexpected = partition_skips(skipped, patterns)
+
+        self.assertEqual(
+            known,
+            [
+                "gifts/foo.md: Gift could not be loaded: bad category",
+                "gifts/bar.md: Gift could not be loaded: missing name",
+            ],
+        )
+        self.assertEqual(
+            unexpected, ["gifts/baz.md: Gift could not be loaded: totally new failure"]
+        )
+
+    def test_no_patterns_means_everything_unexpected(self) -> None:
+        skipped = ["gifts/foo.md: Gift could not be loaded: bad category"]
+
+        known, unexpected = partition_skips(skipped, [])
+
+        self.assertEqual(known, [])
+        self.assertEqual(unexpected, skipped)
+
+
+class RenderHealthReportTests(SimpleTestCase):
+    def test_healthy_when_all_skips_known(self) -> None:
+        skipped = [
+            "gifts/foo.md: Gift could not be loaded: bad category",
+            "gifts/foo.md: Technique could not be loaded: bad category",
+        ]
+        patterns = ["bad category"]
+
+        lines, healthy = render_health_report(skipped, patterns)
+
+        self.assertTrue(healthy)
+        self.assertTrue(any("gifts/foo.md" in line for line in lines))
+        self.assertTrue(any("known" in line.lower() for line in lines))
+
+    def test_unhealthy_when_unexpected_skip_present(self) -> None:
+        skipped = [
+            "gifts/foo.md: Gift could not be loaded: bad category",
+            "gifts/baz.md: Gift could not be loaded: totally new failure",
+        ]
+        patterns = ["bad category"]
+
+        lines, healthy = render_health_report(skipped, patterns)
+
+        self.assertFalse(healthy)
+        self.assertTrue(
+            any(
+                "gifts/baz.md: Gift could not be loaded: totally new failure" in line
+                for line in lines
+            )
+        )
+
+    def test_empty_skipped_is_healthy_with_no_unexpected(self) -> None:
+        _lines, healthy = render_health_report([], [])
+
+        self.assertTrue(healthy)

--- a/src/world/conditions/AGENT_GLOSSARY.md
+++ b/src/world/conditions/AGENT_GLOSSARY.md
@@ -54,3 +54,11 @@ _Avoid_: cure template, heal type
 **Damage interaction**:
 An authored `ConditionDamageInteraction` row that fires when a conditioned target takes a specific damage type — amplifying (`damage_modifier_percent` > 0), dampening (< 0), consuming (`removes_condition=True`), or transforming (`applies_condition` set) the condition. Wired into the combat damage path after all soak/resistance/armor (#2018). Narration fires only on transitions (removal/transform), not on every-hit modifiers — a pure damage modifier is silent math.
 _Avoid_: elemental reaction, status effect combo (for the damage-axis interaction)
+
+**awareness** (CapabilityType):
+The foundational passive sense-gate every character has (`FoundationalCapability.AWARENESS`, `world/conditions/constants.py`) — `innate_baseline=1`, required by ~all techniques, zeroed by Unconscious via a large negative `ConditionCapabilityEffect`. Distinct from **perception** (below): awareness is "can you sense anything at all," not "how well." See ADR-0143 for the canonical capability vocabulary this belongs to.
+_Avoid_: using "awareness" and "perception" interchangeably — they are separate `CapabilityType` rows with different baselines and different roles.
+
+**perception** (CapabilityType):
+The active, supernormal-sensing capability from the affordance matrix (`docs/architecture/capability-challenge-content.md`) — `innate_baseline=0` (granted by techniques/gifts, not innate), used for Application eligibility (e.g. Scout, Detect, Analyze, Spot) rather than as a baseline sense-gate. A character can have full `awareness` (conscious, sensing normally) with zero `perception` (no supernormal detection). See ADR-0143.
+_Avoid_: awareness, sense, detection (as a synonym for the granted capability specifically)

--- a/tools/build_content_fixtures.py
+++ b/tools/build_content_fixtures.py
@@ -29,6 +29,7 @@ from core_management.content_fixtures import (  # noqa: E402
     build_all,
     write_fixtures,
 )
+from core_management.content_health import load_known_drift, render_health_report  # noqa: E402
 from core_management.content_repo import load_dotenv_content_path  # noqa: E402
 
 
@@ -136,8 +137,16 @@ def _load_world(content_root: Path) -> WorldLoadResult:
         raise _ExitEarly(2) from exc
 
 
-def _print_load_report(world_result: WorldLoadResult) -> None:
-    """Print the ``--load`` summary: content counts, grid counts, deferred, skips."""
+def _print_load_report(world_result: WorldLoadResult, content_root: Path) -> bool:
+    """Print the ``--load`` summary + health report; return the health verdict.
+
+    Summary covers content counts, grid counts, deferred, and skips (as
+    before). The health report (#2501) always follows: it groups
+    ``world_result.skipped`` against ``fixtures/KNOWN_DRIFT.txt`` so expected,
+    pre-existing drift doesn't drown out a genuinely new regression. The
+    returned bool is ``True`` iff every skip matched a known-drift pattern —
+    ``_run`` uses it to decide the ``--strict`` exit code.
+    """
     print(f"loaded: {world_result.created} created, {world_result.updated} updated.")
     if world_result.deferred_resolved:
         print(
@@ -157,6 +166,13 @@ def _print_load_report(world_result: WorldLoadResult) -> None:
         print(f"skipped: {len(world_result.skipped)} object(s):")
         for msg in world_result.skipped:
             print(f"  {msg}")
+
+    patterns = load_known_drift(content_root)
+    lines, healthy = render_health_report(world_result.skipped, patterns)
+    print("health report:")
+    for line in lines:
+        print(f"  {line}")
+    return healthy
 
 
 def _run(args: argparse.Namespace) -> int:
@@ -188,7 +204,9 @@ def _run(args: argparse.Namespace) -> int:
         # Upsert path (NOT loaddata — see load_entries docstring). Sequences
         # content fixtures -> grid bundles -> deferred natural-key retry
         # (#2448) via load_world_content, rather than a bare load_entries.
-        _print_load_report(_load_world(content_root))
+        healthy = _print_load_report(_load_world(content_root), content_root)
+        if args.strict and not healthy:
+            return 7
     return 0
 
 
@@ -205,7 +223,14 @@ def main() -> int:
         default=None,
         help="override the content checkout location (default: CONTENT_REPO_PATH)",
     )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="with --load: exit 7 if any skip is not covered by fixtures/KNOWN_DRIFT.txt",
+    )
     args = parser.parse_args()
+    if args.strict and not args.load:
+        parser.error("--strict requires --load")
 
     try:
         return _run(args)


### PR DESCRIPTION
Closes #2501

## Summary

Content loads are never silently lossy again, and the capability/affordance vocabulary is canonical + loadable.

**arxii side (this PR):** `core_management/content_health.py` (skip grouping, KNOWN_DRIFT allowlist, health verdict) + `tools/build_content_fixtures.py --load --strict` (always-on health report; exit 7 on any skip not baselined in the content repo's `fixtures/KNOWN_DRIFT.txt`); CONTENT_MODELS gains `mechanics.{application,prerequisite,property,propertycategory}` (export side — the loader was always dynamic); ADR-0143 (canonical 27-name capability vocabulary) + docs (INDEX, dev-commands, evennia-quirks, checks.md CheckType name-uniqueness rule, conditions glossary awareness-vs-perception).

**Content-repo companion (already pushed, ArxII-lore `d0059cb53`):** the slug-era conditions family (~300 rows, never loadable since the NK migration) rewritten to current schema; canonical capabilitytype.json (27); NEW mechanics property/application matrix (5/29/46 incl. Ignite=generation×flammable); check_types.json retired in favor of seeded CheckTypes by (name,category) NK + 15 genuinely-new rows; KNOWN_DRIFT.txt baselines 70 pre-existing unrelated skips. Verified: `--load --strict` exit 0, idempotent (0 created/2665 updated ×3); dev DB CapabilityType 27, ConditionTemplate 93 (was 52), Ignite Application live.

**Found + fixed in review:** new CheckType rows colliding by NAME with seeded rows (Stealth, Endurance) broke two wired name-only lookups (guard detection silently no-op'd via run_safely; vitals endurance check raised MultipleObjectsReturned). Fixture rule now recorded in checks.md; dup DB rows removed.

**Content judgment calls surfaced for ratification (not silent):** perception→awareness / speech→communication / fine-manipulation→limb_use remaps; 5 no-successor capability effects converted to ConditionCheckModifier at value×5 (blocked cases land ±500 = auto-best/worst); 10 Emotional-ladder rows hours→permanent, refresh→intensity; forms species parent Elven→Elf (the Arx-City-class silent skip this issue exists to prevent).

Phase 0 of the #2503 capabilities-universal-currency spec (approved; #2501 pre-approved by TehomCD 2026-07-18). Unblocks #2504 (oracle merge), #2505 (checks folding), and the wave-A capability-grant content pass.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2501 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: branch created from main tip 45843c595; sync-with-main reported up to date; no conflicts

<!-- last-addressed-comment: 0 -->