### PR TITLE
flows: Trigger.should_trigger_for_event is dead code, uses a different (untested-live) filter engine than the real dispatch path

### DIFF
--- a/src/flows/emit.py
+++ b/src/flows/emit.py
@@ -78,21 +78,33 @@ def _gather_triggers(event_name: str, location: Any) -> list[Any]:
 
 
 def _trigger_should_fire(trigger: Any, payload: Any, event_name: str) -> bool:
-    """Whether ``trigger`` passes its filter and is under its dispatch usage cap."""
+    """Whether ``trigger`` passes its base + additional filters and is under its dispatch usage cap.
+
+    Evaluates two filters with AND semantics:
+    - ``trigger_definition.base_filter_condition`` — authored on the definition,
+      the base gate every derived trigger inherits.
+    - ``additional_filter_condition`` — per-instance conditions that further
+      refine when this specific trigger activates (the field's help_text:
+      "Optional JSON condition to further refine when this trigger activates").
+
+    Both use ``evaluate_filter()`` (the live DSL), not the dead
+    ``FlowEvent.matches_conditions()`` simple-dict-equality path.
+    """
+    base = trigger.trigger_definition.base_filter_condition
+    additional = trigger.additional_filter_condition
     try:
-        matched = evaluate_filter(
-            trigger.additional_filter_condition,
-            payload,
-            self_ref=trigger.obj,
-        )
+        if base is not None:
+            if not evaluate_filter(base, payload, self_ref=trigger.obj):
+                return False
+        if additional is not None:
+            if not evaluate_filter(additional, payload, self_ref=trigger.obj):
+                return False
     except FilterPathError:
         logger.warning(
             "FilterPathError on trigger %s during dispatch of %s",
             trigger.pk,
             event_name,
         )
-        return False
-    if not matched:
         return False
 
     handler = trigger.obj.trigger_handler

--- a/src/flows/models/triggers.py
+++ b/src/flows/models/triggers.py
@@ -177,15 +177,6 @@ class Trigger(SharedMemoryModel):
             return None
         return limit
 
-    def should_trigger_for_event(self, event: FlowEvent) -> bool:
-        if not self.trigger_definition.matches_event(event, obj=self.obj):
-            return False
-        additional = resolve_self_placeholders(
-            cast(dict[str, object] | None, self.additional_filter_condition),
-            self.obj,
-        )
-        return event.matches_conditions(additional)
-
     def __str__(self) -> str:
         return f"{self.trigger_definition.name} for {self.obj.key}"
 

