### PR TITLE
Wire the reactive-challenge content family (interpose/succor/catch/plummet seeds) into production seeding

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -4737,7 +4737,11 @@ reactive maneuvers (COVER, INTERPOSE, DEFEND stance), and clash-of-wills.
     returns the action backed by the higher-rated one (`_select_best_rated_action`) —
     deterministic (ADR-0019), no invented actions (ADR-0032). Existing callers (Succor,
     the scene-cover path) leave it `False` and keep the prior first-match behavior.
-- **Reactive content seeds:**
+- **Reactive content seeds:** (interpose/succor/fall-catch/redirect run in production
+  via the `reactive_challenges` cluster in `world.seeds.clusters`, #2636 — after
+  `combat_checks`, which seeds the Melee Defense `CheckType` Interpose looks up;
+  `ensure_defend_content` is deliberately NOT in the cluster: it seeds a placeholder
+  Gift/Technique, which is lore-repo content territory)
   - `ensure_interpose_content()` (`src/world/combat/interpose_content.py`) — idempotent
     seed for the INTERPOSE `ChallengeTemplate` + four capability-gated `Application` rows
     (telekinesis, shield, barrier, pull_aside) + Reflexes `CheckType` + SUCCESS-tier DESTROY

--- a/docs/systems/areas.md
+++ b/docs/systems/areas.md
@@ -559,7 +559,9 @@ you":
 
 **Plummet + catch content seed (`world/areas/positioning/plummet_content.py`).**
 `ensure_fall_content()` idempotently seeds all plummet + catch content (it calls
-`ensure_catch_content()`):
+`ensure_catch_content()`); it runs in production via the `reactive_challenges`
+cluster in `world.seeds.clusters` (#2636), alongside the Interpose/Succor/redirect
+siblings:
 
 - the `Fall` `DamageType` (null pools → config-default survivability) and the `Plummeting`
   `ConditionTemplate` — a simple non-progressive, `PERMANENT`-duration marker (no stages,

--- a/src/world/combat/interpose_content.py
+++ b/src/world/combat/interpose_content.py
@@ -19,7 +19,8 @@ Idempotently seeds the content the interpose feature needs:
 
 ``ensure_interpose_content`` mirrors
 ``world.areas.positioning.plummet_content.ensure_catch_content`` and is safe to call
-repeatedly: every write goes through ``get_or_create``. It
+repeatedly: every write goes through ``get_or_create``. It runs in production via
+the ``reactive_challenges`` cluster in ``world.seeds.clusters`` (#2636) and
 doubles as integration-test setup and staff seed data.
 """
 

--- a/src/world/combat/succor_content.py
+++ b/src/world/combat/succor_content.py
@@ -6,15 +6,11 @@ seeds (telekinesis/shield/barrier/pull_aside — "protecting someone bodily" spa
 an incoming blow and an environmental hazard; no new capability taxonomy needed), one
 Application + ChallengeApproach per capability, and a SUCCESS-tier DESTROY consequence.
 
-Mirrors world.combat.interpose_content.ensure_interpose_content exactly. Like that
-module (and world.areas.positioning.plummet_content), this is NOT wired into any
-production bootstrap path today — none of the sibling reactive-challenge content
-modules are (verified 2026-07-01: grepped src/ for callers of
-ensure_interpose_content/ensure_catch_content outside tests — zero hits). Seeding is
-staff-invoked (evennia shell) or test-fixture-invoked, consistent with this repo's
-existing convention for this whole content family; wiring an automatic seed hook for
-the family is out of scope for #1744 (would be a separate follow-up touching all
-siblings, not specific to Succor).
+Mirrors world.combat.interpose_content.ensure_interpose_content exactly. Like the
+whole reactive-challenge content family (interpose/catch/redirect siblings), this
+is seeded in production by the ``reactive_challenges`` cluster in
+``world.seeds.clusters`` (#2636) and also remains directly callable as
+integration-test setup or from the evennia shell.
 """
 
 from world.checks.models import CheckCategory, CheckType, Consequence

--- a/src/world/seeds/clusters.py
+++ b/src/world/seeds/clusters.py
@@ -56,6 +56,23 @@ def _seed_battles() -> None:
     seed_war_funding_contribution_methods()
 
 
+def _seed_reactive_challenges() -> None:
+    from world.areas.positioning.plummet_content import ensure_fall_content  # noqa: PLC0415
+    from world.combat.interpose_content import ensure_interpose_content  # noqa: PLC0415
+    from world.combat.redirect_content import ensure_redirect_content  # noqa: PLC0415
+    from world.combat.succor_content import ensure_succor_content  # noqa: PLC0415
+
+    # Interpose first: it creates the four shared guardian CapabilityType rows
+    # (telekinesis/shield/barrier/pull_aside) that Succor reuses, and looks up
+    # the Melee Defense CheckType seeded by the "combat_checks" cluster.
+    ensure_interpose_content()
+    ensure_succor_content()
+    # Fall content also seeds the Catch-the-Faller challenge (shares the
+    # Reflexes catch CheckType with Interpose).
+    ensure_fall_content()
+    ensure_redirect_content()
+
+
 def _seed_checks() -> None:
     from world.seeds.checks import seed_check_resolution_tables  # noqa: PLC0415
 
@@ -383,6 +400,15 @@ CLUSTER_SEEDERS: dict[str, Callable[[], None]] = {
     # Battles: the Champion-duel-outcome ENCOUNTER_COMPLETED wiring (#1710). After
     # "combat" — depends on the combat seed cluster's content existing first.
     "battles": _seed_battles,
+    # Reactive challenges (#2636): the declared-guardian / environmental-rescue
+    # content family — Interpose, Succor, fall/Plummeting + Catch the Faller,
+    # and the redirect detonation example Property. Built for #1273/#1744/#1228/
+    # #2210 but previously staff/test-invoked only; wiring it here makes
+    # declared interpose, succor, and the reactive catch live in real play
+    # (covenant-vow reactive grammar, gap G1). After "combat_checks" (Interpose
+    # looks up its Melee Defense CheckType) and "combat" (same family of
+    # resolution content); all four seeds are get_or_create-idempotent.
+    "reactive_challenges": _seed_reactive_challenges,
     # Consent: seeds default SocialConsentCategory rows; tags ActionTemplates if present.
     "consent": _seed_consent,
     # Character-creation "world" content (Realm/StartingArea/Beginnings/Species/
@@ -568,6 +594,7 @@ def seeded_models_by_cluster() -> dict[str, list[type[Model]]]:
     from world.justice.models import CrimeKind  # noqa: PLC0415
     from world.magic.models import Affinity, Resonance, Ritual  # noqa: PLC0415
     from world.magic.models.techniques import Technique  # noqa: PLC0415
+    from world.mechanics.models import ChallengeTemplate  # noqa: PLC0415
     from world.missions.models import MissionGiver, MissionTemplate  # noqa: PLC0415
     from world.npc_services.models import NPCRole  # noqa: PLC0415
     from world.progression.models import (  # noqa: PLC0415
@@ -634,6 +661,10 @@ def seeded_models_by_cluster() -> dict[str, list[type[Model]]]:
         # GM battle-staging catalog: 2 BattleMapBlueprint + 3 BattleUnitTemplate
         # rows (#2010).
         "battles": [BattleMapBlueprint, BattleUnitTemplate],
+        # Reactive challenges: Interpose/Succor/Catch-the-Faller ChallengeTemplates
+        # + the Plummeting marker condition + the redirect detonation Property
+        # (#2636 — activates the #1273/#1744/#1228/#2210 content family).
+        "reactive_challenges": [ChallengeTemplate],
         "consent": [SocialConsentCategory],
         "character_creation": [StartingArea, Beginnings, Species, CGExplanation],
         # Missions: the starter notice board (#2121) — 1 BOARD MissionGiver +

--- a/src/world/seeds/tests/test_clusters.py
+++ b/src/world/seeds/tests/test_clusters.py
@@ -23,6 +23,7 @@ class TestClusterRegistry(TestCase):
                 "items",
                 "combat",
                 "battles",
+                "reactive_challenges",
                 "consent",
                 "character_creation",
                 "missions",
@@ -61,6 +62,40 @@ class TestClusterRegistry(TestCase):
         keys = list(CLUSTER_SEEDERS)
         assert "character_creation" in keys
         self.assertLess(keys.index("magic"), keys.index("character_creation"))
+
+    def test_reactive_challenges_cluster_registered_after_combat_checks(self) -> None:
+        # Interpose's Melee-Defense twin approaches look up the "Melee Defense"
+        # CheckType seeded by the combat_checks cluster (#2636).
+        keys = list(CLUSTER_SEEDERS)
+        assert "reactive_challenges" in keys
+        self.assertLess(keys.index("combat_checks"), keys.index("reactive_challenges"))
+
+    def test_reactive_challenges_cluster_seeds_the_content_family(self) -> None:
+        from world.areas.positioning.constants import (
+            CATCH_THE_FALLER_NAME,
+            PLUMMETING_CONDITION_NAME,
+        )
+        from world.combat.interpose_content import INTERPOSE_CHALLENGE_NAME
+        from world.combat.redirect_content import (
+            VOLATILE_POWDER_PROPERTY_NAME,
+        )
+        from world.conditions.models import ConditionTemplate
+        from world.mechanics.models import ChallengeTemplate, Property
+        from world.mechanics.succor_shared import SUCCOR_CHALLENGE_NAME
+
+        CLUSTER_SEEDERS["reactive_challenges"]()
+
+        for name in (INTERPOSE_CHALLENGE_NAME, SUCCOR_CHALLENGE_NAME, CATCH_THE_FALLER_NAME):
+            self.assertTrue(
+                ChallengeTemplate.objects.filter(name=name).exists(),
+                f"expected seeded ChallengeTemplate {name!r}",
+            )
+        self.assertTrue(ConditionTemplate.objects.filter(name=PLUMMETING_CONDITION_NAME).exists())
+        self.assertTrue(Property.objects.filter(name=VOLATILE_POWDER_PROPERTY_NAME).exists())
+
+        # Idempotent on re-run: no duplicate challenge rows.
+        CLUSTER_SEEDERS["reactive_challenges"]()
+        self.assertEqual(ChallengeTemplate.objects.filter(name=INTERPOSE_CHALLENGE_NAME).count(), 1)
 
     def test_seeded_models_are_model_classes(self) -> None:
         models = seeded_models()


### PR DESCRIPTION
Closes #2636

## Summary

Adds a `reactive_challenges` cluster to `world.seeds.clusters` that runs the four idempotent content seeds — `ensure_interpose_content`, `ensure_succor_content`, `ensure_fall_content` (which includes Catch the Faller), and `ensure_redirect_content` — on every Big Button run. The family (built for #1273/#1744/#1228/#2210) previously had zero production callers; declared interpose, succor, and the reactive catch are now live on a fresh database. Registered after `combat_checks` because Interpose's Melee-Defense twin approaches look up that cluster's CheckType. `ensure_defend_content` is deliberately NOT wired: it seeds a placeholder Gift/Technique, which is lore-repo content territory — flagging for a ruling rather than silently including it. Stale 'not wired' docstrings and docs corrected in tandem.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2636 (in the issue body)
- Brainstorm/plan: skipped (wiring chore — no new mechanics; scope fixed by the issue)
- Sync-with-main: Branched from current main (203fd79f9); no sync needed.

<!-- last-addressed-comment: 0 -->