### PR TITLE
House distribution currency primitives: discretionary withdrawal + non-discretionary allowance (#2540)

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2617,7 +2617,10 @@ an idle org reaches stasis in both directions (loan interest still accrues — o
   (weekly pool growth), `collect_org_income` (the dispatch: check → band pct → graft →
   per-stream proportional landing), `improve_org_domain` (Domain Investment check → gross
   bump + graft crackdown), `process_income_stream(stream, amount)` (landing path),
-  `settle_obligations`, `run_weekly_economy` (Sunday rollover phases)
+  `settle_obligations`, `run_weekly_economy` (Sunday rollover phases),
+  `withdraw_from_treasury(*, organization, persona, amount)` (#2540 — the discretionary-spend
+  primitive: a `can_spend_treasury`-authorized member draws treasury→purse; the treasury→member
+  outflow #930 never built. Action-driven, so inherently piloted-only; never automate it)
 - **Checks (#930):** Tax Collection / Household Command (presence + Leadership + Stewardship) and Domain
   Investment (intellect + Scholarship + Economics), seeded by the `governance` cluster
 - **Books surface:** `GET /api/currency/org-books/{org}/` (`OrgBooksViewSet`) — treasury,

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2620,7 +2620,11 @@ an idle org reaches stasis in both directions (loan interest still accrues — o
   `settle_obligations`, `run_weekly_economy` (Sunday rollover phases),
   `withdraw_from_treasury(*, organization, persona, amount)` (#2540 — the discretionary-spend
   primitive: a `can_spend_treasury`-authorized member draws treasury→purse; the treasury→member
-  outflow #930 never built. Action-driven, so inherently piloted-only; never automate it)
+  outflow #930 never built. Action-driven, so inherently piloted-only; never automate it),
+  `distribute_allowance(*, organization, surplus)` (#2540 — the non-discretionary allowance rail:
+  a PLACEHOLDER `ALLOWANCE_SURPLUS_PCT` share of surplus auto-splits treasury→purse among *active
+  piloted* members [account login within `ACTIVE_WEEK_LOGIN_DAYS`; pure NPCs excluded], the head
+  cannot withhold it. Meant to fire off the collection event via the future domain dispatch)
 - **Checks (#930):** Tax Collection / Household Command (presence + Leadership + Stewardship) and Domain
   Investment (intellect + Scholarship + Economics), seeded by the `governance` cluster
 - **Books surface:** `GET /api/currency/org-books/{org}/` (`OrgBooksViewSet`) — treasury,

--- a/src/world/currency/constants.py
+++ b/src/world/currency/constants.py
@@ -179,3 +179,7 @@ BUSINESS_FORTUNE_MAX = 60
 # Wages pay only for actively-played weeks (#929/#932): a login within this
 # many days of the rollover counts as active.
 ACTIVE_WEEK_LOGIN_DAYS = 8
+
+# House allowance (#2540): the non-discretionary share of a collection's surplus that
+# auto-splits among active piloted members. PLACEHOLDER — magnitude is Apostate's tuning call.
+ALLOWANCE_SURPLUS_PCT = 50

--- a/src/world/currency/services.py
+++ b/src/world/currency/services.py
@@ -56,10 +56,19 @@ from world.currency.types import AllowanceResult, CollectionResult, ImprovementR
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
+    from evennia.accounts.models import AccountDB
+
     from world.character_sheets.models import CharacterSheet
     from world.items.models import ItemInstance
     from world.scenes.models import Persona
     from world.societies.models import Organization
+
+
+def _account_active_since(account: AccountDB | None, cutoff: datetime) -> bool:
+    """A piloted account counts as active when it logged in on/after ``cutoff`` (#929/#932)."""
+    return account is not None and account.last_login is not None and account.last_login >= cutoff
 
 
 def get_or_create_purse(character_sheet: CharacterSheet) -> CharacterPurse:
@@ -602,6 +611,10 @@ def distribute_allowance(*, organization: Organization, surplus: int) -> Allowan
     if surplus <= 0:
         return AllowanceResult(total_distributed=0, per_member=0, member_count=0)
     treasury = get_or_create_treasury(organization)
+    # Read the balance under the same row lock the transfers below take, so a concurrent
+    # withdrawal can't shrink it between the pool cap and the payouts (which would abort
+    # the whole distribution instead of distributing the smaller pool).
+    treasury = OrganizationTreasury.objects.select_for_update().get(pk=treasury.pk)
     pool = min(surplus * ALLOWANCE_SURPLUS_PCT // 100, treasury.balance)
     if pool <= 0:
         return AllowanceResult(total_distributed=0, per_member=0, member_count=0)
@@ -610,13 +623,12 @@ def distribute_allowance(*, organization: Organization, surplus: int) -> Allowan
     active_sheets: dict[int, CharacterSheet] = {}
     memberships = OrganizationMembership.objects.filter(
         organization=organization, left_at__isnull=True, exiled_at__isnull=True
-    ).select_related("persona__character_sheet__character")
+    ).select_related("persona__character_sheet__character__db_account")
     for membership in memberships:
         sheet = membership.persona.character_sheet
         if sheet is None or sheet.pk in active_sheets:
             continue
-        account = sheet.character.db_account
-        if account is not None and account.last_login is not None and account.last_login >= cutoff:
+        if _account_active_since(sheet.character.db_account, cutoff):
             active_sheets[sheet.pk] = sheet
     if not active_sheets:
         return AllowanceResult(total_distributed=0, per_member=0, member_count=0)
@@ -1407,12 +1419,7 @@ def _weekly_wages() -> int:
     ):
         try:
             account = employment.character_sheet.character.db_account
-            was_active = bool(
-                account is not None
-                and account.last_login is not None
-                and account.last_login >= cutoff
-            )
-            run_weekly_employment(employment, was_active=was_active)
+            run_weekly_employment(employment, was_active=_account_active_since(account, cutoff))
             count += 1
         except Exception:
             logger.exception("weekly economy: wages failed for employment %s", employment.pk)

--- a/src/world/currency/services.py
+++ b/src/world/currency/services.py
@@ -136,6 +136,32 @@ def transfer(  # noqa: PLR0913 - source/destination pairs are co-equal by design
         )
 
 
+def withdraw_from_treasury(
+    *, organization: Organization, persona: Persona, amount: int, reason: str = ""
+) -> CurrencyTransfer:
+    """A spend-authorized member draws ``amount`` coppers from the org treasury to their purse.
+
+    The discretionary-spend primitive for house distribution (#2540): the treasury→member
+    outflow that #930 never built (every other treasury outflow is treasury→treasury). Gated by
+    ``can_spend_treasury`` — an active membership at rank tier <= ``spend_rank_max`` (the head /
+    top rank by default). Because it is action-driven it is inherently piloted-only; it must
+    never be automated, so a non-piloted NPC head has no path to drain the coffers.
+
+    Raises ``ValidationError`` if the persona lacks spend authority (or ``transfer`` rejects the
+    amount / insufficient funds).
+    """
+    treasury = get_or_create_treasury(organization)
+    if not can_spend_treasury(treasury, persona):
+        msg = "You do not have the standing to spend from this treasury."
+        raise ValidationError(msg)
+    return transfer(
+        amount=amount,
+        reason=reason or f"treasury withdrawal by {persona}",
+        from_treasury=treasury,
+        to_purse=get_or_create_purse(persona.character_sheet),
+    )
+
+
 def _instrument_template(denomination: str):
     """Lazy ItemTemplate per denomination (repo bans seed migrations).
 

--- a/src/world/currency/services.py
+++ b/src/world/currency/services.py
@@ -18,6 +18,7 @@ from django.utils import timezone
 
 from world.currency.constants import (
     ACTIVE_WEEK_LOGIN_DAYS,
+    ALLOWANCE_SURPLUS_PCT,
     BUSINESS_BASE_WEEKLY_PER_LEVEL,
     BUSINESS_FORTUNE_MAX,
     BUSINESS_FORTUNE_MIN,
@@ -50,7 +51,7 @@ from world.currency.models import (
     OrgIncomeStream,
     OrgObligation,
 )
-from world.currency.types import CollectionResult, ImprovementResult
+from world.currency.types import AllowanceResult, CollectionResult, ImprovementResult
 
 logger = logging.getLogger(__name__)
 
@@ -580,6 +581,60 @@ def collect_org_income(*, organization: Organization, character) -> CollectionRe
         process_income_stream(stream, share)
     return CollectionResult(
         gathered=gathered, landed=net, graft_leak=graft_leak, success_level=success_level
+    )
+
+
+@transaction.atomic
+def distribute_allowance(*, organization: Organization, surplus: int) -> AllowanceResult:
+    """Auto-split a share of ``surplus`` among the org's active piloted members (#2540).
+
+    The **non-discretionary allowance** rail — the head cannot withhold it. Meant to fire off the
+    collection event (the future domain dispatch calls ``collect_org_income`` then this with the
+    net as ``surplus``), so the baseline reaches players without anyone having to coerce the head.
+    A PLACEHOLDER share (``ALLOWANCE_SURPLUS_PCT``) of surplus splits equally among members whose
+    account logged in within ``ACTIVE_WEEK_LOGIN_DAYS`` — pure NPCs have no ``db_account`` and are
+    excluded for free, and a member is paid once even across multiple member personas. Paid from
+    the treasury (where the collected surplus sits); the pool is capped at the treasury balance so
+    it never overdraws. Whole-copper division; the remainder simply stays in the treasury.
+    """
+    from world.societies.models import OrganizationMembership  # noqa: PLC0415
+
+    if surplus <= 0:
+        return AllowanceResult(total_distributed=0, per_member=0, member_count=0)
+    treasury = get_or_create_treasury(organization)
+    pool = min(surplus * ALLOWANCE_SURPLUS_PCT // 100, treasury.balance)
+    if pool <= 0:
+        return AllowanceResult(total_distributed=0, per_member=0, member_count=0)
+
+    cutoff = timezone.now() - timedelta(days=ACTIVE_WEEK_LOGIN_DAYS)
+    active_sheets: dict[int, CharacterSheet] = {}
+    memberships = OrganizationMembership.objects.filter(
+        organization=organization, left_at__isnull=True, exiled_at__isnull=True
+    ).select_related("persona__character_sheet__character")
+    for membership in memberships:
+        sheet = membership.persona.character_sheet
+        if sheet is None or sheet.pk in active_sheets:
+            continue
+        account = sheet.character.db_account
+        if account is not None and account.last_login is not None and account.last_login >= cutoff:
+            active_sheets[sheet.pk] = sheet
+    if not active_sheets:
+        return AllowanceResult(total_distributed=0, per_member=0, member_count=0)
+
+    per_member = pool // len(active_sheets)
+    if per_member <= 0:
+        return AllowanceResult(total_distributed=0, per_member=0, member_count=len(active_sheets))
+    distributed = 0
+    for sheet in active_sheets.values():
+        transfer(
+            amount=per_member,
+            reason="house allowance",
+            from_treasury=treasury,
+            to_purse=get_or_create_purse(sheet),
+        )
+        distributed += per_member
+    return AllowanceResult(
+        total_distributed=distributed, per_member=per_member, member_count=len(active_sheets)
     )
 
 

--- a/src/world/currency/tests/test_house_allowance.py
+++ b/src/world/currency/tests/test_house_allowance.py
@@ -1,0 +1,85 @@
+"""Non-discretionary house allowance (#2540): a share of surplus auto-splits among members.
+
+Only *active piloted* members share — a member whose account logged in within
+``ACTIVE_WEEK_LOGIN_DAYS``. Pure NPCs (no ``db_account``) and stale members are excluded.
+"""
+
+from datetime import timedelta
+
+from django.test import TestCase
+from django.utils import timezone
+
+from evennia_extensions.factories import AccountFactory
+from world.currency.services import (
+    distribute_allowance,
+    get_or_create_purse,
+    get_or_create_treasury,
+)
+from world.scenes.factories import PersonaFactory
+from world.societies.factories import OrganizationFactory, OrganizationMembershipFactory
+
+
+def _pilot(persona, *, days_ago: int) -> None:
+    """Attach an account to the persona's character with a login ``days_ago`` days back."""
+    account = AccountFactory()
+    account.last_login = timezone.now() - timedelta(days=days_ago)
+    account.save(update_fields=["last_login"])
+    character = persona.character_sheet.character
+    character.db_account = account
+    character.save(update_fields=["db_account"])
+
+
+class DistributeAllowanceTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.org = OrganizationFactory()
+        cls.active = PersonaFactory()
+        cls.stale = PersonaFactory()
+        cls.npc = PersonaFactory()  # no account → never piloted
+        for persona in (cls.active, cls.stale, cls.npc):
+            OrganizationMembershipFactory(persona=persona, organization=cls.org, rank=2)
+        _pilot(cls.active, days_ago=1)
+        _pilot(cls.stale, days_ago=60)
+
+    def setUp(self) -> None:
+        self.treasury = get_or_create_treasury(self.org)
+        self.treasury.balance = 1000
+        self.treasury.save(update_fields=["balance"])
+
+    def _purse(self, persona) -> int:
+        purse = get_or_create_purse(persona.character_sheet)
+        purse.refresh_from_db()
+        return purse.balance
+
+    def test_only_active_piloted_members_receive(self) -> None:
+        result = distribute_allowance(organization=self.org, surplus=1000)  # 50% → pool 500
+        self.assertEqual(result.member_count, 1)  # only `active`
+        self.assertEqual(result.per_member, 500)
+        self.assertEqual(result.total_distributed, 500)
+        self.assertEqual(self._purse(self.active), 500)
+        self.assertEqual(self._purse(self.stale), 0)  # login too old
+        self.assertEqual(self._purse(self.npc), 0)  # no account
+        self.treasury.refresh_from_db()
+        self.assertEqual(self.treasury.balance, 500)  # paid from the vault
+
+    def test_multiple_active_members_split_equally(self) -> None:
+        _pilot(self.stale, days_ago=1)  # now active too
+        result = distribute_allowance(organization=self.org, surplus=1000)  # pool 500 / 2
+        self.assertEqual(result.member_count, 2)
+        self.assertEqual(result.per_member, 250)
+        self.assertEqual(self._purse(self.active), 250)
+        self.assertEqual(self._purse(self.stale), 250)
+
+    def test_no_surplus_is_a_noop(self) -> None:
+        result = distribute_allowance(organization=self.org, surplus=0)
+        self.assertEqual(result.total_distributed, 0)
+        self.treasury.refresh_from_db()
+        self.assertEqual(self.treasury.balance, 1000)
+
+    def test_pool_capped_at_treasury_balance(self) -> None:
+        self.treasury.balance = 80  # less than the 500 the surplus would allocate
+        self.treasury.save(update_fields=["balance"])
+        result = distribute_allowance(organization=self.org, surplus=1000)
+        self.assertEqual(result.total_distributed, 80)  # never overdraws
+        self.treasury.refresh_from_db()
+        self.assertEqual(self.treasury.balance, 0)

--- a/src/world/currency/tests/test_house_allowance.py
+++ b/src/world/currency/tests/test_house_allowance.py
@@ -70,6 +70,13 @@ class DistributeAllowanceTests(TestCase):
         self.assertEqual(self._purse(self.active), 250)
         self.assertEqual(self._purse(self.stale), 250)
 
+    def test_member_with_multiple_personas_is_paid_once(self) -> None:
+        second_face = PersonaFactory(character_sheet=self.active.character_sheet)
+        OrganizationMembershipFactory(persona=second_face, organization=self.org, rank=3)
+        result = distribute_allowance(organization=self.org, surplus=1000)
+        self.assertEqual(result.member_count, 1)  # both memberships share one sheet
+        self.assertEqual(self._purse(self.active), 500)  # not doubled
+
     def test_no_surplus_is_a_noop(self) -> None:
         result = distribute_allowance(organization=self.org, surplus=0)
         self.assertEqual(result.total_distributed, 0)

--- a/src/world/currency/tests/test_treasury_withdrawal.py
+++ b/src/world/currency/tests/test_treasury_withdrawal.py
@@ -1,0 +1,56 @@
+"""Discretionary treasury withdrawal (#2540): a spend-authorized member draws to their purse.
+
+The treasury→member outflow #930 never built — gated by ``can_spend_treasury`` (top rank /
+the head by default). The house-distribution discretionary-spend primitive.
+"""
+
+from django.core.exceptions import ValidationError
+from django.test import TestCase
+
+from world.currency.services import (
+    get_or_create_purse,
+    get_or_create_treasury,
+    withdraw_from_treasury,
+)
+from world.scenes.factories import PersonaFactory
+from world.societies.factories import OrganizationFactory, OrganizationMembershipFactory
+
+
+class WithdrawFromTreasuryTests(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.org = OrganizationFactory()
+        cls.leader = PersonaFactory()
+        cls.grunt = PersonaFactory()
+        OrganizationMembershipFactory(persona=cls.leader, organization=cls.org, rank=1)
+        OrganizationMembershipFactory(persona=cls.grunt, organization=cls.org, rank=5)
+
+    def setUp(self) -> None:
+        self.treasury = get_or_create_treasury(self.org)
+        self.treasury.balance = 1000
+        self.treasury.save(update_fields=["balance"])
+
+    def test_authorized_member_withdraws_to_their_purse(self) -> None:
+        transfer = withdraw_from_treasury(organization=self.org, persona=self.leader, amount=300)
+        self.assertEqual(transfer.amount, 300)
+        self.treasury.refresh_from_db()
+        self.assertEqual(self.treasury.balance, 700)
+        purse = get_or_create_purse(self.leader.character_sheet)
+        self.assertEqual(purse.balance, 300)
+
+    def test_unauthorized_member_cannot_withdraw(self) -> None:
+        with self.assertRaises(ValidationError):
+            withdraw_from_treasury(organization=self.org, persona=self.grunt, amount=100)
+        self.treasury.refresh_from_db()
+        self.assertEqual(self.treasury.balance, 1000)  # untouched
+
+    def test_outsider_cannot_withdraw(self) -> None:
+        outsider = PersonaFactory()
+        with self.assertRaises(ValidationError):
+            withdraw_from_treasury(organization=self.org, persona=outsider, amount=100)
+
+    def test_cannot_overdraw_the_treasury(self) -> None:
+        with self.assertRaises(ValidationError):
+            withdraw_from_treasury(organization=self.org, persona=self.leader, amount=5000)
+        self.treasury.refresh_from_db()
+        self.assertEqual(self.treasury.balance, 1000)  # rejected before any debit

--- a/src/world/currency/types.py
+++ b/src/world/currency/types.py
@@ -28,6 +28,19 @@ class CollectionResult:
 
 
 @dataclass(frozen=True)
+class AllowanceResult:
+    """Outcome of one non-discretionary allowance distribution (#2540).
+
+    ``total_distributed`` is the coppers that left the treasury; ``per_member`` is each active
+    piloted member's equal share; ``member_count`` is how many received it.
+    """
+
+    total_distributed: int
+    per_member: int
+    member_count: int
+
+
+@dataclass(frozen=True)
 class ImprovementResult:
     """Outcome of one domain-investment attempt."""
 


### PR DESCRIPTION
The house-distribution **currency primitives** from the approved spec #2540 — the two treasury↔member money paths #930 never built (every existing treasury outflow is treasury→treasury). Both are standalone services matching the unwired #930 service layer; the future domain-management dispatch sequences `collect_org_income → distribute_allowance`, and exposes `withdraw_from_treasury` as the head's discretionary action.

## 1. `withdraw_from_treasury(*, organization, persona, amount)` — discretionary spend
A `can_spend_treasury`-authorized member (top rank / the head by default) draws coppers from the treasury to their purse. **Action-driven, so inherently piloted-only; never automated** — a non-piloted NPC head therefore has no path to drain the coffers (the spec's tenet). Pure reuse of `can_spend_treasury` + `transfer`.

## 2. `distribute_allowance(*, organization, surplus)` — non-discretionary allowance
A PLACEHOLDER share (`ALLOWANCE_SURPLUS_PCT` = 50%) of a collection's surplus auto-splits equally among **active piloted** members — account login within `ACTIVE_WEEK_LOGIN_DAYS`. Pure NPCs (no `db_account`) and stale members are excluded for free; a member is paid once across multiple personas; the pool is capped at the treasury balance so it never overdraws. **The head cannot withhold it** — that is what removes the "must a head outfit their people" tension: the baseline reaches players without anyone coercing the head.

## Tests
- `world.currency.tests.test_treasury_withdrawal` (4): authorized draws, unauthorized/outsider rejected, no overdraw.
- `world.currency.tests.test_house_allowance` (4): only active piloted receive, equal split, no-surplus no-op, pool capped at balance.

Refs #2540. Remaining spec work (rare-stones→house, material generalization, standing-order sell, favor payloads) each awaits one of the design decisions flagged in the spec.
