### PR TITLE
Gem mining — haul-generation engine (common bulk + Rare-Find rolls, Build 0b slice 4)

### DIFF
--- a/docs/roadmap/crafting-economy.md
+++ b/docs/roadmap/crafting-economy.md
@@ -72,9 +72,17 @@ The enchant-and-attach flow for facets and styles is fully playable end-to-end.
   embedded gem instance (narration + provenance); `adorn_item()` gates on
   `ItemTemplate.adornment_capacity`, embeds the gem, and adds its worth to the host's `lore_value`
   (so `appraise()` reflects it). `adorned_materials()` is the queryable "materials on this piece"
-  seam the magic app reads. Safe craft-time path only. Remaining 0b slices: **mining/distribution**
-  (common aggregate + Rare-Find rolls), the **cut recipe** + risky prying/re-set, and the
-  **value-denominated / bucket** bulk path.
+  seam the magic app reads. Safe craft-time path only.
+
+- **Gem mining engine (Build 0b, slice 4) — DONE.** `roll_gem_haul()` — the pure, deterministic
+  haul generator: one mine cycle yields a common-gem **aggregate value** plus, rarely, a few
+  **Rare-Find** gem instances (born uncut). Mine quality + minister bonus raise the Rare-Find
+  chance and shift every axis roll up; size/purity floored above common on a find. The multiplicative
+  axes give the fat "remarkable find" tail for free. **Deferred to the Build-1 domain track:** the
+  weekly cron, the per-holding `mine_quality` field, the minister-check seam (#2239, schema-only),
+  and where common value accrues (a per-tier vault bucket). Remaining 0b slices: the **cut recipe**
+  (see slice 3 PR) + risky prying/re-set, the **value-denominated / bucket** bulk path, and the
+  domain-cron wiring for this engine.
 
 - **Handler registry** (`CraftingHandler` ABC + `FacetAttachHandler` / `StyleAttachHandler`).
   New kinds (alchemy, wand-crafting, etc.) plug in by authoring a `CraftingRecipe` row +

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -3574,6 +3574,16 @@ holder is never notified a claim exists.
     wired `appraise()` reflects it. `adorned_materials(host)` is the queryable "materials on this
     piece" seam magic reads. Exceptions: `AdornmentCapacityExceeded` / `NotAGem` / `GemAlreadyAdorned`.
     Safe craft-time path only; risky prying/re-set defers to the cut slice.
+  - **Gem mining engine** (`world.items.gems.mining.roll_gem_haul`, Build 0b slice 4) — the pure,
+    deterministic (injected `roll` seam) haul generator. One mine cycle → a common-gem **aggregate
+    value** (`GemHaul.common_value`, never instanced) plus, rarely, a few **Rare-Find** gem
+    `ItemInstance`s (born uncut, loose). Mine quality + minister bonus both raise the Rare-Find
+    chance (base 1%) and shift every axis roll up; a find rolls 1d4 stones with `size`/`purity`
+    floored above common (type not floored), top-heavy grade distribution (`_grade_index`, roll²).
+    Does **not** schedule or wire domains — the weekly cron, the per-holding `mine_quality` field,
+    and the schema-only minister-check seam (`OrganizationOffice.feeds_check`, #2239) are the
+    Build-1 wiring that *calls* this; where common value accrues (a per-tier vault bucket) is the
+    caller's concern. All magnitudes PLACEHOLDER.
 - **New fields on `ItemTemplate` (Spec D PR1):** `facet_capacity` (max attachable facets,
   default 0), `gear_archetype` (CharField, `GearArchetype` enum choices)
 - **New field on `ItemTemplate` (#1024):** `on_use_target_kind` (nullable `TargetKind` CharField)

--- a/src/world/items/gems/constants.py
+++ b/src/world/items/gems/constants.py
@@ -22,3 +22,16 @@ class GemAxis(models.TextChoices):
     SIZE = "size", "Size"
     PURITY = "purity", "Purity"
     CUT = "cut", "Cut"
+
+
+# --- Mining / haul distribution (Build 0b slice 4) ---
+# All magnitudes are PLACEHOLDER, admin/caller-tunable — the *shape* is the point.
+#
+# A weekly offscreen mine yields a bulk of common gems as an aggregate *value* (never
+# instanced) plus, rarely, a few individuated "Rare Find" stones. Mine quality and the
+# overseeing minister's skill both help: they add to the Rare-Find chance AND shift every
+# axis roll up (a +10 mine turns a 90 into a 100 — max for the roll).
+RARE_FIND_BASE_CHANCE = 1  # percent, before mine-quality / minister bonuses
+RARE_FIND_MAX_COUNT = 4  # 1dN finds when a Rare Find occurs
+# Common-bulk value produced per point of mine quality per cycle (pure placeholder).
+COMMON_VALUE_PER_QUALITY = 50

--- a/src/world/items/gems/mining.py
+++ b/src/world/items/gems/mining.py
@@ -1,0 +1,133 @@
+"""Gem mining — the weekly haul-generation engine (Build 0b slice 4).
+
+Given a mine's quality and the overseeing minister's bonus, produce a **haul**: a
+bulk of common gems expressed as an aggregate *value* (never instanced) plus, rarely,
+a few individuated "Rare Find" stones (real ``ItemInstance``s, born uncut).
+
+This module is the pure distribution engine — deterministic when handed an injected
+``roll``, so it is fully testable. It does **not** schedule anything or know about
+domains/vaults/ministers: the weekly cron, the per-holding ``mine_quality`` field, and
+the (schema-only, #2239) minister-check seam are the Build-1 wiring that *calls* this.
+Where the common value accrues (a per-tier bucket on a vault) is likewise the caller's
+concern — this returns the number.
+
+All magnitudes are PLACEHOLDER (see constants); the *shape* is the deliverable:
+multiplicative axes + independent skewed rolls give the fat "remarkable find" tail for
+free, and mine quality both raises the Rare-Find chance and shifts every axis roll up.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass
+import random
+from typing import TYPE_CHECKING
+
+from world.items.gems.constants import (
+    COMMON_VALUE_PER_QUALITY,
+    RARE_FIND_BASE_CHANCE,
+    RARE_FIND_MAX_COUNT,
+    GemAxis,
+)
+from world.items.gems.models import GemGrade, GemInstanceDetails
+from world.items.models import ItemInstance, ItemTemplate
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+# A roll returns a d100 (1-100). Injectable so the engine is deterministic in tests.
+Rng = Callable[[], int]
+
+
+def _d100() -> int:
+    return random.randint(1, 100)  # noqa: S311
+
+
+@dataclass(frozen=True)
+class GemHaul:
+    """One mine cycle's output: bulk common value + any individuated Rare Finds."""
+
+    common_value: int
+    rare_finds: list[ItemInstance]
+
+
+def _grade_index(effective_roll: int, num_grades: int, floor_index: int) -> int:
+    """Map an effective (already mine-boosted) d100 roll to a grade index.
+
+    Top-heavy by design — high grades are genuinely rare (``(roll/100)**2`` scaling), so
+    the product of two rare rolls (size × purity) is what makes a legendary stone. Never
+    below ``floor_index`` (Rare Finds floor size/purity above the common band); capped at
+    the top grade. PLACEHOLDER distribution — the curve is tunable, the *structure* isn't.
+    """
+    if num_grades <= 1:
+        return 0
+    clamped = max(1, min(effective_roll, 100))
+    span = num_grades - 1 - floor_index
+    if span <= 0:
+        return min(floor_index, num_grades - 1)
+    idx = floor_index + int((clamped / 100) ** 2 * span)
+    return max(floor_index, min(idx, num_grades - 1))
+
+
+def _all_gem_types() -> list[ItemTemplate]:
+    """Every gem *type* (an ItemTemplate with a GemDetails sidecar), rarest last."""
+    return list(
+        ItemTemplate.objects.filter(gem_details__isnull=False).order_by(
+            "gem_details__quality_level"
+        )
+    )
+
+
+def _mint_raw_gem(
+    gem_type: ItemTemplate, size: GemGrade, purity: GemGrade, uncut: GemGrade
+) -> ItemInstance:
+    """Create a loose, uncut Rare-Find gem instance (holder unset — the caller places it)."""
+    instance = ItemInstance.objects.create(template=gem_type)
+    GemInstanceDetails.objects.create(
+        item_instance=instance, size_grade=size, purity_grade=purity, cut_grade=uncut
+    )
+    return instance
+
+
+def roll_gem_haul(
+    *,
+    mine_quality: int,
+    minister_bonus: int = 0,
+    type_pool: Sequence[ItemTemplate] | None = None,
+    roll: Rng = _d100,
+) -> GemHaul:
+    """Roll one mine cycle's haul.
+
+    ``mine_quality`` and ``minister_bonus`` both (a) raise the Rare-Find chance and
+    (b) add to every axis roll (a +10 mine turns a 90 into a 100 — max for the roll).
+    ``type_pool`` limits which gem types this mine can yield (default: all gem types).
+    ``roll`` is the injectable d100 source. Common bulk is returned as a value only;
+    Rare Finds are minted as loose uncut ``ItemInstance``s with ``size``/``purity``
+    floored above the common band (``type`` is not floored — a huge flawless *common*
+    stone is a legitimate find).
+    """
+    quality = max(0, mine_quality)
+    boost = quality + max(0, minister_bonus)
+    common_value = quality * COMMON_VALUE_PER_QUALITY
+
+    chance = RARE_FIND_BASE_CHANCE + boost
+    if roll() > chance:
+        return GemHaul(common_value=common_value, rare_finds=[])
+
+    size_grades = list(GemGrade.objects.filter(axis=GemAxis.SIZE).order_by("sort_order"))
+    purity_grades = list(GemGrade.objects.filter(axis=GemAxis.PURITY).order_by("sort_order"))
+    cut_grades = list(GemGrade.objects.filter(axis=GemAxis.CUT).order_by("sort_order"))
+    types = list(type_pool) if type_pool is not None else _all_gem_types()
+    if not (size_grades and purity_grades and cut_grades and types):
+        # Not enough seeded content to mint a stone — yield the common bulk only.
+        return GemHaul(common_value=common_value, rare_finds=[])
+    uncut = cut_grades[0]
+
+    count = 1 + (roll() - 1) % RARE_FIND_MAX_COUNT  # 1..RARE_FIND_MAX_COUNT
+    finds: list[ItemInstance] = []
+    for _ in range(count):
+        gem_type = types[_grade_index(roll() + boost, len(types), 0)]  # type: not floored
+        size = size_grades[_grade_index(roll() + boost, len(size_grades), 1)]  # floored
+        purity = purity_grades[_grade_index(roll() + boost, len(purity_grades), 1)]  # floored
+        finds.append(_mint_raw_gem(gem_type, size, purity, uncut))
+    return GemHaul(common_value=common_value, rare_finds=finds)

--- a/src/world/items/tests/test_gem_mining.py
+++ b/src/world/items/tests/test_gem_mining.py
@@ -1,0 +1,86 @@
+"""Tests for the gem mining haul engine (Build 0b slice 4)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.test import TestCase
+
+from world.items.factories import (
+    GemDetailsFactory,
+    GemGradeFactory,
+    ItemTemplateFactory,
+)
+from world.items.gems.constants import COMMON_VALUE_PER_QUALITY, GemAxis
+from world.items.gems.mining import _grade_index, roll_gem_haul
+
+
+class GradeIndexTests(TestCase):
+    def test_floor_respected(self):
+        self.assertGreaterEqual(_grade_index(1, 4, floor_index=1), 1)
+
+    def test_caps_at_top(self):
+        self.assertEqual(_grade_index(100, 4, floor_index=0), 3)
+
+    def test_top_heavy_high_rolls_reach_higher_grades(self):
+        self.assertLess(_grade_index(50, 5, floor_index=0), _grade_index(95, 5, floor_index=0))
+
+    def test_single_grade_axis(self):
+        self.assertEqual(_grade_index(77, 1, floor_index=0), 0)
+
+
+def _roll(*values):
+    """A deterministic d100 source returning ``values`` in order."""
+    it = iter(values)
+    return lambda: next(it)
+
+
+class RollGemHaulTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        for i in range(1, 5):
+            GemGradeFactory(axis=GemAxis.SIZE, sort_order=i, label=f"s{i}", multiplier=Decimal(i))
+            GemGradeFactory(axis=GemAxis.PURITY, sort_order=i, label=f"p{i}", multiplier=Decimal(i))
+        cls.uncut = GemGradeFactory(
+            axis=GemAxis.CUT, sort_order=1, label="uncut", multiplier=Decimal("1.0")
+        )
+        GemGradeFactory(axis=GemAxis.CUT, sort_order=2, label="fine", multiplier=Decimal("1.5"))
+        for lvl in (1, 3, 6):
+            tmpl = ItemTemplateFactory(name=f"gem-{lvl}", value=100)
+            GemDetailsFactory(item_template=tmpl, quality_level=lvl)
+
+    def test_no_rare_find_yields_common_value_only(self):
+        # mine_quality 3 → chance 1+3=4; occurrence roll 99 > 4 → no find.
+        haul = roll_gem_haul(mine_quality=3, roll=_roll(99))
+        self.assertEqual(haul.rare_finds, [])
+        self.assertEqual(haul.common_value, 3 * COMMON_VALUE_PER_QUALITY)
+
+    def test_rare_find_is_minted_uncut_with_floored_axes(self):
+        # mine_quality 10 → chance 11; occurrence 5 → find; count roll 1 → one find;
+        # per-find rolls type/size/purity = 10 each (boosted +10 → 20).
+        haul = roll_gem_haul(mine_quality=10, roll=_roll(5, 1, 10, 10, 10))
+        self.assertEqual(len(haul.rare_finds), 1)
+        gem = haul.rare_finds[0].gem_or_none
+        self.assertIsNotNone(gem)
+        self.assertEqual(gem.cut_grade, self.uncut)  # born uncut
+        self.assertGreaterEqual(gem.size_grade.sort_order, 2)  # floored above the bottom band
+        self.assertGreaterEqual(gem.purity_grade.sort_order, 2)
+        # loose — no holder; the caller (cron) places it
+        self.assertIsNone(haul.rare_finds[0].holder_character_sheet_id)
+
+    def test_count_is_bounded_one_to_four(self):
+        # count roll 100 → 1 + (100-1) % 4 = 4 finds. Need 1(occ)+1(count)+4*3 rolls.
+        rolls = [5, 100, *([10] * 12)]
+        haul = roll_gem_haul(mine_quality=10, roll=_roll(*rolls))
+        self.assertEqual(len(haul.rare_finds), 4)
+
+    def test_type_is_not_floored(self):
+        # A low type roll can still yield the cheapest gem type (level 1).
+        haul = roll_gem_haul(mine_quality=0, minister_bonus=20, roll=_roll(1, 1, 1, 1, 1))
+        gem = haul.rare_finds[0].gem_or_none
+        self.assertEqual(gem.item_instance.template.gem_details.quality_level, 1)
+
+    def test_minister_bonus_raises_chance(self):
+        # mine_quality 0 alone → chance 1 (a 5 would miss); minister +20 → chance 21, 5 hits.
+        haul = roll_gem_haul(mine_quality=0, minister_bonus=20, roll=_roll(5, 1, 50, 50, 50))
+        self.assertEqual(len(haul.rare_finds), 1)


### PR DESCRIPTION
## Gem mining — the haul-generation engine (Build 0b, slice 4)

How gems *enter* the world. `roll_gem_haul()` is the pure, deterministic distribution engine at the heart of mining — one mine cycle in, a haul out. Standalone off main (depends only on the merged gem models).

### What one cycle produces (`GemHaul`)
- **Common bulk → an aggregate `common_value`**, never instanced (a cloudy small stone nobody inspects doesn't deserve a row).
- **Rare Finds → a few individuated gem `ItemInstance`s**, born uncut and loose (for the caller to place). Rare because the multiplicative axes make it so.

### The distribution (your design, encoded)
- **Rare-Find chance** = base **1%** + mine quality + minister bonus.
- On a find: **1d4** stones; each rolls **type / size / purity** on a d100, with **mine quality + minister added to every roll** (a +10 mine turns a 90 into a 100 — max for the roll).
- **size/purity floored above common** (a Rare Find that came out common-grade would betray the label); **type is not floored** (a huge, flawless *common* stone is a legitimate find).
- **Top-heavy grade curve** (`_grade_index`, `roll²`) so high grades are genuinely rare — and because size × purity are independent, the product of two rare rolls is what makes a legendary stone. The fat "remarkable find" tail falls out of the structure; no special-casing.

### Deliberately deferred (the Build-1 domain track)
This is the **engine only** — it schedules nothing and knows nothing about domains. The **weekly cron**, the **per-holding `mine_quality` field** (Finding 7: `DomainHolding` has none today), the **minister-check seam** (`OrganizationOffice.feeds_check`, #2239 — schema-only, with the documented offline-holder problem), and **where the common value accrues** (a per-tier vault bucket) are the wiring that *calls* this. Keeping the engine pure means it's fully testable now and drops cleanly into that wiring later.

### Testing
- New `test_gem_mining` — 9 tests via an **injected `roll` seam** (deterministic): occurrence gating, common-value formula, Rare-Find minting (uncut, floored size/purity, loose), 1d4 count bound, type-not-floored, minister-raises-chance, and the `_grade_index` curve (floor / cap / top-heavy / single-grade). All pass (17 with the value-model suite).
- No models/migration; `arx manage check` clean. All magnitudes are PLACEHOLDER.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
