### PR TITLE
Content pipeline: author prose-bearing content as per-entry markdown (#2688)

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -5906,6 +5906,24 @@ Admin-hosted, superuser-only HTMX dashboards for difficulty tuning/simulation an
   `skills` → `traits.Trait` (#944); `npc_roles` → `npc_services.NPCRole`, `items` →
   `items.ItemTemplate`, `building_kinds` → `buildings.BuildingKind`, `decoration_kinds` →
   `buildings.DecorationKind` (#2266) — every domain upserts by a DB-unique `name`.
+  **#2688 adds four prose domains** whose content is authored as per-entry markdown
+  instead of fixture JSON, keyed under `content/` because build-domain and
+  reference-canon directory names share one namespace in the content repo:
+  `content/codex_entries` → `codex.CodexEntry`, `content/beginnings` →
+  `character_creation.Beginnings`, `content/starting_areas` →
+  `character_creation.StartingArea`, `content/traditions` → `magic.Tradition`.
+  `codex.CodexEntry` is the only multi-prose domain: `## Lore` → `lore_content`
+  and `## Mechanics` → `mechanics_content`, with **at least one** required rather
+  than all (`CodexEntry.clean()` needs only one, and 25 of 28 authored entries have
+  no mechanics content). Every single-prose domain keeps the whole-body-to-one-field
+  rule unchanged. `export_to_content_repo` writes these four back **as markdown and
+  emits no JSON for them** (`MARKDOWN_EXPORT_DOMAINS`), so each model keeps exactly
+  one home — and the export is **field-scoped**: only author-owned fields are
+  written, so admin-tuned columns (`share_cost`, `learn_*`, `display_order`,
+  `is_public`/`is_featured`) are never round-tripped into frontmatter. An optional
+  model field must stay optional in its builder, or export can emit a file the
+  builder then rejects (regression-tested: `StartingArea.realm` is nullable, and
+  `default_starting_room` round-trips because the fallback-room bootstrap needs it).
   `CONTENT_MODELS` (`core_management/content_export.py`) additionally covers
   `character_creation.startingarea`, `evennia_extensions.roomsizetier`, and
   `weather.climate` (#2436/#2448) now that all three carry `NaturalKeyMixin`, plus

--- a/src/core_management/content_export.py
+++ b/src/core_management/content_export.py
@@ -17,9 +17,15 @@ standalone). All Django imports are deferred.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+import json
 import logging
 from pathlib import Path
 
+from core_management.content_fixtures import (
+    MARKDOWN_EXPORT_DOMAINS,
+    content_slug,
+    render_entry_markdown,
+)
 from core_management.content_repo import resolve_content_root
 
 logger = logging.getLogger(__name__)
@@ -196,6 +202,31 @@ CONTENT_MODELS: frozenset[str] = frozenset(
 )
 
 
+def _write_markdown_entries(root: Path, spec: dict, serialized: str) -> list[Path]:
+    """Write one markdown file per record for a prose domain (#2688).
+
+    Existing files are overwritten; files with no corresponding row are left
+    alone rather than deleted. Deleting is how an export destroys authored
+    content when the database is a subset of the repo (see the content repo's
+    own README), so removing an entry stays a deliberate manual act.
+    """
+    domain_dir = root / spec["domain"]
+    written: list[Path] = []
+    for record in json.loads(serialized):
+        fields = record["fields"]
+        out_dir = domain_dir
+        subdir_key = spec.get("subdir_from")
+        if subdir_key:
+            value = fields.get(subdir_key)
+            if isinstance(value, list) and value:
+                out_dir = domain_dir / content_slug(str(value[-1]))
+        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path = out_dir / f"{content_slug(fields['name'])}.md"
+        out_path.write_text(render_entry_markdown(fields, spec), encoding="utf-8")
+        written.append(out_path)
+    return written
+
+
 @dataclass
 class ExportResult:
     """Outcome of an export pass."""
@@ -256,6 +287,14 @@ def export_to_content_repo(content_root: Path | None = None) -> ExportResult:
             )
         except (TypeError, ValueError, AttributeError) as exc:
             result.errors.append(f"{model_label}: serialization failed: {exc}")
+            continue
+
+        spec = MARKDOWN_EXPORT_DOMAINS.get(model_label)
+        if spec is not None:
+            # Prose domain (#2688): write per-entry markdown and emit NO JSON,
+            # so the generated file cannot compete with the markdown source.
+            result.written.extend(_write_markdown_entries(root, spec, data))
+            result.total_records += count
             continue
 
         out_dir = fixtures_dir / app_label

--- a/src/core_management/content_fixtures.py
+++ b/src/core_management/content_fixtures.py
@@ -91,7 +91,9 @@ from dataclasses import dataclass, field
 from functools import partial
 import json
 from pathlib import Path
+import re
 from typing import TYPE_CHECKING
+import unicodedata
 
 import yaml
 
@@ -127,6 +129,18 @@ FIELD_DEFAULT_RAPPORT_STARTING_VALUE = "default_rapport_starting_value"
 FIELD_DEFAULT_DESCRIPTION_TEMPLATE = "default_description_template"
 FIELD_VALUE = "value"
 FIELD_WEIGHT = "weight"
+
+# Prose fields for the multi-section domains (#2688). A domain whose model
+# carries more than one long-form text field maps ``## Heading`` sections in
+# the markdown body onto these, instead of the whole-body-to-one-field rule
+# every single-prose domain uses.
+FIELD_DESCRIPTION = "description"
+FIELD_LORE_CONTENT = "lore_content"
+FIELD_MECHANICS_CONTENT = "mechanics_content"
+FIELD_SUMMARY = "summary"
+FIELD_SUBJECT = "subject"
+
+HEADING_DELIMITER = "## "
 
 # _upsert_fixture_object()/load_entries()/load_world_content() outcome tokens
 # (#2448) — module constants for the same reason as the FIELD_* group above:
@@ -230,6 +244,70 @@ def _require_name_and_body(entry: ContentEntry) -> str:
         msg = f"{entry.path}: description body is required (PLACEHOLDER is fine)."
         raise ContentError(msg)
     return name
+
+
+def _prose_sections(entry: ContentEntry, field_by_heading: dict[str, str]) -> dict[str, str]:
+    """Split a markdown body into prose fields keyed by ``##`` heading (#2688).
+
+    Only for domains whose model carries more than one long-form text field.
+    Every single-prose domain keeps the existing whole-body-to-one-field rule
+    via ``_require_name_and_body`` — this function is not involved there, so
+    those domains are unaffected.
+
+    Headings match case-insensitively. Rules, each chosen so the round trip
+    (markdown -> fixture -> DB -> markdown) cannot silently lose prose:
+
+    - Body text before the first ``##`` is an error rather than being assigned
+      to some default field, because there is no way to write it back out.
+    - An unrecognised ``##`` heading is an error naming the file and the
+      heading, mirroring how an invalid ``category`` is reported.
+    - At least one declared section must carry text. Individual sections stay
+      optional: ``CodexEntry.clean()`` requires only ONE of ``lore_content`` /
+      ``mechanics_content``, and 25 of the 28 authored entries have no
+      mechanics content, so requiring all declared sections would reject
+      nearly the whole corpus.
+
+    Returns only the sections actually present, so absent optional fields are
+    omitted from ``fields`` entirely — which the loader already reads as
+    "leave this column alone" (see the module docstring on optional fields).
+    """
+    lookup = {heading.casefold(): field for heading, field in field_by_heading.items()}
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+
+    for line in entry.body.splitlines():
+        if line.startswith(HEADING_DELIMITER):
+            heading = line[len(HEADING_DELIMITER) :].strip()
+            field = lookup.get(heading.casefold())
+            if field is None:
+                msg = (
+                    f"{entry.path}: unknown section heading '{heading}'. "
+                    f"Expected one of: {', '.join(sorted(field_by_heading))}."
+                )
+                raise ContentError(msg)
+            current = field
+            sections.setdefault(current, [])
+            continue
+        if current is None:
+            if line.strip():
+                msg = (
+                    f"{entry.path}: body text appears before the first '## ' heading. "
+                    f"Every line must sit under a section: "
+                    f"{', '.join(sorted(field_by_heading))}."
+                )
+                raise ContentError(msg)
+            continue
+        sections[current].append(line)
+
+    prose = {field: "\n".join(lines).strip() for field, lines in sections.items()}
+    prose = {field: text for field, text in prose.items() if text}
+    if not prose:
+        msg = (
+            f"{entry.path}: needs at least one non-empty section "
+            f"({', '.join(sorted(field_by_heading))}). PLACEHOLDER text is fine."
+        )
+        raise ContentError(msg)
+    return prose
 
 
 def _build_trait_fixture(entry: ContentEntry, *, trait_type: str) -> dict:
@@ -370,6 +448,121 @@ def _build_decoration_kind_fixture(entry: ContentEntry) -> dict:
 
 
 # domain dir -> {builder callable, output fixture path relative to src/}
+def _require_meta_natural_key(entry: ContentEntry, key: str) -> list:
+    """Return a frontmatter FK value as Django's natural-key list form.
+
+    Accepts either a plain scalar (``starting_area: The City of Arx``), which
+    is what authors should write for a single-field natural key, or an explicit
+    list for multi-field keys (``subject: [Magic, null, Resonance]``).
+    ``_resolve_natural_key_fields`` resolves either at upsert time.
+    """
+    value = _optional_meta_natural_key(entry, key)
+    if value is None:
+        msg = f"{entry.path}: '{key}' is required."
+        raise ContentError(msg)
+    return value
+
+
+def _optional_meta_natural_key(entry: ContentEntry, key: str) -> list | None:
+    """Same as ``_require_meta_natural_key`` but returns None when unset.
+
+    Used for FK columns the model allows to be null. Returning None means the
+    key is omitted from ``fields`` entirely, which the loader already reads as
+    "leave this column alone" rather than "set it to null".
+    """
+    value = entry.meta.get(key)
+    if value is None or value == "":
+        return None
+    return list(value) if isinstance(value, list) else [value]
+
+
+def _build_codex_entry_fixture(entry: ContentEntry) -> dict:
+    """Map a codex_entries/ entry to a codex.CodexEntry fixture object (#2688).
+
+    The only multi-prose domain: ``## Lore`` -> ``lore_content`` and
+    ``## Mechanics`` -> ``mechanics_content``, at least one required.
+
+    Deliberately carries ONLY author-owned fields. Every tuning and
+    publication column (``share_cost``, ``learn_cost``, ``learn_difficulty``,
+    ``learn_threshold``, ``display_order``, ``is_public``, ``is_featured``,
+    ``featured_order``) plus ``prerequisites``, ``modifier_target`` and ``art``
+    is admin-owned and omitted, so a load never overwrites values tuned in the
+    admin. Omission already means "leave this column alone" — see the module
+    docstring on optional-field semantics.
+    """
+    name = entry.meta.get("name")
+    if not name or not isinstance(name, str):
+        msg = f"{entry.path}: 'name' (string) is required."
+        raise ContentError(msg)
+    fields: dict = {
+        "name": name,
+        FIELD_SUBJECT: _require_meta_natural_key(entry, FIELD_SUBJECT),
+    }
+    summary = entry.meta.get(FIELD_SUMMARY)
+    if summary:
+        fields[FIELD_SUMMARY] = summary
+    fields.update(
+        _prose_sections(
+            entry,
+            {"Lore": FIELD_LORE_CONTENT, "Mechanics": FIELD_MECHANICS_CONTENT},
+        )
+    )
+    return {"model": "codex.codexentry", "fields": fields}
+
+
+def _build_beginnings_fixture(entry: ContentEntry) -> dict:
+    """Map a beginnings/ entry to a character_creation.Beginnings object (#2688).
+
+    Natural key is (starting_area, name), so ``starting_area`` is required.
+    Body is the ``description`` — these run past 1,000 characters, which is
+    the whole reason this domain moves out of JSON string literals.
+    """
+    name = _require_name_and_body(entry)
+    return {
+        "model": "character_creation.beginnings",
+        "fields": {
+            "name": name,
+            "starting_area": _require_meta_natural_key(entry, "starting_area"),
+            FIELD_DESCRIPTION: entry.body,
+        },
+    }
+
+
+def _build_starting_area_fixture(entry: ContentEntry) -> dict:
+    """Map a starting_areas/ entry to character_creation.StartingArea (#2688).
+
+    ``realm`` and ``default_starting_room`` are both OPTIONAL, matching the
+    model (both are ``null=True``). Neither may be required here:
+
+    - The canonical bootstrap area is created without a realm, so requiring it
+      would make ``export_to_content_repo`` emit a file that this builder then
+      rejects — the round trip must not be able to produce unreadable output.
+    - ``default_starting_room`` is structural bootstrap wiring rather than
+      admin tuning, and ``load_world_content`` deliberately defers it until the
+      grid bundles have loaded. Dropping it would break the fallback-room
+      guarantee, so it round-trips even though it is a FK.
+
+    Genuinely admin-owned placement columns (``sort_order``, ``access_level``,
+    ``minimum_trust``, ``grants_residence_tenancy``, ``is_active``) stay out.
+    """
+    name = _require_name_and_body(entry)
+    fields: dict = {"name": name, FIELD_DESCRIPTION: entry.body}
+    for key in ("realm", "default_starting_room"):
+        value = _optional_meta_natural_key(entry, key)
+        if value is not None:
+            fields[key] = value
+    return {"model": "character_creation.startingarea", "fields": fields}
+
+
+def _build_tradition_fixture(entry: ContentEntry) -> dict:
+    """Map a traditions/ entry to a magic.Tradition fixture object (#2688)."""
+    name = _require_name_and_body(entry)
+    return {
+        "model": "magic.tradition",
+        "fields": {"name": name, FIELD_DESCRIPTION: entry.body},
+    }
+
+
 DOMAIN_BUILDERS = {
     "stats": {
         "builder": partial(_build_trait_fixture, trait_type="stat"),
@@ -395,7 +588,107 @@ DOMAIN_BUILDERS = {
         "builder": _build_decoration_kind_fixture,
         "output": "world/buildings/fixtures/content_decoration_kinds.json",
     },
+    # Prose-bearing domains (#2688). Nested under ``content/`` because build
+    # domains and reference-canon directories share one namespace in the
+    # content repo, and several of these names already exist there as prose
+    # directories — registering them flat would make ``build_all`` try to
+    # parse world-bible documents as entries. ``build_all`` computes
+    # ``content_root / domain``, so a separator in the key resolves through
+    # pathlib with no code change.
+    "content/codex_entries": {
+        "builder": _build_codex_entry_fixture,
+        "output": "world/codex/fixtures/content_codex_entries.json",
+    },
+    "content/beginnings": {
+        "builder": _build_beginnings_fixture,
+        "output": "world/character_creation/fixtures/content_beginnings.json",
+    },
+    "content/starting_areas": {
+        "builder": _build_starting_area_fixture,
+        "output": "world/character_creation/fixtures/content_starting_areas.json",
+    },
+    "content/traditions": {
+        "builder": _build_tradition_fixture,
+        "output": "world/magic/fixtures/content_traditions.json",
+    },
 }
+
+
+#: Models whose content lives as per-entry markdown rather than fixture JSON
+#: (#2688). ``export_to_content_repo`` writes these back as markdown and MUST
+#: NOT emit ``fixtures/<app>/<model>.json`` for them, or the generated JSON
+#: would compete with the markdown source and reintroduce two homes per model.
+#:
+#: ``meta`` lists the ONLY fields written to frontmatter and ``prose`` the only
+#: body sections. Everything absent is admin-owned and is deliberately never
+#: round-tripped — omitting a key already means "leave this column alone" on
+#: load, so a full-field export would silently convert admin-owned tuning
+#: columns (costs, difficulty, display order, publication flags) into
+#: markdown-owned ones across the whole corpus.
+MARKDOWN_EXPORT_DOMAINS: dict[str, dict] = {
+    "codex.codexentry": {
+        "domain": "content/codex_entries",
+        "meta": ["name", FIELD_SUBJECT, FIELD_SUMMARY],
+        "prose": [("Lore", FIELD_LORE_CONTENT), ("Mechanics", FIELD_MECHANICS_CONTENT)],
+        # Nest by the entry's own subject so the tree stays navigable as this
+        # domain grows; ``build_all`` uses rglob, so depth costs nothing.
+        "subdir_from": FIELD_SUBJECT,
+    },
+    "character_creation.beginnings": {
+        "domain": "content/beginnings",
+        "meta": ["name", "starting_area"],
+        "prose": [(None, FIELD_DESCRIPTION)],
+    },
+    "character_creation.startingarea": {
+        "domain": "content/starting_areas",
+        # default_starting_room is bootstrap wiring, not admin tuning — the
+        # fallback-room guarantee depends on it surviving the round trip.
+        "meta": ["name", "realm", "default_starting_room"],
+        "prose": [(None, FIELD_DESCRIPTION)],
+    },
+    "magic.tradition": {
+        "domain": "content/traditions",
+        "meta": ["name"],
+        "prose": [(None, FIELD_DESCRIPTION)],
+    },
+}
+
+
+def content_slug(value: str) -> str:
+    """Filename/directory slug for an exported entry. ASCII, lowercase, hyphens."""
+    text = unicodedata.normalize("NFKD", value).encode("ascii", "ignore").decode()
+    text = re.sub(r"[^\w\s-]", "", text).strip().lower()
+    return re.sub(r"[-\s]+", "-", text) or "entry"
+
+
+def render_entry_markdown(fields: dict, spec: dict) -> str:
+    """Render one record's author-owned fields as frontmatter + markdown body.
+
+    Inverse of the domain's builder. Only ``spec["meta"]`` and ``spec["prose"]``
+    are emitted; every other column stays admin-owned (see
+    ``MARKDOWN_EXPORT_DOMAINS``).
+    """
+    head: list[str] = []
+    for key in spec["meta"]:
+        value = fields.get(key)
+        if value is None or value == "":
+            continue
+        # Collapse a one-element natural key to a plain scalar — nicer to author,
+        # and ``_require_meta_natural_key`` accepts either form back.
+        if isinstance(value, list) and len(value) == 1 and isinstance(value[0], str):
+            value = value[0]
+        head.append(f"{key}: {json.dumps(value, ensure_ascii=False)}")
+
+    body: list[str] = []
+    for heading, prose_field in spec["prose"]:
+        text = (fields.get(prose_field) or "").strip()
+        if not text:
+            continue
+        if heading:
+            body.extend([f"{HEADING_DELIMITER}{heading}", ""])
+        body.extend([text, ""])
+
+    return "---\n" + "\n".join(head) + "\n---\n\n" + "\n".join(body).rstrip() + "\n"
 
 
 def build_fixture_json(content_root: Path, result: BuildResult) -> None:

--- a/src/core_management/tests/test_content_fixtures.py
+++ b/src/core_management/tests/test_content_fixtures.py
@@ -798,3 +798,279 @@ class LoadEntriesM2MTest(TestCase):
         assert (created, updated) == (0, 0)
         assert len(result.skipped) == 1
         assert not Technique.objects.filter(name="M2M Trip").exists()
+
+
+GOOD_CODEX_ENTRY = """---
+name: "Understanding Resonance"
+subject: ["Magic", null, "Resonance"]
+summary: "What resonance is."
+---
+
+## Lore
+
+Resonance is the shape a working takes.
+
+## Mechanics
+
+Each thread carries one resonance.
+"""
+
+
+class MarkdownProseDomainTests(TestCase):
+    """#2688: the four prose domains, and the ``##``-section splitter."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def _codex_fields(self) -> dict:
+        result = build_all(self.root)
+        return result.fixtures["world/codex/fixtures/content_codex_entries.json"][0]["fields"]
+
+    def test_all_four_domains_build(self) -> None:
+        _write(self.root, "content/codex_entries/magic/resonance.md", GOOD_CODEX_ENTRY)
+        _write(
+            self.root,
+            "content/beginnings/caretaker.md",
+            '---\nname: Caretaker\nstarting_area: "The City of Arx"\n---\nYou tend the dead.\n',
+        )
+        _write(
+            self.root,
+            "content/starting_areas/arx.md",
+            '---\nname: "The City of Arx"\nrealm: Arx\n---\nThe central hub.\n',
+        )
+        _write(
+            self.root,
+            "content/traditions/the-vigil.md",
+            "---\nname: The Vigil\n---\nSolemn wardens.\n",
+        )
+        outputs = set(build_all(self.root).fixtures)
+        assert "world/codex/fixtures/content_codex_entries.json" in outputs
+        assert "world/character_creation/fixtures/content_beginnings.json" in outputs
+        assert "world/character_creation/fixtures/content_starting_areas.json" in outputs
+        assert "world/magic/fixtures/content_traditions.json" in outputs
+
+    def test_sections_map_to_prose_fields(self) -> None:
+        _write(self.root, "content/codex_entries/magic/resonance.md", GOOD_CODEX_ENTRY)
+        fields = self._codex_fields()
+        assert fields["lore_content"] == "Resonance is the shape a working takes."
+        assert fields["mechanics_content"] == "Each thread carries one resonance."
+        assert fields["subject"] == ["Magic", None, "Resonance"]
+
+    def test_one_section_is_enough(self) -> None:
+        """CodexEntry.clean() requires only ONE of the two prose fields.
+
+        25 of the 28 authored entries have no mechanics content, so requiring
+        every declared section would reject nearly the whole corpus.
+        """
+        _write(
+            self.root,
+            "content/codex_entries/magic/lore-only.md",
+            "---\nname: Lore Only\n"
+            'subject: ["Magic", null, "Resonance"]\n---\n\n## Lore\n\nJust lore.\n',
+        )
+        fields = self._codex_fields()
+        assert fields["lore_content"] == "Just lore."
+        assert "mechanics_content" not in fields
+
+    def test_unknown_heading_names_file_and_heading(self) -> None:
+        _write(
+            self.root,
+            "content/codex_entries/magic/bad.md",
+            '---\nname: Bad\nsubject: ["Magic", null, "Resonance"]\n---\n\n## Trivia\n\nNope.\n',
+        )
+        with self.assertRaises(ContentError) as ctx:
+            build_all(self.root)
+        message = str(ctx.exception)
+        assert "Trivia" in message
+        assert "bad.md" in message
+
+    def test_text_before_first_heading_is_an_error(self) -> None:
+        """Unassigned prose has nowhere to be written back to, so it must fail."""
+        _write(
+            self.root,
+            "content/codex_entries/magic/stray.md",
+            '---\nname: Stray\nsubject: ["Magic", null, "Resonance"]\n---\n\n'
+            "Orphan line.\n\n## Lore\n\nBody.\n",
+        )
+        with self.assertRaises(ContentError) as ctx:
+            build_all(self.root)
+        assert "before the first" in str(ctx.exception)
+
+    def test_no_sections_at_all_is_an_error(self) -> None:
+        _write(
+            self.root,
+            "content/codex_entries/magic/empty.md",
+            '---\nname: Empty\nsubject: ["Magic", null, "Resonance"]\n---\n',
+        )
+        with self.assertRaises(ContentError):
+            build_all(self.root)
+
+    def test_missing_required_natural_key_field_errors(self) -> None:
+        _write(
+            self.root,
+            "content/beginnings/orphan.md",
+            "---\nname: Orphan\n---\nNo starting area.\n",
+        )
+        with self.assertRaises(ContentError) as ctx:
+            build_all(self.root)
+        assert "starting_area" in str(ctx.exception)
+
+    def test_admin_owned_fields_are_never_emitted(self) -> None:
+        """The core guard: a load must not overwrite values tuned in the admin.
+
+        Omitting a key already means "leave this column alone" on upsert, so
+        emitting these would silently convert admin-owned tuning columns into
+        markdown-owned ones across the whole corpus.
+        """
+        _write(self.root, "content/codex_entries/magic/resonance.md", GOOD_CODEX_ENTRY)
+        fields = self._codex_fields()
+        for admin_owned in (
+            "share_cost",
+            "learn_cost",
+            "learn_difficulty",
+            "learn_threshold",
+            "display_order",
+            "is_public",
+            "is_featured",
+            "featured_order",
+            "prerequisites",
+            "modifier_target",
+            "art",
+        ):
+            assert admin_owned not in fields, f"{admin_owned} must stay admin-owned"
+
+    def test_scalar_and_list_natural_keys_both_accepted(self) -> None:
+        _write(
+            self.root,
+            "content/traditions/a.md",
+            "---\nname: A\n---\nbody\n",
+        )
+        _write(
+            self.root,
+            "content/beginnings/scalar.md",
+            '---\nname: Scalar\nstarting_area: "The City of Arx"\n---\nbody\n',
+        )
+        _write(
+            self.root,
+            "content/beginnings/listy.md",
+            '---\nname: Listy\nstarting_area: ["The City of Arx"]\n---\nbody\n',
+        )
+        built = build_all(self.root).fixtures[
+            "world/character_creation/fixtures/content_beginnings.json"
+        ]
+        for record in built:
+            assert record["fields"]["starting_area"] == ["The City of Arx"]
+
+    def test_existing_single_prose_domains_are_unaffected(self) -> None:
+        """The six pre-existing domains must keep whole-body-to-one-field behaviour."""
+        _write(self.root, "skills/performance.md", GOOD_SKILL)
+        fixtures = build_all(self.root).fixtures
+        skill = fixtures["world/traits/fixtures/content_skills.json"][0]["fields"]
+        assert skill["description"].startswith("PLACEHOLDER Captivating an audience")
+        assert "## " not in skill["description"]
+
+
+class MarkdownExportRoundTripTests(TestCase):
+    """#2688: DB -> markdown -> fixture round trip is lossless and field-scoped."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def test_rendered_markdown_parses_back_to_the_same_fields(self) -> None:
+        from core_management.content_fixtures import (
+            MARKDOWN_EXPORT_DOMAINS,
+            render_entry_markdown,
+        )
+
+        original = {
+            "name": "Understanding Resonance",
+            "subject": ["Magic", None, "Resonance"],
+            "summary": "What resonance is.",
+            "lore_content": "Resonance is the shape a working takes.",
+            "mechanics_content": "Each thread carries one resonance.",
+            # admin-owned; must not survive the render
+            "share_cost": 9,
+            "is_public": True,
+        }
+        spec = MARKDOWN_EXPORT_DOMAINS["codex.codexentry"]
+        rendered = render_entry_markdown(original, spec)
+        assert "share_cost" not in rendered
+        assert "is_public" not in rendered
+
+        _write(self.root, "content/codex_entries/magic/rt.md", rendered)
+        fields = build_all(self.root).fixtures["world/codex/fixtures/content_codex_entries.json"][
+            0
+        ]["fields"]
+        for key in ("name", "subject", "summary", "lore_content", "mechanics_content"):
+            assert fields[key] == original[key], key
+
+    def test_single_prose_domain_round_trips_without_headings(self) -> None:
+        from core_management.content_fixtures import (
+            MARKDOWN_EXPORT_DOMAINS,
+            render_entry_markdown,
+        )
+
+        spec = MARKDOWN_EXPORT_DOMAINS["magic.tradition"]
+        rendered = render_entry_markdown(
+            {"name": "The Vigil", "description": "Solemn wardens of the Tree of Souls."}, spec
+        )
+        assert "## " not in rendered
+        _write(self.root, "content/traditions/vigil.md", rendered)
+        fields = build_all(self.root).fixtures["world/magic/fixtures/content_traditions.json"][0][
+            "fields"
+        ]
+        assert fields["name"] == "The Vigil"
+        assert fields["description"] == "Solemn wardens of the Tree of Souls."
+
+    def test_export_of_a_minimal_row_still_builds(self) -> None:
+        """Export must never emit a file its own builder rejects.
+
+        Regression: ``realm`` was required by the starting_areas builder while
+        being ``null=True`` on the model. The canonical bootstrap area is
+        created without one, so ``export_to_content_repo`` wrote a file that
+        ``build_all`` then refused — breaking the fresh-load path
+        (``test_load_sequencing``). Any optional model field must stay optional
+        in the builder.
+        """
+        from core_management.content_fixtures import (
+            MARKDOWN_EXPORT_DOMAINS,
+            render_entry_markdown,
+        )
+
+        spec = MARKDOWN_EXPORT_DOMAINS["character_creation.startingarea"]
+        rendered = render_entry_markdown(
+            {"name": "Bootstrap City", "description": "The bootstrap starting area."}, spec
+        )
+        assert "realm" not in rendered
+        _write(self.root, "content/starting_areas/bootstrap.md", rendered)
+        fields = build_all(self.root).fixtures[
+            "world/character_creation/fixtures/content_starting_areas.json"
+        ][0]["fields"]
+        assert fields["name"] == "Bootstrap City"
+        assert "realm" not in fields
+
+    def test_default_starting_room_round_trips(self) -> None:
+        """Bootstrap wiring, not admin tuning — the fallback-room guarantee needs it."""
+        from core_management.content_fixtures import (
+            MARKDOWN_EXPORT_DOMAINS,
+            render_entry_markdown,
+        )
+
+        spec = MARKDOWN_EXPORT_DOMAINS["character_creation.startingarea"]
+        rendered = render_entry_markdown(
+            {
+                "name": "Bootstrap City",
+                "description": "Body.",
+                "default_starting_room": ["fallback-room-key"],
+            },
+            spec,
+        )
+        _write(self.root, "content/starting_areas/bootstrap.md", rendered)
+        fields = build_all(self.root).fixtures[
+            "world/character_creation/fixtures/content_starting_areas.json"
+        ][0]["fields"]
+        assert fields["default_starting_room"] == ["fallback-room-key"]


### PR DESCRIPTION
Closes #2688

Four prose domains move from fixture JSON to per-entry markdown, so long-form prose is authored as markdown rather than inside JSON string literals. `Beginnings` descriptions run to a **median of ~1176 characters** — that's the case that motivated this.

| domain key | model | records |
|---|---|---|
| `content/codex_entries` | `codex.CodexEntry` | 28 |
| `content/beginnings` | `character_creation.Beginnings` | 17 |
| `content/traditions` | `magic.Tradition` | 17 |
| `content/starting_areas` | `character_creation.StartingArea` | 6 |

All four already carried `NaturalKeyMixin`, so **no model changes and no migrations**.

## Nested domain keys

Build-domain and reference-canon directory names share one namespace in the content repo, and several of these names already exist there as prose directories — registering them flat would make `build_all` parse world-bible documents as entries and fail every `--check`. `build_all` computes `content_root / domain`, so a separator in the key resolves through `pathlib` with no code change.

## Multi-prose sections

`CodexEntry` is the only model here with two long-form fields: `## Lore` → `lore_content`, `## Mechanics` → `mechanics_content`.

**At least one** declared section is required, not all — `CodexEntry.clean()` needs only one, and 25 of the 28 authored entries carry no mechanics content, so requiring all would have rejected nearly the whole corpus. Unknown headings and text before the first heading are errors, so the round trip cannot silently drop prose.

All six pre-existing domains keep whole-body-to-one-field behaviour, with a regression test asserting it.

## Field-scoped export

`export_to_content_repo` writes these four back **as markdown and emits no JSON for them** (`MARKDOWN_EXPORT_DOMAINS`), so each model keeps exactly one home.

Only author-owned fields are written. Admin-tuned columns (`share_cost`, `learn_*`, `display_order`, `is_public`, `is_featured`, `featured_order`) plus `prerequisites`, `modifier_target` and `art` are never round-tripped — omitting a key already means "leave this column alone" on upsert. A full-field export would silently convert every admin-owned column into a markdown-owned one across the corpus, which is the main hazard the spec called out.

## Round-trip bug this surfaced

**An optional model field must stay optional in its builder.** `StartingArea.realm` is `null=True`, but the builder required it — so exporting the canonical bootstrap area (which has no realm) produced a file `build_all` then rejected, breaking the fresh-load path in `test_load_sequencing`. `default_starting_room` now round-trips as well: it's bootstrap wiring rather than admin tuning, and the fallback-room guarantee depends on it. Both are regression-tested.

## Verification

Against the real 68-entry corpus:

- markdown builds to **byte-equivalent records** — same counts (28/17/6/17), zero field differences versus the JSON it replaces
- load unchanged afterwards: `CodexEntry` 28, `Beginnings` 17, `StartingArea` 6, `Tradition` 17
- a full `load → export` cycle **converges with zero diff**

Tests: `core_management` 210 OK (+8 new), `world.character_creation` 359 OK.

`world.codex` has 8 pre-existing failures on `main` (`breadcrumb_cache` KeyError, test isolation) — verified identical without this branch, so untouched here.

No `MODEL_MAP` regeneration: no model or service-signature changes.

**Content-repo side is already committed** — the 68 markdown entries and the removal of their source JSON. Until this merges, `main` has no builders for those domains and treats `content/` as reference canon, so those four don't load. Everything else is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)