### PR TITLE
NaturalKeyManager.get_by_natural_key bypasses identity-map cache entirely

### DIFF
--- a/docs/adr/0163-case-insensitive-natural-keys-and-opt-in-lookup-tables.md
+++ b/docs/adr/0163-case-insensitive-natural-keys-and-opt-in-lookup-tables.md
@@ -1,0 +1,135 @@
+# Natural-key lookups are case-insensitive; a tuple→pk index removes the repeat query; whole-table warming is opt-in per model
+
+#2687 asks why `get_by_natural_key` — the fixture-load and FK-resolution path every
+`NaturalKeyMixin` model shares — re-queries the database every time a row is
+referenced, even though the row is already sitting in the identity map. A single
+species referenced by a dozen `SpeciesStatBonus`/grant/gift rows during a fixture
+load paid a full lookup query for every reference. The fix adds a process-level
+index and, for a deliberately small set of tables, an opt-in whole-table warm.
+
+## Decision
+
+**Natural-key lookups are case-insensitive everywhere.** Text natural-key
+components (`CharField`/`TextField`) match via `__iexact`; numeric and boolean
+components keep exact matching. There is no case in which two spellings of the
+same natural key should resolve to different rows — a fixture author and an admin
+typing "Fire Bolt" versus "fire bolt" mean the same content.
+
+**The index stores `tuple -> pk`, never `-> instance`.** `_NK_PK_INDEX` is a
+module-level `dict[type, dict[tuple, int]]`, keyed per model via `index_owner()`
+(which resolves to `__dbclass__` so a proxy and its concrete model share one
+index). A hit resolves through `self.get(pk=cached_pk)`, which for a
+`SharedMemoryModel` is a pure identity-map lookup — zero queries — and for the 7
+`NaturalKeyMixin` models that are plain `models.Model` (no identity map) is a
+primary-key `SELECT`, still cheaper than the `iexact` scan it replaces. A dead
+entry (row deleted, or a pk recycled by a rolled-back test transaction) is
+self-healing: `DoesNotExist` on the cached pk drops the entry and falls through to
+a fresh natural-key query.
+
+**Whole-table warming (`NaturalKeyConfig.lookup_table = True`) is opt-in per
+model, not automatic.** A warmed table's `get_by_natural_key` never issues an
+`iexact` query at all — it loads the whole table once via `warm_lookup_table()`
+and answers every subsequent lookup from the index. This is deliberately not the
+default: some natural-key tables are large and must never be bulk-loaded on a
+lookup a caller expected to be cheap. Whether a table is small-and-always-used
+(a catalog like `ConditionTemplate` or `Trait`) versus large-and-growable
+(authored content like `ThreatPool` or `RampartElementProfile`) is a per-model
+judgement the model author states explicitly, not something the framework can
+infer from schema alone. `warm_lookup_table()` refuses (raises
+`NaturalKeyConfigError`) if the natural key contains a `ForeignKey` component,
+because building the index calls `natural_key()` per row, which traverses FK
+descriptors and would cost a query per row — the opposite of the point.
+
+**Case-variant duplicate rows are now a loud content bug, not a silent one.** On
+a lazy (non-lookup-table) model, two rows whose natural keys casefold to the same
+value make `get_by_natural_key` raise `MultipleObjectsReturned` — the same class
+of failure the old case-sensitive `.get()` never saw, because "Fire" and "fire"
+used to resolve independently. This is the case-insensitivity decision above,
+carried through to its logical consequence, not a new defect; it is loud (an
+exception), not silent. On a `lookup_table` model the same collision is caught
+earlier and more precisely: `warm_lookup_table()` raises with both offending pks
+named, at warm time.
+
+**Known limitation: `queryset.update(name=...)` bypasses `save()`.** The index is
+invalidated in `NaturalKeyMixin.save()`, which a bulk `.update()` never calls —
+so a bulk rename leaves a stale index entry pointing the old key at the renamed
+row. This is the same class of hazard the Evennia identity map already has
+(`.update()` does not refresh cached instances either); it is not a new failure
+mode this change introduces.
+
+## Why tuple→pk, not tuple→instance
+
+Caching the resolved instance directly was rejected: the index would then be able
+to retain an instance and grow without bound as the identity map's own contents
+grew, instance freshness would become the index's problem instead of staying the
+identity map's, and a deleted row would need explicit index maintenance instead of
+self-healing on `DoesNotExist`. Storing a pk keeps the index a pure fast-path over
+`self.get(pk=...)`, which is already the identity map's job to make cheap.
+
+## Rejected alternatives
+
+- **Eager indexing in `cache_instance`** — populate the index the moment any
+  instance enters the identity map, rather than lazily on first
+  `get_by_natural_key` lookup. Rejected: `natural_key()` traverses FK descriptors
+  to build its tuple, so eager indexing would fire a query per instance across
+  every one of the ~180 `NaturalKeyMixin` models, including hot game-loop paths
+  that never call `get_by_natural_key` at all. The lazy, on-first-lookup approach
+  pays the cost only where the caller already asked for it.
+- **Dual-keying `__instance_cache__` directly** — store the natural key as a
+  second key into Evennia's own identity-map dict instead of a separate index.
+  Rejected: `cached_all()` and `get_all_cached_instances()` both return
+  `__instance_cache__.values()`, so every row would appear twice in any code that
+  iterates "all cached instances" — a correctness bug, not just a memory cost.
+- **`Upper()` functional unique indexes (for now)** — add a PostgreSQL functional
+  index so a cold `__iexact` lookup can use a btree instead of a sequential scan.
+  Rejected for now: opt-in lookup tables already remove the need for a cold
+  `iexact` query on every table where warming makes sense, so a ~150-model
+  migration is not justified against a cost nobody has measured. **Trigger for
+  revisiting: a measured slow cold lookup on a large lazy (non-lookup-table)
+  model** — not a hypothesis about scale.
+
+## Facts for future readers
+
+- **180** concrete classes declare `NaturalKeyMixin` (181 raw
+  `class X(...NaturalKeyMixin...)` grep hits outside migrations, minus one false
+  positive: `NaturalKeyManager`'s own `models.Manager["NaturalKeyMixin"]` generic
+  parameter matches the same regex). **182** `NaturalKeyConfig` declarations exist
+  (a few models share a `NaturalKeyConfig` inherited from a base). **173** of the
+  180 are concrete, registered models with both `NaturalKeyMixin` and
+  `SharedMemoryModel` in their MRO — enforced by a guard test walking
+  `django.apps.apps.get_models()`.
+- The other **7** declare `NaturalKeyMixin` but have no `SharedMemoryModel`
+  anywhere in their MRO, so they have no identity map: 5 subclasses of
+  `ConditionOrStageEffect` (plain `models.Model`), plus `PathCodexGrant` and
+  `PathGiftGrant` (also plain `models.Model`, each `# noqa: SHARED_MEMORY`). For
+  these, `get(pk=N)` after an index hit is a real query — the index still helps
+  (a primary-key lookup replacing an `iexact` lookup, which on PostgreSQL is a
+  sequential scan) but it is **not** a zero-query win. `NaturalKeyMixin.save()`
+  invalidation still runs correctly for all 7 (the mixin precedes `models.Model`
+  in each of their own base lists).
+- **The MRO invariant is "`NaturalKeyMixin` precedes `SharedMemoryModel`"**, not
+  "is the first base." Two models, `VowSituationalPerkSituation` and
+  `VowSituationalPerkRung`, list `SituationRequirementMixin` first — harmless,
+  because that mixin defines no `save()` of its own, but the invariant was being
+  asserted rather than enforced until this branch's guard test made it real.
+- **The SQLite fast tier is weak evidence for case-insensitivity behaviour.**
+  SQLite's `LIKE` is already ASCII-case-insensitive and text-converts numeric
+  operands, so a behavioural assertion that a wrong-cased value still matches can
+  pass on SQLite even when the underlying lookup is broken — proven by mutation-
+  testing `_text_lookup_key` to return `__iexact` unconditionally and watching
+  `test_integer_component_matches_exactly` still pass. Prefer asserting the
+  lookup-dict/index-key shape directly; treat CI's PostgreSQL parity run as the
+  real gate for case-sensitivity behaviour.
+- **This branch also closes #2679**, which independently proposed a per-manager-
+  instance `_name_cache` for the same symptom on `ThreatPool.objects.get(name=...)`
+  and `RampartElementProfile.objects.get(name=...)`
+  (`world/magic/services/effect_handlers.py:295,585`). #2679's design was
+  unworkable as written (a manager-instance cache is useless across
+  `db_manager()`'s manager-copy behaviour on the loaddata path, and it cached
+  instances rather than pks — the same problem rejected above). Both call sites
+  were converted to `get_by_natural_key`, which now covers them for free; #2679
+  was closed as superseded rather than implemented separately.
+
+> Status: accepted · Source: issue #2687 (case-insensitive natural-key resolution
+> + opt-in lookup tables) · relates to ADR-0008 (SharedMemoryModel); supersedes
+> nothing.

--- a/docs/evennia-quirks.md
+++ b/docs/evennia-quirks.md
@@ -88,6 +88,49 @@ against alphabetical load order, `load_world_content`'s retry step is a **fixpoi
 loop** (`_retry_deferred`) — repeated deferral-on passes until one resolves nothing
 new — not the single one-shot retry pass described above for the content/grid case.
 
