### PR TITLE
Risky adornment prying — pry_adornment, shatter on botch (Build 0b slice 6)

### DIFF
--- a/docs/roadmap/crafting-economy.md
+++ b/docs/roadmap/crafting-economy.md
@@ -74,6 +74,10 @@ The enchant-and-attach flow for facets and styles is fully playable end-to-end.
   (so `appraise()` reflects it). `adorned_materials()` is the queryable "materials on this piece"
   seam the magic app reads. Safe craft-time path only.
 
+- **Risky adornment prying (Build 0b, slice 6) — DONE.** `pry_adornment()` completes the adornment
+  lifecycle: a risky `perform_check` removes a set gem — freed to the pryer on success, **shattered**
+  on a botch (the cut's shatter spine); the host's worth drops either way. High risk, high reward.
+
 - **Gem mining engine (Build 0b, slice 4) — DONE.** `roll_gem_haul()` — the pure, deterministic
   haul generator: one mine cycle yields a common-gem **aggregate value** plus, rarely, a few
   **Rare-Find** gem instances (born uncut). Mine quality + minister bonus raise the Rare-Find

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -3578,7 +3578,11 @@ holder is never notified a claim exists.
     a gem and unset, embeds it (clears holder), and adds its worth to the host's `lore_value` so the
     wired `appraise()` reflects it. `adorned_materials(host)` is the queryable "materials on this
     piece" seam magic reads. Exceptions: `AdornmentCapacityExceeded` / `NotAGem` / `GemAlreadyAdorned`.
-    Safe craft-time path only; risky prying/re-set defers to the cut slice.
+    Safe craft-time path only. **Risky prying** (`pry_adornment`, Build 0b slice 6): the risky
+    end of the lifecycle — a `perform_check` (skill feeds the roll) removes a set gem; the stone
+    leaves the piece either way (host `lore_value` drops by its worth), freed to the pryer's
+    inventory on success or **shattered** on a botch (same shatter spine as gem cutting).
+    Returns `PryResult`; spends AP up front.
   - **Gem mining engine** (`world.items.gems.mining.roll_gem_haul`, Build 0b slice 4) — the pure,
     deterministic (injected `roll` seam) haul generator. One mine cycle → a common-gem **aggregate
     value** (`GemHaul.common_value`, never instanced) plus, rarely, a few **Rare-Find** gem

--- a/src/world/items/gems/services.py
+++ b/src/world/items/gems/services.py
@@ -1,14 +1,17 @@
-"""Gem worth computation + adornment (Build 0b slices 1-2)."""
+"""Gem worth computation, adornment, and risky prying (Build 0b slices 1-2, 6)."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from django.db import transaction
 
+from world.checks.services import perform_check
 from world.items.exceptions import (
     AdornmentCapacityExceeded,
+    CraftingCostUnaffordable,
     GemAlreadyAdorned,
     NotAGem,
 )
@@ -16,7 +19,10 @@ from world.items.gems.models import Adornment
 
 if TYPE_CHECKING:
     from evennia.accounts.models import AccountDB
+    from evennia.objects.models import ObjectDB
 
+    from world.character_sheets.models import CharacterSheet
+    from world.checks.models import CheckType
     from world.items.gems.models import GemInstanceDetails
     from world.items.models import ItemInstance, ItemTemplate
 
@@ -87,3 +93,61 @@ def adorned_materials(host_instance: ItemInstance) -> list[ItemTemplate]:
         adornment.gem_instance.template
         for adornment in host_instance.adornments.select_related("gem_instance__template")
     ]
+
+
+@dataclass(frozen=True)
+class PryResult:
+    """Outcome of a ``pry_adornment`` attempt.
+
+    The gem leaves the piece either way (so ``worth_removed`` always drops from the
+    host). On success ``freed_gem`` is the stone, returned to the pryer's inventory;
+    on a botch the stone shatters (``shattered=True``, ``freed_gem=None``).
+    """
+
+    shattered: bool
+    freed_gem: ItemInstance | None
+    worth_removed: int
+
+
+def pry_adornment(  # noqa: PLR0913 — keyword-only adornment + crafter + check-config params
+    *,
+    adornment: Adornment,
+    crafter_character: ObjectDB,
+    crafter_character_sheet: CharacterSheet,
+    check_type: CheckType,
+    base_difficulty: int = 0,
+    min_success_level: int = 1,
+    ap_cost: int = 0,
+) -> PryResult:
+    """Attempt to pry a set gem out of its piece — the risky end of the adornment lifecycle.
+
+    Reuses ``perform_check`` (skill feeds the roll). The gem *leaves the piece regardless*
+    of outcome, so the host's ``lore_value`` drops by the gem's worth. On success the gem
+    is **freed** to the pryer's inventory; on a botch it **shatters** (destroyed). Spends
+    the ``ap_cost`` up front. Same high-risk/high-reward spine as gem cutting.
+    """
+    from world.action_points.models import ActionPointPool  # noqa: PLC0415
+
+    gem_instance = adornment.gem_instance
+    host = adornment.host_instance
+    worth = compute_gem_worth(gem_instance.gem_or_none)
+
+    if ap_cost > 0:
+        pool = ActionPointPool.get_or_create_for_character(crafter_character)
+        if not pool.spend(ap_cost):
+            msg = f"You need {ap_cost} action points but only have {pool.current}."
+            raise CraftingCostUnaffordable(msg)
+
+    with transaction.atomic():
+        host.lore_value = max(0, (host.lore_value or 0) - worth)
+        host.save(update_fields=["lore_value"])
+
+        check_result = perform_check(crafter_character, check_type, base_difficulty)
+        if check_result.success_level < min_success_level:
+            gem_instance.delete()  # CASCADE removes the Adornment + GemInstanceDetails
+            return PryResult(shattered=True, freed_gem=None, worth_removed=worth)
+
+        adornment.delete()  # remove the setting; the stone survives
+        gem_instance.holder_character_sheet = crafter_character_sheet
+        gem_instance.save(update_fields=["holder_character_sheet"])
+        return PryResult(shattered=False, freed_gem=gem_instance, worth_removed=worth)

--- a/src/world/items/tests/test_adornment_pry.py
+++ b/src/world/items/tests/test_adornment_pry.py
@@ -1,0 +1,120 @@
+"""Tests for risky adornment prying (Build 0b slice 6)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.test import TestCase
+
+from evennia_extensions.factories import CharacterFactory
+from world.action_points.factories import ActionPointPoolFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.factories import CheckTypeFactory
+from world.checks.test_helpers import force_check_outcome
+from world.items.exceptions import CraftingCostUnaffordable
+from world.items.factories import (
+    GemGradeFactory,
+    GemInstanceDetailsFactory,
+    ItemInstanceFactory,
+    ItemTemplateFactory,
+)
+from world.items.gems.constants import GemAxis
+from world.items.gems.models import Adornment
+from world.items.gems.services import adorn_item, pry_adornment
+from world.items.models import ItemInstance
+from world.items.services.pricing import appraise
+from world.traits.factories import CheckOutcomeFactory
+
+
+def _gem(value=100):
+    """A gem ItemInstance worth exactly ``value`` (all grades ×1.0)."""
+    inst = ItemInstanceFactory(template=ItemTemplateFactory(value=value))
+    GemInstanceDetailsFactory(
+        item_instance=inst,
+        size_grade=GemGradeFactory(axis=GemAxis.SIZE, multiplier=Decimal("1.0")),
+        purity_grade=GemGradeFactory(axis=GemAxis.PURITY, multiplier=Decimal("1.0")),
+        cut_grade=GemGradeFactory(axis=GemAxis.CUT, multiplier=Decimal("1.0")),
+    )
+    inst.refresh_from_db()
+    return inst
+
+
+class PryAdornmentTests(TestCase):
+    def setUp(self):
+        self.character = CharacterFactory()
+        self.pool = ActionPointPoolFactory(character=self.character, current=200, maximum=200)
+        self.sheet = CharacterSheetFactory(character=self.character)
+        self.check_type = CheckTypeFactory()
+        self.host = ItemInstanceFactory(
+            template=ItemTemplateFactory(name="Scepter", value=50, adornment_capacity=3),
+            lore_value=0,
+        )
+
+    def _adorn(self, worth=100):
+        gem = _gem(value=worth)
+        adornment = adorn_item(host_instance=self.host, gem_instance=gem)
+        self.host.refresh_from_db()
+        return adornment, gem
+
+    def test_success_frees_the_gem_and_drops_host_worth(self):
+        adornment, gem = self._adorn(worth=100)
+        self.assertEqual(appraise(self.host), 50 + 100)  # base + adorned worth
+        with force_check_outcome(CheckOutcomeFactory(name="PryOk", success_level=2)):
+            result = pry_adornment(
+                adornment=adornment,
+                crafter_character=self.character,
+                crafter_character_sheet=self.sheet,
+                check_type=self.check_type,
+                ap_cost=5,
+            )
+        self.assertFalse(result.shattered)
+        self.assertEqual(result.freed_gem, gem)
+        gem.refresh_from_db()
+        self.assertEqual(gem.holder_character_sheet_id, self.sheet.pk)  # back in inventory
+        self.assertFalse(Adornment.objects.filter(pk=adornment.pk).exists())
+        self.host.refresh_from_db()
+        self.assertEqual(appraise(self.host), 50)  # worth dropped back to base
+
+    def test_botch_shatters_the_gem(self):
+        adornment, gem = self._adorn(worth=100)
+        gem_pk = gem.pk
+        with force_check_outcome(CheckOutcomeFactory(name="PryBotch", success_level=-1)):
+            result = pry_adornment(
+                adornment=adornment,
+                crafter_character=self.character,
+                crafter_character_sheet=self.sheet,
+                check_type=self.check_type,
+                ap_cost=5,
+            )
+        self.assertTrue(result.shattered)
+        self.assertIsNone(result.freed_gem)
+        self.assertFalse(ItemInstance.objects.filter(pk=gem_pk).exists())  # destroyed
+        self.assertFalse(Adornment.objects.filter(pk=adornment.pk).exists())
+        self.host.refresh_from_db()
+        self.assertEqual(appraise(self.host), 50)  # worth dropped either way
+
+    def test_ap_spent_on_the_attempt(self):
+        adornment, _ = self._adorn()
+        with force_check_outcome(CheckOutcomeFactory(name="PryAp", success_level=1)):
+            pry_adornment(
+                adornment=adornment,
+                crafter_character=self.character,
+                crafter_character_sheet=self.sheet,
+                check_type=self.check_type,
+                ap_cost=5,
+            )
+        self.pool.refresh_from_db()
+        self.assertEqual(self.pool.current, 195)
+
+    def test_unaffordable_ap_raises(self):
+        adornment, _ = self._adorn()
+        self.pool.current = 2
+        self.pool.save(update_fields=["current"])
+        with self.assertRaises(CraftingCostUnaffordable):
+            pry_adornment(
+                adornment=adornment,
+                crafter_character=self.character,
+                crafter_character_sheet=self.sheet,
+                check_type=self.check_type,
+                ap_cost=5,
+            )


### PR DESCRIPTION
## Risky adornment prying (Build 0b, slice 6)

Completes the adornment lifecycle — **set → pry** — with the risky end you flagged when we built adornment. `pry_adornment()` is the desperate-noble-prying-gems-off-the-heirloom move: high risk, high reward. Standalone off main (adornment is merged; this reuses `perform_check` directly, no dependency on the open cut PR).

### What's in it
- **`pry_adornment(adornment, crafter, sheet, check_type, …)`** — reuses `perform_check` (the crafter's skill feeds the roll). The gem **leaves the piece either way**, so the host's `lore_value` drops by the gem's worth. Then:
  - **success** → the stone is **freed** to the pryer's inventory (holder restored);
  - **botch** → the stone **shatters** (destroyed) — the exact shatter spine as gem cutting.
  Spends the AP cost up front; returns a `PryResult` (shattered / freed gem / worth removed).

### Design notes
- **Symmetric with `adorn_item`**: adorning added the gem's worth to `lore_value`; prying removes it. `appraise()` reflects both automatically.
- **No new recipe kind**: prying takes the check config as keyword params rather than inventing a `PRY` `CraftingRecipeKind` (which would collide with the open cut PR's `GEM_CUT`). When cut merges, a shared "jeweler risky act" config can unify cut + pry.
- No models, no migration — pure service.

### Testing
- New `test_adornment_pry` — 4 tests via `force_check_outcome`: success frees the gem + drops host worth back to base, botch shatters it (gem destroyed, adornment gone) with worth still dropped, AP spent on the attempt, unaffordable-AP guard. All pass (20 with the adornment/value suites).
- `arx manage check` + `ty` clean.

### Remaining 0b
- **Domain-cron wiring** (Build-1 track) — the weekly cron calling `roll_gem_haul`, the `mine_quality` field, the minister seam (#2239), and where a mine's output accrues. This one has real economy-ownership design questions (a domain reservoir vs the player buckets, rare-find holder, minister lending) — worth a design touch before building.
- Cut refinements (hard skill-cap, consequence-pool narration) — after the cut PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