--- a/src/flows/tests/test_dispatch_filters.py
+++ b/src/flows/tests/test_dispatch_filters.py
@@ -1,0 +1,90 @@
+"""Tests for the live trigger dispatch path (_trigger_should_fire) (#2531).
+
+Verifies that _trigger_should_fire evaluates both base_filter_condition
+(from the TriggerDefinition) and additional_filter_condition (from the Trigger
+instance) with AND semantics, using evaluate_filter() (the live DSL).
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from django.test import TestCase
+
+from flows.emit import _trigger_should_fire
+from flows.factories import TriggerDefinitionFactory, TriggerFactory
+
+
+class TriggerShouldFireTests(TestCase):
+    """_trigger_should_fire evaluates base + additional filters with AND semantics."""
+
+    def _make_trigger(self, *, base=None, additional=None, event_name="test_event"):
+        """Create a trigger with the given base/additional filters."""
+        trigger_def = TriggerDefinitionFactory(
+            event_name=event_name,
+            base_filter_condition=base,
+        )
+        return TriggerFactory(
+            trigger_definition=trigger_def,
+            additional_filter_condition=additional,
+        )
+
+    def test_no_filters_passes(self):
+        """A trigger with no base and no additional filter fires (pass-through)."""
+        trigger = self._make_trigger(base=None, additional=None)
+        self.assertTrue(_trigger_should_fire(trigger, SimpleNamespace(), "test_event"))
+
+    def test_base_filter_must_pass(self):
+        """A trigger whose base filter doesn't match the payload does not fire."""
+        trigger = self._make_trigger(
+            base={"path": "type", "op": "==", "value": "fire"},
+        )
+        # Payload with wrong type — base filter fails.
+        self.assertFalse(_trigger_should_fire(trigger, SimpleNamespace(type="cold"), "test_event"))
+        # Payload with matching type — base filter passes.
+        self.assertTrue(_trigger_should_fire(trigger, SimpleNamespace(type="fire"), "test_event"))
+
+    def test_additional_filter_must_pass(self):
+        """A trigger whose additional filter doesn't match the payload does not fire."""
+        trigger = self._make_trigger(
+            base=None,
+            additional={"path": "amount", "op": ">", "value": 5},
+        )
+        self.assertFalse(_trigger_should_fire(trigger, SimpleNamespace(amount=3), "test_event"))
+        self.assertTrue(_trigger_should_fire(trigger, SimpleNamespace(amount=10), "test_event"))
+
+    def test_both_filters_must_pass_and_semantics(self):
+        """Both base and additional must pass (AND semantics)."""
+        trigger = self._make_trigger(
+            base={"path": "type", "op": "==", "value": "fire"},
+            additional={"path": "amount", "op": ">", "value": 5},
+        )
+        # Both pass.
+        self.assertTrue(
+            _trigger_should_fire(trigger, SimpleNamespace(type="fire", amount=10), "test_event")
+        )
+        # Base fails.
+        self.assertFalse(
+            _trigger_should_fire(trigger, SimpleNamespace(type="cold", amount=10), "test_event")
+        )
+        # Additional fails.
+        self.assertFalse(
+            _trigger_should_fire(trigger, SimpleNamespace(type="fire", amount=3), "test_event")
+        )
+        # Both fail.
+        self.assertFalse(
+            _trigger_should_fire(trigger, SimpleNamespace(type="cold", amount=3), "test_event")
+        )
+
+    def test_base_only_no_additional_soul_tether_pattern(self):
+        """The soul tether pattern: base filter set, no additional — fires when base matches."""
+        trigger = self._make_trigger(
+            base={"path": "type", "op": "==", "value": "corruption"},
+        )
+        # No additional_filter_condition — only the base filter is evaluated.
+        self.assertTrue(
+            _trigger_should_fire(trigger, SimpleNamespace(type="corruption"), "test_event")
+        )
+        self.assertFalse(
+            _trigger_should_fire(trigger, SimpleNamespace(type="healing"), "test_event")
+        )

--- a/src/flows/tests/test_models/test_trigger.py
+++ b/src/flows/tests/test_models/test_trigger.py
@@ -1,14 +1,10 @@
-from unittest.mock import MagicMock, patch
-
 from django.test import TestCase
 
 from flows.factories import (
-    FlowEventFactory,
     SceneDataManagerFactory,
     TriggerDefinitionFactory,
     TriggerFactory,
 )
-from flows.flow_event import FlowEvent
 
 
 class TestTrigger(TestCase):
@@ -36,96 +32,6 @@ class TestTrigger(TestCase):
             # Second access uses cache
             data_again = self.trigger.data_map
             assert data_again == data
-
-    def test_should_trigger_for_event_checks_definition_match(self):
-        """Test that the trigger checks its definition's match first."""
-        event = FlowEventFactory(event_type="test_event")
-
-        with patch.object(
-            self.trigger.trigger_definition,
-            "matches_event",
-        ) as mock_matches:
-            mock_matches.return_value = False
-            assert not self.trigger.should_trigger_for_event(event)
-            mock_matches.assert_called_once_with(event, obj=self.trigger.obj)
-
-    def test_should_trigger_for_event_checks_additional_conditions(self):
-        """Test that additional filter conditions are checked."""
-        event = FlowEventFactory(event_type="test_event")
-
-        with patch.object(
-            self.trigger.trigger_definition,
-            "matches_event",
-            return_value=True,
-        ):
-            # Patch the event's matches_conditions method to verify it's called
-            with patch.object(
-                event,
-                "matches_conditions",
-                return_value=True,
-            ) as mock_check:
-                assert self.trigger.should_trigger_for_event(event)
-                mock_check.assert_called_once_with(
-                    self.trigger.additional_filter_condition,
-                )
-
-    def test_should_trigger_for_event_checks_conditions(self):
-        """Test that the trigger checks conditions against event data."""
-        # Create a mock source for the event
-        source = MagicMock()
-        source.context = MagicMock()
-
-        # Test with no conditions
-        event = FlowEvent(
-            "test_event",
-            source=source,
-            data={"foo": "bar", "baz": "qux"},
-        )
-        with patch.object(
-            self.trigger.trigger_definition,
-            "matches_event",
-            return_value=True,
-        ):
-            self.trigger.additional_filter_condition = {}
-            assert self.trigger.should_trigger_for_event(event)
-
-        # Test with passing conditions
-        event = FlowEvent(
-            "test_event",
-            source=source,
-            data={"foo": "bar", "baz": "qux"},
-        )
-        with patch.object(
-            self.trigger.trigger_definition,
-            "matches_event",
-            return_value=True,
-        ):
-            self.trigger.additional_filter_condition = {"baz": "qux"}
-            assert self.trigger.should_trigger_for_event(event)
-
-        # Test with failing conditions
-        event = FlowEvent(
-            "test_event",
-            source=source,
-            data={"foo": "bar", "baz": "wrong"},
-        )
-        with patch.object(
-            self.trigger.trigger_definition,
-            "matches_event",
-            return_value=True,
-        ):
-            self.trigger.additional_filter_condition = {"baz": "qux"}
-            assert not self.trigger.should_trigger_for_event(event)
-
-        # Test with missing data
-        event = FlowEvent("test_event", source=source, data={"foo": "bar"})
-        with patch.object(
-            self.trigger.trigger_definition,
-            "matches_event",
-            return_value=True,
-        ):
-            self.trigger.additional_filter_condition = {"missing": "value"}
-            assert not self.trigger.should_trigger_for_event(event)
 
 
 class TestSystemInstalledTrigger(TestCase):

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -1103,7 +1103,6 @@ def _install_reactive_side_effects(
                     trigger_definition=td,
                     obj=target,
                     source_condition=instance,
-                    additional_filter_condition=td.base_filter_condition,
                 )
                 for td in trigger_defs
             ]

