### PR TITLE
Fix fresh-DB migrate: order the PlayerMedia→Media rename after all old-name references

### DIFF
--- a/src/evennia_extensions/migrations/0013_rename_playermedia_to_media.py
+++ b/src/evennia_extensions/migrations/0013_rename_playermedia_to_media.py
@@ -4,6 +4,19 @@ from django.db import migrations, models
 class Migration(migrations.Migration):
     dependencies = [
         ("evennia_extensions", "0012_playerdata_looking_for_table"),
+        # The rename must apply AFTER every migration that references the old
+        # "playermedia" name: on a fresh database the graph otherwise permits
+        # this rename first, and those AddField/CreateModel operations then
+        # fail with "Related model 'evennia_extensions.playermedia' cannot be
+        # resolved" (fresh-DB migrate broke under server settings; the test
+        # settings happened to order the plan the other way, so CI never saw
+        # it).
+        ("combat", "0012_combatopponent_portrait"),
+        ("conditions", "0018_thumbnail_fields"),
+        ("forms", "0009_alternateself_thumbnail"),
+        ("items", "0002_initial"),
+        ("roster", "0001_initial"),
+        ("scenes", "0001_initial"),
     ]
 
     operations = [


### PR DESCRIPTION
## Problem

`evennia_extensions.0013_rename_playermedia_to_media` (#2515) declares no dependency on the six migrations that reference the old `playermedia` name (`combat.0012`, `conditions.0018`, `forms.0009`, `items.0002`, `roster.0001`, `scenes.0001`). The migration graph therefore permits the rename to apply before them; on a fresh database under `server.conf.settings` the executor actually chooses that order, and `forms.0009` fails:

```
ValueError: Related model 'evennia_extensions.playermedia' cannot be resolved
```

The test-settings plan happens to order the other way, so CI's fresh test databases never hit it — but any fresh dev-DB provisioning (and a future first deploy) does.

## Fix

Add the six missing dependencies to `evennia_extensions.0013` so the rename always applies after every old-name reference. No cycles: those migrations depend only on `evennia_extensions` ≤0009, and all new-name referencers (`forms.0011`, `character_creation.0013`, `codex.0005`) already depend on ≥0014.

## Verification

- Fresh `dropdb`/`createdb` + full `python -m django migrate`: previously failed at `forms.0009`, now completes.
- `arx seed dev` against the lore content repo: completes, 3782 rows across 46 clusters.
- `just test-fast evennia_extensions`: 56 tests, OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)