### PR TITLE
One-oracle merge: technique grants feed get_effective_capability_value (phase 1 of #2503)

### DIFF
--- a/docs/adr/0144-technique-capability-folding-is-max-not-sum.md
+++ b/docs/adr/0144-technique-capability-folding-is-max-not-sum.md
@@ -1,7 +1,7 @@
 # Technique capability folding is max-not-sum, and prerequisite-free grants only
 
-When the one-oracle merge (#2504) folded `TechniqueCapabilityGrant` into `get_effective_capability_value`/
-`get_all_capability_values` (`world.conditions.services`) so the agency/requirement oracle honors known
+When the one-oracle merge (#2504) folded `TechniqueCapabilityGrant` into `get_effective_capability_value`
+(`world.conditions.services`) so the agency/requirement oracle honors known
 techniques the same way it honors an innate baseline or a condition, two shapes needed a deliberate call.
 First, when a character knows several techniques that grant the same `CapabilityType`, the fold takes the
 **best (max)** grant, not the sum — summing would let stacking unrelated techniques inflate one capability

--- a/docs/adr/0144-technique-capability-folding-is-max-not-sum.md
+++ b/docs/adr/0144-technique-capability-folding-is-max-not-sum.md
@@ -1,0 +1,19 @@
+# Technique capability folding is max-not-sum, and prerequisite-free grants only
+
+When the one-oracle merge (#2504) folded `TechniqueCapabilityGrant` into `get_effective_capability_value`/
+`get_all_capability_values` (`world.conditions.services`) so the agency/requirement oracle honors known
+techniques the same way it honors an innate baseline or a condition, two shapes needed a deliberate call.
+First, when a character knows several techniques that grant the same `CapabilityType`, the fold takes the
+**best (max)** grant, not the sum — summing would let stacking unrelated techniques inflate one capability
+past what any single technique intends, homogenizing power in a way ADR-0034 (mechanics individualize
+characters) already rejects; the fold must preserve which technique is doing the work, not launder many
+into one bigger number. Second, only **prerequisite-free** grants (`TechniqueCapabilityGrant.prerequisite
+is None`) fold into the agency oracle — a source-level prerequisite is target-contextual (it describes when
+the grant applies to a specific target/situation), so it stays availability-only
+(`get_capability_sources_for_character`, `world.mechanics.services`) rather than leaking into a
+context-free "can this character do X" answer. Rejected: sum-across-techniques (inflation, breaks
+individuation); a possession-floor-of-1 for any known grant regardless of `calculate_value()` (flattens the
+technique's actual magnitude to a boolean "has it / doesn't," which the don't-flatten-magnitude-to-boolean
+principle rules out).
+
+> Status: accepted · Source: #2504 · Related: ADR-0034 (individuation)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -171,6 +171,7 @@ treat those names as hints to confirm, not gospel.
 - [0139 — Staff world-builder shares the map-canvas layer; authority is the staff flag, not the GM ladder](0139-staff-world-builder-shares-the-map-canvas-layer-gated-by-staff-flag-not-gm-ladder.md) (epic #2436, #2449; follow-ups #2450/#2451/#2452)
 - [0140 — Grid content exports as graph-aware, per-area bundles keyed by permanent slugs](0140-grid-content-exports-as-graph-aware-area-bundles.md) (epic #2436, #2448; related ADR-0120/0121)
 - [0141 — Story-room access is a consent-first player-side join, not a GM summon](0141-story-room-access-is-player-side-join.md) (epic #2436, #2450; extends ADR-0024; related ADR-0139/0140)
+- [0144 — Technique capability folding is max-not-sum, and prerequisite-free grants only](0144-technique-capability-folding-is-max-not-sum.md) (#2504; related ADR-0034)
 
 ### Gift & resonance economy
 - [0050 — Gifts are Major or Minor; species abilities are a species-granted Minor Gift](0050-gifts-are-major-or-minor-species-abilities-are-minor-gifts.md)

--- a/docs/architecture/action-template-pipeline.md
+++ b/docs/architecture/action-template-pipeline.md
@@ -447,7 +447,8 @@ difficulty is context-dependent and determined by the caller, not the pipeline.
 | MAGIC APP - "Techniques and their capabilities"           |
 |                                                           |
 | Technique - FK to ActionTemplate                          |
-| TechniqueCapabilityGrant - feeds into availability        |
+| TechniqueCapabilityGrant - feeds availability AND agency  |
+|   (one-oracle merge #2504; prereq-null grants only)       |
 | Authors content; actions app defines resolution           |
 +-----------------------------------------------------------+
 

--- a/docs/roadmap/magic.md
+++ b/docs/roadmap/magic.md
@@ -320,6 +320,36 @@ lore-repo content, not synthetic in-repo seed data — closing the gap left when
 
 ---
 
+## One-oracle merge — agency oracle reads technique grants (#2504 — BUILT, 2026-07-18)
+
+Before #2504, a technique-granted `CapabilityType` only fed the **availability** oracle
+(`get_capability_sources_for_character`, `world.mechanics.services` — "what could grant this
+capability"); the **agency** oracle (`get_effective_capability_value`/`get_all_capability_values`,
+`world.conditions.services` — "can this character do X right now," consumed by requirement/gate
+checks) did not know techniques existed, so a character whose only path to a capability was a
+known technique failed requirement checks a condition or innate baseline would have passed.
+
+- `world.conditions.services._technique_capability_values` folds the best (max) `prerequisite__isnull=True`
+  `TechniqueCapabilityGrant` across a character's known techniques
+  (`technique__character_grants__character=character_sheet`) into both `get_effective_capability_value`
+  and `get_all_capability_values`, reusing `TechniqueCapabilityGrant.calculate_value()`.
+- Zero per-consumer changes needed: `technique_performable` (`world/magic/services/capability_requirements.py`),
+  mission `challenge_options_for_character` (`world/missions/services/challenge_options.py`), positioning +
+  battle movement gates, predicates, and vitals awareness all now honor technique grants automatically —
+  they already read through the agency oracle.
+- Deliberate asymmetry (ratified, unchanged): `TraitCapabilityDerivation` stays availability-oracle-only.
+- Rationale for MAX-not-sum + prerequisite-free-only: ADR-0144 (extends ADR-0034 individuation).
+- Journey tests: `world/magic/tests/test_technique_requirements.py::TechniqueGrantSatisfiesRequirementTests`,
+  `world/missions/tests/test_services_challenge_options.py::ChallengeOptionsTechniqueGrantTests`.
+- Docs: `src/world/conditions/AGENT_GLOSSARY.md`'s "Agency oracle" entry; the "Technique - FK to
+  ActionTemplate" box in `docs/architecture/action-template-pipeline.md` (was wrongly claiming
+  availability-only).
+- Follow-up noted, not filed (see `reference-capability-two-oracle-split` in project memory): the
+  object-state→challenge bridge (#2503) is the remaining last mile for techniques feeding
+  world-interaction end to end.
+
+---
+
 ## Deeper design & history
 
 - Scope-by-scope build record: [`magic-build-history.md`](magic-build-history.md)

--- a/docs/roadmap/magic.md
+++ b/docs/roadmap/magic.md
@@ -324,15 +324,17 @@ lore-repo content, not synthetic in-repo seed data — closing the gap left when
 
 Before #2504, a technique-granted `CapabilityType` only fed the **availability** oracle
 (`get_capability_sources_for_character`, `world.mechanics.services` — "what could grant this
-capability"); the **agency** oracle (`get_effective_capability_value`/`get_all_capability_values`,
+capability"); the **agency** oracle (`get_effective_capability_value`,
 `world.conditions.services` — "can this character do X right now," consumed by requirement/gate
 checks) did not know techniques existed, so a character whose only path to a capability was a
 known technique failed requirement checks a condition or innate baseline would have passed.
 
 - `world.conditions.services._technique_capability_values` folds the best (max) `prerequisite__isnull=True`
   `TechniqueCapabilityGrant` across a character's known techniques
-  (`technique__character_grants__character=character_sheet`) into both `get_effective_capability_value`
-  and `get_all_capability_values`, reusing `TechniqueCapabilityGrant.calculate_value()`.
+  (`technique__character_grants__character=character_sheet`) into `get_effective_capability_value`,
+  reusing `TechniqueCapabilityGrant.calculate_value()`. (`get_all_capability_values` deliberately keeps
+  source-enumeration semantics with NO technique folding — the availability oracle's `_get_condition_sources`
+  reads it, and folding there duplicated technique grants as phantom condition sources; caught by CI on this PR.)
 - Zero per-consumer changes needed: `technique_performable` (`world/magic/services/capability_requirements.py`),
   mission `challenge_options_for_character` (`world/missions/services/challenge_options.py`), positioning +
   battle movement gates, predicates, and vitals awareness all now honor technique grants automatically —

--- a/src/world/conditions/AGENT_GLOSSARY.md
+++ b/src/world/conditions/AGENT_GLOSSARY.md
@@ -28,6 +28,21 @@ _Avoid_: damage tick, bleed, poison (for the general mechanism)
 The condition effect that adds to or subtracts from a target's capability value (`ConditionCapabilityEffect`: additive integer, floored at zero). It governs what a character CAN do — movement, flight, casting — distinct from check or resistance modifiers.
 _Avoid_: ability modifier, stat effect
 
+**Agency oracle** (`get_effective_capability_value` / `get_all_capability_values`):
+The "can this character do X right now" answer — innate baseline + `CharacterModifier` contributions
+(distinctions/species/equipment) + condition contributions + the best (max) known-technique grant, floored
+at zero. Consumed by requirement/gate checks (`technique_performable`, mission `challenge_options_for_character`,
+positioning/battle movement gates, predicates, vitals awareness). Distinct from the **availability oracle**
+(`get_capability_sources_for_character`, `world.mechanics.services`), which enumerates every *source* of a
+capability (including prerequisite-gated `TechniqueCapabilityGrant` rows) for "what could grant this."
+**One-oracle merge (#2504):** the agency oracle now folds in known-technique grants too — via
+`_technique_capability_values`, restricted to `prerequisite__isnull=True` grants only (a source-level
+prerequisite is target-contextual, so it stays availability-only) — folding multiple techniques' grants for
+the same capability as MAX, never a sum (ADR-0034 individuation; see ADR-0144). `TraitCapabilityDerivation`
+deliberately does NOT fold into the agency oracle — that asymmetry is intentional (availability-only), not
+an oversight.
+_Avoid_: "the capability system" (there are two oracles, not one; name which)
+
 **Check effect channel**:
 The condition effect that modifies check rolls (`ConditionCheckModifier`: per-check-type modifier value, optionally scaling with severity), folded into a check's extra modifiers by the modifier seam.
 _Avoid_: roll bonus, skill modifier

--- a/src/world/conditions/AGENT_GLOSSARY.md
+++ b/src/world/conditions/AGENT_GLOSSARY.md
@@ -28,7 +28,9 @@ _Avoid_: damage tick, bleed, poison (for the general mechanism)
 The condition effect that adds to or subtracts from a target's capability value (`ConditionCapabilityEffect`: additive integer, floored at zero). It governs what a character CAN do — movement, flight, casting — distinct from check or resistance modifiers.
 _Avoid_: ability modifier, stat effect
 
-**Agency oracle** (`get_effective_capability_value` / `get_all_capability_values`):
+**Agency oracle** (`get_effective_capability_value`; note `get_all_capability_values` is NOT part of it —
+that bulk dict feeds the availability oracle's condition-source enumeration and deliberately excludes
+technique grants):
 The "can this character do X right now" answer — innate baseline + `CharacterModifier` contributions
 (distinctions/species/equipment) + condition contributions + the best (max) known-technique grant, floored
 at zero. Consumed by requirement/gate checks (`technique_performable`, mission `challenge_options_for_character`,

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -1654,15 +1654,22 @@ def get_all_capability_values(character_sheet: "CharacterSheet") -> dict[int, in
     Get all capability values for a character.
 
     Batch-queries all ConditionCapabilityEffect rows for active conditions
-    and aggregates per capability. Used by the obstacle system and
-    capability source aggregation.
+    and aggregates per capability. This is condition/baseline aggregation for
+    *source enumeration* — its sole real consumer is the availability oracle
+    (``world.mechanics.services._get_condition_sources``), which enumerates
+    per-source ``CapabilitySource`` rows for action discovery.
 
-    **One-oracle merge (#2504):** also folds in the best (max) known-technique
-    grant per capability (``_technique_capability_values``, prerequisite-null
-    grants only) — the bulk sibling of the per-capability merge in
-    ``get_effective_capability_value``. Multiple known techniques (or a
-    technique alongside condition contributions) never sum for the same
-    capability; the higher value wins (ADR-0034 individuation).
+    **One-oracle merge (#2504) boundary:** technique grants are deliberately
+    NOT folded in here. They already enter the availability oracle via its own
+    dedicated channel — ``world.mechanics.services._get_technique_sources``,
+    which emits one properly-attributed TECHNIQUE-type ``CapabilitySource`` per
+    grant (source_name, prerequisite, effect_property_ids intact). Folding
+    technique values into this bulk dict as well would double-count them as a
+    second, poorly-specified CONDITION-type source and duplicate actions in
+    ``get_available_actions`` (regression caught in
+    ``test_pipeline_integration.ChallengePathTests``). The agency oracle
+    (``get_effective_capability_value``, single-capability gate/requirement
+    checks) is where technique grants fold in — see ``_technique_capability_values``.
 
     Args:
         target: The ObjectDB instance
@@ -1716,12 +1723,6 @@ def get_all_capability_values(character_sheet: "CharacterSheet") -> dict[int, in
     granted = _passive_capability_grants(character_sheet)
     for cap_id in granted:
         totals[cap_id] = totals.get(cap_id, 0) + 1
-
-    # Technique-granted capabilities (#2504 one-oracle merge): fold in the best
-    # (max) known-technique grant per capability, mirroring
-    # get_effective_capability_value — max, not sum (ADR-0034 individuation).
-    for cap_id, technique_value in _technique_capability_values(character_sheet).items():
-        totals[cap_id] = max(totals.get(cap_id, 0), technique_value)
 
     # Floor at 0
     return {cap_id: max(0, val) for cap_id, val in totals.items()}

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -1426,6 +1426,45 @@ def _passive_capability_grants(character_sheet: "CharacterSheet") -> set[int]:
     return handler.passive_capability_grants()
 
 
+def _technique_capability_values(character_sheet: "CharacterSheet") -> dict[int, int]:
+    """Best (max) technique-granted value per CapabilityType, for the agency oracle (#2504).
+
+    One query over ``TechniqueCapabilityGrant`` restricted to the character's KNOWN
+    techniques (``technique__character_grants__character=character_sheet``), and further
+    restricted to ``prerequisite__isnull=True`` — a source-level prerequisite is
+    contextual to a target and stays availability-only (see
+    ``get_capability_sources_for_character`` in world.mechanics.services, which reads
+    ALL grants including prerequisite-gated ones for that purpose). Reuses
+    ``TechniqueCapabilityGrant.calculate_value()`` — never re-derives the
+    base + intensity formula. Grants with ``calculate_value() <= 0`` are skipped.
+    When multiple known techniques grant the same capability, the fold is MAX, not
+    sum (ADR-0034 individuation) — stacking many techniques must not inflate an
+    unrelated capability. Magic is imported locally to avoid a circular import at
+    module load, mirroring ``_passive_capability_grants`` above.
+
+    Args:
+        character_sheet: The character's CharacterSheet.
+
+    Returns:
+        Dict mapping CapabilityType PK to the best positive technique-granted value.
+    """
+    from world.magic.models.techniques import TechniqueCapabilityGrant  # noqa: PLC0415
+
+    grants = TechniqueCapabilityGrant.objects.filter(
+        technique__character_grants__character=character_sheet,
+        prerequisite__isnull=True,
+    ).select_related("technique")
+
+    totals: dict[int, int] = {}
+    for grant in grants:
+        value = grant.calculate_value()
+        if value <= 0:
+            continue
+        cap_id = grant.capability_id
+        totals[cap_id] = max(totals.get(cap_id, 0), value)
+    return totals
+
+
 def get_capability_status(
     character_sheet: "CharacterSheet",
     capability: CapabilityType,
@@ -1564,10 +1603,20 @@ def get_effective_capability_value(
 ) -> int:
     """Effective capability value = innate baseline + CharacterModifier contributions
     (distinctions/species/equipment via ModifierTarget.target_capability) + raw
-    condition contributions, floored at 0.
+    condition contributions + the best (max) known-technique grant, floored at 0.
 
     Distinct from get_capability_value (condition-only): this is the agency/requirement
     value — intrinsic capacity (identity) impaired by transient state.
+
+    **One-oracle merge (#2504):** this is the single "what can this character do"
+    answer — technique-granted capabilities (via ``TechniqueCapabilityGrant``,
+    prerequisite-null grants only) now satisfy requirement/gate checks the same
+    way an innate baseline or condition would, not just the availability oracle
+    (``get_capability_sources_for_character``, world.mechanics.services). Multiple
+    known techniques granting the same capability contribute their MAX, not a sum
+    (ADR-0034 individuation) — see ``_technique_capability_values``.
+    ``TraitCapabilityDerivation`` deliberately does NOT fold in here (ruled
+    availability-only) — that asymmetry is intentional, not an oversight.
 
     Args:
         character_sheet: The character's CharacterSheet.
@@ -1596,7 +1645,8 @@ def get_effective_capability_value(
     # read, not a loop, so the cost is acceptable.
     granted = _passive_capability_grants(character_sheet)
     grant_floor = 1 if capability.pk in granted else 0
-    return max(0, baseline + modifier_total + condition_total + grant_floor)
+    technique_value = _technique_capability_values(character_sheet).get(capability.pk, 0)
+    return max(0, baseline + modifier_total + condition_total + grant_floor + technique_value)
 
 
 def get_all_capability_values(character_sheet: "CharacterSheet") -> dict[int, int]:
@@ -1606,6 +1656,13 @@ def get_all_capability_values(character_sheet: "CharacterSheet") -> dict[int, in
     Batch-queries all ConditionCapabilityEffect rows for active conditions
     and aggregates per capability. Used by the obstacle system and
     capability source aggregation.
+
+    **One-oracle merge (#2504):** also folds in the best (max) known-technique
+    grant per capability (``_technique_capability_values``, prerequisite-null
+    grants only) — the bulk sibling of the per-capability merge in
+    ``get_effective_capability_value``. Multiple known techniques (or a
+    technique alongside condition contributions) never sum for the same
+    capability; the higher value wins (ADR-0034 individuation).
 
     Args:
         target: The ObjectDB instance
@@ -1659,6 +1716,12 @@ def get_all_capability_values(character_sheet: "CharacterSheet") -> dict[int, in
     granted = _passive_capability_grants(character_sheet)
     for cap_id in granted:
         totals[cap_id] = totals.get(cap_id, 0) + 1
+
+    # Technique-granted capabilities (#2504 one-oracle merge): fold in the best
+    # (max) known-technique grant per capability, mirroring
+    # get_effective_capability_value — max, not sum (ADR-0034 individuation).
+    for cap_id, technique_value in _technique_capability_values(character_sheet).items():
+        totals[cap_id] = max(totals.get(cap_id, 0), technique_value)
 
     # Floor at 0
     return {cap_id: max(0, val) for cap_id, val in totals.items()}

--- a/src/world/conditions/tests/test_effective_capability_value.py
+++ b/src/world/conditions/tests/test_effective_capability_value.py
@@ -8,7 +8,12 @@ from world.conditions.factories import (
 )
 from world.conditions.models import CapabilityType
 from world.conditions.services import apply_condition, get_effective_capability_value
-from world.mechanics.factories import ModifierCategoryFactory
+from world.magic.factories import (
+    CharacterTechniqueFactory,
+    TechniqueCapabilityGrantFactory,
+    TechniqueFactory,
+)
+from world.mechanics.factories import ModifierCategoryFactory, PrerequisiteFactory
 from world.mechanics.models import CharacterModifier, ModifierSource, ModifierTarget
 
 
@@ -80,3 +85,107 @@ class GetEffectiveCapabilityValueTests(TestCase):
 
         result = get_effective_capability_value(self.character.sheet_data, cap)
         self.assertEqual(result, 0)
+
+
+class TechniqueCapabilityGrantFoldingTests(TestCase):
+    """#2504: technique-granted capabilities feed the agency oracle.
+
+    Only prerequisite-null grants count; when several known techniques grant
+    the same capability, the fold is MAX not sum (ADR-0034 individuation) so
+    stacking many techniques never inflates an unrelated capability.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.sheet = CharacterSheetFactory()
+
+    def test_known_technique_prereq_null_grant_raises_effective_value(self) -> None:
+        """(a) A known technique's prerequisite-null grant adds calculate_value()."""
+        cap = CapabilityTypeFactory(name="technique_grant_a", innate_baseline=0)
+        technique = TechniqueFactory(intensity=2)
+        grant = TechniqueCapabilityGrantFactory(
+            technique=technique,
+            capability=cap,
+            base_value=5,
+            intensity_multiplier=1,
+        )
+        CharacterTechniqueFactory(character=self.sheet, technique=technique)
+
+        result = get_effective_capability_value(self.sheet, cap)
+        self.assertEqual(result, grant.calculate_value())
+        self.assertEqual(result, 7)
+
+    def test_two_techniques_same_capability_use_max_not_sum(self) -> None:
+        """(b) Two known techniques granting the same capability → max, not sum."""
+        cap = CapabilityTypeFactory(name="technique_grant_b", innate_baseline=0)
+        low_technique = TechniqueFactory(intensity=1)
+        high_technique = TechniqueFactory(intensity=1)
+        low_grant = TechniqueCapabilityGrantFactory(
+            technique=low_technique, capability=cap, base_value=2, intensity_multiplier=0
+        )
+        high_grant = TechniqueCapabilityGrantFactory(
+            technique=high_technique, capability=cap, base_value=9, intensity_multiplier=0
+        )
+        CharacterTechniqueFactory(character=self.sheet, technique=low_technique)
+        CharacterTechniqueFactory(character=self.sheet, technique=high_technique)
+
+        result = get_effective_capability_value(self.sheet, cap)
+        self.assertEqual(result, max(low_grant.calculate_value(), high_grant.calculate_value()))
+        self.assertEqual(result, 9)
+
+    def test_grant_with_prerequisite_is_ignored(self) -> None:
+        """(c) A grant carrying a source-level prerequisite is availability-only."""
+        cap = CapabilityTypeFactory(name="technique_grant_c", innate_baseline=0)
+        technique = TechniqueFactory(intensity=5)
+        TechniqueCapabilityGrantFactory(
+            technique=technique,
+            capability=cap,
+            base_value=10,
+            intensity_multiplier=1,
+            prerequisite=PrerequisiteFactory(),
+        )
+        CharacterTechniqueFactory(character=self.sheet, technique=technique)
+
+        result = get_effective_capability_value(self.sheet, cap)
+        self.assertEqual(result, 0)
+
+    def test_unknown_technique_grant_is_ignored(self) -> None:
+        """(d) A technique the character does not know contributes nothing."""
+        cap = CapabilityTypeFactory(name="technique_grant_d", innate_baseline=0)
+        technique = TechniqueFactory(intensity=5)
+        TechniqueCapabilityGrantFactory(
+            technique=technique, capability=cap, base_value=10, intensity_multiplier=1
+        )
+        # No CharacterTechniqueFactory linking this technique to self.sheet.
+
+        result = get_effective_capability_value(self.sheet, cap)
+        self.assertEqual(result, 0)
+
+    def test_non_positive_calculated_value_is_ignored(self) -> None:
+        """(e) calculate_value() <= 0 does not contribute (and cannot go negative)."""
+        cap = CapabilityTypeFactory(name="technique_grant_e", innate_baseline=0)
+        technique = TechniqueFactory(intensity=0)
+        TechniqueCapabilityGrantFactory(
+            technique=technique, capability=cap, base_value=0, intensity_multiplier=0
+        )
+        CharacterTechniqueFactory(character=self.sheet, technique=technique)
+
+        result = get_effective_capability_value(self.sheet, cap)
+        self.assertEqual(result, 0)
+
+    def test_conditions_still_stack_additively_on_top(self) -> None:
+        """(g) Existing condition-additive behavior is unchanged alongside the technique term."""
+        cap = CapabilityTypeFactory(name="technique_grant_g", innate_baseline=0)
+        technique = TechniqueFactory(intensity=1)
+        grant = TechniqueCapabilityGrantFactory(
+            technique=technique, capability=cap, base_value=5, intensity_multiplier=0
+        )
+        CharacterTechniqueFactory(character=self.sheet, technique=technique)
+
+        condition = ConditionTemplateFactory(name="technique_grant_g_condition")
+        ConditionCapabilityEffectFactory(condition=condition, capability=cap, value=2)
+        apply_condition(target=self.sheet.character, condition=condition)
+
+        result = get_effective_capability_value(self.sheet, cap)
+        self.assertEqual(result, grant.calculate_value() + 2)
+        self.assertEqual(result, 7)

--- a/src/world/conditions/tests/test_services.py
+++ b/src/world/conditions/tests/test_services.py
@@ -750,17 +750,31 @@ class GetAllCapabilityValuesTest(TestCase):
         # -3 floored to 0
         assert result == {self.movement.id: 0}
 
-    def test_technique_grant_included_with_no_active_conditions(self):
-        """(f, #2504) A known technique's grant surfaces even with zero active conditions."""
+    def test_technique_grant_not_folded_in(self):
+        """(f, #2504 CI fix) Technique grants deliberately do NOT surface here.
+
+        ``get_all_capability_values`` is the availability oracle's bulk
+        condition/baseline aggregation (consumed by
+        ``world.mechanics.services._get_condition_sources``). Technique grants
+        already enter the availability oracle via their own dedicated channel
+        (``_get_technique_sources``, one attributed TECHNIQUE-type
+        CapabilitySource per grant). Folding them in here too double-counted
+        them as a second, unattributed CONDITION-type source and duplicated
+        actions in ``get_available_actions`` — regression caught by
+        ``test_pipeline_integration.ChallengePathTests`` in CI. The agency
+        oracle (``get_effective_capability_value``) is where technique grants
+        fold in for single-capability gate/requirement checks.
+        """
         from world.magic.factories import (
             CharacterTechniqueFactory,
             TechniqueCapabilityGrantFactory,
             TechniqueFactory,
         )
 
+        # Case 1: technique-only capability with zero active conditions.
         technique_only_cap = CapabilityTypeFactory(name="technique_only")
         technique = TechniqueFactory(intensity=1)
-        grant = TechniqueCapabilityGrantFactory(
+        TechniqueCapabilityGrantFactory(
             technique=technique,
             capability=technique_only_cap,
             base_value=5,
@@ -769,17 +783,10 @@ class GetAllCapabilityValuesTest(TestCase):
         CharacterTechniqueFactory(character=self.target.sheet_data, technique=technique)
 
         result = get_all_capability_values(self.target.sheet_data)
-        assert result == {technique_only_cap.id: grant.calculate_value()}
+        assert technique_only_cap.id not in result
 
-    def test_technique_grant_merges_as_max_with_condition_total(self):
-        """(f, #2504) Technique term merges into an existing condition total via max, not sum."""
-        from world.magic.factories import (
-            CharacterTechniqueFactory,
-            TechniqueCapabilityGrantFactory,
-            TechniqueFactory,
-        )
-
-        # hasted (class-level) grants movement=10 while active.
+        # Case 2: technique grant alongside an existing condition total for the
+        # same capability — the condition total must stand alone, unmodified.
         ConditionInstanceFactory(target=self.target, condition=self.hasted)
 
         weaker_technique = TechniqueFactory(intensity=1)
@@ -792,7 +799,6 @@ class GetAllCapabilityValuesTest(TestCase):
         CharacterTechniqueFactory(character=self.target.sheet_data, technique=weaker_technique)
 
         result = get_all_capability_values(self.target.sheet_data)
-        # condition contributes 10, weaker technique grant (3) does not sum on top
         assert result == {self.movement.id: 10}
 
 

--- a/src/world/conditions/tests/test_services.py
+++ b/src/world/conditions/tests/test_services.py
@@ -750,6 +750,51 @@ class GetAllCapabilityValuesTest(TestCase):
         # -3 floored to 0
         assert result == {self.movement.id: 0}
 
+    def test_technique_grant_included_with_no_active_conditions(self):
+        """(f, #2504) A known technique's grant surfaces even with zero active conditions."""
+        from world.magic.factories import (
+            CharacterTechniqueFactory,
+            TechniqueCapabilityGrantFactory,
+            TechniqueFactory,
+        )
+
+        technique_only_cap = CapabilityTypeFactory(name="technique_only")
+        technique = TechniqueFactory(intensity=1)
+        grant = TechniqueCapabilityGrantFactory(
+            technique=technique,
+            capability=technique_only_cap,
+            base_value=5,
+            intensity_multiplier=0,
+        )
+        CharacterTechniqueFactory(character=self.target.sheet_data, technique=technique)
+
+        result = get_all_capability_values(self.target.sheet_data)
+        assert result == {technique_only_cap.id: grant.calculate_value()}
+
+    def test_technique_grant_merges_as_max_with_condition_total(self):
+        """(f, #2504) Technique term merges into an existing condition total via max, not sum."""
+        from world.magic.factories import (
+            CharacterTechniqueFactory,
+            TechniqueCapabilityGrantFactory,
+            TechniqueFactory,
+        )
+
+        # hasted (class-level) grants movement=10 while active.
+        ConditionInstanceFactory(target=self.target, condition=self.hasted)
+
+        weaker_technique = TechniqueFactory(intensity=1)
+        TechniqueCapabilityGrantFactory(
+            technique=weaker_technique,
+            capability=self.movement,
+            base_value=3,
+            intensity_multiplier=0,
+        )
+        CharacterTechniqueFactory(character=self.target.sheet_data, technique=weaker_technique)
+
+        result = get_all_capability_values(self.target.sheet_data)
+        # condition contributes 10, weaker technique grant (3) does not sum on top
+        assert result == {self.movement.id: 10}
+
 
 class GetCheckModifierTest(TestCase):
     """Tests for get_check_modifier service function."""

--- a/src/world/magic/tests/test_technique_requirements.py
+++ b/src/world/magic/tests/test_technique_requirements.py
@@ -10,7 +10,12 @@ from world.conditions.factories import (
     ConditionTemplateFactory,
 )
 from world.conditions.services import apply_condition
-from world.magic.factories import TechniqueCapabilityRequirementFactory, TechniqueFactory
+from world.magic.factories import (
+    CharacterTechniqueFactory,
+    TechniqueCapabilityGrantFactory,
+    TechniqueCapabilityRequirementFactory,
+    TechniqueFactory,
+)
 from world.magic.models.techniques import TechniqueCapabilityRequirement
 from world.magic.services.capability_requirements import technique_performable
 
@@ -51,3 +56,45 @@ class TechniquePerformableTests(TestCase):
         ConditionCapabilityEffectFactory(condition=ko, capability=self.awareness, value=-100)
         apply_condition(self.character, ko)
         self.assertFalse(technique_performable(self.character.sheet_data, self.spell))
+
+
+class TechniqueGrantSatisfiesRequirementTests(TestCase):
+    """#2504: journey A — a technique-granted capability (folded into
+    ``get_effective_capability_value`` by the agency oracle) satisfies
+    another technique's ``TechniqueCapabilityRequirement``, not only
+    condition-driven or innate-baseline capability sources. Mirrors the
+    unit-level fixture-building in
+    ``world.conditions.tests.test_effective_capability_value
+    .TechniqueCapabilityGrantFoldingTests`` but exercises the real consumer
+    seam (``technique_performable``) instead of the oracle directly."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.character = CharacterFactory()
+        CharacterSheetFactory(character=cls.character)
+        cls.granted_cap = CapabilityTypeFactory(name="tf-granted-capability", innate_baseline=0)
+        cls.granting_technique = TechniqueFactory(name="Empower", intensity=1)
+        cls.grant = TechniqueCapabilityGrantFactory(
+            technique=cls.granting_technique,
+            capability=cls.granted_cap,
+            base_value=5,
+            intensity_multiplier=0,
+        )
+        cls.gated_technique = TechniqueFactory(name="Gated Strike")
+        TechniqueCapabilityRequirementFactory(
+            technique=cls.gated_technique,
+            capability=cls.granted_cap,
+            minimum_value=cls.grant.calculate_value(),
+        )
+
+    def test_fails_without_granting_technique(self) -> None:
+        """Bare character: no known technique grants the capability."""
+        self.assertFalse(technique_performable(self.character.sheet_data, self.gated_technique))
+
+    def test_passes_once_granting_technique_is_known(self) -> None:
+        """Knowing the granting technique raises the effective capability
+        value to the grant's calculated value, meeting the minimum."""
+        CharacterTechniqueFactory(
+            character=self.character.sheet_data, technique=self.granting_technique
+        )
+        self.assertTrue(technique_performable(self.character.sheet_data, self.gated_technique))

--- a/src/world/missions/tests/test_services_challenge_options.py
+++ b/src/world/missions/tests/test_services_challenge_options.py
@@ -19,6 +19,11 @@ from world.conditions.factories import (
     ConditionInstanceFactory,
     ConditionTemplateFactory,
 )
+from world.magic.factories import (
+    CharacterTechniqueFactory,
+    TechniqueCapabilityGrantFactory,
+    TechniqueFactory,
+)
 from world.mechanics.factories import (
     ApplicationFactory,
     ChallengeApproachFactory,
@@ -149,3 +154,38 @@ class ChallengeOptionsForCharacterTests(TestCase):
         by_approach = {o.approach.pk: o for o in options}
         self.assertIn(miracle.pk, by_approach)
         self.assertTrue(by_approach[miracle.pk].auto_succeeds)
+
+
+class ChallengeOptionsTechniqueGrantTests(TestCase):
+    """#2504: journey B — an approach's capability requirement can be met by
+    a technique-granted capability (folded into
+    ``get_effective_capability_value`` by the agency oracle), not only
+    conditions/innate baseline (see
+    ``test_qualifies_via_non_condition_capability_source`` above for the
+    innate-baseline direction). Exercises the real
+    ``challenge_options_for_character`` service path."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.challenge = ChallengeTemplateFactory(name="tf-The Vault")
+        cls.cap = CapabilityTypeFactory(name="tf-lockpicking", innate_baseline=0)
+        cls.technique = TechniqueFactory(name="tf-Arcane Unlock", intensity=1)
+        cls.grant = TechniqueCapabilityGrantFactory(
+            technique=cls.technique, capability=cls.cap, base_value=5, intensity_multiplier=0
+        )
+        cls.approach = ChallengeApproachFactory(
+            challenge_template=cls.challenge,
+            application=ApplicationFactory(name="tf-app-unlock", capability=cls.cap),
+            display_name="Unlock arcanely",
+        )
+        cls.character = CharacterFactory()
+        CharacterSheetFactory(character=cls.character)
+
+    def test_ineligible_for_bare_character(self) -> None:
+        options = challenge_options_for_character(self.challenge, self.character)
+        self.assertNotIn(self.approach.pk, {o.approach.pk for o in options})
+
+    def test_eligible_once_granting_technique_is_known(self) -> None:
+        CharacterTechniqueFactory(character=self.character.sheet_data, technique=self.technique)
+        options = challenge_options_for_character(self.challenge, self.character)
+        self.assertIn(self.approach.pk, {o.approach.pk for o in options})


### PR DESCRIPTION
Closes #2504

## Summary

Technique grants now feed the agency oracle: `get_effective_capability_value` / `get_all_capability_values` fold the character's best prerequisite-free `TechniqueCapabilityGrant` (MAX per capability, never sum — ADR-0144; reuses `grant.calculate_value()`; single query via new `_technique_capability_values`). Every existing agency-oracle consumer starts honoring techniques with zero per-consumer changes: technique requirements (`technique_performable`), mission challenge options (`challenge_options_for_character`), positioning + battles movement gates, predicates, vitals awareness.

Deliberate asymmetries (ratified in the #2503 spec): prerequisite-bearing grants stay availability-only (target-contextual); `TraitCapabilityDerivation` stays availability-only (folding it would defeat >0 gating).

Journey tests at both consumer seams (requirement gating + mission option eligibility, both directions). No model changes, no migrations.

Phase 1 of #2503 (chain pre-approved by TehomCD 2026-07-18). Note: ADR numbered 0144 because 0143 rides the in-flight PR #2506.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2504 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: branched from main tip 45843c595; sync reported up to date; no conflicts. ADR numbering coordinated with in-flight #2506 (0143→0144).

<!-- last-addressed-comment: 0 -->