--- a/src/world/conditions/tests/test_apply_condition_reactive_extension.py
+++ b/src/world/conditions/tests/test_apply_condition_reactive_extension.py
@@ -62,9 +62,10 @@ class ApplyConditionInstallsTriggersTests(TestCase):
 
         self.assertEqual(Trigger.objects.filter(obj=sheet.character).count(), 2)
 
-    def test_base_filter_condition_copied_to_installed_trigger(self):
-        """_install_reactive_side_effects copies TriggerDefinition.base_filter_condition
-        to Trigger.additional_filter_condition so emit_event can evaluate it."""
+    def test_base_filter_condition_available_via_trigger_definition(self):
+        """_install_reactive_side_effects creates Triggers whose base_filter_condition
+        is accessible via trigger_definition — emit_event evaluates it directly
+        (#2531: two-stage base + additional filter evaluation, no copy needed)."""
         condition = ConditionTemplateFactory(name="T10 filter copy test")
         flow = FlowDefinitionFactory(name="T10 filter copy flow")
         filter_cond = {"path": "target", "op": "==", "value": "self"}
@@ -81,11 +82,16 @@ class ApplyConditionInstallsTriggersTests(TestCase):
 
         self.assertTrue(result.success)
         trigger = Trigger.objects.get(obj=sheet.character, trigger_definition=trigger_def)
+        # The base filter lives on the definition, not copied to additional_filter_condition.
         self.assertEqual(
-            trigger.additional_filter_condition,
+            trigger.trigger_definition.base_filter_condition,
             filter_cond,
-            "base_filter_condition must be copied to Trigger.additional_filter_condition"
-            " on auto-install",
+            "base_filter_condition must be set on the TriggerDefinition",
+        )
+        self.assertIsNone(
+            trigger.additional_filter_condition,
+            "additional_filter_condition should be None when no per-instance filter is set"
+            " (#2531: base filter is read from the definition, not copied)",
         )
 
 


### PR DESCRIPTION
Closes #2531

## Summary

Fix the flows trigger dispatch path to evaluate both base_filter_condition (from TriggerDefinition) and additional_filter_condition (from the Trigger instance) with AND semantics. The live path was only checking additional, dropping the base filter entirely.

Changes:
1. Delete dead should_trigger_for_event() method (zero production callers, used a different filter engine than the live path).
2. Fix _trigger_should_fire() to evaluate both base + additional filters.
3. Remove the conditions/services.py copy workaround (additional_filter_condition=td.base_filter_condition) — no longer needed.
4. Add tests for the live dispatch path (base filter, additional filter, AND semantics, soul tether pattern).

This fixes a real bug: soul_tether.py creates Triggers without additional_filter_condition, so their base_filter_condition was lost entirely — triggers fired unconditionally.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2531 (in the issue body)
- Brainstorm/plan: skipped
- Sync-with-main: Already up to date with main.

<!-- last-addressed-comment: 0 -->