### PR TITLE
Design question: player room-building constraints — project-mediated digs + desc-permission tiers (epic #2436, slice 5)

### DIFF
--- a/docs/roadmap/rooms-and-estates.md
+++ b/docs/roadmap/rooms-and-estates.md
@@ -232,7 +232,7 @@ defenses:
   #2449 (staff world-builder canvas, since built — see `docs/roadmap/tooling.md`),
   #2450 (GM story areas, since built — see `docs/roadmap/tooling.md` and
   `docs/roadmap/gm-system.md`), #2451 (discovery/portal authoring), #2452 (player
-  building via projects — `needs-design`).
+  room-building constraints, resolved — see docs/roadmap/tooling.md).
 - **Details:** see `docs/systems/INDEX.md`'s "Areas" + "Grid content export/import"
   entries, `docs/adr/0140-grid-content-exports-as-graph-aware-area-bundles.md`.
 

--- a/docs/roadmap/tooling.md
+++ b/docs/roadmap/tooling.md
@@ -18,7 +18,9 @@ sub-issues, not designed here: **#2449** (staff world-builder canvas — the dra
 authoring surface this document's "GM dashboard UI" / "Staff world management" items
 below actually need), **#2450** (GM story areas — `STORY`-origin, never exported),
 **#2451** (discovery/portal authoring — clue placement + portal anchors from the
-canvas), **#2452** (player building via projects, `needs-design`).
+canvas), **#2452** (player room-building constraints — resolved: dig_room stays
+instant, RoomEditAction widened to owner-or-tenant, player rooms confirmed never
+touch the authored grid export).
 
 ## Built (2026-07-17, epic #2436 slice 2 / #2449 — staff world-builder canvas)
 