+### Natural-key lookup index and case-insensitivity (#2687, ADR-0163)
+
+`get_by_natural_key` is backed by a process-level `tuple -> pk` index
+(`core.natural_keys._NK_PK_INDEX`), invisible to callers — no code needs to know
+it exists. The first lookup for a given key queries; every later lookup for that
+same key resolves through the index plus the identity map (zero queries for a
+`SharedMemoryModel`; a pk `SELECT` for the 7 `NaturalKeyMixin` models that aren't
+one). This matters most for fixture loads and FK-heavy natural keys: a species
+referenced by a dozen stat-bonus/grant rows used to pay a full lookup query per
+reference and now pays one.
+
+**Natural-key text matching is case-insensitive** — `name="Fire Bolt"` and
+`name="fire bolt"` resolve to the same row via `__iexact` (numeric/boolean
+components still match exactly). A pair of rows whose natural keys differ only by
+case is a content bug, not a supported state: on a lazy model it now surfaces
+loudly as `MultipleObjectsReturned` from `get_by_natural_key`; on a model that
+opts into `lookup_table = True` (below), `warm_lookup_table()` catches it earlier
+and more precisely, naming both offending pks, at warm time.
+
+**`NaturalKeyConfig.lookup_table = True` opts a model into whole-table warming**
+— the first lookup loads and indexes the entire table, and every later lookup
+for that model never issues an `iexact` query at all. Opt-in, not automatic,
+because some natural-key tables are large and must never be bulk-loaded on what
+a caller expects to be a cheap single-row lookup; whether a table qualifies is a
+per-model judgement about its size and access pattern (a small always-used
+catalog like `ConditionTemplate` or `Trait`, versus growable authored content
+like `ThreatPool`). The natural key must also be FK-free to opt in — warming
+calls `natural_key()` per row, which would cost a query per row if any
+component were a ForeignKey.
+
+**Gap:** `queryset.update(name=...)` bypasses `save()`, so it leaves a stale
+index entry pointing the old key at the renamed row — the invalidation lives in
+`NaturalKeyMixin.save()`, which a bulk `.update()` never calls. This is the same
+class of hazard the identity map already has (`.update()` doesn't refresh cached
+instances either); use `save()` on individual instances, not a bulk `.update()`,
+when renaming a natural-key field.
+
+**Testing note:** SQLite's `LIKE` is already ASCII-case-insensitive and
+text-converts numeric operands, so a behavioural case-insensitivity assertion
+can pass on the fast SQLite tier even when the underlying `__iexact` wiring is
+broken — CI's PostgreSQL parity run is the real gate for this behaviour. See
+`docs/adr/0163-case-insensitive-natural-keys-and-opt-in-lookup-tables.md`.
+
 ### Migration-number collisions on sync-with-main
 
 When `sync-with-main.sh` conflicts on `migrations/max_migration.txt` for an app, both branches added an independent field-add migration at the same sequence number. Resolve by keeping HEAD's stable and renumbering main's:

--- a/docs/systems/traits.md
+++ b/docs/systems/traits.md
@@ -67,10 +67,12 @@ from world.traits.models import Trait
 
 # Case-insensitive cached lookup (returns Trait or None)
 trait = Trait.get_by_name("strength")
