### PR TITLE
Cron ordering is declared, not emergent: CronPhase + anchored upkeep (#2609)

### DIFF
--- a/docs/adr/0150-income-lands-before-upkeep.md
+++ b/docs/adr/0150-income-lands-before-upkeep.md
@@ -1,0 +1,77 @@
+# ADR-0150: Weekly income lands before upkeep drains
+
+**Status:** Accepted (2026-07-20)
+**Issue:** #2609
+
+## Context
+
+`buildings.weekly_upkeep` sinks directly from `CharacterPurse`. `weekly_rollover` —
+which runs `run_weekly_economy()` and therefore wages, income, asset yields, and
+contract settlement — lands money in that same purse. Both are weekly.
+
+Until now their relative order was an accident twice over: upkeep was registered with
+no weekly anchor (it drifted on a rolling 7-day interval while the rollover stayed
+pinned to Sunday), and ordering within a shared tick fell out of `register_task` call
+order — two lines hundreds apart in `tasks.py`, with nothing marking the relationship
+as load-bearing. Whether a player could afford their own upkeep was partly a function
+of server restart timing.
+
+Fixing the nondeterminism forced the question the accident had been hiding: which
+order is actually correct.
+
+## Decision
+
+**Income lands first; upkeep drains after.** Encoded as `CronPhase` bands on
+`CronDefinition` — `ECONOMY = 200` before `UPKEEP = 300` — with
+`buildings.weekly_upkeep` sharing the rollover's anchor so the two fall due in the
+same tick at all.
+
+This deliberately **inverts** the pre-existing behaviour, which ran upkeep first.
+
+## Rationale
+
+Upkeep-first puts the sweep on the wrong side of the paycheck. A character living
+paycheck-to-paycheck has a near-empty purse at week's end, so obligations-first makes
+missed upkeep — and the arrears and condition-tier slide that follow — the *guaranteed*
+weekly outcome rather than the coin flip it was before. Determinism would have locked
+in the bad branch.
+
+Income-first is the purse-level analogue of the debt philosophy already recorded for
+org treasuries in #927: *"honest debtors never manage debt, they just see smaller
+incomes… over-leverage bottoms out at zero spendable income, never offscreen loss."*
+A player experiences a smaller effective paycheck. They never experience an
+unpreventable slide toward losing their home.
+
+## Alternatives rejected
+
+**Keep upkeep first (the status quo).** Preserves existing behaviour, but only by
+preserving an accident — and the accident is the harmful branch. The status quo had no
+argument behind it beyond line numbers.
+
+**Fold upkeep into `weekly_rollover_task`'s processor list.** Guarantees ordering
+without a phase field. Rejected: each `CronDefinition` owns a `ScheduledTaskRecord`
+carrying an `enabled` flag that staff toggle from admin, plus its own `last_run_at`.
+Making upkeep a processor destroys that independent staff control and its
+observability.
+
+**A bare `order: int` on `CronDefinition`.** Simpler than a named enum, but bare
+numbers carry no rationale, everything defaults to the same value, and the failure mode
+is `order=95` hacks squeezed between neighbours.
+
+**Declarative `runs_after` dependencies with a topological sort.** More precise and
+self-validating — cycles would become startup errors. Rejected as disproportionate
+machinery for ~36 tasks, almost none of which have an ordering opinion at all.
+
+## Consequences
+
+- A character short on funds sees a reduced net paycheck rather than an arrears hit,
+  in the common case.
+- Ordering is now declared, not emergent. New tasks land in `CronPhase.DEFAULT` and are
+  unaffected; the sort is stable, so registration order still breaks ties within a band.
+- `SNAPSHOT = 100` exists for tasks that must read balances *before* income moves. It has
+  no members yet — it is the seam the "Somehow Always Broke" economic distinction
+  (#2540) needs to capture a start-of-week baseline, and is declared here so that
+  feature does not have to renumber the bands.
+- Phases only order tasks that are already due in the same tick. A task must share an
+  anchor with its neighbours for its band to have any effect — the two halves are
+  independent and both required.

--- a/src/world/game_clock/CLAUDE.md
+++ b/src/world/game_clock/CLAUDE.md
@@ -43,6 +43,35 @@ Created automatically in `at_server_start()`.
 ### Task Registry
 Tasks registered in `tasks.py` via `register_all_tasks()`, called at server startup.
 
+### Execution Order — `CronPhase` (#2609)
+`CronDefinition.phase` is the **ordering contract** for tasks that come due in the same
+tick. `run_due_tasks()` sorts by it; the sort is stable, so registration order only
+breaks ties *within* a band. Before #2609 ordering was emergent — a side effect of the
+relative line numbers of two `register_task` calls — and nothing marked it load-bearing.
+
+| Band | Value | For |
+|------|-------|-----|
+| `SNAPSHOT` | 100 | Pre-income baselines — read balances before anything moves them |
+| `ECONOMY` | 200 | `weekly_rollover`: income, wages, debt service, contracts |
+| `UPKEEP` | 300 | Building upkeep and personal recurring drains |
+| `DEFAULT` | 500 | Everything with no ordering opinion (the default) |
+| `CLEANUP` | 900 | Sweeps, decay, garbage collection |
+
+Values are spaced so new bands can be inserted without renumbering.
+
+**A phase only orders tasks that are already due together.** It does nothing on its own —
+a task must also share an anchor with its neighbours for its band to ever come into play.
+`buildings.weekly_upkeep` therefore carries *both* `phase=CronPhase.UPKEEP` and the
+rollover's `anchor_weekday=0, anchor_hour_utc=5`.
+
+`ECONOMY` before `UPKEEP` is deliberate and inverts the pre-#2609 accident: **income lands
+before upkeep drains**, so a short player sees a smaller effective paycheck rather than an
+unpreventable arrears hit and condition-tier slide. See
+`docs/adr/0150-income-lands-before-upkeep.md`.
+
+`SNAPSHOT` currently has no members — it is the declared seam for tasks needing a
+start-of-week balance baseline (the "Somehow Always Broke" distinction, #2540).
+
 ### Wired Tasks
 | Task | Frequency | Source App |
 |------|-----------|------------|
@@ -59,6 +88,10 @@ Tasks registered in `tasks.py` via `register_all_tasks()`, called at server star
 | Persona pursuit-heat decay | 24h real | justice (#1765) |
 | Sanctum resonance generation (`sanctum.resonance_generation_tick`) | 24h real | magic |
 | Room ward upkeep (`room_features.ward_upkeep_tick`) | 24h real | room_features (#2177) |
+| Weekly rollover (`weekly_rollover`) | weekly, Sun 00:00 EST anchor, `ECONOMY` | game_clock (#932) |
+| Building upkeep sweep (`buildings.weekly_upkeep`) | weekly, same anchor, `UPKEEP` | buildings (#1930, #2609) |
+
+(Table is partial — `register_all_tasks()` in `tasks.py` is the authoritative list.)
 
 ## API Endpoints
 

--- a/src/world/game_clock/task_registry.py
+++ b/src/world/game_clock/task_registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
-from enum import Enum
+from enum import Enum, IntEnum
 import logging
 
 from django.utils import timezone
@@ -20,6 +20,29 @@ class FrequencyType(Enum):
     IC = "ic"
 
 
+class CronPhase(IntEnum):
+    """Execution-order bands for tasks that share a tick (#2609).
+
+    Ordering used to be an emergent property of ``register_task`` call order —
+    two lines hundreds apart in ``tasks.py``, with nothing saying the
+    relationship was load-bearing. A phase states the intent at the call site.
+
+    Bands are spaced so new ones can be inserted without renumbering. Tasks
+    that do not care stay in ``DEFAULT``; sorting is stable, so within a band
+    registration order still decides.
+
+    The money bands encode the income-before-upkeep ruling (see
+    ``docs/adr/0150-income-lands-before-upkeep.md``): a player experiences a
+    smaller effective paycheck, never an unpreventable condition slide.
+    """
+
+    SNAPSHOT = 100  # pre-income baselines — read balances before anything moves
+    ECONOMY = 200  # weekly_rollover: income, wages, debt service, contracts
+    UPKEEP = 300  # building upkeep and personal recurring drains
+    DEFAULT = 500  # everything with no ordering opinion
+    CLEANUP = 900  # sweeps, decay, garbage collection
+
+
 @dataclass(frozen=True)
 class CronDefinition:
     task_key: str
@@ -32,6 +55,11 @@ class CronDefinition:
     # last run — instead of the rolling interval. 0=Monday … 6=Sunday.
     anchor_weekday: int | None = None
     anchor_hour_utc: int = 0
+    # Execution-order band within a single run_due_tasks pass (#2609). This is
+    # the ordering contract; registration order is only a tiebreak within a
+    # band. Phases order tasks that are due *together* — a task must also share
+    # an anchor with its neighbours for the ordering to ever come into play.
+    phase: CronPhase = CronPhase.DEFAULT
 
 
 # Module-level registry populated once at server startup via register_all_tasks().
@@ -59,12 +87,16 @@ def clear_registry() -> None:
 def run_due_tasks(*, ic_now: datetime | None = None) -> list[str]:
     """Check all registered tasks and run any that are due.
 
+    Tasks execute in ``CronPhase`` order (#2609). The sort is stable, so tasks
+    sharing a phase keep registration order — the pre-#2609 behaviour for every
+    task that has not opted into a band.
+
     Returns list of task_keys that were executed.
     """
     now = timezone.now()
     executed: list[str] = []
 
-    for task_def in _registry:
+    for task_def in sorted(_registry, key=lambda task: task.phase):
         record, _ = ScheduledTaskRecord.objects.get_or_create(
             task_key=task_def.task_key,
         )

--- a/src/world/game_clock/tasks.py
+++ b/src/world/game_clock/tasks.py
@@ -9,6 +9,7 @@ from django.db import models
 
 from world.game_clock.task_registry import (
     CronDefinition,
+    CronPhase,
     register_task,
 )
 
@@ -589,6 +590,13 @@ def register_all_tasks() -> None:
             task_key="buildings.weekly_upkeep",
             callable=apply_weekly_upkeep_all_buildings,
             interval=timedelta(days=7),
+            # #2609: shares the rollover's anchor so upkeep and the economy
+            # pass fall due in the same tick, and sits in UPKEEP so it drains
+            # AFTER income lands (see ADR-0150). Both halves are required —
+            # a phase only orders tasks that are already due together.
+            anchor_weekday=0,
+            anchor_hour_utc=5,
+            phase=CronPhase.UPKEEP,
             description=(
                 "Weekly upkeep sweep: all-or-nothing deduction from the "
                 "owner wallet; misses accrue capped arrears then slide the "
@@ -741,6 +749,8 @@ def register_all_tasks() -> None:
             # moment, per Apostate's #932 ruling. EST fixed (no DST shift).
             anchor_weekday=0,
             anchor_hour_utc=5,
+            # #2609: income lands before upkeep drains (ADR-0150).
+            phase=CronPhase.ECONOMY,
             description="Weekly rollover: advance GameWeek and process all weekly systems.",
         )
     )

--- a/src/world/game_clock/tests/test_task_registry.py
+++ b/src/world/game_clock/tests/test_task_registry.py
@@ -9,8 +9,10 @@ from django.utils import timezone
 from world.game_clock.models import ScheduledTaskRecord
 from world.game_clock.task_registry import (
     CronDefinition,
+    CronPhase,
     FrequencyType,
     clear_registry,
+    get_registered_tasks,
     register_task,
     run_due_tasks,
 )
@@ -243,3 +245,86 @@ class AnchoredWeeklyDueTests(TestCase):
         )
         now = datetime(2026, 6, 15, 4, 0, tzinfo=UTC)
         assert _is_task_due(record, self._task(), now=now, ic_now=None) is False
+
+
+class CronPhaseOrderingTests(TestCase):
+    """Execution order within a single pass is declared, not emergent (#2609)."""
+
+    def setUp(self) -> None:
+        clear_registry()
+        self.calls: list[str] = []
+
+    def tearDown(self) -> None:
+        clear_registry()
+
+    def _register(self, key: str, phase: CronPhase | None = None) -> None:
+        """Register a due-immediately task that appends its key to self.calls."""
+        kwargs = {} if phase is None else {"phase": phase}
+        register_task(
+            CronDefinition(
+                task_key=key,
+                callable=lambda key=key: self.calls.append(key),
+                interval=timedelta(minutes=10),
+                **kwargs,
+            )
+        )
+
+    def test_phase_beats_registration_order(self) -> None:
+        # Registered late-band first; phase must override the call order.
+        self._register("cleanup", CronPhase.CLEANUP)
+        self._register("upkeep", CronPhase.UPKEEP)
+        self._register("snapshot", CronPhase.SNAPSHOT)
+        self._register("economy", CronPhase.ECONOMY)
+
+        run_due_tasks()
+
+        assert self.calls == ["snapshot", "economy", "upkeep", "cleanup"]
+
+    def test_income_lands_before_upkeep(self) -> None:
+        """ADR-0150 — the ordering this whole change exists to guarantee."""
+        self._register("buildings.weekly_upkeep", CronPhase.UPKEEP)
+        self._register("weekly_rollover", CronPhase.ECONOMY)
+
+        run_due_tasks()
+
+        assert self.calls.index("weekly_rollover") < self.calls.index("buildings.weekly_upkeep")
+
+    def test_snapshot_runs_before_economy(self) -> None:
+        """SNAPSHOT must see balances before any income moves them."""
+        self._register("economy", CronPhase.ECONOMY)
+        self._register("snapshot", CronPhase.SNAPSHOT)
+
+        run_due_tasks()
+
+        assert self.calls == ["snapshot", "economy"]
+
+    def test_same_phase_keeps_registration_order(self) -> None:
+        """Stable sort — the pre-#2609 behaviour within a band."""
+        self._register("first", CronPhase.ECONOMY)
+        self._register("second", CronPhase.ECONOMY)
+        self._register("third", CronPhase.ECONOMY)
+
+        run_due_tasks()
+
+        assert self.calls == ["first", "second", "third"]
+
+    def test_unphased_tasks_default_and_keep_order(self) -> None:
+        """Tasks that never opt in behave exactly as before."""
+        self._register("alpha")
+        self._register("beta")
+
+        run_due_tasks()
+
+        assert self.calls == ["alpha", "beta"]
+        registered = get_registered_tasks()
+        assert all(task.phase is CronPhase.DEFAULT for task in registered)
+
+    def test_default_sits_between_upkeep_and_cleanup(self) -> None:
+        """An unphased task must not accidentally outrank the money bands."""
+        self._register("unphased")
+        self._register("upkeep", CronPhase.UPKEEP)
+        self._register("cleanup", CronPhase.CLEANUP)
+
+        run_due_tasks()
+
+        assert self.calls == ["upkeep", "unphased", "cleanup"]

--- a/src/world/game_clock/tests/test_tasks.py
+++ b/src/world/game_clock/tests/test_tasks.py
@@ -395,3 +395,47 @@ class SpecCResonanceGainTaskRegistrationTests(TestCase):
 
         weekly_summary = resonance_weekly_settlement_tick()
         self.assertIsNotNone(weekly_summary)
+
+
+class WeeklyMoneyOrderingWiringTests(TestCase):
+    """The real registrations carry the anchor and bands ADR-0150 depends on (#2609)."""
+
+    def setUp(self) -> None:
+        from world.game_clock.task_registry import clear_registry
+
+        clear_registry()
+
+    def tearDown(self) -> None:
+        from world.game_clock.task_registry import clear_registry
+
+        clear_registry()
+
+    def _registered(self) -> dict:
+        from world.game_clock.task_registry import get_registered_tasks
+        from world.game_clock.tasks import register_all_tasks
+
+        register_all_tasks()
+        return {t.task_key: t for t in get_registered_tasks()}
+
+    def test_upkeep_shares_the_rollover_anchor(self) -> None:
+        """Without a shared anchor the bands never come into play at all."""
+        tasks = self._registered()
+        upkeep = tasks["buildings.weekly_upkeep"]
+        rollover = tasks["weekly_rollover"]
+
+        self.assertEqual(upkeep.anchor_weekday, rollover.anchor_weekday)
+        self.assertEqual(upkeep.anchor_hour_utc, rollover.anchor_hour_utc)
+        self.assertIsNotNone(upkeep.anchor_weekday)
+
+    def test_rollover_outranks_upkeep(self) -> None:
+        """Income lands before upkeep drains (ADR-0150)."""
+        from world.game_clock.task_registry import CronPhase
+
+        tasks = self._registered()
+
+        self.assertEqual(tasks["weekly_rollover"].phase, CronPhase.ECONOMY)
+        self.assertEqual(tasks["buildings.weekly_upkeep"].phase, CronPhase.UPKEEP)
+        self.assertLess(
+            tasks["weekly_rollover"].phase,
+            tasks["buildings.weekly_upkeep"].phase,
+        )


### PR DESCRIPTION
Closes #2609.

## The bug

Two independent defects made weekly money ordering nondeterministic. Both had to go for
either to matter.

**`buildings.weekly_upkeep` had no weekly anchor.** It fired on a rolling 7-day interval
while `weekly_rollover` stayed pinned to Sunday, so the gap between them drifted with
server restarts. Upkeep sinks from `CharacterPurse`; the rollover's `run_weekly_economy()`
fills it. Whether a player could afford their own upkeep therefore depended on which side
of their paycheck the sweep happened to land that week. A miss is not cosmetic — it
accrues capped arrears and then slides the building's condition tier.

**Ordering within a shared tick was equally accidental.** `run_due_tasks` iterated the
registry in `register_task` call order, so the contract was the relative line numbers of
two calls ~150 lines apart in `tasks.py`, with nothing marking the relationship as
load-bearing.

## The fix

`CronPhase` — an `IntEnum` of execution-order bands — becomes a `phase` field on
`CronDefinition`, sorted in `run_due_tasks`:

| Band | Value | For |
|------|-------|-----|
| `SNAPSHOT` | 100 | Pre-income baselines |
| `ECONOMY` | 200 | `weekly_rollover`: income, wages, debt service, contracts |
| `UPKEEP` | 300 | Building upkeep and personal recurring drains |
| `DEFAULT` | 500 | Everything with no ordering opinion |
| `CLEANUP` | 900 | Sweeps, decay, GC |

The sort is **stable**, so tasks sharing a band keep registration order and every task that
does not opt in behaves exactly as before. Values are spaced so new bands can be inserted
without renumbering.

`buildings.weekly_upkeep` gets **both** `phase=CronPhase.UPKEEP` and the rollover's anchor.
Both halves are required: a phase only orders tasks that are already due in the same tick,
so without a shared anchor the band never comes into play at all.

## ⚠️ Deliberate behavior change — this inverts the previous order

Upkeep used to run first, by accident of registration order. **This PR makes income land
first.**

The accident was the harmful branch. A character living paycheck-to-paycheck has a
near-empty purse at sweep time *every* week, so upkeep-first makes the missed-upkeep
arrears and condition slide the **guaranteed** weekly outcome rather than the coin flip
the drift produced. Making the old order deterministic would have locked that in.

Income-first is the purse-level analogue of the debt philosophy already recorded for org
treasuries in #927 — *"honest debtors never manage debt, they just see smaller incomes…
never offscreen loss."* A player experiences a smaller effective paycheck. They never
experience an unpreventable slide toward losing their home.

Recorded as **ADR-0150**, with four rejected alternatives: keeping the status quo, folding
upkeep into `weekly_rollover_task`'s processor list (destroys the per-task staff
enable/disable toggle and its `last_run_at` observability), a bare `order: int` (rots into
`order=95` hacks), and declarative `runs_after` with a topological sort (disproportionate
machinery for ~36 tasks that mostly have no ordering opinion).

## Note on `SNAPSHOT`

Ships with **no members**. It is the declared seam for the start-of-week balance baseline
the "Somehow Always Broke" economic distinction (#2540) needs, so that feature will not
have to renumber the bands. Flagging it explicitly as mild YAGNI rather than leaving a
mystery band — reasoning is in the ADR's consequences section.

## Testing

`world.game_clock` — **119 tests, OK**. New coverage:

- `CronPhaseOrderingTests` (6) — phase beats registration order; income-before-upkeep;
  `SNAPSHOT` before `ECONOMY`; same-phase stability; unphased tasks default and keep order;
  `DEFAULT` sits between `UPKEEP` and `CLEANUP`.
- `WeeklyMoneyOrderingWiringTests` (2) — asserts the **real** registrations from
  `register_all_tasks()` carry the shared anchor and the right bands, not just that the
  mechanism works on synthetic tasks.

Verified at `--verbosity 2` that all 8 are collected by name — a passing suite alone does
not prove new tests ran.

## Docs

- `docs/adr/0150-income-lands-before-upkeep.md` — new
- `src/world/game_clock/CLAUDE.md` — `CronPhase` section with the band table and the
  "a phase only orders tasks already due together" caveat; the two weekly money tasks added
  to the Wired Tasks table, which was silently partial (now says so)

🤖 Generated with [Claude Code](https://claude.com/claude-code)