### PR TITLE
Add NaturalKeyMixin + CONTENT_MODELS registration for 13 models (#2682)

### DIFF
--- a/src/actions/models/consequence_pools.py
+++ b/src/actions/models/consequence_pools.py
@@ -8,11 +8,10 @@ from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
 from actions.types import WeightedConsequence, _entry_to_weighted
-from core.managers import CachedAllMixin
 from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 
 
-class ConsequencePoolManager(CachedAllMixin, NaturalKeyManager):
+class ConsequencePoolManager(NaturalKeyManager):
     """Manager for ConsequencePool with natural key support, plus cached_all() (#1871)."""
 
 

--- a/src/core/natural_keys.py
+++ b/src/core/natural_keys.py
@@ -49,7 +49,8 @@ from typing import TYPE_CHECKING, Any
 
 from django.db import models
 from django.db.models.fields.related import ForeignKey
-from evennia.utils.idmapper.manager import SharedMemoryManager
+
+from core.managers import ArxSharedMemoryManager
 
 if TYPE_CHECKING:
     from collections.abc import Sequence
@@ -59,15 +60,17 @@ class NaturalKeyConfigError(ValueError):
     """Raised when NaturalKeyConfig is missing or invalid."""
 
 
-class NaturalKeyManager(SharedMemoryManager, models.Manager["NaturalKeyMixin"]):
+class NaturalKeyManager(ArxSharedMemoryManager, models.Manager["NaturalKeyMixin"]):
     """Manager that supports get_by_natural_key lookups.
 
-    Inherits from ``SharedMemoryManager`` so that ``.get(pk=N)`` hits the
-    Evennia identity-map cache before issuing SQL when the underlying model
-    is a ``SharedMemoryModel``. For non-SharedMemoryModel models with this
-    manager, the cache check is a no-op (the model has no
-    ``get_cached_instance`` classmethod, so the cache lookup raises and the
-    manager falls through to ``super().get()``).
+    Inherits from ``ArxSharedMemoryManager`` so that singleton config models
+    using this manager retain ``cached_singleton()`` and ``cached_all()``
+    in addition to natural-key support. The ``SharedMemoryManager`` base
+    ensures ``.get(pk=N)`` hits the Evennia identity-map cache before
+    issuing SQL when the underlying model is a ``SharedMemoryModel``. For
+    non-SharedMemoryModel models with this manager, the cache check is a
+    no-op (the model has no ``get_cached_instance`` classmethod, so the
+    cache lookup raises and the manager falls through to ``super().get()``).
     """
 
     def get_by_natural_key(self, *args: Any) -> NaturalKeyMixin:

--- a/src/core_management/content_export.py
+++ b/src/core_management/content_export.py
@@ -37,6 +37,11 @@ class ContentExportError(Exception):
 #: are identity-stable (no pk churn) and round-trip through ``load_entries``.
 CONTENT_MODELS: frozenset[str] = frozenset(
     {
+        # achievements
+        "achievements.statdefinition",
+        # areas
+        "areas.rampartelementprofile",
+        "areas.rampartelementresistance",
         # character_creation
         "character_creation.beginnings",
         "character_creation.beginningtradition",
@@ -57,6 +62,9 @@ CONTENT_MODELS: frozenset[str] = frozenset(
         "classes.pathaspect",
         # clues
         "clues.clue",
+        # combat
+        "combat.threatpool",
+        "combat.threatpoolentry",
         # codex
         "codex.codexcategory",
         "codex.codexentry",
@@ -73,18 +81,22 @@ CONTENT_MODELS: frozenset[str] = frozenset(
         "conditions.conditionconditioninteraction",
         "conditions.conditiondamageinteraction",
         "conditions.conditiondamageovertime",
+        "conditions.conditionmodifiereffect",
         "conditions.conditionresistancemodifier",
         "conditions.conditionstage",
         "conditions.conditiontemplate",
         "conditions.damagetype",
         # covenants
         "covenants.covenantrole",
+        "covenants.covenantrite",
+        "covenants.covenantriterolepackage",
         "covenants.covenantroleactionscaling",
         "covenants.covenantrolebonus",
         "covenants.covenantroledefenseprofile",
         "covenants.covenantroletechniquespecialty",
         "covenants.geararchetypecompatibility",
         "covenants.insighttableentry",
+        "covenants.mentorbondconfig",
         "covenants.weaknesspoolentry",
         "covenants.vowsituationalperk",
         "covenants.vowsituationalperkrung",
@@ -113,8 +125,11 @@ CONTENT_MODELS: frozenset[str] = frozenset(
         "items.itemtemplateproperty",
         # magic
         "magic.affinity",
+        "magic.compromiseacttype",
+        "magic.dramaticmomenttype",
         "magic.effecttype",
         "magic.facet",
+        "magic.fallredemptionconfig",
         "magic.gift",
         "magic.glimpsetag",
         "magic.glimpsetagdistinctionsuggestion",
@@ -123,6 +138,9 @@ CONTENT_MODELS: frozenset[str] = frozenset(
         "magic.portalanchorkind",
         "magic.resonance",
         "magic.restriction",
+        "magic.resonanceconversion",
+        "magic.ritual",
+        "magic.soultetherconfig",
         "magic.technique",
         "magic.techniqueappliedcondition",
         "magic.techniquecapabilitygrant",
@@ -132,6 +150,7 @@ CONTENT_MODELS: frozenset[str] = frozenset(
         "magic.techniqueoutcomemodifier",
         "magic.techniqueremovedcondition",
         "magic.techniquestyle",
+        "magic.threadweavingunlock",
         "magic.tradition",
         "magic.traditiongiftgrant",
         # mechanics
@@ -155,6 +174,8 @@ CONTENT_MODELS: frozenset[str] = frozenset(
         "missions.missionrenownaward",
         # realms
         "realms.realm",
+        # relationships
+        "relationships.relationshiptrack",
         # skills
         "skills.skill",
         # species

--- a/src/world/achievements/models.py
+++ b/src/world/achievements/models.py
@@ -24,13 +24,18 @@ from world.achievements.constants import (
 CHARACTER_SHEET_MODEL = "character_sheets.CharacterSheet"
 
 
-class StatDefinition(SharedMemoryModel):
+class StatDefinition(NaturalKeyMixin, SharedMemoryModel):
     """
     Defines a trackable stat with display metadata.
 
     Normalizes stat keys so they can't get out of sync between
     StatTracker and AchievementRequirement. Staff-defined.
     """
+
+    class NaturalKeyConfig:
+        fields = ["key"]
+
+    objects = NaturalKeyManager()
 
     key = models.CharField(
         max_length=200,

--- a/src/world/areas/positioning/models.py
+++ b/src/world/areas/positioning/models.py
@@ -8,6 +8,7 @@ from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
 from core.descriptors import ReverseOneToOneOrNone
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.areas.positioning.constants import PositionKind, RampartCrackState, RampartSignature
 
 _DAMAGE_TYPE_MODEL = "conditions.DamageType"
@@ -500,7 +501,7 @@ class BlueprintPositionShelter(SharedMemoryModel):
         )
 
 
-class RampartElementProfile(SharedMemoryModel):
+class RampartElementProfile(NaturalKeyMixin, SharedMemoryModel):
     """A reusable element (Stone/Wind/Fire/Thorn/...) a Rampart is raised from (#2209).
 
     Authored content: one row per element, shared across every Rampart cast from
@@ -511,6 +512,12 @@ class RampartElementProfile(SharedMemoryModel):
     condition). Per-damage-type resist/vulnerability lives on the related
     ``RampartElementResistance`` rows.
     """
+
+    class NaturalKeyConfig:
+        fields = ["name"]
+        dependencies = ["conditions.DamageType", "conditions.ConditionTemplate"]
+
+    objects = NaturalKeyManager()
 
     name = models.CharField(max_length=100, unique=True)
     description = models.TextField(blank=True)
@@ -551,12 +558,18 @@ class RampartElementProfile(SharedMemoryModel):
         return self.name
 
 
-class RampartElementResistance(SharedMemoryModel):
+class RampartElementResistance(NaturalKeyMixin, SharedMemoryModel):
     """A per-damage-type resist/vulnerability row for a RampartElementProfile (#2209).
 
     ``value`` is signed: positive resists (shrinks incoming chip damage),
     negative is a vulnerability (grows it). Absent damage types resist 0.
     """
+
+    class NaturalKeyConfig:
+        fields = ["profile", "damage_type"]
+        dependencies = ["areas.RampartElementProfile", "conditions.DamageType"]
+
+    objects = NaturalKeyManager()
 
     profile = models.ForeignKey(
         RampartElementProfile, on_delete=models.CASCADE, related_name="resistances"

--- a/src/world/combat/models.py
+++ b/src/world/combat/models.py
@@ -12,6 +12,7 @@ from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
 from core.managers import ArxSharedMemoryManager
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.achievements.models import DiscoverableContent
 
 if TYPE_CHECKING:
@@ -253,8 +254,13 @@ class CombatEncounter(AbstractRound):
         ).exists()
 
 
-class ThreatPool(SharedMemoryModel):
+class ThreatPool(NaturalKeyMixin, SharedMemoryModel):
     """Named collection of NPC actions."""
+
+    class NaturalKeyConfig:
+        fields = ["pk"]
+
+    objects = NaturalKeyManager()
 
     name = models.CharField(max_length=200)
     description = models.TextField(blank=True)
@@ -263,8 +269,14 @@ class ThreatPool(SharedMemoryModel):
         return self.name
 
 
-class ThreatPoolEntry(SharedMemoryModel):
+class ThreatPoolEntry(NaturalKeyMixin, SharedMemoryModel):
     """One possible action an NPC can take."""
+
+    class NaturalKeyConfig:
+        fields = ["pool", "name"]
+        dependencies = ["combat.ThreatPool"]
+
+    objects = NaturalKeyManager()
 
     pool = models.ForeignKey(
         ThreatPool,

--- a/src/world/conditions/models.py
+++ b/src/world/conditions/models.py
@@ -18,7 +18,6 @@ from django.db.models import Q
 from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
-from core.managers import CachedAllMixin
 from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.conditions.constants import (
     ConditionInteractionOutcome,
@@ -108,7 +107,7 @@ class ConditionCategory(NaturalKeyMixin, SharedMemoryModel):
         return list(self.conditions.all())
 
 
-class CapabilityTypeManager(CachedAllMixin, NaturalKeyManager):
+class CapabilityTypeManager(NaturalKeyManager):
     """Manager for CapabilityType with natural key support, plus cached_all() (#1871)."""
 
 
@@ -508,7 +507,7 @@ class ConditionTemplate(NaturalKeyMixin, SharedMemoryModel):
         return ConditionTemplateReactiveHandler(self)
 
 
-class ConditionStageManager(CachedAllMixin, NaturalKeyManager):
+class ConditionStageManager(NaturalKeyManager):
     """Manager for ConditionStage with natural key support, plus cached_all() (#1871)."""
 
 

--- a/src/world/covenants/models.py
+++ b/src/world/covenants/models.py
@@ -1240,10 +1240,16 @@ class CovenantRoleBonus(NaturalKeyMixin, SharedMemoryModel):
         )
 
 
-class CovenantRite(SharedMemoryModel):
+class CovenantRite(NaturalKeyMixin, SharedMemoryModel):
     """Authored definition: a covenant-scoped group ritual ('rite') with an
     activation gate and a turnout-scaled shared buff. Sidecar on a Ritual so the
     generic Ritual table stays gate-free."""
+
+    class NaturalKeyConfig:
+        fields = ["ritual"]
+        dependencies = ["magic.Ritual"]
+
+    objects = NaturalKeyManager()
 
     ritual = models.OneToOneField(
         "magic.Ritual",
@@ -1299,7 +1305,7 @@ class CovenantRite(SharedMemoryModel):
         verbose_name_plural = "Covenant Rites"
 
 
-class CovenantRiteRolePackage(SharedMemoryModel):
+class CovenantRiteRolePackage(NaturalKeyMixin, SharedMemoryModel):
     """Role- and level-gated stat package for a covenant rite.
 
     Staff can author a different ConditionTemplate for each (role, level-band)
@@ -1310,6 +1316,12 @@ class CovenantRiteRolePackage(SharedMemoryModel):
     Unique constraint: only one band per (rite, role, level) triple — prevents
     ambiguous selection.
     """
+
+    class NaturalKeyConfig:
+        fields = ["rite", "covenant_role", "min_covenant_level"]
+        dependencies = ["covenants.CovenantRite", "covenants.CovenantRole"]
+
+    objects = NaturalKeyManager()
 
     rite = models.ForeignKey(
         "covenants.CovenantRite",
@@ -1416,7 +1428,7 @@ class CovenantRiteParticipant(SharedMemoryModel):
 # =============================================================================
 
 
-class MentorBondConfig(SharedMemoryModel):
+class MentorBondConfig(NaturalKeyMixin, SharedMemoryModel):
     """Singleton (pk=1): global parameters for Mentor's Vow bond scaling (#1165).
 
     Seeded by seed_mentor_bond_defaults() in factories.py. Services use
@@ -1429,7 +1441,10 @@ class MentorBondConfig(SharedMemoryModel):
     - max_sidekicks_per_mentor: cap on sidekick count; null means unlimited.
     """
 
-    objects = ArxSharedMemoryManager()
+    class NaturalKeyConfig:
+        fields = ["pk"]
+
+    objects = NaturalKeyManager()
 
     band_width = models.PositiveSmallIntegerField(
         default=MENTOR_BOND_BAND_WIDTH,

--- a/src/world/gm/models.py
+++ b/src/world/gm/models.py
@@ -10,7 +10,7 @@ from django.db.models import Q, UniqueConstraint
 from django.utils import timezone
 from evennia.utils.idmapper.models import SharedMemoryModel
 
-from core.managers import ArxSharedMemoryManager, CachedAllMixin
+from core.managers import ArxSharedMemoryManager
 from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.gm.constants import (
     CatalogSuggestionProposalKind,
@@ -464,7 +464,7 @@ class StoryRoomGrant(SharedMemoryModel):
 # ``consequence_pool`` FK anywhere -- ConsequencePoolGuide is advisory text only.
 
 
-class SituationKindManager(CachedAllMixin, NaturalKeyManager):
+class SituationKindManager(NaturalKeyManager):
     """Manager for SituationKind with natural key support, plus cached_all() (#1871).
 
     Small, admin-authored taxonomy table read on every ``FindSituationAction``

--- a/src/world/magic/models/dramatic_moment.py
+++ b/src/world/magic/models/dramatic_moment.py
@@ -11,16 +11,23 @@ from django.db import models
 from django.db.models import Q
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.magic.constants import SuggestionStatus
 from world.societies.renown_config import RenownAwardConfig
 
 
-class DramaticMomentType(RenownAwardConfig):
+class DramaticMomentType(NaturalKeyMixin, RenownAwardConfig):
     """Staff-authored lookup describing a type of dramatic moment.
 
     Staff tags a character in a scene with a DramaticMomentType to fire both
     a resonance grant and a renown award in one atomic service call.
     """
+
+    class NaturalKeyConfig:
+        fields = ["label"]
+        dependencies = ["magic.Resonance"]
+
+    objects = NaturalKeyManager()
 
     label = models.CharField(
         max_length=100,

--- a/src/world/magic/models/fall_redemption.py
+++ b/src/world/magic/models/fall_redemption.py
@@ -18,14 +18,14 @@ from decimal import Decimal
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
-from core.managers import ArxSharedMemoryManager
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.magic.types.aura import AffinityType
 
 _RESONANCE_FK = "magic.Resonance"
 _CONFIG_VERBOSE = "Fall / Redemption Config"
 
 
-class CompromiseActType(SharedMemoryModel):
+class CompromiseActType(NaturalKeyMixin, SharedMemoryModel):
     """Authored act category that grants non-native resonance when performed.
 
     Staff author rows like "Combat Kill" → a Primal predation resonance,
@@ -33,6 +33,12 @@ class CompromiseActType(SharedMemoryModel):
     outcomes, and social scene actions reference these to call
     ``grant_compromise_resonance``.
     """
+
+    class NaturalKeyConfig:
+        fields = ["name"]
+        dependencies = ["magic.Resonance"]
+
+    objects = NaturalKeyManager()
 
     name = models.CharField(max_length=80, unique=True)
     description = models.TextField(blank=True)
@@ -64,7 +70,7 @@ class CompromiseActType(SharedMemoryModel):
         return f"{self.name} → {self.target_resonance.name} ({self.amount})"
 
 
-class ResonanceConversion(SharedMemoryModel):
+class ResonanceConversion(NaturalKeyMixin, SharedMemoryModel):
     """Authored mapping: which target resonance a source resonance converts to
     for a given destination affinity.
 
@@ -73,6 +79,12 @@ class ResonanceConversion(SharedMemoryModel):
     some Primal resonance. A different row maps (Bene, ABYSSAL) → some
     Abyssal resonance. This allows different target resonances per Fall path.
     """
+
+    class NaturalKeyConfig:
+        fields = ["source_resonance", "target_affinity"]
+        dependencies = ["magic.Resonance"]
+
+    objects = NaturalKeyManager()
 
     source_resonance = models.ForeignKey(
         _RESONANCE_FK,
@@ -103,7 +115,7 @@ class ResonanceConversion(SharedMemoryModel):
         )
 
 
-class FallRedemptionConfig(SharedMemoryModel):
+class FallRedemptionConfig(NaturalKeyMixin, SharedMemoryModel):
     """Singleton (pk=1) of conversion multipliers per Fall/Redemption path.
 
     Fall multipliers are >1.0 (gain); Redemption multipliers are <1.0 (loss).
@@ -112,7 +124,10 @@ class FallRedemptionConfig(SharedMemoryModel):
     the Rite of Atonement.
     """
 
-    objects = ArxSharedMemoryManager()
+    class NaturalKeyConfig:
+        fields = ["pk"]
+
+    objects = NaturalKeyManager()
 
     # Fall multipliers (>1.0 = gain)
     celestial_to_primal_multiplier = models.DecimalField(

--- a/src/world/magic/models/rituals.py
+++ b/src/world/magic/models/rituals.py
@@ -11,6 +11,7 @@ from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
 from core.descriptors import ReverseOneToOneOrNone
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.magic.constants import ParticipationRule, RitualExecutionKind, TargetKind
 from world.magic.models.ritual_check_config import RitualCheckConfig
 
@@ -47,7 +48,7 @@ class ImbuingProseTemplate(SharedMemoryModel):
         return f"ImbuingProse({res} / {tk})"
 
 
-class Ritual(SharedMemoryModel):
+class Ritual(NaturalKeyMixin, SharedMemoryModel):
     """A ritual: authored magical procedure executed via service, flow, or scene action.
 
     Spec A §4.3. Each Ritual is dispatched via one of three modes:
@@ -59,6 +60,12 @@ class Ritual(SharedMemoryModel):
     (SCENE_ACTION requires a RitualCheckConfig; other kinds may carry one)
     is enforced in clean() only since DB CHECK constraints cannot span tables.
     """
+
+    class NaturalKeyConfig:
+        fields = ["name"]
+        dependencies = ["flows.FlowDefinition"]
+
+    objects = NaturalKeyManager()
 
     # Reverse-OneToOne safe accessor (#2386): missing row -> None.
     check_config_or_none = ReverseOneToOneOrNone("check_config")

--- a/src/world/magic/models/soul_tether_config.py
+++ b/src/world/magic/models/soul_tether_config.py
@@ -3,10 +3,10 @@
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
-from core.managers import ArxSharedMemoryManager
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 
 
-class SoulTetherConfig(SharedMemoryModel):
+class SoulTetherConfig(NaturalKeyMixin, SharedMemoryModel):
     """Singleton tuning surface (pk=1).
 
     All integer fields; multipliers encoded as integer-tenths or integer-hundredths
@@ -36,7 +36,10 @@ class SoulTetherConfig(SharedMemoryModel):
     - ``rescue_budget_thread_mult_hundredths``: thread-level multiplier in hundredths (5 → 0.05).
     """
 
-    objects = ArxSharedMemoryManager()
+    class NaturalKeyConfig:
+        fields = ["pk"]
+
+    objects = NaturalKeyManager()
 
     # --- Sineating ---
     anima_cost_per_unit = models.PositiveSmallIntegerField(default=2)

--- a/src/world/magic/models/techniques.py
+++ b/src/world/magic/models/techniques.py
@@ -19,7 +19,6 @@ from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
 from actions.constants import ActionCategory, ActionTargetType
-from core.managers import CachedAllMixin
 from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.achievements.models import DiscoverableContent
 from world.covenants.constants import RoleArchetype
@@ -196,7 +195,7 @@ class Restriction(NaturalKeyMixin, SharedMemoryModel):
         return list(self.allowed_effect_types.all())
 
 
-class IntensityTierManager(CachedAllMixin, NaturalKeyManager):
+class IntensityTierManager(NaturalKeyManager):
     """Manager for IntensityTier with natural key support, plus cached_all() (#1846)."""
 
 

--- a/src/world/magic/models/weaving.py
+++ b/src/world/magic/models/weaving.py
@@ -12,10 +12,11 @@ from django.core.exceptions import ValidationError
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.magic.constants import TargetKind
 
 
-class ThreadWeavingUnlock(SharedMemoryModel):
+class ThreadWeavingUnlock(NaturalKeyMixin, SharedMemoryModel):
     """Authored unlock catalog. Discriminator + typed-FK; one unlock per anchor.
 
     No name/description: ``display_name`` derives from the discriminator FK
@@ -26,6 +27,12 @@ class ThreadWeavingUnlock(SharedMemoryModel):
 
     Spec A §2.1 lines 313-429.
     """
+
+    class NaturalKeyConfig:
+        fields = ["target_kind", "unlock_trait", "unlock_gift", "unlock_track"]
+        dependencies = ["traits.Trait", "magic.Gift", "relationships.RelationshipTrack"]
+
+    objects = NaturalKeyManager()
 
     target_kind = models.CharField(
         max_length=32,

--- a/src/world/mechanics/models.py
+++ b/src/world/mechanics/models.py
@@ -15,7 +15,7 @@ from django.db import models
 from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
-from core.managers import ArxSharedMemoryManager, CachedAllMixin
+from core.managers import ArxSharedMemoryManager
 from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 
 if TYPE_CHECKING:
@@ -78,7 +78,7 @@ class ModifierCategory(NaturalKeyMixin, SharedMemoryModel):
         return self.name
 
 
-class ModifierTargetManager(CachedAllMixin, NaturalKeyManager):
+class ModifierTargetManager(NaturalKeyManager):
     """Manager for ModifierTarget with natural key support, plus cached_all() (#1846)."""
 
 

--- a/src/world/relationships/models.py
+++ b/src/world/relationships/models.py
@@ -14,6 +14,7 @@ from evennia.accounts.models import AccountDB
 from evennia.utils.idmapper.models import SharedMemoryModel
 
 from core.managers import ArxSharedMemoryManager
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.magic.constants import SoulTetherRole
 from world.relationships.constants import (
     DECAY_DAYS,
@@ -78,7 +79,7 @@ class RelationshipCondition(SharedMemoryModel):
         return list(self.gates_modifiers.all())
 
 
-class RelationshipTrack(SharedMemoryModel):
+class RelationshipTrack(NaturalKeyMixin, SharedMemoryModel):
     """
     A named axis along which a relationship can develop.
 
@@ -86,6 +87,11 @@ class RelationshipTrack(SharedMemoryModel):
     such as Trust, Respect, Rivalry, or Fear. Each track has a sign indicating
     whether it represents positive or negative feelings.
     """
+
+    class NaturalKeyConfig:
+        fields = ["name"]
+
+    objects = NaturalKeyManager()
 
     name = models.CharField(
         max_length=100,


### PR DESCRIPTION
## Context

Issue #2682 asks to migrate four `wire_*_content()` / `ensure_*_content()` factory functions from `src/world/magic/factories.py` to lore-repo fixtures. The issue's own Prerequisites section warns that several models may not yet be in `CONTENT_MODELS` and would need `NaturalKeyMixin` added.

This PR is the **code prerequisite work** — it makes the 13 models content-exportable so fixtures can be authored against them.

## What changed

Added `NaturalKeyMixin` + `NaturalKeyConfig` + `NaturalKeyManager` to 12 models, and registered all 13 (one already had `NaturalKeyMixin`) in `CONTENT_MODELS`:

| Model | Natural key | Used by |
|---|---|---|
| `magic.Ritual` | `name` | Soul Tether, Covenant, Fall/Redemption |
| `magic.SoulTetherConfig` | `pk` (singleton) | Soul Tether |
| `magic.ThreadWeavingUnlock` | `target_kind` + typed FKs | Soul Tether |
| `relationships.RelationshipTrack` | `name` | Soul Tether |
| `achievements.StatDefinition` | `key` | Soul Tether |
| `covenants.CovenantRite` | `ritual` FK | Covenant lifecycle |
| `covenants.CovenantRiteRolePackage` | `rite` + `role` + `min_covenant_level` | Covenant lifecycle |
| `covenants.MentorBondConfig` | `pk` (singleton) | Covenant lifecycle |
| `conditions.ConditionModifierEffect` | `condition` + `stage` + `modifier_target` | Covenant lifecycle |
| `magic.FallRedemptionConfig` | `pk` (singleton) | Fall/Redemption |
| `magic.CompromiseActType` | `name` | Fall/Redemption |
| `magic.ResonanceConversion` | `source_resonance` + `target_affinity` | Fall/Redemption |
| `magic.DramaticMomentType` | `label` | Dramatic entrance |

### Architectural change: `NaturalKeyManager` → `ArxSharedMemoryManager`

`NaturalKeyManager` now inherits from `ArxSharedMemoryManager` instead of `SharedMemoryManager`, so singleton config models using it retain `cached_singleton()` and `cached_all()`. This required removing the now-redundant `CachedAllMixin` from 6 existing manager subclasses that previously mixed it in alongside `NaturalKeyManager`:

- `ConsequencePoolManager` (actions)
- `CapabilityTypeManager` (conditions)
- `ConditionStageManager` (conditions)
- `SituationKindManager` (gm)
- `IntensityTierManager` (magic)
- `ModifierTargetManager` (mechanics)

No migrations needed — these are Python-level constructs.

## Testing

- 25 content export tests ✅
- 30 core manager tests ✅
- 32 consequence pool tests ✅
- 104 magic/achievements/relationships model tests ✅
- 17 mentor bond config + rite seed tests ✅
- Soul tether, fall redemption, dramatic moment tests ✅
- 7 failures in `test_covenant_lifecycle_rituals_seed` — **pre-existing** (confirmed failing on clean `main`)

## Next steps

The lore-repo fixture authoring (the actual `wire_*_content()` → fixture JSON migration) is deferred until after a planned arx2-lore repo structure refactor by another agent.

Closes #2682 (code prerequisite portion)