-
-# Clear name cache when traits are modified (auto-called on save)
-Trait.clear_name_cache()
 ```
+
+`get_by_name` delegates to the generic natural-key index (`core/natural_keys.py`,
+#2687): `Trait.NaturalKeyConfig.lookup_table = True` loads the whole table once and
+serves every subsequent lookup from memory. The index is kept fresh automatically
+by `NaturalKeyMixin.save()` — there is no manual cache to clear.
 
 ### PointConversionRange (trait value to points)
 

--- a/src/core/natural_keys.py
+++ b/src/core/natural_keys.py
@@ -317,6 +317,30 @@ class NaturalKeyMixin:
     key by specifying the field name (the mixin will call natural_key() on it).
     """
 
+    #: The index key this instance was last cached under, if any (#2687).
+    #: Set by ``NaturalKeyManager.get_by_natural_key``; consumed by ``save()``.
+    _nk_index_key: tuple | None = None
+
+    def save(self, *args: Any, **kwargs: Any) -> None:
+        """Save, then drop this instance's stale natural-key index entry.
+
+        After a rename the old key still points at a live pk, so without this the
+        index would return the renamed row instead of raising ``DoesNotExist``.
+        The stashed key is popped unconditionally rather than compared against a
+        recomputed ``natural_key()`` — recomputation traverses FK descriptors and
+        could fire a query on the save path. The cost of dropping an entry that
+        did not actually change is one ``SELECT`` on the next lookup.
+
+        Known limitation: ``queryset.update(name=...)`` bypasses ``save()`` and
+        leaves a stale entry. This is the same class of hazard the identity map
+        already has — ``.update()`` does not refresh cached instances either.
+        """
+        super().save(*args, **kwargs)
+        key = self._nk_index_key
+        if key is not None:
+            natural_key_index(type(self)).pop(key, None)
+            self._nk_index_key = None
+
     def natural_key(self) -> tuple[Any, ...]:
         """Return natural key tuple for this object.
 

--- a/src/core/natural_keys.py
+++ b/src/core/natural_keys.py
@@ -210,13 +210,30 @@ class NaturalKeyManager(ArxSharedMemoryManager, models.Manager["NaturalKeyMixin"
             if isinstance(field, ForeignKey):
                 _resolve_fk_arg(self.model, field, field_name, args_list, lookup)
             else:
-                lookup[field_name] = args_list.pop(0)
+                value = args_list.pop(0)
+                lookup[_text_lookup_key(field, field_name, value)] = value
 
         if args_list:
             msg = f"Too many natural key values for {self.model.__name__}: {len(args)} given"
             raise NaturalKeyConfigError(msg)
 
         return lookup
+
+
+def _text_lookup_key(field: Any, field_name: str, value: Any) -> str:
+    """Return the queryset lookup key for a non-FK natural-key component.
+
+    Natural-key lookups are case-insensitive (#2687), so text components match
+    with ``__iexact``. Numeric and boolean components keep exact matching — a
+    natural key is a mix of text (``name``, ``stat_key``), integers
+    (``min_roll``, ``rank_difference``) and FKs.
+
+    Note: ``"<field>__iexact"`` does not collide with Evennia's
+    ``SharedMemoryManager.get()``, which strips a trailing ``"__exact"`` only.
+    """
+    if isinstance(value, str) and isinstance(field, (models.CharField, models.TextField)):
+        return f"{field_name}__iexact"
+    return field_name
 
 
 def _resolve_fk_arg(

--- a/src/core/natural_keys.py
+++ b/src/core/natural_keys.py
@@ -137,14 +137,19 @@ def is_lookup_table(model: type) -> bool:
     """Whether *model* declares ``NaturalKeyConfig.lookup_table = True``.
 
     Lookup-table status is a per-model judgement about that table's size and
-    access pattern — a small set used everywhere (``Trait``,
-    ``ConditionTemplate``) versus a table that must never be bulk-loaded. It is
-    opt-in and deliberately NOT the default (#2687).
+    access pattern — a small set used everywhere versus a table that must never
+    be bulk-loaded. Opt-in, deliberately NOT the default (#2687).
+
+    ``lookup_table`` is expected to be a plain class attribute. Each access is
+    guarded separately so a missing attribute reads as False without also
+    swallowing an error raised from inside a descriptor.
     """
-    # try/except rather than getattr(): matches the index_owner() precedent
-    # above and the noqa-avoidance precedent in core/mixins.py.
     try:
-        return bool(model.NaturalKeyConfig.lookup_table)
+        config = model.NaturalKeyConfig
+    except AttributeError:
+        return False
+    try:
+        return bool(config.lookup_table)
     except AttributeError:
         return False
 

--- a/src/core/natural_keys.py
+++ b/src/core/natural_keys.py
@@ -133,6 +133,22 @@ def flush_natural_key_indexes() -> None:
     _NK_WARMED.clear()
 
 
+def is_lookup_table(model: type) -> bool:
+    """Whether *model* declares ``NaturalKeyConfig.lookup_table = True``.
+
+    Lookup-table status is a per-model judgement about that table's size and
+    access pattern — a small set used everywhere (``Trait``,
+    ``ConditionTemplate``) versus a table that must never be bulk-loaded. It is
+    opt-in and deliberately NOT the default (#2687).
+    """
+    # try/except rather than getattr(): matches the index_owner() precedent
+    # above and the noqa-avoidance precedent in core/mixins.py.
+    try:
+        return bool(model.NaturalKeyConfig.lookup_table)
+    except AttributeError:
+        return False
+
+
 class NaturalKeyConfigError(ValueError):
     """Raised when NaturalKeyConfig is missing or invalid."""
 
@@ -172,6 +188,9 @@ class NaturalKeyManager(ArxSharedMemoryManager, models.Manager["NaturalKeyMixin"
 
         key = _index_key(args)
         index = natural_key_index(self.model)
+
+        if is_lookup_table(self.model):
+            return self._get_from_lookup_table(key)
 
         cached_pk = index.get(key)
         if cached_pk is not None:
@@ -218,6 +237,79 @@ class NaturalKeyManager(ArxSharedMemoryManager, models.Manager["NaturalKeyMixin"
             raise NaturalKeyConfigError(msg)
 
         return lookup
+
+    def warm_lookup_table(self) -> None:
+        """Load the whole table once and index every row by natural key.
+
+        Only legal for FK-free natural keys: building the index calls
+        ``natural_key()`` per row, which traverses FK descriptors and would cost
+        a query per row on an FK-bearing key.
+
+        Deliberately does its own ``self.all()`` pass rather than reusing
+        ``cached_all()``: ``cached_all()`` returns ``__instance_cache__.values()``,
+        so it goes empty if the identity map is flushed while its ``_all_loaded``
+        flag survives. Storing pks keeps this index valid across an identity-map
+        flush. The pass still primes the identity map as a side effect.
+
+        Raises ``NaturalKeyConfigError`` if two rows casefold to the same key —
+        a case-variant duplicate is a content bug, and this is where it surfaces.
+        """
+        owner = index_owner(self.model)
+        if owner in _NK_WARMED:
+            return
+
+        self._assert_natural_key_is_fk_free()
+
+        index = natural_key_index(self.model)
+        for instance in self.all():
+            key = _index_key(instance.natural_key())
+            existing = index.get(key)
+            if existing is not None and existing != instance.pk:
+                msg = (
+                    f"{self.model.__name__} has two rows whose natural keys differ only "
+                    f"by case: {key!r} matches pk {existing} and pk {instance.pk}. "
+                    "Natural keys are case-insensitive — rename or merge one row."
+                )
+                raise NaturalKeyConfigError(msg)
+            index[key] = instance.pk
+            if isinstance(instance, NaturalKeyMixin):
+                instance._nk_index_key = key  # noqa: SLF001
+        _NK_WARMED.add(owner)
+
+    def _assert_natural_key_is_fk_free(self) -> None:
+        """Raise if this model's natural key contains a ForeignKey component."""
+        for field_name in self.model.NaturalKeyConfig.fields:
+            field = self.model._meta.get_field(field_name)  # noqa: SLF001
+            if isinstance(field, ForeignKey):
+                msg = (
+                    f"{self.model.__name__} cannot be a lookup_table: its natural key "
+                    f"field {field_name!r} is a ForeignKey. Warming would traverse FK "
+                    "descriptors and cost a query per row."
+                )
+                raise NaturalKeyConfigError(msg)
+
+    def _get_from_lookup_table(self, key: tuple) -> NaturalKeyMixin:
+        """Resolve *key* purely from the warmed index — never issues an iexact.
+
+        A dead pk (poisoned entry, or a row deleted since the warm) invalidates
+        the warm and re-warms exactly once, which is one extra query and cannot
+        recurse.
+        """
+        self.warm_lookup_table()
+        index = natural_key_index(self.model)
+        pk = index.get(key)
+        if pk is not None:
+            try:
+                return self.get(pk=pk)
+            except self.model.DoesNotExist:
+                _NK_WARMED.discard(index_owner(self.model))
+                index.clear()
+                self.warm_lookup_table()
+                pk = index.get(key)
+                if pk is not None:
+                    return self.get(pk=pk)
+        msg = f"{self.model.__name__} matching natural key {key!r} does not exist."
+        raise self.model.DoesNotExist(msg)
 
 
 def _text_lookup_key(field: Any, field_name: str, value: Any) -> str:
@@ -336,10 +428,19 @@ class NaturalKeyMixin:
         already has — ``.update()`` does not refresh cached instances either.
         """
         super().save(*args, **kwargs)
-        key = self._nk_index_key
-        if key is not None:
-            natural_key_index(type(self)).pop(key, None)
+        model = type(self)
+        index = natural_key_index(model)
+        old_key = self._nk_index_key
+        if old_key is not None:
+            index.pop(old_key, None)
             self._nk_index_key = None
+        if is_lookup_table(model) and index_owner(model) in _NK_WARMED:
+            # Keep a warmed table complete: newly created and renamed rows must
+            # be findable without a re-warm. FK-free by construction, so this is
+            # pure attribute reads — no query.
+            new_key = _index_key(self.natural_key())
+            index[new_key] = self.pk
+            self._nk_index_key = new_key
 
     def natural_key(self) -> tuple[Any, ...]:
         """Return natural key tuple for this object.

--- a/src/core/natural_keys.py
+++ b/src/core/natural_keys.py
@@ -53,7 +53,7 @@ from django.db.models.fields.related import ForeignKey
 from core.managers import ArxSharedMemoryManager
 
 if TYPE_CHECKING:
-    from collections.abc import Sequence
+    from collections.abc import Iterable, Sequence
 
 
 #: Per-model natural-key index: casefolded natural-key tuple -> pk.
@@ -80,8 +80,12 @@ def index_owner(model: type) -> type:
     mirror that here. Models using ``NaturalKeyManager`` without being a
     ``SharedMemoryModel`` have no ``__dbclass__`` and own their index directly.
     """
-    # Suppression justified: duck-typed check for Evennia's idmapper attribute.
-    return getattr(model, "__dbclass__", model)  # noqa: GETATTR_LITERAL
+    # try/except rather than getattr(): duck-typing an attribute this way needs
+    # no GETATTR_LITERAL suppression, matching the precedent in core/mixins.py.
+    try:
+        return model.__dbclass__
+    except AttributeError:
+        return model
 
 
 def natural_key_index(model: type) -> dict[tuple, int]:
@@ -89,7 +93,7 @@ def natural_key_index(model: type) -> dict[tuple, int]:
     return _NK_PK_INDEX.setdefault(index_owner(model), {})
 
 
-def _index_key(values: Any) -> tuple[Any, ...]:
+def _index_key(values: Iterable[Any]) -> tuple[Any, ...]:
     """Normalize a natural-key value sequence into a hashable, caseless key.
 
     Two normalizations, both required:

--- a/src/core/natural_keys.py
+++ b/src/core/natural_keys.py
@@ -36,6 +36,27 @@ Usage:
     #   -> looks up Category by natural_key("electronics") first
     #   -> then looks up Item with name="widget", category=<Category instance>
 
+    # Text (CharField/TextField) components match case-insensitively
+    # (__iexact); numeric and boolean components match exactly. Two rows whose
+    # natural keys differ only by case are a content bug: on a lazy model this
+    # surfaces as MultipleObjectsReturned from get_by_natural_key(), and on a
+    # lookup_table model warm_lookup_table() catches it earlier, at warm time.
+
+    # A repeat get_by_natural_key() call for the same key is free (#2687): the
+    # first call queries and then caches key -> pk in a process-level index,
+    # and every later call resolves through that index plus the identity map
+    # (SharedMemoryModel) or a pk lookup (non-SharedMemoryModel) instead of
+    # re-running the natural-key query.
+
+    # class NaturalKeyConfig:
+    #     fields = [...]
+    #     lookup_table = True  # opt in only for a small, always-used table
+    # A lookup_table model's whole table is warmed into the index on first
+    # lookup and never issues an `iexact` query again. Opt-in, not automatic:
+    # some natural-key tables are large and must never be bulk-loaded. The
+    # natural key must also be FK-free — warming calls natural_key() per row,
+    # which would cost a query per row if any component were a ForeignKey.
+
 Self-referential FKs (ForeignKey("self")) are handled specially:
     # Instead of flattening (which would require infinite args for variable
     # tree depth), self-referential FK values are nested as a single arg:
@@ -195,6 +216,7 @@ class NaturalKeyManager(ArxSharedMemoryManager, models.Manager["NaturalKeyMixin"
         index = natural_key_index(self.model)
 
         if is_lookup_table(self.model):
+            self._assert_lookup_table_arg_count(args)
             return self._get_from_lookup_table(key)
 
         cached_pk = index.get(key)
@@ -280,6 +302,24 @@ class NaturalKeyManager(ArxSharedMemoryManager, models.Manager["NaturalKeyMixin"
             if isinstance(instance, NaturalKeyMixin):
                 instance._nk_index_key = key  # noqa: SLF001
         _NK_WARMED.add(owner)
+
+    def _assert_lookup_table_arg_count(self, args: tuple[Any, ...]) -> None:
+        """Validate arg count against ``NaturalKeyConfig.fields`` for a lookup_table.
+
+        A lookup_table's natural key is FK-free by construction (enforced by
+        ``_assert_natural_key_is_fk_free``), so the expected arg count is exactly
+        ``len(fields)`` — no FK expansion to account for. ``_get_from_lookup_table``
+        itself only does a dict lookup and can't tell "wrong arg count" apart from
+        "no matching row", so without this check a caller mistake surfaces as a
+        misleading ``DoesNotExist`` instead of a loud ``NaturalKeyConfigError``.
+        """
+        fields = self.model.NaturalKeyConfig.fields
+        if len(args) < len(fields):
+            msg = f"Not enough natural key values provided for {self.model.__name__}"
+            raise NaturalKeyConfigError(msg)
+        if len(args) > len(fields):
+            msg = f"Too many natural key values for {self.model.__name__}: {len(args)} given"
+            raise NaturalKeyConfigError(msg)
 
     def _assert_natural_key_is_fk_free(self) -> None:
         """Raise if this model's natural key contains a ForeignKey component."""

--- a/src/core/natural_keys.py
+++ b/src/core/natural_keys.py
@@ -56,6 +56,79 @@ if TYPE_CHECKING:
     from collections.abc import Sequence
 
 
+#: Per-model natural-key index: casefolded natural-key tuple -> pk.
+#:
+#: Keyed by the model's ``__dbclass__`` (Evennia stores the identity map there so
+#: proxies share one cache), so a proxy and its concrete model share an index.
+#: A module-level registry rather than a class attribute, so an index can never be
+#: silently inherited by a sibling model.
+#:
+#: Stores pks rather than instances deliberately (#2687): the index can then never
+#: retain an instance or grow beyond what the identity map already holds, instance
+#: freshness stays the identity map's concern, and a deleted row self-heals because
+#: ``get(pk=N)`` raises ``DoesNotExist``.
+_NK_PK_INDEX: dict[type, dict[tuple, int]] = {}
+
+#: Models whose whole table has been warmed (``NaturalKeyConfig.lookup_table``).
+_NK_WARMED: set[type] = set()
+
+
+def index_owner(model: type) -> type:
+    """Return the class that owns *model*'s natural-key index.
+
+    ``SharedMemoryModel`` subclasses share one identity map per ``__dbclass__``;
+    mirror that here. Models using ``NaturalKeyManager`` without being a
+    ``SharedMemoryModel`` have no ``__dbclass__`` and own their index directly.
+    """
+    # Suppression justified: duck-typed check for Evennia's idmapper attribute.
+    return getattr(model, "__dbclass__", model)  # noqa: GETATTR_LITERAL
+
+
+def natural_key_index(model: type) -> dict[tuple, int]:
+    """Return (creating if needed) the natural-key -> pk index for *model*."""
+    return _NK_PK_INDEX.setdefault(index_owner(model), {})
+
+
+def _index_key(values: Any) -> tuple[Any, ...]:
+    """Normalize a natural-key value sequence into a hashable, caseless key.
+
+    Two normalizations, both required:
+
+    * nested lists -> tuples. Self-referential FK natural keys nest their value
+      as a list (``("Wolf", ["Mammals", ["Creatures", None]])``), and lists are
+      unhashable.
+    * ``str`` -> ``str.casefold()``. Natural-key lookups are case-insensitive
+      (#2687): there is no case in which a natural key should match
+      case-sensitively. ``casefold()`` rather than ``lower()`` — it is the
+      correct operation for caseless matching.
+
+    Every key entering or querying the index goes through this one function, so
+    the stored and queried spellings can never diverge.
+    """
+    normalized: list[Any] = []
+    for value in values:
+        if isinstance(value, str):
+            normalized.append(value.casefold())
+        elif isinstance(value, (list, tuple)):
+            normalized.append(_index_key(value))
+        else:
+            normalized.append(value)
+    return tuple(normalized)
+
+
+def flush_natural_key_indexes() -> None:
+    """Clear every natural-key index and warm flag.
+
+    Called between tests (see ``core.testing``). Tests roll the database back but
+    leave this process-level index intact, so a pk recycled across a rollback
+    would otherwise resolve to the wrong row — and the ``DoesNotExist`` self-heal
+    does NOT catch that, because the pk is live, just wrong.
+    """
+    for index in _NK_PK_INDEX.values():
+        index.clear()
+    _NK_WARMED.clear()
+
+
 class NaturalKeyConfigError(ValueError):
     """Raised when NaturalKeyConfig is missing or invalid."""
 

--- a/src/core/natural_keys.py
+++ b/src/core/natural_keys.py
@@ -160,15 +160,44 @@ class NaturalKeyManager(ArxSharedMemoryManager, models.Manager["NaturalKeyMixin"
 
         Self-referential FKs consume a single arg that is either None (null FK)
         or a nested list to be recursively resolved.
+
+        Repeat lookups are served from a process-level natural-key -> pk index
+        and resolve through SharedMemoryModel's identity map (zero queries).
+        The index check happens BEFORE the arg->lookup resolution, so a hit on a
+        composite key also skips the recursive FK lookups it would otherwise do.
         """
         if not hasattr(self.model, "NaturalKeyConfig"):
             msg = f"{self.model.__name__} missing NaturalKeyConfig"
             raise NaturalKeyConfigError(msg)
 
+        key = _index_key(args)
+        index = natural_key_index(self.model)
+
+        cached_pk = index.get(key)
+        if cached_pk is not None:
+            try:
+                return self.get(pk=cached_pk)
+            except self.model.DoesNotExist:
+                # Poisoned entry (row deleted, or a pk recycled). Drop it and
+                # fall through to a fresh natural-key query.
+                index.pop(key, None)
+
+        instance = self.get(**self._natural_key_lookup(args))
+        if isinstance(instance, NaturalKeyMixin):
+            index[key] = instance.pk
+            instance._nk_index_key = key  # noqa: SLF001
+        return instance
+
+    def _natural_key_lookup(self, args: tuple[Any, ...]) -> dict[str, Any]:
+        """Build the field->value lookup dict for a natural-key arg tuple.
+
+        Extracted from ``get_by_natural_key`` so the index fast path can skip it
+        entirely — on a composite key this also skips the recursive
+        ``get_by_natural_key`` calls that resolve each FK component.
+        """
         config = self.model.NaturalKeyConfig
         fields: Sequence[str] = config.fields
 
-        # Build lookup dict, handling FKs by consuming multiple args if needed
         lookup: dict[str, Any] = {}
         args_list = list(args)
 
@@ -187,7 +216,7 @@ class NaturalKeyManager(ArxSharedMemoryManager, models.Manager["NaturalKeyMixin"
             msg = f"Too many natural key values for {self.model.__name__}: {len(args)} given"
             raise NaturalKeyConfigError(msg)
 
-        return self.get(**lookup)
+        return lookup
 
 
 def _resolve_fk_arg(

--- a/src/core/testing.py
+++ b/src/core/testing.py
@@ -139,3 +139,18 @@ def _flush_arx_manager_caches() -> None:
 
 
 register_test_cache_flusher(_flush_arx_manager_caches)
+
+
+def _flush_natural_key_indexes() -> None:
+    """Clear the natural-key -> pk indexes and lookup-table warm flags (#2687).
+
+    Replaces the per-model registrations previously made by
+    ``world.conditions.apps`` and ``world.traits.apps`` for their bespoke name
+    caches, both of which this index subsumes.
+    """
+    from core.natural_keys import flush_natural_key_indexes  # noqa: PLC0415
+
+    flush_natural_key_indexes()
+
+
+register_test_cache_flusher(_flush_natural_key_indexes)

--- a/src/core/tests/test_natural_key_index.py
+++ b/src/core/tests/test_natural_key_index.py
@@ -1,0 +1,49 @@
+"""Tests for the natural-key → pk index in core.natural_keys (#2687)."""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from core.natural_keys import (
+    _index_key,
+    flush_natural_key_indexes,
+    index_owner,
+    natural_key_index,
+)
+from world.species.models import Species
+
+
+class IndexKeyNormalizationTests(TestCase):
+    """_index_key() makes keys hashable and caseless."""
+
+    def test_casefolds_string_components(self) -> None:
+        assert _index_key(("Fire Bolt",)) == ("fire bolt",)
+        assert _index_key(("FIRE BOLT",)) == ("fire bolt",)
+
+    def test_leaves_non_string_components_alone(self) -> None:
+        assert _index_key(("Rank", 30, None)) == ("rank", 30, None)
+
+    def test_converts_nested_lists_to_tuples(self) -> None:
+        # Self-referential FK natural keys arrive as nested lists.
+        assert _index_key(("Mammals", ["Creatures", None])) == (
+            "mammals",
+            ("creatures", None),
+        )
+
+    def test_result_is_hashable(self) -> None:
+        {_index_key(("Mammals", ["Creatures", None]))}  # must not raise
+
+
+class IndexRegistryTests(TestCase):
+    """The registry is per-model and flushable."""
+
+    def test_index_is_per_model_and_empty_by_default(self) -> None:
+        assert natural_key_index(Species) == {}
+
+    def test_index_owner_is_the_shared_dbclass(self) -> None:
+        assert index_owner(Species) is Species.__dbclass__
+
+    def test_flush_clears_entries(self) -> None:
+        natural_key_index(Species)[("marker",)] = 999
+        flush_natural_key_indexes()
+        assert natural_key_index(Species) == {}

--- a/src/core/tests/test_natural_key_index.py
+++ b/src/core/tests/test_natural_key_index.py
@@ -113,3 +113,27 @@ class IndexIsolationTests(TestCase):
 
     def test_b_starts_clean(self) -> None:
         assert ("isolation marker species",) not in natural_key_index(Species)
+
+
+class CaseInsensitiveLookupTests(TestCase):
+    """Natural-key text components match regardless of case (#2687)."""
+
+    def test_differently_cased_lookup_finds_the_row(self) -> None:
+        species = SpeciesFactory(name="Fire Elf")
+        assert Species.objects.get_by_natural_key("fire elf") == species
+        assert Species.objects.get_by_natural_key("FIRE ELF") == species
+
+    def test_case_variants_share_one_index_entry(self) -> None:
+        SpeciesFactory(name="Shared Entry Elf")
+        Species.objects.get_by_natural_key("SHARED ENTRY ELF")
+        with self.assertNumQueries(0):
+            Species.objects.get_by_natural_key("shared entry elf")
+        assert list(natural_key_index(Species)) == [("shared entry elf",)]
+
+    def test_numeric_component_still_matches_exactly(self) -> None:
+        """__iexact applies only to text fields — an int component must not be
+        coerced into a string comparison."""
+        species = SpeciesFactory(name="Numeric Elf")
+        bonus = SpeciesStatBonus.objects.create(species=species, stat="strength", value=2)
+        found = SpeciesStatBonus.objects.get_by_natural_key("NUMERIC ELF", "STRENGTH")
+        assert found == bonus

--- a/src/core/tests/test_natural_key_index.py
+++ b/src/core/tests/test_natural_key_index.py
@@ -271,28 +271,32 @@ class LookupTableTests(TestCase):
 
 
 class MroInvariantTests(TestCase):
-    """Every NaturalKeyMixin model must reach NaturalKeyMixin.save() first."""
+    """Every NaturalKeyMixin model must reach NaturalKeyMixin.save() first.
+
+    Uses Django's app registry rather than __subclasses__(): the registry is
+    complete by construction, whereas __subclasses__() only sees classes Python
+    has already imported, so a model could silently escape this check purely
+    because no test in the run happened to import it.
+    """
 
     def test_mixin_precedes_sharedmemorymodel_in_every_model_mro(self) -> None:
+        from django.apps import apps
         from evennia.utils.idmapper.models import SharedMemoryModel
 
         from core.natural_keys import NaturalKeyMixin
 
+        checked = 0
         offenders = []
-        stack = [NaturalKeyMixin]
-        seen = set()
-        while stack:
-            cls = stack.pop()
-            if cls in seen:
-                continue
-            seen.add(cls)
-            stack.extend(cls.__subclasses__())
-            mro = cls.__mro__
+        for model in apps.get_models():
+            mro = model.__mro__
             if NaturalKeyMixin not in mro or SharedMemoryModel not in mro:
                 continue
+            checked += 1
             if mro.index(NaturalKeyMixin) > mro.index(SharedMemoryModel):
-                offenders.append(cls.__name__)
+                offenders.append(model.__name__)
         assert not offenders, (
             "NaturalKeyMixin must precede SharedMemoryModel in the MRO or its "
             f"save() invalidation never runs. Offenders: {offenders}"
         )
+        # Guard against the guard silently checking nothing.
+        assert checked > 150, f"expected ~181 NaturalKeyMixin models, checked {checked}"

--- a/src/core/tests/test_natural_key_index.py
+++ b/src/core/tests/test_natural_key_index.py
@@ -13,6 +13,8 @@ from core.natural_keys import (
 )
 from world.species.factories import SpeciesFactory
 from world.species.models import Species, SpeciesStatBonus
+from world.traits.factories import TraitFactory
+from world.traits.models import TraitRankDescription
 
 
 class IndexKeyNormalizationTests(TestCase):
@@ -130,10 +132,35 @@ class CaseInsensitiveLookupTests(TestCase):
             Species.objects.get_by_natural_key("shared entry elf")
         assert list(natural_key_index(Species)) == [("shared entry elf",)]
 
-    def test_numeric_component_still_matches_exactly(self) -> None:
-        """__iexact applies only to text fields — an int component must not be
-        coerced into a string comparison."""
+    def test_fk_and_text_components_combine_case_insensitively(self) -> None:
+        """A composite key with an FK (species -> name) plus a plain CharField
+        (stat) both match case-insensitively."""
         species = SpeciesFactory(name="Numeric Elf")
         bonus = SpeciesStatBonus.objects.create(species=species, stat="strength", value=2)
         found = SpeciesStatBonus.objects.get_by_natural_key("NUMERIC ELF", "STRENGTH")
         assert found == bonus
+
+    def test_integer_component_matches_exactly(self) -> None:
+        """__iexact applies only to text fields. The FK's name component matches
+        case-insensitively; the integer component must still match exactly and
+        must never be turned into a text comparison."""
+        trait = TraitFactory(name="Rank Trait")
+        description = TraitRankDescription.objects.create(
+            trait=trait, value=30, label="Good", description="Above average"
+        )
+        assert TraitRankDescription.objects.get_by_natural_key("RANK TRAIT", 30) == description
+        with self.assertRaises(TraitRankDescription.DoesNotExist):
+            TraitRankDescription.objects.get_by_natural_key("Rank Trait", 31)
+
+    def test_integer_component_gets_no_iexact_suffix(self) -> None:
+        """Directly pins the branch: the lookup dict must key the integer field
+        plainly, never as '<field>__iexact'."""
+        TraitRankDescription.objects.create(
+            trait=TraitFactory(name="Suffix Trait"),
+            value=40,
+            label="Great",
+            description="x",
+        )
+        lookup = TraitRankDescription.objects._natural_key_lookup(("Suffix Trait", 40))
+        assert "value" in lookup
+        assert "value__iexact" not in lookup

--- a/src/core/tests/test_natural_key_index.py
+++ b/src/core/tests/test_natural_key_index.py
@@ -164,3 +164,22 @@ class CaseInsensitiveLookupTests(TestCase):
         lookup = TraitRankDescription.objects._natural_key_lookup(("Suffix Trait", 40))
         assert "value" in lookup
         assert "value__iexact" not in lookup
+
+
+class RenameInvalidationTests(TestCase):
+    """A renamed row stops resolving under its old natural key."""
+
+    def test_old_key_no_longer_resolves_after_rename(self) -> None:
+        species = SpeciesFactory(name="Old Elf Name")
+        Species.objects.get_by_natural_key("Old Elf Name")
+        species.name = "New Elf Name"
+        species.save()
+        with self.assertRaises(Species.DoesNotExist):
+            Species.objects.get_by_natural_key("Old Elf Name")
+        assert Species.objects.get_by_natural_key("New Elf Name") == species
+
+    def test_save_without_a_prior_lookup_is_harmless(self) -> None:
+        species = SpeciesFactory(name="Never Looked Up")
+        species.description = "changed"
+        species.save()
+        assert Species.objects.get_by_natural_key("Never Looked Up") == species

--- a/src/core/tests/test_natural_key_index.py
+++ b/src/core/tests/test_natural_key_index.py
@@ -299,4 +299,23 @@ class MroInvariantTests(TestCase):
             f"save() invalidation never runs. Offenders: {offenders}"
         )
         # Guard against the guard silently checking nothing.
-        assert checked > 150, f"expected ~181 NaturalKeyMixin models, checked {checked}"
+        assert checked > 150, (
+            f"expected ~173 NaturalKeyMixin+SharedMemoryModel models, checked {checked}"
+        )
+
+
+class FixtureLoadJourneyTests(TestCase):
+    """The journey #2687 is actually about: many FK references to one row."""
+
+    def test_repeated_fk_resolution_queries_the_row_once(self) -> None:
+        species = SpeciesFactory(name="Referenced Elf")
+        for stat in ("strength", "dexterity", "stamina"):
+            SpeciesStatBonus.objects.create(species=species, stat=stat, value=1)
+        # Prime: the first resolution of the FK's natural key queries once.
+        SpeciesStatBonus.objects.get_by_natural_key("Referenced Elf", "strength")
+        # Every later row referencing the same species resolves it for free;
+        # only the SpeciesStatBonus row itself is queried.
+        with self.assertNumQueries(1):
+            SpeciesStatBonus.objects.get_by_natural_key("Referenced Elf", "dexterity")
+        with self.assertNumQueries(1):
+            SpeciesStatBonus.objects.get_by_natural_key("Referenced Elf", "stamina")

--- a/src/core/tests/test_natural_key_index.py
+++ b/src/core/tests/test_natural_key_index.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from django.test import TestCase
 
 from core.natural_keys import (
     _NK_WARMED,
+    NaturalKeyConfigError,
     _index_key,
     flush_natural_key_indexes,
     index_owner,
+    is_lookup_table,
     natural_key_index,
 )
 from world.species.factories import SpeciesFactory
@@ -183,3 +187,112 @@ class RenameInvalidationTests(TestCase):
         species.description = "changed"
         species.save()
         assert Species.objects.get_by_natural_key("Never Looked Up") == species
+
+    def test_rename_removes_the_old_key_from_the_index_dict(self) -> None:
+        """Assert the dict itself, not just lookup behaviour — the SQLite fast
+        tier has already been shown to let a behavioural assertion pass against a
+        deliberately broken implementation."""
+        species = SpeciesFactory(name="Dict Checked Elf")
+        Species.objects.get_by_natural_key("Dict Checked Elf")
+        assert ("dict checked elf",) in natural_key_index(Species)
+        species.name = "Dict Checked Renamed"
+        species.save()
+        assert ("dict checked elf",) not in natural_key_index(Species)
+
+
+def as_lookup_table(model: type):
+    """Context manager opting *model* into lookup-table behaviour for one test.
+
+    Task 5 builds the machinery; ConditionTemplate and Trait don't opt in until
+    Tasks 6-7. Patching lets these tests exercise the warm without depending on
+    a later task, so this task ends green on its own.
+    """
+    return patch.object(model.NaturalKeyConfig, "lookup_table", True, create=True)
+
+
+class LookupTableTests(TestCase):
+    """Opted-in models load whole and resolve from memory, never via iexact."""
+
+    def test_opt_in_is_off_by_default(self) -> None:
+        assert not is_lookup_table(Species)
+
+    def test_warm_happens_once_then_lookups_are_free(self) -> None:
+        SpeciesFactory(name="Warm One")
+        SpeciesFactory(name="Warm Two")
+        with as_lookup_table(Species):
+            Species.objects.get_by_natural_key("Warm One")  # warms
+            with self.assertNumQueries(0):
+                Species.objects.get_by_natural_key("Warm One")
+                Species.objects.get_by_natural_key("warm two")
+
+    def test_miss_raises_without_falling_back_to_sql(self) -> None:
+        SpeciesFactory(name="Present Elf")
+        with as_lookup_table(Species):
+            Species.objects.get_by_natural_key("Present Elf")  # warms
+            with self.assertNumQueries(0), self.assertRaises(Species.DoesNotExist):
+                Species.objects.get_by_natural_key("Absent Elf")
+
+    def test_row_created_after_the_warm_is_findable(self) -> None:
+        SpeciesFactory(name="Before Warm")
+        with as_lookup_table(Species):
+            Species.objects.get_by_natural_key("Before Warm")  # warms
+            later = SpeciesFactory(name="After Warm")
+            assert Species.objects.get_by_natural_key("after warm") == later
+
+    def test_warm_raises_on_a_casefold_collision(self) -> None:
+        """Two rows differing only in case are a content bug — fail loudly
+        rather than letting one silently win the dict slot."""
+        SpeciesFactory(name="Duplicate Elf")
+        SpeciesFactory(name="duplicate elf")
+        with as_lookup_table(Species):
+            with self.assertRaises(NaturalKeyConfigError) as ctx:
+                Species.objects.get_by_natural_key("Duplicate Elf")
+        assert "duplicate elf" in str(ctx.exception).casefold()
+
+    def test_stale_pk_triggers_one_rewarm(self) -> None:
+        species = SpeciesFactory(name="Rewarm Me")
+        with as_lookup_table(Species):
+            Species.objects.get_by_natural_key("Rewarm Me")  # warms
+            natural_key_index(Species)[("rewarm me",)] = 999_999
+            assert Species.objects.get_by_natural_key("Rewarm Me") == species
+
+    def test_fk_bearing_natural_key_is_rejected(self) -> None:
+        """Warming calls natural_key() per row, which traverses FK descriptors —
+        a query per row. Opting such a model in must fail loudly."""
+        SpeciesStatBonus.objects.create(
+            species=SpeciesFactory(name="FK Elf"), stat="strength", value=1
+        )
+        with as_lookup_table(SpeciesStatBonus):
+            with self.assertRaises(NaturalKeyConfigError) as ctx:
+                SpeciesStatBonus.objects.get_by_natural_key("FK Elf", "strength")
+        message = str(ctx.exception)
+        assert "lookup_table" in message
+        assert "species" in message
+
+
+class MroInvariantTests(TestCase):
+    """Every NaturalKeyMixin model must reach NaturalKeyMixin.save() first."""
+
+    def test_mixin_precedes_sharedmemorymodel_in_every_model_mro(self) -> None:
+        from evennia.utils.idmapper.models import SharedMemoryModel
+
+        from core.natural_keys import NaturalKeyMixin
+
+        offenders = []
+        stack = [NaturalKeyMixin]
+        seen = set()
+        while stack:
+            cls = stack.pop()
+            if cls in seen:
+                continue
+            seen.add(cls)
+            stack.extend(cls.__subclasses__())
+            mro = cls.__mro__
+            if NaturalKeyMixin not in mro or SharedMemoryModel not in mro:
+                continue
+            if mro.index(NaturalKeyMixin) > mro.index(SharedMemoryModel):
+                offenders.append(cls.__name__)
+        assert not offenders, (
+            "NaturalKeyMixin must precede SharedMemoryModel in the MRO or its "
+            f"save() invalidation never runs. Offenders: {offenders}"
+        )

--- a/src/core/tests/test_natural_key_index.py
+++ b/src/core/tests/test_natural_key_index.py
@@ -11,7 +11,8 @@ from core.natural_keys import (
     index_owner,
     natural_key_index,
 )
-from world.species.models import Species
+from world.species.factories import SpeciesFactory
+from world.species.models import Species, SpeciesStatBonus
 
 
 class IndexKeyNormalizationTests(TestCase):
@@ -58,3 +59,57 @@ class IndexRegistryTests(TestCase):
         flush_natural_key_indexes()
         assert natural_key_index(Species) == {}
         assert index_owner(Species) not in _NK_WARMED
+
+
+class LazyIndexTests(TestCase):
+    """Non-lookup-table models fill the index on lookup."""
+
+    def test_repeat_lookup_issues_no_queries(self) -> None:
+        species = SpeciesFactory(name="Indexed Elf")
+        Species.objects.get_by_natural_key("Indexed Elf")  # priming call
+        with self.assertNumQueries(0):
+            result = Species.objects.get_by_natural_key("Indexed Elf")
+        assert result == species
+
+    def test_first_lookup_populates_the_index(self) -> None:
+        species = SpeciesFactory(name="Recorded Elf")
+        Species.objects.get_by_natural_key("Recorded Elf")
+        assert natural_key_index(Species)[("recorded elf",)] == species.pk
+
+    def test_composite_key_repeat_lookup_issues_no_queries(self) -> None:
+        """A hit short-circuits BEFORE the recursive FK resolution, so a
+        composite key costs nothing on repeat — not even the FK's own lookup."""
+        species = SpeciesFactory(name="Composite Elf")
+        SpeciesStatBonus.objects.create(species=species, stat="strength", value=1)
+        SpeciesStatBonus.objects.get_by_natural_key("Composite Elf", "strength")
+        with self.assertNumQueries(0):
+            result = SpeciesStatBonus.objects.get_by_natural_key("Composite Elf", "strength")
+        assert result.value == 1
+
+    def test_missing_row_is_not_cached(self) -> None:
+        with self.assertRaises(Species.DoesNotExist):
+            Species.objects.get_by_natural_key("Not Yet Created")
+        assert ("not yet created",) not in natural_key_index(Species)
+        species = SpeciesFactory(name="Not Yet Created")
+        assert Species.objects.get_by_natural_key("Not Yet Created") == species
+
+    def test_deleted_row_self_heals(self) -> None:
+        """A dead pk raises DoesNotExist on the by-pk fetch; the entry is
+        dropped and the natural-key query re-run (which then also misses)."""
+        species = SpeciesFactory(name="Doomed Elf")
+        Species.objects.get_by_natural_key("Doomed Elf")
+        Species.objects.filter(pk=species.pk).delete()
+        with self.assertRaises(Species.DoesNotExist):
+            Species.objects.get_by_natural_key("Doomed Elf")
+
+
+class IndexIsolationTests(TestCase):
+    """Companion pair: proves the test-runner flush clears the index."""
+
+    def test_a_seeds_the_index(self) -> None:
+        SpeciesFactory(name="Isolation Marker Species")
+        Species.objects.get_by_natural_key("Isolation Marker Species")
+        assert ("isolation marker species",) in natural_key_index(Species)
+
+    def test_b_starts_clean(self) -> None:
+        assert ("isolation marker species",) not in natural_key_index(Species)

--- a/src/core/tests/test_natural_key_index.py
+++ b/src/core/tests/test_natural_key_index.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from django.test import TestCase
 
 from core.natural_keys import (
+    _NK_WARMED,
     _index_key,
     flush_natural_key_indexes,
     index_owner,
@@ -33,6 +34,14 @@ class IndexKeyNormalizationTests(TestCase):
     def test_result_is_hashable(self) -> None:
         {_index_key(("Mammals", ["Creatures", None]))}  # must not raise
 
+    def test_tuple_and_list_spellings_normalize_identically(self) -> None:
+        """A nested value may arrive as a list (from JSON) or a tuple (from
+        natural_key()). If the two spellings diverged, a key stored via one
+        would never be found via the other."""
+        assert _index_key(("Wolf", ["Mammals", ["Creatures", None]])) == _index_key(
+            ("Wolf", ("Mammals", ("Creatures", None)))
+        )
+
 
 class IndexRegistryTests(TestCase):
     """The registry is per-model and flushable."""
@@ -43,7 +52,9 @@ class IndexRegistryTests(TestCase):
     def test_index_owner_is_the_shared_dbclass(self) -> None:
         assert index_owner(Species) is Species.__dbclass__
 
-    def test_flush_clears_entries(self) -> None:
+    def test_flush_clears_entries_and_warm_flags(self) -> None:
         natural_key_index(Species)[("marker",)] = 999
+        _NK_WARMED.add(index_owner(Species))
         flush_natural_key_indexes()
         assert natural_key_index(Species) == {}
+        assert index_owner(Species) not in _NK_WARMED

--- a/src/core/tests/test_natural_keys.py
+++ b/src/core/tests/test_natural_keys.py
@@ -146,6 +146,21 @@ class NaturalKeyManagerTests(TestCase):
             Trait.objects.get_by_natural_key("nk_test_trait", "extra_arg")
         self.assertIn("Too many", str(cm.exception))
 
+    def test_lookup_table_too_few_args_raises_error(self):
+        """Test that a lookup_table model's too-few-args case raises the config
+        error, not a silent DoesNotExist.
+
+        Trait is a lookup_table model (NaturalKeyConfig.lookup_table = True), so
+        get_by_natural_key() short-circuits to _get_from_lookup_table() before
+        _natural_key_lookup() ever runs -- _assert_lookup_table_arg_count() is
+        the only thing standing between a caller mistake and a misleading
+        DoesNotExist. Trait's natural key takes exactly one argument, so "too
+        few" means zero args.
+        """
+        with self.assertRaises(NaturalKeyConfigError) as cm:
+            Trait.objects.get_by_natural_key()
+        self.assertIn("Not enough", str(cm.exception))
+
 
 class CountNaturalKeyArgsTests(TestCase):
     """Test the count_natural_key_args helper function."""

--- a/src/core_management/content_fixtures.py
+++ b/src/core_management/content_fixtures.py
@@ -969,6 +969,32 @@ def _case_insensitive_lookup(model, lookup: dict) -> dict:
     return result
 
 
+def _get_or_create_case_insensitive(model, lookup: dict, fields: dict) -> tuple:
+    """Match an existing row by natural key case-insensitively, or create one.
+
+    Returns ``(instance, created)``. A hand-rolled get/create instead of
+    ``update_or_create`` (#2687): Django's ``update_or_create`` can't take an
+    ``__iexact`` lookup — it drops ``LOOKUP_SEP`` keys when building the
+    create-path params, so the row would be created with that field unset.
+
+    Split out of ``_upsert_fixture_object`` (#2687 review) both to keep the
+    ``try`` scoped to ONLY the lookup — a ``model.DoesNotExist`` raised from
+    inside a custom ``save()`` override on the update path must not be
+    misclassified as "row not found" and silently retried as a create — and to
+    keep ``_upsert_fixture_object``'s own branch count (ruff PLR0912) at parity
+    with the single ``update_or_create`` call it replaces.
+    """
+    try:
+        instance = model.objects.get(**_case_insensitive_lookup(model, lookup))
+    except model.DoesNotExist:
+        return model.objects.create(**lookup, **fields), True
+
+    for field_name, value in fields.items():
+        setattr(instance, field_name, value)
+    instance.save()
+    return instance, False
+
+
 def _coerce_scalar_fields(model, fields: dict) -> None:
     """Normalize JSON-native scalar values into the types their model fields expect.
 
@@ -1071,19 +1097,10 @@ def _upsert_fixture_object(  # noqa: C901 — one branch per distinct skip reaso
         resolved_m2m = _resolve_m2m_fields(model, m2m_fields, source_path)
         _coerce_scalar_fields(model, fields)
         # Case-insensitive upsert (#2687): match an existing row regardless of
-        # casing, but write a NEW row with the fixture's own casing.
-        # update_or_create can't do this — Django drops LOOKUP_SEP keys when
-        # building create params, so an "__iexact" lookup would create a row
-        # with that field unset.
-        try:
-            instance = model.objects.get(**_case_insensitive_lookup(model, lookup))
-            for field_name, value in fields.items():
-                setattr(instance, field_name, value)
-            instance.save()
-            created = False
-        except model.DoesNotExist:
-            instance = model.objects.create(**lookup, **fields)
-            created = True
+        # casing, but write a NEW row with the fixture's own casing. See
+        # _get_or_create_case_insensitive's docstring for why this can't be a
+        # plain update_or_create call.
+        instance, created = _get_or_create_case_insensitive(model, lookup, fields)
     except UnresolvedNaturalKeyError as exc:
         # Must be caught before the broader ContentError clause below (it's a
         # subclass) — this is the ONLY failure mode ever deferred.

--- a/src/core_management/content_fixtures.py
+++ b/src/core_management/content_fixtures.py
@@ -952,6 +952,23 @@ def _extract_natural_key(model, fields: dict, source_path: Path | None) -> dict:
     return lookup
 
 
+def _case_insensitive_lookup(model, lookup: dict) -> dict:
+    """Return *lookup* with text components switched to ``__iexact``.
+
+    Natural keys are case-insensitive (#2687), so the upsert must match an
+    existing row regardless of casing. Kept separate from the create path: the
+    plain ``lookup`` is what a newly created row is written with, preserving the
+    fixture's own casing.
+    """
+    from core.natural_keys import _text_lookup_key  # noqa: PLC0415
+
+    result = {}
+    for field_name, value in lookup.items():
+        field = model._meta.get_field(field_name)  # noqa: SLF001
+        result[_text_lookup_key(field, field_name, value)] = value
+    return result
+
+
 def _coerce_scalar_fields(model, fields: dict) -> None:
     """Normalize JSON-native scalar values into the types their model fields expect.
 
@@ -1053,7 +1070,20 @@ def _upsert_fixture_object(  # noqa: C901 — one branch per distinct skip reaso
         _resolve_natural_key_fields(model, fields, source_path)
         resolved_m2m = _resolve_m2m_fields(model, m2m_fields, source_path)
         _coerce_scalar_fields(model, fields)
-        instance, created = model.objects.update_or_create(**lookup, defaults=fields)
+        # Case-insensitive upsert (#2687): match an existing row regardless of
+        # casing, but write a NEW row with the fixture's own casing.
+        # update_or_create can't do this — Django drops LOOKUP_SEP keys when
+        # building create params, so an "__iexact" lookup would create a row
+        # with that field unset.
+        try:
+            instance = model.objects.get(**_case_insensitive_lookup(model, lookup))
+            for field_name, value in fields.items():
+                setattr(instance, field_name, value)
+            instance.save()
+            created = False
+        except model.DoesNotExist:
+            instance = model.objects.create(**lookup, **fields)
+            created = True
     except UnresolvedNaturalKeyError as exc:
         # Must be caught before the broader ContentError clause below (it's a
         # subclass) — this is the ONLY failure mode ever deferred.
@@ -1086,9 +1116,10 @@ def _upsert_fixture_object(  # noqa: C901 — one branch per distinct skip reaso
         # malformed duration string).
         skip_msg = f"{source_path}: {model.__name__} could not be loaded: {exc}"
     except model.DoesNotExist as exc:
-        # The model's own DoesNotExist — the natural-key lookup didn't find
-        # an existing row (shouldn't happen for update_or_create, but catch
-        # just in case).
+        # The model's own DoesNotExist. The case-insensitive get()/create()
+        # miss above is handled inline (that's the expected create path), so
+        # this clause only fires for some OTHER DoesNotExist raised by this
+        # model during the try block — defensive, not a known live path today.
         skip_msg = f"{source_path}: {model.__name__} could not be loaded (lookup failed): {exc}"
     except IntegrityError as exc:
         # DB constraint violation (e.g. a unique constraint on a

--- a/src/core_management/tests/test_content_fixtures.py
+++ b/src/core_management/tests/test_content_fixtures.py
@@ -1074,3 +1074,34 @@ class MarkdownExportRoundTripTests(TestCase):
             "world/character_creation/fixtures/content_starting_areas.json"
         ][0]["fields"]
         assert fields["default_starting_room"] == ["fallback-room-key"]
+
+
+class LoadEntriesCaseInsensitiveUpsertTest(TestCase):
+    """Upsert matches an existing row by natural key regardless of casing (#2687)."""
+
+    def _result_with(self, objects: list[dict]) -> BuildResult:
+        key = "fixtures/conditions/condition_template.json"
+        path = Path(key)
+        result = BuildResult()
+        result.fixtures[key] = objects
+        result.source_paths[key] = [path] * len(objects)
+        return result
+
+    def test_upsert_matches_existing_row_case_insensitively(self) -> None:
+        from world.conditions.factories import ConditionTemplateFactory
+        from world.conditions.models import ConditionTemplate
+
+        existing = ConditionTemplateFactory(name="Fire Ward", description="old")
+        result = self._result_with(
+            [
+                {
+                    "model": "conditions.conditiontemplate",
+                    "fields": {"name": "fire ward", "description": "new"},
+                }
+            ]
+        )
+        created, updated, _ = load_entries(result)
+        assert (created, updated) == (0, 1), result.skipped
+        existing.refresh_from_db()
+        assert existing.description == "new"
+        assert ConditionTemplate.objects.filter(name__iexact="fire ward").count() == 1

--- a/src/world/conditions/apps.py
+++ b/src/world/conditions/apps.py
@@ -5,15 +5,3 @@ class ConditionsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "world.conditions"
     verbose_name = "Conditions"
-
-    def ready(self) -> None:
-        """Register the ConditionTemplate name→PK cache with the test runner.
-
-        Test-only hook — in production the cache stays populated across
-        requests. The registration is a no-op outside tests because the
-        test runner is what consumes the registry (see core.testing).
-        """
-        from core.testing import register_test_cache_flusher  # noqa: PLC0415
-        from world.conditions.models import ConditionTemplate  # noqa: PLC0415
-
-        register_test_cache_flusher(lambda: ConditionTemplate._name_pk_cache.clear())  # noqa: SLF001

--- a/src/world/conditions/models.py
+++ b/src/world/conditions/models.py
@@ -445,15 +445,11 @@ class ConditionTemplate(NaturalKeyMixin, SharedMemoryModel):
 
     objects = NaturalKeyManager()
 
-    # Name → PK cache for get_by_name (below). Class-level so service hot
-    # paths (round ticks, condition advancement) reuse the cached PK
-    # across calls. Flushed between tests via core.testing's registered
-    # cache hook so test rollback can't leave stale PKs (see
-    # core.testing module docstring for the rationale).
-    _name_pk_cache: dict[str, int] = {}
-
     class NaturalKeyConfig:
         fields = ["name"]
+        # Small catalog read by name on hot paths (battle resolution, plummet,
+        # perk evaluators) — load it whole once (#2687).
+        lookup_table = True
 
     class Meta:
         ordering = ["category", "name"]
@@ -463,33 +459,15 @@ class ConditionTemplate(NaturalKeyMixin, SharedMemoryModel):
 
     @classmethod
     def get_by_name(cls, name: str) -> ConditionTemplate:
-        """Return the template with this name, leveraging the identity map.
+        """Return the template with this name, case-insensitively.
 
-        Service hot paths repeatedly look up known-must-exist templates by name
-        (Soulfray, Audere, Bleeding-Out, etc.). Plain ``objects.get(name=NAME)``
-        issues a fresh query every call because the identity map is keyed by PK,
-        not name. This method maintains a class-level name→PK index so the
-        second-and-after calls hit SharedMemoryModel's identity map directly
-        (zero queries) instead of re-querying by name.
-
-        Cache invalidation: the project test runner flushes ``_name_pk_cache``
-        and ``SharedMemoryModel``'s identity map between tests (see
-        ``core.testing``). In production the cache is stable because rows
-        aren't deleted out from under it.
+        Delegates to the generic natural-key index (#2687). ``ConditionTemplate``
+        is a ``lookup_table``, so the whole (small, always-used) table is loaded
+        once and every lookup after that resolves from memory.
 
         Raises ConditionTemplate.DoesNotExist if no row matches.
         """
-        cached_pk = cls._name_pk_cache.get(name)
-        if cached_pk is not None:
-            try:
-                return cls.objects.get(pk=cached_pk)
-            except cls.DoesNotExist:
-                # Cache poisoned (e.g. somebody deleted the row in production);
-                # drop and refetch.
-                cls._name_pk_cache.pop(name, None)
-        obj = cls.objects.get(name=name)  # raises DoesNotExist
-        cls._name_pk_cache[name] = obj.pk
-        return obj
+        return cls.objects.get_by_natural_key(name)
 
     @cached_property
     def cached_stages(self) -> list[ConditionStage]:

--- a/src/world/conditions/tests/test_get_by_name.py
+++ b/src/world/conditions/tests/test_get_by_name.py
@@ -1,19 +1,20 @@
 """Tests for ConditionTemplate.get_by_name cached lookup.
 
 Pins the contract:
-- First call queries by name and caches the PK.
+- First call queries by name and warms the natural-key index (#2687).
 - Subsequent calls hit SharedMemoryModel's identity map (zero queries).
-- Cache survives within a test; the project's TimedEvenniaTestRunner clears
+- The index survives within a test; the project's TimedEvenniaTestRunner clears
   it between tests so test rollback can't leak a stale PK.
 - DoesNotExist raised when no row matches.
-- A stale PK (e.g., production-side deletion that bypassed the cache) is
-  detected via DoesNotExist on the by-PK fetch and the cache repopulates.
+- A stale PK (e.g., production-side deletion that bypassed the index) is
+  detected via DoesNotExist on the by-PK fetch and the index re-warms.
 """
 
 from __future__ import annotations
 
 from django.test import TestCase
 
+from core.natural_keys import natural_key_index
 from world.conditions.factories import ConditionTemplateFactory
 from world.conditions.models import ConditionTemplate
 
@@ -31,32 +32,39 @@ class GetByNameTests(TestCase):
     def test_second_call_returns_same_object_no_query(self) -> None:
         ConditionTemplateFactory(name="Cached Twice")
         ConditionTemplate.get_by_name("Cached Twice")  # priming call
-        # After priming, the second call should not issue any SQL — the cache
+        # After priming, the second call should not issue any SQL — the index
         # provides the PK and SharedMemoryModel's identity map returns the
         # cached Python object directly.
         with self.assertNumQueries(0):
             result = ConditionTemplate.get_by_name("Cached Twice")
         assert result.name == "Cached Twice"
 
+    def test_condition_template_is_a_lookup_table(self) -> None:
+        """The whole (small, hot-path) catalog loads once — a second lookup of a
+        DIFFERENT name costs nothing."""
+        ConditionTemplateFactory(name="Warm Alpha")
+        ConditionTemplateFactory(name="Warm Beta")
+        ConditionTemplate.get_by_name("Warm Alpha")  # warms the table
+        with self.assertNumQueries(0):
+            assert ConditionTemplate.get_by_name("warm beta").name == "Warm Beta"
+
     def test_stale_pk_recovers_via_does_not_exist(self) -> None:
-        """If the cached PK no longer exists (e.g., admin-deleted row), the cache
-        drops the stale entry and refetches by name."""
+        """A poisoned index entry (e.g. admin-deleted row) is detected on the
+        by-pk fetch; the lookup table re-warms and resolves correctly."""
         template = ConditionTemplateFactory(name="Will Be Refound")
-        # Poison the cache: name maps to a PK that doesn't exist.
-        ConditionTemplate._name_pk_cache["Will Be Refound"] = 999_999
+        ConditionTemplate.get_by_name("Will Be Refound")  # warms
+        natural_key_index(ConditionTemplate)[("will be refound",)] = 999_999
         result = ConditionTemplate.get_by_name("Will Be Refound")
         assert result == template
-        # Cache is now repaired.
-        assert ConditionTemplate._name_pk_cache["Will Be Refound"] == template.pk
+        assert natural_key_index(ConditionTemplate)[("will be refound",)] == template.pk
 
     def test_cache_isolated_across_tests(self) -> None:
         """Companion to the test below — together they verify the test-runner
-        flush actually clears the name cache between tests."""
+        flush actually clears the natural-key index between tests."""
         ConditionTemplateFactory(name="Isolation Test Marker")
         ConditionTemplate.get_by_name("Isolation Test Marker")
-        assert "Isolation Test Marker" in ConditionTemplate._name_pk_cache
+        assert ("isolation test marker",) in natural_key_index(ConditionTemplate)
 
     def test_cache_starts_empty_in_each_test(self) -> None:
-        """The previous test populated the cache; this one should start clean
-        thanks to the test-runner flush."""
-        assert "Isolation Test Marker" not in ConditionTemplate._name_pk_cache
+        """The previous test populated the index; this one should start clean."""
+        assert ("isolation test marker",) not in natural_key_index(ConditionTemplate)

--- a/src/world/magic/services/effect_handlers.py
+++ b/src/world/magic/services/effect_handlers.py
@@ -4,7 +4,7 @@ Each handler is keyword-only ``def h(*, payload) -> None`` and is referenced by
 its dotted path from a seeded FlowDefinition's CALL_SERVICE_FUNCTION step.
 """
 
-from typing import Any
+from typing import Any, cast
 
 from world.areas.positioning.models import Position, PositionEdge
 from world.areas.positioning.services import (
@@ -292,7 +292,11 @@ def summon_ally(*, payload: Any) -> None:
     encounter = participant.encounter
     caster_sheet = participant.character_sheet
 
-    threat_pool = ThreatPool.objects.get(name=payload.threat_pool_name)
+    # get_by_natural_key routes through the natural-key index (#2687, closes #2679)
+    # and matches case-insensitively (__iexact on text components).
+    threat_pool = cast(
+        "ThreatPool", ThreatPool.objects.get_by_natural_key(payload.threat_pool_name)
+    )
     # Suppression justified: flow-payload optional param (fields vary per FlowDefinition).
     max_health: int = getattr(payload, "max_health", 30)  # noqa: GETATTR_LITERAL
     # Suppression justified: flow-payload optional param (fields vary per FlowDefinition).
@@ -582,7 +586,12 @@ def raise_rampart_on_condition(
     else:
         return  # no position resolved — no-op
 
-    element_profile = RampartElementProfile.objects.get(name=element_profile_name)
+    # get_by_natural_key routes through the natural-key index (#2687, closes #2679)
+    # and matches case-insensitively (__iexact on text components).
+    element_profile = cast(
+        "RampartElementProfile",
+        RampartElementProfile.objects.get_by_natural_key(element_profile_name),
+    )
     caster_sheet = _caster_sheet_from_instance(instance)
 
     raise_rampart(

--- a/src/world/magic/tests/test_effect_palette_summon.py
+++ b/src/world/magic/tests/test_effect_palette_summon.py
@@ -13,11 +13,14 @@ from django.test import TestCase
 from flows.constants import EventName
 from flows.consts import FlowActionChoices
 from flows.models.flows import FlowStepDefinition
+from world.areas.positioning.factories import RampartElementProfileFactory
+from world.areas.positioning.models import RampartElementProfile
 from world.combat.constants import CombatAllegiance, ParticipantStatus
 from world.combat.factories import (
     CombatEncounterFactory,
     CombatOpponentFactory,
     CombatParticipantFactory,
+    ThreatPoolFactory,
 )
 from world.combat.models import CombatOpponent, ThreatPool
 from world.conditions.constants import SUMMONING_CONDITION_NAME
@@ -121,3 +124,28 @@ class SummonAllyOnConditionAdapterTests(TestCase):
         self.assertEqual(summon.summoned_by, participant.character_sheet)
         self.assertEqual(summon.threat_pool_id, pool.pk)
         self.assertEqual(summon.bond_expires_round, encounter.round_number + 5)
+
+
+class ThreatPoolNaturalKeyIndexTests(TestCase):
+    """#2679: summon_ally's pool lookup must go through get_by_natural_key so the
+    natural-key index applies — a plain objects.get(name=...) bypasses it."""
+
+    def test_threat_pool_lookup_is_served_from_the_natural_key_index(self) -> None:
+        pool = ThreatPoolFactory(name="Indexed Pool")
+        ThreatPool.objects.get_by_natural_key("Indexed Pool")  # prime the index
+        with self.assertNumQueries(0):
+            self.assertEqual(ThreatPool.objects.get_by_natural_key("indexed pool"), pool)
+
+
+class RampartElementProfileNaturalKeyIndexTests(TestCase):
+    """#2679: raise_rampart's element-profile lookup must go through
+    get_by_natural_key so the natural-key index applies — a plain
+    objects.get(name=...) bypasses it."""
+
+    def test_element_profile_lookup_is_served_from_the_natural_key_index(self) -> None:
+        profile = RampartElementProfileFactory(name="Indexed Element")
+        RampartElementProfile.objects.get_by_natural_key("Indexed Element")  # prime
+        with self.assertNumQueries(0):
+            self.assertEqual(
+                RampartElementProfile.objects.get_by_natural_key("indexed element"), profile
+            )

--- a/src/world/mechanics/models.py
+++ b/src/world/mechanics/models.py
@@ -168,12 +168,13 @@ class ModifierTarget(NaturalKeyMixin, SharedMemoryModel):
     # See TECH_DEBT.md §"Future Target FKs" for full tracking list.
     objects = ModifierTargetManager()
 
-    # Class-level cache mapping target_trait_id -> ModifierTarget, mirroring
-    # Trait._name_to_trait_map. The stat-modifier hot path (TraitHandler.
-    # _get_stat_modifier) resolves a ModifierTarget by its target_trait FK
-    # per stat read; that lookup is keyed by a non-PK field, so it misses the
-    # SharedMemoryModel identity map and re-queries each call. This cache
-    # serves it from memory after the first build (#552).
+    # Class-level cache mapping target_trait_id -> ModifierTarget, the same
+    # whole-table-once idea Trait's natural-key lookup_table uses (#2687). The
+    # stat-modifier hot path (TraitHandler._get_stat_modifier) resolves a
+    # ModifierTarget by its target_trait FK per stat read; that lookup is keyed
+    # by a non-PK field, so it misses the SharedMemoryModel identity map and
+    # re-queries each call. This cache serves it from memory after the first
+    # build (#552).
     _trait_cache_built = False
     _trait_to_target_map: dict[int, "ModifierTarget"] = {}
 

--- a/src/world/traits/apps.py
+++ b/src/world/traits/apps.py
@@ -5,16 +5,3 @@ class TraitsConfig(AppConfig):
     default_auto_field = "django.db.models.BigAutoField"
     name = "world.traits"
     verbose_name = "Traits System"
-
-    def ready(self) -> None:
-        """Clear Trait._name_to_trait_map between tests.
-
-        With ``_build_name_cache`` querying the DB directly (see Trait model),
-        clearing the cache between tests is safe and necessary — the rebuild
-        on next access fetches fresh Trait instances rather than holding
-        stale Python objects from a rolled-back test.
-        """
-        from core.testing import register_test_cache_flusher  # noqa: PLC0415
-        from world.traits.models import Trait  # noqa: PLC0415
-
-        register_test_cache_flusher(Trait.clear_name_cache)

--- a/src/world/traits/models.py
+++ b/src/world/traits/models.py
@@ -102,14 +102,13 @@ class Trait(NaturalKeyMixin, SharedMemoryModel):
         help_text="Whether this trait should display by default in character sheets",
     )
 
-    # Caching for case-insensitive lookups
-    _name_cache_built = False
-    _name_to_trait_map: dict[str, "Trait"] = {}
-
     objects = NaturalKeyManager()
 
     class NaturalKeyConfig:
         fields = ["name"]
+        # Small set of stats/skills read by name from handlers and predicates
+        # everywhere — load it whole once (#2687).
+        lookup_table = True
 
     class Meta:
         ordering = ["trait_type", "category", "name"]
@@ -131,51 +130,21 @@ class Trait(NaturalKeyMixin, SharedMemoryModel):
 
     @classmethod
     def get_by_name(cls, name: str) -> Optional["Trait"]:
+        """Get a trait by name (case-insensitive), or None if absent.
+
+        Delegates to the generic natural-key index (#2687). ``Trait`` is a
+        ``lookup_table``: a small set used everywhere, so the whole table loads
+        once and every lookup after resolves from memory — the same
+        one-query-then-free behaviour the hand-rolled ``_build_name_cache``
+        provided, minus the bespoke cache.
+
+        Returns None rather than raising, because callers branch on it
+        (``world/traits/handlers.py``, ``world/predicates/predicates.py``).
         """
-        Get a trait by name with case-insensitive lookup and caching.
-
-        Args:
-            name: Trait name to look up (case-insensitive)
-
-        Returns:
-            Trait instance or None if not found
-        """
-        if not cls._name_cache_built:
-            cls._build_name_cache()
-
-        return cls._name_to_trait_map.get(name.lower())
-
-    @classmethod
-    def _build_name_cache(cls) -> None:
-        """Build the name-to-trait mapping cache from the database.
-
-        Queries every row once on first use; subsequent ``get_by_name`` calls
-        return from the cache without further queries. The query also primes
-        SharedMemoryModel's identity map as a side effect, so ``objects.get(pk=X)``
-        calls in the same process hit the cache too.
-
-        Previously iterated ``get_all_cached_instances()`` which depends on the
-        identity map being pre-populated — a fragile assumption that fails in
-        tests where the runner flushes the identity map between methods (the
-        cache would rebuild empty, and ``get_by_name`` would return None for
-        every lookup). Querying the DB directly makes this independent of
-        identity-map state.
-        """
-        cls._name_to_trait_map = {}
-        for trait in cls.objects.all():
-            cls._name_to_trait_map[trait.name.lower()] = trait
-        cls._name_cache_built = True
-
-    @classmethod
-    def clear_name_cache(cls) -> None:
-        """Clear the name cache (call when traits are modified)."""
-        cls._name_cache_built = False
-        cls._name_to_trait_map = {}
-
-    def save(self, *args: Any, **kwargs: Any) -> None:
-        """Override save to clear name cache when traits are modified."""
-        super().save(*args, **kwargs)
-        self.__class__.clear_name_cache()
+        try:
+            return cast("Trait", cls.objects.get_by_natural_key(name))
+        except cls.DoesNotExist:
+            return None
 
 
 class TraitRankDescription(NaturalKeyMixin, SharedMemoryModel):

--- a/tools/noqa_ratchet_baseline.txt
+++ b/tools/noqa_ratchet_baseline.txt
@@ -4,6 +4,6 @@
 # reviewed exception — justify it in the commit message.
 # Plain tokens count '# noqa: <TOKEN>' suppressions; 'pattern:' tokens count
 # the regexes defined in lint_noqa_ratchet.py's PATTERNS map.
-GETATTR_LITERAL 64
+GETATTR_LITERAL 63
 pattern:BARE_OBJECTDB_CREATE 2
 pattern:BROAD_EXCEPT 112

--- a/tools/noqa_ratchet_baseline.txt
+++ b/tools/noqa_ratchet_baseline.txt
@@ -4,6 +4,6 @@
 # reviewed exception — justify it in the commit message.
 # Plain tokens count '# noqa: <TOKEN>' suppressions; 'pattern:' tokens count
 # the regexes defined in lint_noqa_ratchet.py's PATTERNS map.
-GETATTR_LITERAL 63
+GETATTR_LITERAL 64
 pattern:BARE_OBJECTDB_CREATE 2
 pattern:BROAD_EXCEPT 112


### PR DESCRIPTION
Closes #2687
Closes #2679

## Summary

Adds a natural-key → pk index to `NaturalKeyManager` so repeat `get_by_natural_key()` lookups cost **zero queries**, makes natural-key text components match **case-insensitively**, and adds an opt-in `NaturalKeyConfig.lookup_table` mode that warms a whole table once and then resolves purely from memory.

**Design (two findings revised the issue's original sketch):**

- The natural key could NOT go into `__instance_cache__` itself — `CachedAllMixin.cached_all()` and Evennia's `get_all_cached_instances()` both return `__instance_cache__.values()`, so a second key would make every row appear twice. The index is a separate structure.
- It had to be class-level, not manager-level — Django's deserializer calls `_default_manager.db_manager(db).get_by_natural_key(...)` and `db_manager()` returns a manager *copy*, so a per-manager cache would be discarded on every FK resolution during `loaddata`, i.e. exactly the path being optimized.

The index stores `tuple → pk`, never `tuple → instance`: it can never retain an instance or grow with table size, instance freshness stays the identity map's concern, and a deleted row self-heals because `get(pk=N)` raises `DoesNotExist`. This generalizes a pattern already proven in-repo at `world/conditions/models.py` rather than inventing a new one.

**Consolidations (net-negative diffs):** `ConditionTemplate._name_pk_cache` (−26) and `Trait._name_to_trait_map` / `_build_name_cache` (−41) are deleted — both were hand-rolled halves of this same idea. Their two app-config test flushers collapse into one registration in `core/testing.py`. `Trait`'s existing case-insensitivity test passes **unmodified**, which is the proof behaviour was preserved.

**A regression this branch found and fixed:** opting a model into `lookup_table` silently disabled its argument-count validation — `get_by_natural_key` short-circuits before `_natural_key_lookup`, which is where arity checking lives, so a wrong arg count raised `DoesNotExist` instead of `NaturalKeyConfigError`. Fixed with `_assert_lookup_table_arg_count`, and confirmed by mutation testing (disable the guard → the test fails with `Trait.DoesNotExist`). A reviewer walked every other thing the skipped path does to confirm no sibling validation was lost.

**Known and deliberate, flagged for reviewers:**

- Three `cast(...)` sites are needed because `get_by_natural_key` is annotated `-> NaturalKeyMixin`. Fixing that at source means making `NaturalKeyManager` generic and re-annotating `objects = ...` on ~173 models — a repo-wide typing project, deliberately not folded into this PR. Open design question.
- A case-variant duplicate row (`"Fire"` / `"fire"`) now raises `MultipleObjectsReturned` on the lazy path, and is caught at warm time by the collision check on lookup-table models. Loud by design, per ADR-0163.
- `loaddata` FK resolution and the content-loader upsert are now case-insensitive, so fixtures differing only in casing resolve to one row instead of forking it. This is a real change to how content lands.
- The SQLite fast tier masks case-insensitivity defects (its `LIKE` is ASCII-case-insensitive and text-converts numbers) — proven by mutation testing during this work. CI's PostgreSQL parity run is the real gate here.

**Docs:** ADR-0163 records the decisions and the three rejected alternatives (eager indexing in `cache_instance`; dual-keying `__instance_cache__`; `Upper()` functional unique indexes, with "a measured slow cold lookup" as the revisit trigger). `docs/evennia-quirks.md`, `docs/systems/traits.md` and the `core/natural_keys.py` module docstring are updated in tandem.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2687 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main; one keep-both conflict in core_management/tests/test_content_fixtures.py (main added #2688 prose-domain tests at the same end-of-file location as this branch's upsert test) — both sides kept, ruff-formatted, core_management 213 OK / core 63 OK after. No migration files in the branch, so no merge-queue collision risk.

<!-- last-addressed-comment: 0 -->