@@ -63,8 +65,9 @@ required); telnet play verbs only (`sceneroom`/`joinroom`/`leaveroom`,
 are excluded from the player-facing `AreaViewSet`/`RoomProfileViewSet` and never
 publicly listed regardless of a room's own `is_public` flag — see
 `docs/systems/INDEX.md`'s GM section ("Story areas & story rooms") for the full
-model/service/action/API rundown. Remaining: clue/portal layers (#2451), player
-building via projects (#2452, `needs-design`).
+model/service/action/API rundown. Remaining: clue/portal layers (#2451).
+Player room-building constraints resolved (#2452 — dig_room stays instant;
+RoomEditAction opened to tenants).
 
 ## Overview
 Tools for players, GMs, and staff to interact with and manage the game world. Player tools focus on building and customizing spaces. GM tools are granular and level-gated — GMs can only do what their trust level allows. Staff tools are unrestricted for the one staffer coordinating the entire game.

--- a/docs/systems/MODEL_MAP.md
+++ b/docs/systems/MODEL_MAP.md
@@ -3034,6 +3034,7 @@
 **Pointed to by:**
   - action_enhancements <- actions.ActionEnhancement
   - species_gift_drawbacks <- species.SpeciesGiftGrant
+  - glimpse_tag_suggestions <- magic.GlimpseTagDistinctionSuggestion
   - ritual_grants <- magic.DistinctionRitualGrant
   - resonance_grants <- magic.DistinctionResonanceGrant
   - resonance_rank_thresholds <- magic.DistinctionResonanceRankThreshold
@@ -3065,6 +3066,7 @@
   - character -> objects.ObjectDB [FK]
   - distinction -> distinctions.Distinction [FK]
   - secret -> secrets.Secret [OneToOne] (nullable)
+  - from_glimpse -> magic.CharacterAura [FK] (nullable)
 **Pointed to by:**
   - resonance_grants <- magic.ResonanceGrant
   - modifier_sources <- mechanics.ModifierSource
@@ -3132,6 +3134,8 @@
   - item -> items.ItemInstance [FK]
   - claimant_persona -> scenes.Persona [FK] (nullable)
   - claimant_organization -> societies.Organization [FK] (nullable)
+**Pointed to by:**
+  - reclamation_claims <- items.ReclamationClaim
 
 ### EstateConfig
 
@@ -3529,6 +3533,7 @@
 - `leave_table(membership: 'GMTableMembership') -> 'None' — Soft-leave a membership. No-op if already left.`
 - `promote_gm(profile: 'GMProfile', new_level: 'str', *, changed_by: 'AccountDB', reason: 'str') -> 'GMLevelChange' — Set profile.level (promotion OR demotion), writing the audit row.`
 - `revoke_invite(invite: 'GMRosterInvite') -> 'None' — Revoke an invite by setting expires_at to now.`
+- `set_looking_for_table(player_data: 'PlayerData', looking: 'bool') -> 'None' — Set or clear the looking-for-table flag on a player's profile (#2431).`
 - `soft_leave_memberships_for_retired_persona(persona: 'Persona') -> 'int' — Future integration hook: called when a persona is retired.`
 - `submit_catalog_suggestion(account: 'AccountDB', *, proposal_kind: 'str', proposal_text: 'str', situation_kind: 'SituationKind | None' = None) -> 'CatalogSuggestion' — Create a ``CatalogSuggestion`` row, routed to the staff inbox (#2127).`
 - `surrender_character_story(gm: 'GMProfile', story: 'Story') -> 'None' — GM surrenders oversight of a story.`
@@ -3579,13 +3584,14 @@
 **Foreign Keys:**
   - room -> objects.ObjectDB [OneToOne]
   - owner -> character_sheets.CharacterSheet [FK] (nullable)
+  - gm_owner -> gm.GMProfile [FK] (nullable)
   - return_location -> objects.ObjectDB [FK] (nullable)
 **Pointed to by:**
   - captivities <- captivity.Captivity
 
 ### Service Functions
 - `complete_instanced_room(room: evennia.objects.models.ObjectDB) -> None — Mark room completed, relocate occupants, delete if no history.`
-- `spawn_instanced_room(name: str, description: str, owner: world.character_sheets.models.CharacterSheet, return_location: evennia.objects.models.ObjectDB | None, source_key: str = '') -> evennia.objects.models.ObjectDB — Create a temporary instanced room and its lifecycle record.`
+- `spawn_instanced_room(name: str, description: str, owner: world.character_sheets.models.CharacterSheet | None, return_location: evennia.objects.models.ObjectDB | None, source_key: str = '', gm_owner: world.gm.models.GMProfile | None = None) -> evennia.objects.models.ObjectDB — Create a temporary instanced room, its RoomProfile, and lifecycle record.`
 
 
 ## world.items
@@ -4029,6 +4035,37 @@
 **Pointed to by:**
   - frame_jobs <- justice.FrameJobDetails
 
+### LieLowState
+**Foreign Keys:**
+  - persona -> scenes.Persona [FK]
+  - area -> areas.Area [FK]
+
+### PardonGrant
+**Foreign Keys:**
+  - granter_persona -> scenes.Persona [FK]
+  - target_persona -> scenes.Persona [FK]
+  - area -> areas.Area [FK]
+  - society -> societies.Society [FK]
+
+### GuardEncounter
+**Foreign Keys:**
+  - persona -> scenes.Persona [FK]
+  - area -> areas.Area [FK]
+
+### JusticeCase
+**Foreign Keys:**
+  - persona -> scenes.Persona [FK]
+  - area -> areas.Area [FK]
+  - society -> societies.Society [FK]
+  - captivity -> captivity.Captivity [FK] (nullable)
+**Pointed to by:**
+  - exculpatory_evidence <- justice.ExculpatoryEvidence
+
+### ExculpatoryEvidence
+**Foreign Keys:**
+  - case -> justice.JusticeCase [FK]
+  - submitter_persona -> scenes.Persona [FK]
+
 ### Service Functions
 - `accrue_accusation_heat(*, secret: 'Secret', area: 'Area | None', scale: 'int' = 1) -> 'PersonaHeat | None' — Mint pursuit heat on an accusation's subject, where the allegation landed.`
 - `accrue_for_deed_knowledge(*, deed: 'LegendEntry', room: 'ObjectDB', new_knower_count: 'int') -> 'None' — The deed-knowledge accrual writer: word landed at ``room`` for ``new_knower_count`` ears.`
@@ -4109,7 +4146,7 @@
 - `room_exposure_breakdown(room: 'DefaultObject') -> 'list[AxisBreakdown]' — Per-axis pressure/mitigation/net for a room — the build-HUD's engine (#1514).`
 - `set_primary_home(*, persona: 'Persona', room: 'DefaultObject', notes: 'str' = '') -> 'LocationTenancy' — Designate one of the persona's active room tenancies as their home (#670, #2036).`
 - `set_residence(*, character: 'DefaultObject', room: 'DefaultObject') -> 'None' — Set a character's primary residence (#1514).`
-- `set_room_display_data(*, room: 'DefaultObject', persona: 'Persona | None' = None, name: 'str | None' = None, description: 'str | None' = None, is_public: 'bool | None' = None, bypass_ownership: 'bool' = False) -> 'None' — Owner-gated edit of a room's display name, description, and public listing.`
+- `set_room_display_data(*, room: 'DefaultObject', persona: 'Persona | None' = None, name: 'str | None' = None, description: 'str | None' = None, is_public: 'bool | None' = None, bypass_ownership: 'bool' = False) -> 'None' — Owner-or-tenant-gated edit of a room's display name, description, and public listing.`
 - `set_room_stat_modifier(room_profile: 'RoomProfile', stat_key: 'StatKey', *, source: 'str', value: 'int') -> 'LocationValueModifier | None' — Set the room-level ``(room_profile, stat_key, source)`` cascade row to ``value``.`
 - `tenancies_for(persona: 'Persona', room: 'DefaultObject') -> 'QuerySet[LocationTenancy]' — Return the QuerySet of currently-active tenancies that give this`
 - `tenancies_for_rooms(rooms: 'Iterable[DefaultObject]') -> 'dict[int, list[LocationTenancy]]' — Bulk-resolve currently-active tenancies for many rooms.`
@@ -6505,8 +6542,8 @@
 - `handle_training_room_progression(project: 'Project', target_level: 'int', outcome_tier: 'CheckOutcome | None' = None) -> 'None' — TRAINING_ROOM strategy (#675): row-only install/level.`
 - `handle_workshop_of_iniquity_progression(project: 'Project', target_level: 'int', outcome_tier: 'CheckOutcome | None' = None) -> 'None' — WORKSHOP_OF_INIQUITY strategy (#1825): row-only install/level.`
 - `react_to_unauthorized_entry(actor, room) -> 'None' — React to `actor` entering `room` when an active ward/alarm is present`
-- `register_room_feature_strategy(strategy_key: 'str', handler: 'RoomFeatureStrategyHandler') -> 'None' — Register/override the strategy handler for ``strategy_key``.`
-- `reset_room_feature_strategies() -> 'None' — Restore the empty baseline. Test-only escape hatch.`
+- `register_room_feature_strategy(strategy_key: 'str', handler: 'RoomFeatureStrategyHandler', *, as_default: 'bool' = False) -> 'None' — Register/override the strategy handler for ``strategy_key``.`
+- `reset_room_feature_strategies() -> 'None' — Restore the at-ready baseline registrations. Test-only escape hatch.`
 - `room_ward_upkeep_tick() -> 'None' — Drain each active ward's resonance_reserve; lapse it if depleted (#2177).`
 - `sync_social_hub_traffic(room_profile: 'RoomProfile') -> 'None' — Reconcile the room's crowd-draw TRAFFIC modifier to its hub's current level.`
 

--- a/src/actions/CLAUDE.md
+++ b/src/actions/CLAUDE.md
@@ -53,8 +53,9 @@ They do not use the command system, dispatchers, or handlers.
   existing combat service; shared by telnet `CmdCombat` (`combat <subverb>`) and the web
   `CombatEncounterViewSet`. `yield` is not here — `YieldAction` (`duels.py`) is reused. The one
   new service is `toggle_action_ready`, extracted from the inline web `ready` toggle;
-  `locations.py` — `RoomEditAction`, key `"edit_room"` (#1470), owner-gated
-  (`IsRoomOwnerPrerequisite`) edit of the current room's name/description/public-listing via
+  `locations.py` — `RoomEditAction`, key `"edit_room"` (#1470, widened #2452),
+  owner-or-tenant-gated (`IsRoomTenantPrerequisite`) edit of the current room's
+  name/description/public-listing via
   `world.locations.services.set_room_display_data`; shared by the telnet `room` family (`CmdRoom`)
   + web dispatch. Plus the #670 Room Builder family (all REGISTRY, `target_type=SELF`, thin over
   `world.buildings.room_services` / `world.locations.services`): `DigRoomAction` (`"dig_room"`),

--- a/src/actions/definitions/locations.py
+++ b/src/actions/definitions/locations.py
@@ -1,10 +1,12 @@
 """Player-facing room actions — the room-editor MVP seam (#1470) + the Room Builder (#670).
 
-``RoomEditAction`` lets a room **owner** edit the room they're standing in: its
-display name, description, and public/private listing. It is the single seam both
-telnet (``CmdManageRoom``) and the web (action-dispatch + ``RoomEditorPanel``)
-call. Ownership is gated by ``IsRoomOwnerPrerequisite``; the write + the
-public-toggle guard live in ``world.locations.services.set_room_display_data``.
+``RoomEditAction`` lets a room's **owner or tenant** edit the room they're
+standing in (or targeting via ``room_id``): its display name, description, and
+public/private listing (#2452 widened this from owner-only). It is the single
+seam both telnet (``CmdManageRoom``) and the web (action-dispatch +
+``RoomEditorPanel``) call. Owner-or-tenant standing is gated by
+``IsRoomTenantPrerequisite``; the write + the public-toggle guard live in
+``world.locations.services.set_room_display_data``.
 
 The Room Builder actions (#670) follow the same shape: thin dispatch over
 ``world.buildings.room_services`` / ``world.locations.services``, permission
@@ -38,10 +40,12 @@ if TYPE_CHECKING:
 
 @dataclass
 class RoomEditAction(Action):
-    """Owner edits the room they're standing in: name, description, public/private.
+    """Owner or tenant edits the room they're standing in: name, description,
+    public/private (#2452).
 
-    Operates on ``actor.location`` (the room the actor is in). Each field is
-    optional — only those supplied are changed.
+    Operates on ``actor.location`` (the room the actor is in), or the resolved
+    ``room_id`` when the web canvas supplies one. Each field is optional — only
+    those supplied are changed.
     """
 
     key: str = "edit_room"
@@ -52,7 +56,7 @@ class RoomEditAction(Action):
     target_type: TargetType = TargetType.SELF
 
     def get_prerequisites(self) -> list[Prerequisite]:
-        return [IsRoomOwnerPrerequisite()]
+        return [IsRoomTenantPrerequisite()]
 
     def execute(
         self,

--- a/src/actions/prerequisites.py
+++ b/src/actions/prerequisites.py
@@ -207,6 +207,11 @@ class IsRoomTenantPrerequisite(Prerequisite):
     via ``is_owner``/``is_tenant``) is exactly "does this persona have standing
     at this room," which every current caller (``SetPrimaryHomeAction``,
     ``TagRoomResonanceAction``, ``UntagRoomResonanceAction``) wants.
+
+    Anchors on the ``room_id`` kwarg when supplied (web canvas), else the
+    actor's own location — the same resolution ``IsRoomOwnerPrerequisite`` uses,
+    needed so ``RoomEditAction`` (#2452) can use this prerequisite for its own
+    room_id-aware targeting.
     """
 
     def is_met(
@@ -220,9 +225,21 @@ class IsRoomTenantPrerequisite(Prerequisite):
         from world.locations.services import is_owner, is_tenant  # noqa: PLC0415
         from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-        room = actor.location
-        if room is None:
-            return False, "You're not in a room."
+        kwargs = (context or {}).get("kwargs", {})
+        room_id = kwargs.get("room_id")
+        if room_id:
+            from evennia_extensions.models import RoomProfile  # noqa: PLC0415
+
+            profile = (
+                RoomProfile.objects.filter(objectdb_id=room_id).select_related("objectdb").first()
+            )
+            if profile is None:
+                return False, "No such room."
+            room = profile.objectdb
+        else:
+            room = actor.location
+            if room is None:
+                return False, "You're not in a room."
         try:
             sheet = actor.sheet_data
         except (AttributeError, ObjectDoesNotExist):

--- a/src/actions/prerequisites.py
+++ b/src/actions/prerequisites.py
@@ -193,6 +193,32 @@ class IsSceneGMPrerequisite(Prerequisite):
         return False, "Only the scene's GM or staff can do that."
 
 
+def _resolve_room_from_kwarg_or_location(
+    actor: ObjectDB, context: dict | None
+) -> tuple[ObjectDB | None, str]:
+    """Resolve the anchor room: the ``room_id`` kwarg (web canvas) when supplied,
+    else the room the actor is standing in.
+
+    Returns ``(room, "")`` on success, or ``(None, refusal_message)`` on failure.
+    Shared by ``IsRoomOwnerPrerequisite`` and ``IsRoomTenantPrerequisite`` — both
+    prerequisites need identical room-anchor resolution, differing only in what
+    standing check they run against the resolved room.
+    """
+    kwargs = (context or {}).get("kwargs", {})
+    room_id = kwargs.get("room_id")
+    if room_id:
+        from evennia_extensions.models import RoomProfile  # noqa: PLC0415
+
+        profile = RoomProfile.objects.filter(objectdb_id=room_id).select_related("objectdb").first()
+        if profile is None:
+            return None, "No such room."
+        return profile.objectdb, ""
+    room = actor.location
+    if room is None:
+        return None, "You're not in a room."
+    return room, ""
+
+
 @dataclass
 class IsRoomTenantPrerequisite(Prerequisite):
     """The actor's active persona must have owner OR tenant standing in the room
@@ -225,21 +251,9 @@ class IsRoomTenantPrerequisite(Prerequisite):
         from world.locations.services import is_owner, is_tenant  # noqa: PLC0415
         from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-        kwargs = (context or {}).get("kwargs", {})
-        room_id = kwargs.get("room_id")
-        if room_id:
-            from evennia_extensions.models import RoomProfile  # noqa: PLC0415
-
-            profile = (
-                RoomProfile.objects.filter(objectdb_id=room_id).select_related("objectdb").first()
-            )
-            if profile is None:
-                return False, "No such room."
-            room = profile.objectdb
-        else:
-            room = actor.location
-            if room is None:
-                return False, "You're not in a room."
+        room, error = _resolve_room_from_kwarg_or_location(actor, context)
+        if room is None:
+            return False, error
         try:
             sheet = actor.sheet_data
         except (AttributeError, ObjectDoesNotExist):
@@ -270,21 +284,9 @@ class IsRoomOwnerPrerequisite(Prerequisite):
         from world.locations.services import is_owner  # noqa: PLC0415
         from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-        kwargs = (context or {}).get("kwargs", {})
-        room_id = kwargs.get("room_id")
-        if room_id:
-            from evennia_extensions.models import RoomProfile  # noqa: PLC0415
-
-            profile = (
-                RoomProfile.objects.filter(objectdb_id=room_id).select_related("objectdb").first()
-            )
-            if profile is None:
-                return False, "No such room."
-            room = profile.objectdb
-        else:
-            room = actor.location
-            if room is None:
-                return False, "You're not in a room."
+        room, error = _resolve_room_from_kwarg_or_location(actor, context)
+        if room is None:
+            return False, error
         try:
             sheet = actor.sheet_data
         except (AttributeError, ObjectDoesNotExist):

--- a/src/actions/tests/room_test_helpers.py
+++ b/src/actions/tests/room_test_helpers.py
@@ -1,0 +1,19 @@
+"""Shared room/character fixtures for prerequisite and action tests that need a
+character standing in a specific room with an active persona.
+"""
+
+from __future__ import annotations
+
+from evennia_extensions.models import RoomProfile
+from world.character_sheets.factories import CharacterSheetFactory
+
+
+def character_in_room(room_profile: RoomProfile):
+    """A fresh character (with a CharacterSheet + primary persona) standing in
+    ``room_profile``'s room. Returns ``(sheet, character)``.
+    """
+    sheet = CharacterSheetFactory()
+    character = sheet.character
+    character.location = room_profile.objectdb
+    character.save()
+    return sheet, character

--- a/src/actions/tests/test_room_edit_action.py
+++ b/src/actions/tests/test_room_edit_action.py
@@ -6,19 +6,11 @@ owner-OR-tenant now, not owner-only.
 from django.test import TestCase, tag
 
 from actions.registry import get_action
+from actions.tests.room_test_helpers import character_in_room
 from evennia_extensions.factories import RoomProfileFactory
 from evennia_extensions.models import ObjectDisplayData
-from world.character_sheets.factories import CharacterSheetFactory
 from world.locations.constants import HolderType, LocationParentType
 from world.locations.models import LocationOwnership, LocationTenancy
-
-
-def _character_in_room(room_profile):
-    sheet = CharacterSheetFactory()
-    character = sheet.character
-    character.location = room_profile.objectdb
-    character.save()
-    return sheet, character
 
 
 @tag("postgres")  # is_owner/is_tenant walk the areas_areaclosure materialized view
@@ -28,7 +20,7 @@ class RoomEditActionTenantTests(TestCase):
         self.room = self.profile.objectdb
 
     def test_tenant_can_edit_name_and_description(self) -> None:
-        sheet, character = _character_in_room(self.profile)
+        sheet, character = character_in_room(self.profile)
         LocationTenancy.objects.create(
             parent_type=LocationParentType.ROOM,
             room_profile=self.profile,
@@ -45,7 +37,7 @@ class RoomEditActionTenantTests(TestCase):
         self.assertEqual(display.longname, "The Tenant's Room")
 
     def test_owner_can_still_edit(self) -> None:
-        sheet, character = _character_in_room(self.profile)
+        sheet, character = character_in_room(self.profile)
         LocationOwnership.objects.create(
             parent_type=LocationParentType.ROOM,
             room_profile=self.profile,
@@ -58,7 +50,7 @@ class RoomEditActionTenantTests(TestCase):
         self.assertTrue(result.success, result.message)
 
     def test_stranger_with_no_standing_is_refused(self) -> None:
-        _sheet, character = _character_in_room(self.profile)
+        _sheet, character = character_in_room(self.profile)
 
         result = get_action("edit_room").run(actor=character, name="Hijacked")
 
@@ -67,7 +59,7 @@ class RoomEditActionTenantTests(TestCase):
 
     def test_tenant_can_edit_via_room_id_while_standing_elsewhere(self) -> None:
         elsewhere = RoomProfileFactory()
-        sheet, character = _character_in_room(elsewhere)
+        sheet, character = character_in_room(elsewhere)
         LocationTenancy.objects.create(
             parent_type=LocationParentType.ROOM,
             room_profile=self.profile,

--- a/src/actions/tests/test_room_edit_action.py
+++ b/src/actions/tests/test_room_edit_action.py
@@ -1,0 +1,84 @@
+"""RoomEditAction (#1470) widened to owner-or-tenant standing (#2452) —
+IsRoomTenantPrerequisite + set_room_display_data's own re-check both gate on
+owner-OR-tenant now, not owner-only.
+"""
+
+from django.test import TestCase, tag
+
+from actions.registry import get_action
+from evennia_extensions.factories import RoomProfileFactory
+from evennia_extensions.models import ObjectDisplayData
+from world.character_sheets.factories import CharacterSheetFactory
+from world.locations.constants import HolderType, LocationParentType
+from world.locations.models import LocationOwnership, LocationTenancy
+
+
+def _character_in_room(room_profile):
+    sheet = CharacterSheetFactory()
+    character = sheet.character
+    character.location = room_profile.objectdb
+    character.save()
+    return sheet, character
+
+
+@tag("postgres")  # is_owner/is_tenant walk the areas_areaclosure materialized view
+class RoomEditActionTenantTests(TestCase):
+    def setUp(self) -> None:
+        self.profile = RoomProfileFactory()
+        self.room = self.profile.objectdb
+
+    def test_tenant_can_edit_name_and_description(self) -> None:
+        sheet, character = _character_in_room(self.profile)
+        LocationTenancy.objects.create(
+            parent_type=LocationParentType.ROOM,
+            room_profile=self.profile,
+            tenant_type=HolderType.PERSONA,
+            tenant_persona=sheet.primary_persona,
+        )
+
+        result = get_action("edit_room").run(
+            actor=character, name="The Tenant's Room", description="Lived in."
+        )
+
+        self.assertTrue(result.success, result.message)
+        display = ObjectDisplayData.objects.get(object=self.room)
+        self.assertEqual(display.longname, "The Tenant's Room")
+
+    def test_owner_can_still_edit(self) -> None:
+        sheet, character = _character_in_room(self.profile)
+        LocationOwnership.objects.create(
+            parent_type=LocationParentType.ROOM,
+            room_profile=self.profile,
+            holder_type=HolderType.PERSONA,
+            holder_persona=sheet.primary_persona,
+        )
+
+        result = get_action("edit_room").run(actor=character, name="Owner's Room")
+
+        self.assertTrue(result.success, result.message)
+
+    def test_stranger_with_no_standing_is_refused(self) -> None:
+        _sheet, character = _character_in_room(self.profile)
+
+        result = get_action("edit_room").run(actor=character, name="Hijacked")
+
+        self.assertFalse(result.success)
+        self.assertFalse(ObjectDisplayData.objects.filter(object=self.room).exists())
+
+    def test_tenant_can_edit_via_room_id_while_standing_elsewhere(self) -> None:
+        elsewhere = RoomProfileFactory()
+        sheet, character = _character_in_room(elsewhere)
+        LocationTenancy.objects.create(
+            parent_type=LocationParentType.ROOM,
+            room_profile=self.profile,
+            tenant_type=HolderType.PERSONA,
+            tenant_persona=sheet.primary_persona,
+        )
+
+        result = get_action("edit_room").run(
+            actor=character, room_id=self.room.pk, name="Remote Edit"
+        )
+
+        self.assertTrue(result.success, result.message)
+        display = ObjectDisplayData.objects.get(object=self.room)
+        self.assertEqual(display.longname, "Remote Edit")

--- a/src/actions/tests/test_room_resonance_actions.py
+++ b/src/actions/tests/test_room_resonance_actions.py
@@ -5,21 +5,13 @@
 
 from django.test import TestCase
 
+from actions.tests.room_test_helpers import character_in_room
 from evennia_extensions.factories import RoomProfileFactory
-from world.character_sheets.factories import CharacterSheetFactory
 from world.locations.constants import KeyType, LocationParentType
 from world.locations.factories import LocationOwnershipFactory, LocationTenancyFactory
 from world.locations.models import LocationValueModifier
 from world.magic.factories import CharacterResonanceFactory, ResonanceFactory
 from world.magic.services.gain import ROOM_RESONANCE_TAG_SOURCE
-
-
-def _character_in_room(room_profile):
-    sheet = CharacterSheetFactory()
-    character = sheet.character
-    character.location = room_profile.objectdb
-    character.save()
-    return sheet, character
 
 
 class TagRoomResonanceActionTests(TestCase):
@@ -28,7 +20,7 @@ class TagRoomResonanceActionTests(TestCase):
 
         self.action_cls = TagRoomResonanceAction
         self.room_profile = RoomProfileFactory()
-        self.sheet, self.character = _character_in_room(self.room_profile)
+        self.sheet, self.character = character_in_room(self.room_profile)
         self.resonance = ResonanceFactory()
 
     def _tag_row(self):
@@ -114,7 +106,7 @@ class SetPrimaryHomeActionOwnerStandingTests(TestCase):
         from world.locations.models import LocationTenancy
 
         room_profile = RoomProfileFactory()
-        sheet, character = _character_in_room(room_profile)
+        sheet, character = character_in_room(room_profile)
         LocationOwnershipFactory(
             on_room=True,
             room_profile=room_profile,
@@ -140,7 +132,7 @@ class UntagRoomResonanceActionTests(TestCase):
         self.tag_action_cls = TagRoomResonanceAction
         self.action_cls = UntagRoomResonanceAction
         self.room_profile = RoomProfileFactory()
-        self.sheet, self.character = _character_in_room(self.room_profile)
+        self.sheet, self.character = character_in_room(self.room_profile)
         self.resonance = ResonanceFactory()
         LocationOwnershipFactory(
             on_room=True,
@@ -172,7 +164,7 @@ class UntagRoomResonanceActionTests(TestCase):
         self.assertTrue(result.success, result.message)
 
     def test_no_standing_rejected(self) -> None:
-        _stranger_sheet, stranger = _character_in_room(self.room_profile)
+        _stranger_sheet, stranger = character_in_room(self.room_profile)
 
         result = self.action_cls().run(actor=stranger, resonance_id=self.resonance.pk)
 

--- a/src/actions/tests/test_room_tenant_prerequisite_room_id.py
+++ b/src/actions/tests/test_room_tenant_prerequisite_room_id.py
@@ -7,18 +7,10 @@ use this prerequisite (#2452).
 from django.test import TestCase, tag
 
 from actions.prerequisites import IsRoomTenantPrerequisite
+from actions.tests.room_test_helpers import character_in_room
 from evennia_extensions.factories import RoomProfileFactory
-from world.character_sheets.factories import CharacterSheetFactory
 from world.locations.constants import HolderType, LocationParentType
 from world.locations.models import LocationOwnership, LocationTenancy
-
-
-def _character_in_room(room_profile):
-    sheet = CharacterSheetFactory()
-    character = sheet.character
-    character.location = room_profile.objectdb
-    character.save()
-    return sheet, character
 
 
 @tag("postgres")  # is_owner/is_tenant walk the areas_areaclosure materialized view
@@ -28,7 +20,7 @@ class RoomIdAnchoringTests(TestCase):
         self.elsewhere_profile = RoomProfileFactory()
 
     def test_room_id_kwarg_checks_the_targeted_room_not_actors_location(self) -> None:
-        sheet, character = _character_in_room(self.elsewhere_profile)
+        sheet, character = character_in_room(self.elsewhere_profile)
         LocationOwnership.objects.create(
             parent_type=LocationParentType.ROOM,
             room_profile=self.target_profile,
@@ -42,7 +34,7 @@ class RoomIdAnchoringTests(TestCase):
         assert met is True
 
     def test_room_id_kwarg_refuses_standing_only_in_actors_own_location(self) -> None:
-        sheet, character = _character_in_room(self.elsewhere_profile)
+        sheet, character = character_in_room(self.elsewhere_profile)
         LocationOwnership.objects.create(
             parent_type=LocationParentType.ROOM,
             room_profile=self.elsewhere_profile,
@@ -57,7 +49,7 @@ class RoomIdAnchoringTests(TestCase):
         assert "no standing" in msg.lower()
 
     def test_tenant_standing_via_room_id(self) -> None:
-        sheet, character = _character_in_room(self.elsewhere_profile)
+        sheet, character = character_in_room(self.elsewhere_profile)
         LocationTenancy.objects.create(
             parent_type=LocationParentType.ROOM,
             room_profile=self.target_profile,
@@ -71,7 +63,7 @@ class RoomIdAnchoringTests(TestCase):
         assert met is True
 
     def test_no_room_id_falls_back_to_actors_location(self) -> None:
-        sheet, character = _character_in_room(self.target_profile)
+        sheet, character = character_in_room(self.target_profile)
         LocationOwnership.objects.create(
             parent_type=LocationParentType.ROOM,
             room_profile=self.target_profile,
@@ -84,7 +76,7 @@ class RoomIdAnchoringTests(TestCase):
         assert met is True
 
     def test_unknown_room_id_is_refused(self) -> None:
-        _sheet, character = _character_in_room(self.elsewhere_profile)
+        _sheet, character = character_in_room(self.elsewhere_profile)
         context = {"kwargs": {"room_id": 999999999}}
 
         met, msg = IsRoomTenantPrerequisite().is_met(character, context=context)

--- a/src/actions/tests/test_room_tenant_prerequisite_room_id.py
+++ b/src/actions/tests/test_room_tenant_prerequisite_room_id.py
@@ -1,0 +1,93 @@
+"""IsRoomTenantPrerequisite must anchor on the room_id kwarg when supplied
+(mirroring IsRoomOwnerPrerequisite), not always the actor's current location —
+required so RoomEditAction (which supports web-canvas room_id targeting) can
+use this prerequisite (#2452).
+"""
+
+from django.test import TestCase, tag
+
+from actions.prerequisites import IsRoomTenantPrerequisite
+from evennia_extensions.factories import RoomProfileFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.locations.constants import HolderType, LocationParentType
+from world.locations.models import LocationOwnership, LocationTenancy
+
+
+def _character_in_room(room_profile):
+    sheet = CharacterSheetFactory()
+    character = sheet.character
+    character.location = room_profile.objectdb
+    character.save()
+    return sheet, character
+
+
+@tag("postgres")  # is_owner/is_tenant walk the areas_areaclosure materialized view
+class RoomIdAnchoringTests(TestCase):
+    def setUp(self) -> None:
+        self.target_profile = RoomProfileFactory()
+        self.elsewhere_profile = RoomProfileFactory()
+
+    def test_room_id_kwarg_checks_the_targeted_room_not_actors_location(self) -> None:
+        sheet, character = _character_in_room(self.elsewhere_profile)
+        LocationOwnership.objects.create(
+            parent_type=LocationParentType.ROOM,
+            room_profile=self.target_profile,
+            holder_type=HolderType.PERSONA,
+            holder_persona=sheet.primary_persona,
+        )
+        context = {"kwargs": {"room_id": self.target_profile.objectdb_id}}
+
+        met, _msg = IsRoomTenantPrerequisite().is_met(character, context=context)
+
+        assert met is True
+
+    def test_room_id_kwarg_refuses_standing_only_in_actors_own_location(self) -> None:
+        sheet, character = _character_in_room(self.elsewhere_profile)
+        LocationOwnership.objects.create(
+            parent_type=LocationParentType.ROOM,
+            room_profile=self.elsewhere_profile,
+            holder_type=HolderType.PERSONA,
+            holder_persona=sheet.primary_persona,
+        )
+        context = {"kwargs": {"room_id": self.target_profile.objectdb_id}}
+
+        met, msg = IsRoomTenantPrerequisite().is_met(character, context=context)
+
+        assert met is False
+        assert "no standing" in msg.lower()
+
+    def test_tenant_standing_via_room_id(self) -> None:
+        sheet, character = _character_in_room(self.elsewhere_profile)
+        LocationTenancy.objects.create(
+            parent_type=LocationParentType.ROOM,
+            room_profile=self.target_profile,
+            tenant_type=HolderType.PERSONA,
+            tenant_persona=sheet.primary_persona,
+        )
+        context = {"kwargs": {"room_id": self.target_profile.objectdb_id}}
+
+        met, _msg = IsRoomTenantPrerequisite().is_met(character, context=context)
+
+        assert met is True
+
+    def test_no_room_id_falls_back_to_actors_location(self) -> None:
+        sheet, character = _character_in_room(self.target_profile)
+        LocationOwnership.objects.create(
+            parent_type=LocationParentType.ROOM,
+            room_profile=self.target_profile,
+            holder_type=HolderType.PERSONA,
+            holder_persona=sheet.primary_persona,
+        )
+
+        met, _msg = IsRoomTenantPrerequisite().is_met(character, context=None)
+
+        assert met is True
+
+    def test_unknown_room_id_is_refused(self) -> None:
+        _sheet, character = _character_in_room(self.elsewhere_profile)
+        context = {"kwargs": {"room_id": 999999999}}
+
+        met, msg = IsRoomTenantPrerequisite().is_met(character, context=context)
+
+        assert met is False
+        assert msg == "No such room."

--- a/src/world/locations/CLAUDE.md
+++ b/src/world/locations/CLAUDE.md
@@ -521,8 +521,9 @@ violation.
 ## Owner-facing room editing (#1470)
 
 `set_room_display_data(*, room, persona=None, name=None, description=None, is_public=None,
-bypass_ownership=False)` is the owner-gated MVP seam for a player editing a room they
-own — the first player-facing write over `RoomProfile` / `ObjectDisplayData`.
+bypass_ownership=False)` is the owner-or-tenant-gated MVP seam for a player editing
+a room they own or hold tenancy in (widened #2452) — the first player-facing write
+over `RoomProfile` / `ObjectDisplayData`.
 `bypass_ownership=True` (staff world-builder, #2449) skips only the ownership raise;
 the #1287 scene-privacy re-check always runs, and `persona` may be `None` only in
 bypass mode. It:
@@ -535,7 +536,8 @@ bypass mode. It:
   listing → `RoomProfile.is_public`; idempotent, only supplied fields change.
 
 Callers: `actions.definitions.locations.RoomEditAction` (key `edit_room`), gated by
-`actions.prerequisites.IsRoomOwnerPrerequisite`. Faces: the telnet `room` family
+`actions.prerequisites.IsRoomTenantPrerequisite` (owner-or-tenant, widened #2452).
+Faces: the telnet `room` family
 (`CmdRoom`, aliases `build`/`manageroom` — `room/name|desc|public` plus the #670
 builder verbs), the web action-dispatch endpoint, and the React `RoomEditorPanel`.
 

--- a/src/world/locations/CLAUDE.md
+++ b/src/world/locations/CLAUDE.md
@@ -528,8 +528,9 @@ over `RoomProfile` / `ObjectDisplayData`.
 the #1287 scene-privacy re-check always runs, and `persona` may be `None` only in
 bypass mode. It:
 
-- re-checks `is_owner(persona, room)` as a hard boundary (raises `RoomEditError`,
-  which carries a player-facing `user_message` — never surface `str(exc)`);
+- re-checks `is_owner(persona, room) or is_tenant(persona, room)` as a hard
+  boundary (raises `RoomEditError`, which carries a player-facing
+  `user_message` — never surface `str(exc)`);
 - refuses to flip `is_public`→True while a non-public scene is live in the room
   (`_has_active_non_public_scene`, the inverse of the #1287 scene-privacy invariant);
 - writes name → `ObjectDisplayData.longname`, description → `permanent_description`,

--- a/src/world/locations/CLAUDE.md
+++ b/src/world/locations/CLAUDE.md
@@ -518,7 +518,7 @@ Same `_validate_location_kwargs` shape as the lifecycle helpers —
 exactly one of `area` or `room_profile`. Raises `ValueError` on
 violation.
 
-## Owner-facing room editing (#1470)
+## Owner-or-tenant room editing (#1470, widened #2452)
 
 `set_room_display_data(*, room, persona=None, name=None, description=None, is_public=None,
 bypass_ownership=False)` is the owner-or-tenant-gated MVP seam for a player editing

--- a/src/world/locations/services.py
+++ b/src/world/locations/services.py
@@ -1584,9 +1584,9 @@ def set_room_display_data(  # noqa: PLR0913 — staff bypass adds one flag to th
     is_public: bool | None = None,
     bypass_ownership: bool = False,
 ) -> None:
-    """Owner-gated edit of a room's display name, description, and public listing.
+    """Owner-or-tenant-gated edit of a room's display name, description, and public listing.
 
-    Re-checks ownership as a hard boundary (the action prerequisite is the primary
+    Re-checks owner-or-tenant standing as a hard boundary (the action prerequisite is the primary
     UX gate). Refuses to make a room public while a non-public scene is active in
     it. Writes name → ``ObjectDisplayData.longname``, description →
     ``permanent_description``, listing → ``RoomProfile.is_public``. Idempotent;
@@ -1601,7 +1601,9 @@ def set_room_display_data(  # noqa: PLR0913 — staff bypass adds one flag to th
     """
     from evennia_extensions.models import ObjectDisplayData  # noqa: PLC0415
 
-    if not bypass_ownership and (persona is None or not is_owner(persona, room)):
+    if not bypass_ownership and (
+        persona is None or not (is_owner(persona, room) or is_tenant(persona, room))
+    ):
         msg = "You don't own this room."
         raise RoomEditError(msg)
     if is_public is True and _has_active_non_public_scene(room):

--- a/src/world/locations/tests/test_room_editor.py
+++ b/src/world/locations/tests/test_room_editor.py
@@ -84,12 +84,6 @@ class SetRoomDisplayDataTests(TestCase):
         assert display.longname == "The Tenant's Nook"
         assert display.permanent_description == "Cluttered but home."
 
-    def test_neither_owner_nor_tenant_is_still_refused(self) -> None:
-        stranger = PersonaFactory()
-        with self.assertRaises(RoomEditError):
-            set_room_display_data(room=self.room, persona=stranger, name="Hijacked")
-        assert not ObjectDisplayData.objects.filter(object=self.room).exists()
-
     def test_no_persona_and_no_bypass_is_refused(self) -> None:
         """``persona`` defaults to ``None`` now (#2449); without a bypass, that's
 

--- a/src/world/locations/tests/test_room_editor.py
+++ b/src/world/locations/tests/test_room_editor.py
@@ -4,7 +4,7 @@ Covers the ``set_room_display_data`` service (writes + owner gate + the
 public-toggle scene-privacy guard) and the ``IsRoomOwnerPrerequisite`` gate.
 """
 
-from django.test import TestCase
+from django.test import TestCase, tag
 
 from actions.prerequisites import IsRoomOwnerPrerequisite
 from evennia_extensions.factories import RoomProfileFactory
@@ -13,7 +13,7 @@ from world.areas.constants import AreaLevel
 from world.areas.factories import AreaFactory
 from world.character_sheets.factories import CharacterSheetFactory
 from world.locations.constants import HolderType, LocationParentType
-from world.locations.models import LocationOwnership
+from world.locations.models import LocationOwnership, LocationTenancy
 from world.locations.services import RoomEditError, set_room_display_data
 from world.scenes.constants import ScenePrivacyMode
 from world.scenes.factories import PersonaFactory, SceneFactory
@@ -28,6 +28,7 @@ def _own_room(profile, persona) -> LocationOwnership:
     )
 
 
+@tag("postgres")
 class SetRoomDisplayDataTests(TestCase):
     def setUp(self) -> None:
         self.ward = AreaFactory(level=AreaLevel.WARD)
@@ -59,6 +60,31 @@ class SetRoomDisplayDataTests(TestCase):
         assert display.permanent_description == "Old desc."
 
     def test_non_owner_is_refused(self) -> None:
+        stranger = PersonaFactory()
+        with self.assertRaises(RoomEditError):
+            set_room_display_data(room=self.room, persona=stranger, name="Hijacked")
+        assert not ObjectDisplayData.objects.filter(object=self.room).exists()
+
+    def test_tenant_with_no_ownership_can_set_name_description_and_privacy(self) -> None:
+        tenant = PersonaFactory()
+        LocationTenancy.objects.create(
+            parent_type=LocationParentType.ROOM,
+            room_profile=self.profile,
+            tenant_type=HolderType.PERSONA,
+            tenant_persona=tenant,
+        )
+        set_room_display_data(
+            room=self.room,
+            persona=tenant,
+            name="The Tenant's Nook",
+            description="Cluttered but home.",
+            is_public=False,
+        )
+        display = ObjectDisplayData.objects.get(object=self.room)
+        assert display.longname == "The Tenant's Nook"
+        assert display.permanent_description == "Cluttered but home."
+
+    def test_neither_owner_nor_tenant_is_still_refused(self) -> None:
         stranger = PersonaFactory()
         with self.assertRaises(RoomEditError):
             set_room_display_data(room=self.room, persona=stranger, name="Hijacked")
@@ -115,6 +141,7 @@ class SetRoomDisplayDataTests(TestCase):
         assert RoomProfile.objects.get(objectdb=self.room).is_public is False
 
 
+@tag("postgres")
 class IsRoomOwnerPrerequisiteTests(TestCase):
     def setUp(self) -> None:
         self.ward = AreaFactory(level=AreaLevel.WARD)


### PR DESCRIPTION
Closes #2452

## Summary

Resolves the three open design questions from epic #2436 slice 5 (player room-building constraints):

1. **dig_room stays instant everywhere** (ruling, no code change) — the space_budget model already treats in-budget digs as pre-paid by the construction/extension project; a second project gate would double-charge the same resource.
2. **RoomEditAction widens from owner-only to owner-or-tenant** (name/description/is_public) — IsRoomTenantPrerequisite gained room_id-kwarg anchoring (matching IsRoomOwnerPrerequisite, needed since the web canvas targets rooms by id, not just actor.location), set_room_display_data's internal re-check widened to match, and RoomEditAction's prerequisite swapped over. A tenant can now make the room they live in feel lived-in without needing ownership.
3. **Player-built rooms never touch the authored grid beyond exits** (ruling, no code change) — origin=PLAYER is already the create_room() default and already excluded from grid export.

Fold-in fix: two test classes in test_room_editor.py were missing @tag("postgres") and silently erroring under the SQLite fast tier (is_owner/is_tenant require the Postgres-only AreaClosure materialized view) — fixed alongside the tenant-widening work in the same file.

Docs updated in tandem: src/actions/CLAUDE.md, src/world/locations/CLAUDE.md (including a section heading), docs/roadmap/tooling.md, docs/roadmap/rooms-and-estates.md (both updated from needs-design to record the resolution), and docs/systems/MODEL_MAP.md (regenerated).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2452 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch was already up to date with origin/main — no rebase or merge needed.

<!-- last-addressed-comment: 0 -->