### PR TITLE
Reactive-effect content seam: make summon/ward/teleport payloads expressible from lore-repo content (no production seeds)

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -5804,7 +5804,7 @@ Database-driven game logic engine for complex branching sequences, plus the reac
 - **Object States:** `BaseState`, `CharacterState`, `RoomState`, `ExitState` — ephemeral wrappers with permission methods (`can_move`, `can_traverse`) and appearance rendering
 - **Service Functions:** `send_message`, `message_location`, `send_room_state`, `move_object`, `check_exit_traversal`, `traverse_exit`, `get_formatted_description`, `show_inventory` — accept `BaseState` directly (no `FlowExecution` dependency)
 - **Where events are emitted:** `world/combat/services.py` (damage/attack/incap/death), `world/conditions/services.py` (apply/stage-change/remove), `world/magic/services.py` (technique pre-cast/cast/affected), and the typeclass move/examine hooks
-- **Critical Note:** No `FlowDefinition` records exist in the database yet. The reactive layer ships the plumbing; authoring trigger content (e.g., retaliation scars, environmental wards) happens against `ConditionTemplate.reactive_triggers` and similar M2Ms in later scopes.
+- **Critical Note:** `FlowDefinition`/`FlowStepDefinition`/`TriggerDefinition` are content-exportable via `NaturalKeyMixin` + `CONTENT_MODELS` (#2663), so the lore repo can author the trigger→flow→step wiring that `ConditionTemplate.reactive_triggers` references. The `ensure_*` palette seeds in `world/magic/effect_palette_content.py` remain test/E2E fixtures only; real content ships as lore-repo fixtures. Flow step parameters use name-based lookups (e.g. `threat_pool_name`) rather than raw PKs so they are identity-stable across environments.
 - **Source:** `src/flows/`
 - **Details:** [flows.md](flows.md)
 

--- a/docs/systems/flows.md
+++ b/docs/systems/flows.md
@@ -190,6 +190,8 @@ These can be added later without breaking existing trigger content.
 | `FlowStepDefinition` | One step of a flow (set/eval/call/emit/cancel/modify/prompt) | `flow`, `parent`, `action`, `variable_name`, `parameters` (JSON) |
 | `FlowStack` | Per-execution recursion-capped stack | `owner`, `originating_event`, `depth`, `cap` |
 
+All three reactive-layer definition models (`FlowDefinition`, `FlowStepDefinition`, `TriggerDefinition`) carry `NaturalKeyMixin` and are in `CONTENT_MODELS` (#2663), so the lore repo can author the trigger→flow→step wiring as fixtures. Flow step parameters use name-based lookups (not raw PKs) for entity references, keeping fixtures identity-stable across environments.
+
 ### Reactive
 
 | Model | Purpose | Key Fields |

--- a/docs/systems/magic.md
+++ b/docs/systems/magic.md
@@ -1751,7 +1751,7 @@ grammar is what #2206 made actually reach validation/persistence in combat.
 | `summon_ally(*, payload)` | direct handler | Create a `CombatOpponent` with `allegiance=ALLY`, `summoned_by=caster` |
 | `move_position_on_condition(*, payload, destination_position_id)` | CONDITION_APPLIED adapter | Thin wrapper → `move_position` |
 | `create_obstacle_on_condition(*, payload, ...)` | CONDITION_APPLIED adapter | Thin wrapper → `create_obstacle` |
-| `summon_ally_on_condition(*, payload, threat_pool_id, ...)` | CONDITION_APPLIED adapter | Bridges `ConditionAppliedPayload` (`.target` as bearer/caster) → `summon_ally` |
+| `summon_ally_on_condition(*, payload, threat_pool_name, ...)` | CONDITION_APPLIED adapter | Bridges `ConditionAppliedPayload` (`.target` as bearer/caster) → `summon_ally` |
 | `init_absorb_buffer(*, payload, buffer)` | CONDITION_APPLIED handler | Seeds `ConditionInstance.absorb_remaining` on Aegis Field application |
 
 **Reactive interceptor cost pattern** (ADR-0060):

--- a/src/core_management/content_export.py
+++ b/src/core_management/content_export.py
@@ -105,6 +105,10 @@ CONTENT_MODELS: frozenset[str] = frozenset(
         "forms.formtraitoption",
         "forms.heightband",
         "forms.speciesformtrait",
+        # flows
+        "flows.flowdefinition",
+        "flows.flowstepdefinition",
+        "flows.triggerdefinition",
         # items
         "items.itemtemplateproperty",
         # magic

--- a/src/flows/models/flows.py
+++ b/src/flows/models/flows.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Any, Optional, cast
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from flows.consts import ITEM_REF, OPERATOR_MAP, RESULT_VARIABLE_KEY, FlowActionChoices, FlowState
 from flows.execution.prompts import register_pending_prompt
 from flows.flow_event import FlowEvent
@@ -41,11 +42,17 @@ def _resolve_emit_location(flow_execution: "FlowExecution") -> Any:
     return owner.location
 
 
-class FlowDefinition(SharedMemoryModel):
+class FlowDefinition(NaturalKeyMixin, SharedMemoryModel):
     """Represents a reusable definition for a flow, consisting of multiple steps."""
 
     name = models.CharField(max_length=255, unique=True)
     description = models.TextField(blank=True, null=True)
+
+    objects = NaturalKeyManager()
+
+    class NaturalKeyConfig:
+        fields = ["name"]
+
     if TYPE_CHECKING:
         steps: "models.Manager[FlowStepDefinition]"
         _unsaved_steps: list["FlowStepDefinition"]
@@ -68,7 +75,7 @@ class FlowDefinition(SharedMemoryModel):
         return flow_def
 
 
-class FlowStepDefinition(SharedMemoryModel):
+class FlowStepDefinition(NaturalKeyMixin, SharedMemoryModel):
     """Represents a single step in a flow definition.
 
     The ``variable_name`` field is a generic reference whose meaning depends on
@@ -114,6 +121,12 @@ class FlowStepDefinition(SharedMemoryModel):
         blank=True,
         help_text="Additional parameters for this step.",
     )
+
+    objects = NaturalKeyManager()
+
+    class NaturalKeyConfig:
+        fields = ["flow", "variable_name", "parent"]
+        dependencies = ["flows.FlowDefinition"]
 
     def _parameters_mapping(self) -> dict[str, Any]:
         """Return step parameters as a dictionary."""

--- a/src/flows/models/triggers.py
+++ b/src/flows/models/triggers.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from flows.constants import EventName
 from flows.filters.validator import validate_filter_schema
 from flows.flow_event import FlowEvent
@@ -12,7 +13,7 @@ from flows.helpers.logic import resolve_self_placeholders
 from flows.models.flows import FlowDefinition
 
 
-class TriggerDefinition(SharedMemoryModel):
+class TriggerDefinition(NaturalKeyMixin, SharedMemoryModel):
     """Reusable template describing when to launch another flow.
 
     ``base_filter_condition`` allows simple equality checks against event data to
@@ -55,6 +56,11 @@ class TriggerDefinition(SharedMemoryModel):
         help_text="Higher priority triggers fire first.",
     )
 
+    objects = NaturalKeyManager()
+
+    class NaturalKeyConfig:
+        fields = ["name"]
+
     def clean(self) -> None:
         super().clean()
         if self.base_filter_condition:
@@ -84,8 +90,6 @@ class Trigger(SharedMemoryModel):
         on_delete=models.CASCADE,
         help_text="The trigger template this is based on.",
     )
-    # ObjectDB by design (#2608): triggers install on rooms (combat/duel wiring) and
-    # reactive items (condition installs), not just characters.
     obj = models.ForeignKey(
         "objects.ObjectDB",
         on_delete=models.CASCADE,

--- a/src/world/magic/effect_palette_content.py
+++ b/src/world/magic/effect_palette_content.py
@@ -269,7 +269,7 @@ def ensure_summon_content() -> None:
        damage_type) so the summon can attack. The pool is created FIRST so its pk can
        be embedded as a static parameter in the flow step.
     2. A ``FlowDefinition`` with a single ``CALL_SERVICE_FUNCTION`` step whose
-       ``parameters`` carry ``{"payload": "@payload", "threat_pool_id": <pool.pk>,
+       ``parameters`` carry ``{"payload": "@payload", "threat_pool_name": "<pool name>",
        "bond_rounds": 5, "max_health": 30}`` — the static literals resolve alongside
        ``@payload``.
     3. A ``TriggerDefinition`` on ``CONDITION_APPLIED`` with ``base_filter_condition``
@@ -310,7 +310,7 @@ def ensure_summon_content() -> None:
             "parent_id": None,
             "parameters": {
                 "payload": PAYLOAD_PLACEHOLDER,
-                "threat_pool_id": pool.pk,
+                "threat_pool_name": pool.name,
                 "bond_rounds": _SUMMON_BOND_ROUNDS,
                 "max_health": _SUMMON_MAX_HEALTH,
             },
@@ -1256,7 +1256,7 @@ def ensure_rampart_content() -> None:
        ``signature_behavior``/``signature_value`` and a couple of small
        ``RampartElementResistance`` rows (2-6).
     2. A ``FlowDefinition`` with a single ``CALL_SERVICE_FUNCTION`` step pointing at
-       ``raise_rampart_on_condition``, carrying the profile's pk and a mid-tier
+       ``raise_rampart_on_condition``, carrying the profile's name and a mid-tier
        ``integrity`` (24) as static params alongside the placeholder ``position_id``
        (runtime destination selection is the cast-time ``cast_destination``, same
        mechanism Barricade/teleport use).
@@ -1343,7 +1343,7 @@ def ensure_rampart_content() -> None:
             _RAISE_RAMPART_ADAPTER_PATH,
             extra_params={
                 "position_id": _PLACEHOLDER_POSITION_ID,
-                "element_profile_id": profile.pk,
+                "element_profile_name": profile.name,
                 "integrity": _RAMPART_INTEGRITY,
             },
         )

--- a/src/world/magic/services/effect_handlers.py
+++ b/src/world/magic/services/effect_handlers.py
@@ -232,7 +232,7 @@ def summon_ally(*, payload: Any) -> None:
 
     Reads from payload:
     - ``payload.caster``         – caster's character ObjectDB.
-    - ``payload.threat_pool_id`` – pk of the ThreatPool to use.
+    - ``payload.threat_pool_name`` – name of the ThreatPool to use.
     - ``payload.bond_rounds``    – optional int; sets bond_expires_round on the
                                    skirmish summon. Not applicable to the military
                                    branch (battles have no per-encounter round-bond
@@ -292,7 +292,7 @@ def summon_ally(*, payload: Any) -> None:
     encounter = participant.encounter
     caster_sheet = participant.character_sheet
 
-    threat_pool = ThreatPool.objects.get(pk=payload.threat_pool_id)
+    threat_pool = ThreatPool.objects.get(name=payload.threat_pool_name)
     # Suppression justified: flow-payload optional param (fields vary per FlowDefinition).
     max_health: int = getattr(payload, "max_health", 30)  # noqa: GETATTR_LITERAL
     # Suppression justified: flow-payload optional param (fields vary per FlowDefinition).
@@ -555,7 +555,7 @@ def raise_rampart_on_condition(
     *,
     payload: Any,
     position_id: int,
-    element_profile_id: int,
+    element_profile_name: str,
     integrity: int,
     duration_rounds: int | None = None,
 ) -> None:
@@ -582,7 +582,7 @@ def raise_rampart_on_condition(
     else:
         return  # no position resolved — no-op
 
-    element_profile = RampartElementProfile.objects.get(pk=element_profile_id)
+    element_profile = RampartElementProfile.objects.get(name=element_profile_name)
     caster_sheet = _caster_sheet_from_instance(instance)
 
     raise_rampart(
@@ -595,14 +595,14 @@ def raise_rampart_on_condition(
 
 
 def summon_ally_on_condition(
-    *, payload: Any, threat_pool_id: int, bond_rounds: int | None = None, max_health: int = 30
+    *, payload: Any, threat_pool_name: str, bond_rounds: int | None = None, max_health: int = 30
 ) -> None:
     """CONDITION_APPLIED adapter that bridges to ``summon_ally`` (#1584, Task 14a).
 
     Seeded as the CALL_SERVICE_FUNCTION step of the Summoning condition's reactive
     flow: casting a SELF summon technique applies the Summoning condition, whose
     trigger fires this with the event's ``ConditionAppliedPayload`` plus the static
-    ``threat_pool_id`` / ``bond_rounds`` / ``max_health`` params from the flow step.
+    ``threat_pool_name`` / ``bond_rounds`` / ``max_health`` params from the flow step.
 
     ``payload.target`` is the bearer of the condition, which — for a SELF condition —
     is the caster. We repackage it into the bespoke namespace ``summon_ally`` reads.
@@ -612,7 +612,7 @@ def summon_ally_on_condition(
     summon_ally(
         payload=SimpleNamespace(
             caster=payload.target,
-            threat_pool_id=threat_pool_id,
+            threat_pool_name=threat_pool_name,
             bond_rounds=bond_rounds,
             max_health=max_health,
         )

--- a/src/world/magic/tests/test_effect_palette_summon.py
+++ b/src/world/magic/tests/test_effect_palette_summon.py
@@ -82,7 +82,7 @@ class EnsureSummonContentSeedTests(TestCase):
             "world.magic.services.effect_handlers.summon_ally_on_condition",
         )
         self.assertEqual(step.parameters["payload"], "@payload")
-        self.assertEqual(step.parameters["threat_pool_id"], pool.pk)
+        self.assertEqual(step.parameters["threat_pool_name"], pool.name)
 
         # 5. The technique applies the Summoning condition to SELF.
         applied = TechniqueAppliedCondition.objects.filter(
@@ -113,7 +113,7 @@ class SummonAllyOnConditionAdapterTests(TestCase):
         stub = SimpleNamespace(target=caster_objectdb, instance=None, stage=None)
 
         before = CombatOpponent.objects.filter(encounter=encounter).count()
-        summon_ally_on_condition(payload=stub, threat_pool_id=pool.pk, bond_rounds=5)
+        summon_ally_on_condition(payload=stub, threat_pool_name=pool.name, bond_rounds=5)
         after = CombatOpponent.objects.filter(encounter=encounter).count()
 
         self.assertEqual(after, before + 1)

--- a/src/world/magic/tests/test_summon_ally.py
+++ b/src/world/magic/tests/test_summon_ally.py
@@ -49,7 +49,7 @@ class SummonAllyHandlerTests(TestCase):
 
         payload = SimpleNamespace(
             caster=caster_objectdb,
-            threat_pool_id=pool.pk,
+            threat_pool_name=pool.name,
             bond_rounds=5,
         )
 
@@ -104,7 +104,7 @@ class SummonAllyHandlerTests(TestCase):
 
         payload = SimpleNamespace(
             caster=unrelated_caster,
-            threat_pool_id=pool.pk,
+            threat_pool_name=pool.name,
             bond_rounds=5,
         )
 
@@ -145,7 +145,7 @@ class SummonAllyMilitaryBranchTests(TestCase):
 
         payload = SimpleNamespace(
             caster=sheet.character,
-            threat_pool_id=pool.pk,
+            threat_pool_name=pool.name,
             military=True,
             max_health=200,
             properties=["flying"],
@@ -178,7 +178,7 @@ class SummonAllyMilitaryBranchTests(TestCase):
         ThreatPoolEntryFactory(pool=pool)
         caster = CharacterFactory()
 
-        payload = SimpleNamespace(caster=caster, threat_pool_id=pool.pk, military=True)
+        payload = SimpleNamespace(caster=caster, threat_pool_name=pool.name, military=True)
 
         before = BattleUnit.objects.count()
         result = summon_ally(payload=payload)
@@ -193,7 +193,7 @@ class SummonAllyMilitaryBranchTests(TestCase):
         participant = CombatParticipantFactory(encounter=encounter, status=ParticipantStatus.ACTIVE)
         caster_objectdb = participant.character_sheet.character
 
-        payload = SimpleNamespace(caster=caster_objectdb, threat_pool_id=pool.pk)
+        payload = SimpleNamespace(caster=caster_objectdb, threat_pool_name=pool.name)
 
         before = CombatOpponent.objects.filter(encounter=encounter).count()
         summon_ally(payload=payload)


### PR DESCRIPTION
Closes #2663

## Summary

Make FlowDefinition, FlowStepDefinition, and TriggerDefinition content-exportable via NaturalKeyMixin + CONTENT_MODELS so the lore repo can author reactive-effect wiring (summon/ward/teleport). Switch two PK-in-JSON parameter references to name-based lookups for identity-stable fixtures.

## Follow-ups filed

- #2679

## Notes

- Spec: reviewed & approved on #2663 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Clean sync, no conflicts.

<!-- last-addressed-comment: 0 -->