### PR TITLE
Telnet surface (dchange) for the post-CG distinction-change flow (#2607 follow-up)

### DIFF
--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -52,6 +52,7 @@ from commands.crafting_station import CmdLabStation
 from commands.currency import CmdDeposit, CmdSecure, CmdSteal
 from commands.deeds import CmdDeed
 from commands.defenses import CmdDefense
+from commands.distinction_change import CmdDistinctionChange
 from commands.domains import CmdDomain
 from commands.door import CmdBreak, CmdLock, CmdPick, CmdUnlock
 from commands.dramatic_moments import CmdMoment
@@ -389,6 +390,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdProgressionUnlock,
             # #2116 — gift/technique/thread-weaving acquisition namespace.
             CmdLearn,
+            # #2607 follow-up — telnet surface for the distinction-change flow.
+            CmdDistinctionChange,
             # #1350 — journal authoring namespace: write/respond/edit subverbs + list hub.
             CmdJournal,
             # #1350 — goal authoring namespace.

--- a/src/commands/distinction_change.py
+++ b/src/commands/distinction_change.py
@@ -1,0 +1,102 @@
+"""Distinction-change telnet command — ``dchange`` (#2607 follow-up).
+
+Telnet surface for the post-CG distinction-change flow merged in #2624 (which
+shipped web-only). Routes the GM authorize and player accept verbs through the
+shared ``dispatch_player_action`` seam — the same REGISTRY path the web uses —
+reaching ``AuthorizeDistinctionChangeAction`` / ``AcceptDistinctionChangeAction``
+in ``actions/definitions/distinctions.py``. Bare ``dchange`` shows the caller's
+pending authorizations. No business logic lives here.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from actions.constants import ActionBackend
+from commands.command import DispatchCommand
+from commands.exceptions import CommandError
+
+if TYPE_CHECKING:
+    from actions.types import ActionRef
+
+_SUBVERBS: dict[str, str] = {
+    "authorize": "authorize_distinction_change",
+    "accept": "accept_distinction_change",
+}
+
+
+def _kv(rest: str) -> dict[str, str]:
+    """Parse ``key=value key=value`` telnet args into a dict."""
+    out: dict[str, str] = {}
+    for token in rest.split():
+        if "=" in token:
+            key, value = token.split("=", 1)
+            out[key.strip()] = value.strip()
+    return out
+
+
+class CmdDistinctionChange(DispatchCommand):
+    """Authorize (GM) or accept (player) a post-CG distinction change.
+
+    Usage:
+        dchange                                           — your pending authorizations
+        dchange authorize target_name=<char> action=<add|remove> \
+distinction_slug=<slug> reason=<...>     — GM (add)
+        dchange authorize target_name=<char> action=remove \
+character_distinction_id=<id> reason=<...>   — GM (remove)
+        dchange accept authorization_id=<n>               — spend XP to apply an authorized change
+    """
+
+    key = "distinctionchange"
+    aliases = ["dchange"]
+    locks = "cmd:all()"
+
+    _subverb: str = ""
+    _rest: str = ""
+
+    def func(self) -> None:
+        raw = (self.args or "").strip()
+        if not raw or raw.lower() == "status":
+            self._show_hub()
+            return
+        parts = raw.split(maxsplit=1)
+        self._subverb = parts[0].lower()
+        self._rest = parts[1].strip() if len(parts) > 1 else ""
+        if self._subverb not in _SUBVERBS:
+            self.msg(f"Unknown action '{self._subverb}'. Try: {', '.join(_SUBVERBS)}.")
+            return
+        super().func()
+
+    def resolve_action_ref(self) -> ActionRef:
+        from actions.types import ActionRef  # noqa: PLC0415
+
+        return ActionRef(backend=ActionBackend.REGISTRY, registry_key=_SUBVERBS[self._subverb])
+
+    def resolve_action_args(self) -> dict[str, Any]:
+        kwargs = _kv(self._rest)
+        if not kwargs:
+            msg = f"Usage: dchange {self._subverb} key=value ..."
+            raise CommandError(msg)
+        return kwargs
+
+    def _show_hub(self) -> None:
+        sheet = self.caller.character_sheet
+        lines = ["|wDistinction change|n: authorize (GM) / accept <authorization_id>"]
+        if sheet is None:
+            self.msg("\n".join(lines))
+            return
+        pending = sheet.distinction_change_authorizations.filter(is_consumed=False).select_related(
+            "target_distinction", "target_character_distinction__distinction"
+        )[:20]
+        lines.append("")
+        lines.append("Your pending authorizations:")
+        if not pending:
+            lines.append("  (none)")
+        for auth in pending:
+            if auth.action == "add":
+                name = auth.target_distinction.name if auth.target_distinction else "?"
+            else:
+                cd = auth.target_character_distinction
+                name = cd.distinction.name if cd else "?"
+            lines.append(f"  #{auth.pk} {auth.action} {name} — {auth.xp_cost} XP")
+        self.msg("\n".join(lines))

--- a/src/commands/tests/test_distinction_change_command.py
+++ b/src/commands/tests/test_distinction_change_command.py
@@ -1,0 +1,58 @@
+"""CmdDistinctionChange telnet command (#2607 follow-up) — parsing, routing, hub."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from django.test import TestCase
+
+from commands.distinction_change import CmdDistinctionChange, _kv
+from world.character_sheets.factories import CharacterSheetFactory
+from world.distinctions.factories import DistinctionFactory
+from world.distinctions.models import DistinctionChangeAuthorization
+
+
+def _build(caller, args: str = "") -> CmdDistinctionChange:
+    cmd = CmdDistinctionChange()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.msg = MagicMock()
+    return cmd
+
+
+class KvParsingTests(TestCase):
+    def test_parses_pairs(self) -> None:
+        assert _kv("target_name=Bob action=add distinction_slug=silver") == {
+            "target_name": "Bob",
+            "action": "add",
+            "distinction_slug": "silver",
+        }
+
+
+class RoutingTests(TestCase):
+    def test_unknown_subverb_messages(self) -> None:
+        sheet = CharacterSheetFactory()
+        cmd = _build(sheet.character, "frobnicate x=1")
+        cmd.func()
+        assert "Unknown action" in cmd.msg.call_args[0][0]
+
+
+class HubTests(TestCase):
+    def test_hub_lists_pending_add_authorization(self) -> None:
+        sheet = CharacterSheetFactory()
+        distinction = DistinctionFactory(name="Silver Tongue")
+        auth = DistinctionChangeAuthorization.objects.create(
+            character_sheet=sheet,
+            action="add",
+            target_distinction=distinction,
+            reason="mentor",
+            xp_cost=12,
+        )
+
+        cmd = _build(sheet.character, "")
+        cmd.func()
+
+        output = cmd.msg.call_args[0][0]
+        assert f"#{auth.pk}" in output
+        assert "Silver Tongue" in output
+        assert "12 XP" in output


### PR DESCRIPTION
Small additive follow-up to **#2624** (TehomCD's post-CG distinction-change flow), which
shipped **web-only**. This adds the missing telnet parity — nothing else.

## What

`CmdDistinctionChange` (key `distinctionchange`, alias `dchange`), registered in the default
cmdset. Routes the two verbs through the shared `dispatch_player_action` seam (the same REGISTRY
path the web uses) to the **existing** actions from #2624:

- `dchange authorize target_name=<char> action=<add|remove> distinction_slug=<slug> reason=<...>`
  → `AuthorizeDistinctionChangeAction` (GM, JUNIOR-tier)
- `dchange accept authorization_id=<n>` → `AcceptDistinctionChangeAction` (player, spends XP)
- bare `dchange` → a hub listing the caller's pending `DistinctionChangeAuthorization` rows
  (action, distinction name, XP cost)

No business logic and no model/service changes — thin over the merged actions/model, so the
#2624 design is untouched.

## Why

The action layer converges web + telnet on `action.run()` (ADR-0001); #2624 wired the web side
but not telnet. Telnet is a secondary compatibility goal, so if the omission was deliberate,
close this — no harm.

## Context

This is the salvaged additive piece from a parallel implementation of #2607 (my #2627, now
closed as superseded by #2624). The rest of that PR was a competing design (general
`TableUpdateRequest` framework, `post_cg_immutable` vs `is_teachable`, player-initiated flow) —
deliberately **not** brought over, to avoid re-forking the merged design. See #2627's closing
comment for the full comparison.

## Testing

`commands.tests.test_distinction_change_command` — arg parsing, subverb routing, and the hub
listing a pending authorization. Green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)