### PR TITLE
Species content buildout: elf form traits + pipeline test (#2463)

### DIFF
--- a/src/core_management/tests/test_content_export.py
+++ b/src/core_management/tests/test_content_export.py
@@ -471,3 +471,86 @@ class MagicCatalogContentExportTests(TestCase):
             tradition=tradition, gift=reloaded_gift
         )
         assert list(reloaded_tradition_grant.signature_techniques.all()) == [reloaded_technique]
+
+
+class SpeciesFormTraitContentExportTests(TestCase):
+    """Round-trip coverage for Species/FormTrait/FormTraitOption/SpeciesFormTrait.
+
+    These four models are the CG Appearance stage's data source (#2463): a
+    species with zero ``SpeciesFormTrait`` rows renders an empty Appearance
+    stage. The round-trip below proves the content pipeline carries a species'
+    full form-trait set (trait + options + the species↔trait link, including
+    the ``allowed_options`` M2M) through an export → wipe → reload — the exact
+    shape that broke when the elf subspecies shipped without form-trait rows.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def test_species_form_traits_round_trip_through_load_world_content(self) -> None:
+        """A species' form traits + options survive a content wipe and reload."""
+        from core_management.content_fixtures import load_world_content
+        from world.forms.factories import (
+            FormTraitFactory,
+            FormTraitOptionFactory,
+            SpeciesFormTraitFactory,
+        )
+        from world.forms.models import FormTrait, FormTraitOption, SpeciesFormTrait
+        from world.species.factories import SpeciesFactory
+        from world.species.models import Species
+
+        species = SpeciesFactory(name="Round Trip Species")
+        hair_trait = FormTraitFactory(name="rt_hair_color", display_name="Hair Color")
+        eye_trait = FormTraitFactory(name="rt_eye_color", display_name="Eye Color")
+        # Two options on hair, one on eye — hair exercises the multi-option path.
+        hair_opt_a = FormTraitOptionFactory(trait=hair_trait, name="black", display_name="Black")
+        hair_opt_b = FormTraitOptionFactory(trait=hair_trait, name="silver", display_name="Silver")
+        eye_opt = FormTraitOptionFactory(trait=eye_trait, name="violet", display_name="Violet")
+
+        hair_link = SpeciesFormTraitFactory(species=species, trait=hair_trait)
+        eye_link = SpeciesFormTraitFactory(species=species, trait=eye_trait)
+        # Restrict hair to a subset of options — exercises the allowed_options M2M
+        # round-trip (the path that breaks silently when the M2M isn't carried).
+        hair_link.allowed_options.add(hair_opt_a, hair_opt_b)
+
+        result = export_to_content_repo(self.root)
+        assert result.errors == []
+
+        # Wipe every row the export captured. SpeciesFormTrait first (FK→species,
+        # FK→trait), then options (FK→trait), then traits, then species.
+        SpeciesFormTrait.objects.filter(pk__in=[hair_link.pk, eye_link.pk]).delete()
+        FormTraitOption.objects.filter(pk__in=[hair_opt_a.pk, hair_opt_b.pk, eye_opt.pk]).delete()
+        FormTrait.objects.filter(pk__in=[hair_trait.pk, eye_trait.pk]).delete()
+        Species.objects.filter(pk=species.pk).delete()
+
+        world_result = load_world_content(self.root)
+        assert world_result.skipped == []
+
+        reloaded_species = Species.objects.get(name="Round Trip Species")
+        reloaded_hair = FormTrait.objects.get(name="rt_hair_color")
+        reloaded_eye = FormTrait.objects.get(name="rt_eye_color")
+
+        # Both traits link back to the species, available in CG.
+        links = SpeciesFormTrait.objects.filter(
+            species=reloaded_species, is_available_in_cg=True
+        ).select_related("trait")
+        assert {link.trait.name for link in links} == {"rt_hair_color", "rt_eye_color"}
+
+        # The allowed_options M2M survived the trip for hair; eye (empty) stayed empty.
+        reloaded_hair_link = SpeciesFormTrait.objects.get(
+            species=reloaded_species, trait=reloaded_hair
+        )
+        reloaded_eye_link = SpeciesFormTrait.objects.get(
+            species=reloaded_species, trait=reloaded_eye
+        )
+        assert {opt.name for opt in reloaded_hair_link.allowed_options.all()} == {
+            "black",
+            "silver",
+        }
+        assert reloaded_eye_link.allowed_options.count() == 0
+
+        # The options themselves round-tripped and re-attach to their traits.
+        assert {opt.name for opt in reloaded_hair.options.all()} == {"black", "silver"}
+        assert {opt.name for opt in reloaded_eye.options.all()} == {"violet"}


### PR DESCRIPTION
## What

Closes #2463 — species content buildout for the Arx beginnings.

## Context: the issue was mostly already done

The issue body described two halves. On investigation, both were further along than the issue stated:

- **Language half — already complete.** Commit `8b47392c4` in the lore repo authored the full language table (`fixtures/species/language.json`: Arvani Common + Umbral, Luxeri, Cinderi, Ari, Aythir, Nox'alfar) and wired every `Beginnings.starting_languages` gate. `grants_species_languages=False` (Misbegotten) is no longer a no-op.
- **Form-trait half — Daeva was already done; three elves were missing.** `fixtures/forms/speciesformtrait.json` had rows for Human, Khati, all Khati subspecies, Infernal, Daeva, Vampire, Dhampir, Lycan, Saurian — but **Nox'alfar, Sylv'alfar, Rex'alfar had zero rows**, so the CG Appearance stage rendered empty for them.

## Changes

### Lore repo (ArxII-lore, companion branch `feature-2463-elf-form-traits`)

- `fixtures/forms/speciesformtrait.json`: +12 rows — 4 traits (hair_color, eye_color, skin_tone, ear_type) × 3 elf subspecies. Uniform, unrestricted `allowed_options=[]`, matching every other species in the catalog. `ear_type` lets elves select `pointed`.
- `beginnings/arx.md`: updated the #2463 follow-up note to reflect completion.

### This repo (arxii)

- `src/core_management/tests/test_content_export.py`: new `SpeciesFormTraitContentExportTests` — a round-trip test proving the content pipeline carries a species' form-trait set (trait + options + the `allowed_options` M2M) through export → wipe → `load_world_content`. This is the coverage gap that let the elf rows ship missing: no test asserted the pipeline correctly carried these models.

## Design decision

Option palettes (lore-grounded per-subspecies color restrictions, e.g. Nox'alfar → dark/ashen skin tones) are **deliberately deferred** to a follow-up authoring pass. The lore repo's ground rule is that player-visible content calls are Apostate's to make; which skin tones Nox'alfar get is exactly that kind of decision. This PR ships the consistent-with-every-other-species shape (unrestricted) to unblock the Appearance stage now.

## Verified

- `get_cg_form_options(species)` filters `SpeciesFormTrait.objects.filter(species=species, ...)` with **no parent fallback** — each subspecies needs its own rows. Confirmed by reading `world/forms/services/__init__.py:449`.
- Misbegotten lists parent `Elf` in `allowed_species`; `Beginnings.get_available_species()` expands parent → children (`character_creation/models.py:432`), so the three subspecies are correctly playable.
- New round-trip test passes; existing `test_content_export` suite (14 tests) green; `test_cg_seed_gaps` green.
- `ruff check` + `ruff format --check` clean.