### PR TITLE
Scheduler ticks: stop scaling daily work with the playerbase

### DIFF
--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -2902,16 +2902,27 @@ def decay_all_conditions_tick() -> DecayTickSummary:
     )
 
 
-def _compute_chronic_damage(instance: "ConditionInstance") -> int:
+def _compute_chronic_damage(
+    instance: "ConditionInstance",
+    long_term_rows: "list[ConditionDamageOverTime] | None" = None,
+) -> int:
     """Sum long-term DoT damage for one condition instance.
 
     Applies per-row severity and stacks scaling; rows that resolve to ≤0 are ignored.
+
+    ``long_term_rows`` lets a batch caller pass rows it already fetched. They are
+    keyed on the condition *template*, which many instances share, so re-querying
+    per instance re-reads the same handful of rows once per afflicted character.
+    Omitted, the rows are fetched for this instance alone (the single-instance path).
     """
     total = 0
-    long_term_rows = ConditionDamageOverTime.objects.filter(
-        condition=instance.condition,
-        is_long_term=True,
-    )
+    if long_term_rows is None:
+        long_term_rows = list(
+            ConditionDamageOverTime.objects.filter(
+                condition=instance.condition,
+                is_long_term=True,
+            )
+        )
     for dot in long_term_rows:
         damage = dot.base_damage
         if dot.scales_with_severity:
@@ -2966,6 +2977,17 @@ def batch_chronic_effect_tick() -> ChronicTickSummary:
         .select_related("condition", "current_stage", "target")
         .distinct()
     )
+    instances = list(instances)
+
+    # DoT rows hang off the condition *template*, which afflicted characters
+    # share — fetching them per instance re-reads the same handful of rows once
+    # per sufferer. Group them once and hand each instance its template's rows.
+    rows_by_condition: dict[int, list[ConditionDamageOverTime]] = {}
+    for dot in ConditionDamageOverTime.objects.filter(
+        condition_id__in={instance.condition_id for instance in instances},
+        is_long_term=True,
+    ):
+        rows_by_condition.setdefault(dot.condition_id, []).append(dot)
 
     for instance in instances:
         summary.examined += 1
@@ -2975,7 +2997,7 @@ def batch_chronic_effect_tick() -> ChronicTickSummary:
             summary.active_round_skipped += 1
             continue
 
-        total = _compute_chronic_damage(instance)
+        total = _compute_chronic_damage(instance, rows_by_condition.get(instance.condition_id, []))
         if total > 0 and sheet is not None:
             removed = apply_clamped_chronic_damage(sheet, total)
             if removed > 0:

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -2853,20 +2853,36 @@ def decay_all_conditions_tick() -> DecayTickSummary:
     engagement_blocked = 0
     severity_gated = 0
 
-    qs = ConditionInstance.objects.filter(
-        resolved_at__isnull=True,
-        condition__passive_decay_per_day__gt=0,
-    ).select_related("condition", "current_stage", "target")
+    instances = list(
+        ConditionInstance.objects.filter(
+            resolved_at__isnull=True,
+            condition__passive_decay_per_day__gt=0,
+        ).select_related("condition", "current_stage", "target")
+    )
 
-    for instance in qs:
+    # Resolve the engagement check in ONE query instead of one per instance —
+    # the same hoist `_apply_ap_regen` does for its locked_character_ids set.
+    # Only conditions that opt into the block need it, so the lookup is scoped
+    # to those targets rather than every engaged character.
+    blocked_target_ids = {
+        instance.target_id
+        for instance in instances
+        if instance.condition.passive_decay_blocked_in_engagement
+    }
+    engaged_character_ids: set[int] = (
+        set(
+            CharacterEngagement.objects.filter(
+                character_id__in=blocked_target_ids,
+            ).values_list("character_id", flat=True)
+        )
+        if blocked_target_ids
+        else set()
+    )
+
+    for instance in instances:
         examined += 1
         cond = instance.condition
-        if (
-            cond.passive_decay_blocked_in_engagement
-            and CharacterEngagement.objects.filter(
-                character_id=instance.target_id,
-            ).exists()
-        ):
+        if cond.passive_decay_blocked_in_engagement and instance.target_id in engaged_character_ids:
             engagement_blocked += 1
             continue
         if (

--- a/src/world/conditions/tests/test_decay_tick.py
+++ b/src/world/conditions/tests/test_decay_tick.py
@@ -5,7 +5,9 @@ NULL and opt-in (passive_decay_per_day > 0). Honors
 passive_decay_blocked_in_engagement and passive_decay_max_severity.
 """
 
+from django.db import connection
 from django.test import TestCase
+from django.test.utils import CaptureQueriesContext
 
 from evennia_extensions.factories import ObjectDBFactory
 from world.conditions.factories import (
@@ -141,26 +143,43 @@ class DecayAllConditionsTickTests(TestCase):
         self.assertEqual(summary.engagement_blocked, 0)
         self.assertEqual(summary.examined, 1)
 
-    def test_n_instances_bounded_query_count(self):
-        """Query count grows linearly with instances, not exponentially.
+    def _tick_queries(self, *, add: int, expect_ticked: int) -> int:
+        """Add ``add`` decaying instances, run the tick, return queries executed.
 
-        With 10 instances the cost is 1 outer SELECT + 5 queries per instance
-        (engagement check, stage lookup, savepoint, update, release savepoint) =
-        51 queries. This is acceptable for a daily scheduler tick — not a hot
-        path. The key assertion is linearity: doubling instances should not
-        more than double queries.
+        Instances persist across calls within a test, so ``expect_ticked`` is the
+        running total — that is what lets two successive calls measure the
+        per-instance slope.
         """
         template = ConditionTemplateFactory(passive_decay_per_day=1)
         stage = ConditionStageFactory(condition=template, severity_threshold=1)
-        for _ in range(10):
+        for _ in range(add):
             ConditionInstanceFactory(
                 condition=template,
                 current_stage=stage,
                 severity=3,
             )
-
-        with self.assertNumQueries(51):
+        with CaptureQueriesContext(connection) as ctx:
             summary = decay_all_conditions_tick()
+        self.assertEqual(summary.ticked, expect_ticked)
+        self.assertEqual(summary.examined, expect_ticked)
+        return len(ctx)
 
-        self.assertEqual(summary.ticked, 10)
-        self.assertEqual(summary.examined, 10)
+    def test_n_instances_bounded_query_count(self):
+        """Per-instance cost is 4 queries: stage lookup, savepoint, update, release.
+
+        The engagement gate used to add a fifth (one ``CharacterEngagement``
+        ``.exists()`` per instance); it is now hoisted into a single batched
+        lookup, mirroring ``_apply_ap_regen``'s locked_character_ids set.
+        """
+        self.assertEqual(self._tick_queries(add=10, expect_ticked=10), 42)
+
+    def test_engagement_gate_does_not_scale_with_instance_count(self):
+        """The slope is what matters — a reintroduced N+1 would push it to 5.
+
+        Asserting the *difference* between two sizes rather than a single total
+        pins the invariant without re-pinning whatever fixed overhead the tick
+        happens to carry, so unrelated setup changes don't churn this test.
+        """
+        ten = self._tick_queries(add=10, expect_ticked=10)
+        twenty = self._tick_queries(add=10, expect_ticked=20)
+        self.assertEqual(twenty - ten, 4 * 10)

--- a/src/world/conditions/tests/test_poison.py
+++ b/src/world/conditions/tests/test_poison.py
@@ -23,7 +23,12 @@ from world.conditions.factories import (
     ConditionTemplateFactory,
     DamageTypeFactory,
 )
-from world.conditions.models import ConditionStage, ConditionTemplate, DamageType
+from world.conditions.models import (
+    ConditionDamageOverTime,
+    ConditionStage,
+    ConditionTemplate,
+    DamageType,
+)
 from world.conditions.services import (
     _process_round_tick,
     apply_condition,
@@ -342,6 +347,37 @@ class ChronicPoisonTickTests(TestCase):
         vitals.refresh_from_db()
         self.assertLess(vitals.health, 100)
         self.assertEqual(summary.ticked, 1)
+
+    def test_dot_rows_are_fetched_once_not_per_sufferer(self) -> None:
+        """DoT rows hang off the shared template, so cost must not scale per victim.
+
+        Everyone poisoned by the same condition reads the same handful of
+        ConditionDamageOverTime rows; fetching them per instance re-reads them
+        once per afflicted character. Asserting the slope between one and four
+        sufferers pins that, without pinning the tick's fixed overhead.
+        """
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        def dot_queries(ctx: CaptureQueriesContext) -> int:
+            table = ConditionDamageOverTime._meta.db_table
+            return sum(1 for q in ctx.captured_queries if table in q["sql"])
+
+        self._slow_poisoned(health=100)
+        with CaptureQueriesContext(connection) as one:
+            batch_chronic_effect_tick()
+
+        for _ in range(3):
+            self._slow_poisoned(health=100)
+        with CaptureQueriesContext(connection) as four:
+            summary = batch_chronic_effect_tick()
+        self.assertEqual(summary.ticked, 4)
+
+        # Two statements mention the table either way: the instance queryset
+        # joins it to find long-term conditions, plus the single batched fetch.
+        # What matters is that the number is CONSTANT — per-instance fetching
+        # would add one more for every additional sufferer.
+        self.assertEqual(dot_queries(four), dot_queries(one))
 
     def test_cap_never_kills_or_knocks_out(self) -> None:
         _sheet, character, vitals = self._slow_poisoned(health=25)

--- a/src/world/magic/services/gain.py
+++ b/src/world/magic/services/gain.py
@@ -1080,15 +1080,36 @@ def outfit_daily_trickle_for_character(sheet: CharacterSheet) -> int:
 def outfit_trickle_tick() -> int:
     """Outfit trickle tick (Spec D §5.1).
 
-    Iterates all CharacterSheets, skipping protagonism-locked sheets. For each
-    sheet, delegates to outfit_daily_trickle_for_character per-sheet in its own
-    atomic block so a single failure does not poison the whole tick.
+    Driven from the *narrow* side: a sheet can only earn an outfit trickle
+    through ``thread_for_facet``, so a sheet owning no active FACET-kind Thread
+    would walk its whole wardrobe and grant nothing. Selecting those owners up
+    front is therefore behaviour-identical to scanning every CharacterSheet,
+    and turns a per-playerbase scan into work proportional to the (much
+    smaller) set of characters who have actually woven a facet thread.
+
+    Skips protagonism-locked sheets. Each sheet is processed in its own atomic
+    block so a single failure does not poison the whole tick.
 
     Returns: total count of grants issued across all sheets.
     """
+    from world.magic.constants import TargetKind  # noqa: PLC0415
+    from world.magic.models import Thread  # noqa: PLC0415
+
     total_grants = 0
 
-    for sheet in CharacterSheet.objects.all().iterator():
+    # Matches CharacterThreadHandler._all's notion of "active" (non-retired),
+    # so the narrowing cannot skip a sheet the per-sheet pass would have paid out.
+    facet_thread_owner_ids = set(
+        Thread.objects.filter(
+            target_kind=TargetKind.FACET,
+            retired_at__isnull=True,
+        ).values_list("owner_id", flat=True)
+    )
+    if not facet_thread_owner_ids:
+        return 0
+
+    sheets = CharacterSheet.objects.filter(pk__in=facet_thread_owner_ids)
+    for sheet in sheets.iterator():
         if sheet.is_protagonism_locked:
             continue
         try:

--- a/src/world/magic/tests/test_gain_tick.py
+++ b/src/world/magic/tests/test_gain_tick.py
@@ -113,6 +113,31 @@ class OutfitTrickleTickNoItemsTests(TestCase):
         CharacterSheetFactory()
         self.assertEqual(outfit_trickle_tick(), 0)
 
+    def test_outfit_tick_cost_does_not_grow_with_thread_less_sheets(self) -> None:
+        """The tick must scale with facet-thread owners, not with the playerbase.
+
+        It used to iterate every CharacterSheet and pay per-sheet queries to
+        discover that most characters own no FACET thread and can never earn a
+        trickle. Adding characters who cannot possibly earn one must not make
+        the tick more expensive — that is the whole point of the narrowing.
+        """
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.services.gain import outfit_trickle_tick
+
+        with CaptureQueriesContext(connection) as baseline:
+            self.assertEqual(outfit_trickle_tick(), 0)
+
+        for _ in range(25):
+            CharacterSheetFactory()
+
+        with CaptureQueriesContext(connection) as with_sheets:
+            self.assertEqual(outfit_trickle_tick(), 0)
+
+        self.assertEqual(len(with_sheets), len(baseline))
+
 
 class ResonanceDailyTickTests(TestCase):
     def test_runs_with_no_sheets(self) -> None:


### PR DESCRIPTION
Pre-launch scaling cleanup. No migrations, no schema risk, no behaviour change — only query counts move.

**Context:** with no players yet, work that is O(playerbase) per tick is invisible; at tens of thousands of characters it becomes load-bearing infrastructure that is unsafe to change. This is the cheap moment to fix it.

I swept all **37 registered periodic tasks** for one shape: *work that scales with the playerbase rather than with the thing being acted on.* Three ticks had it. The rest are fine — bounded lookup tables, or driven from a narrow work list (expiring summonses, stale ceremonies, due settlements, active projects) where the queryset tracks pending work.

Every fix is modelled on a tick in this repo that already does it right, so the diffs read as "make this look like its neighbour" rather than introducing a new pattern.

## 1. `decay_all_conditions_tick` — N+1 inside the loop

Ran one `CharacterEngagement.objects.filter(...).exists()` **per condition instance**, daily, over every unresolved decaying condition.

Hoisted into a single batched lookup scoped to the targets whose condition actually opts into the block — the same hoist `_apply_ap_regen` already does for its `locked_character_ids` set.

10 instances: **51 → 42 queries**; per-instance slope **5 → 4**.

## 2. `outfit_trickle_tick` — scanned every character in the database

Iterated every `CharacterSheet` daily in a per-sheet transaction, loading each character's equipped items and threads, only to find that most own no FACET-kind `Thread` and can never earn a trickle.

Now driven from that narrow set. This is behaviour-identical rather than heuristic: the per-item work funnels through `thread_for_facet`, so a sheet with no active FACET thread grants nothing. The filter matches `CharacterThreadHandler._all`'s own definition of active (`retired_at__isnull=True`), so it cannot skip a sheet the old pass would have paid out.

25 thread-less characters: **159 → 1 query**.

## 3. `batch_chronic_effect_tick` — re-read shared rows per sufferer

`_compute_chronic_damage` queried `ConditionDamageOverTime` per instance, but those rows are keyed on the condition *template*, which every character afflicted by the same poison shares. Now fetched once, grouped by `condition_id`. The helper takes the rows as an optional argument so its single-instance path is unchanged; it has exactly one caller.

## Regression guards

Each fix has a test asserting the **slope** (cost difference between two population sizes), not a pinned total — a pinned total cannot distinguish "fixed overhead moved" from "the N+1 came back", and churns whenever unrelated setup changes.

**Each guard was verified by reverting its fix and confirming it fails against the old code**, so none of them are tautological:
- decay: would-be 5/instance vs 4
- outfit: 159 queries vs 1
- chronic: DoT statements grow 3→6 with sufferers vs staying constant

## Deliberately NOT fixed: `sweep_activity_states`

I tried and backed it out, because the obvious fix does not work.

`CharacterSheet.decay_tier`'s docstring tells callers iterating many sheets to `prefetch_related("roster_entry__tenures__player_data__account")`. Adding that prefetch **has no effect**: `RosterEntry.cached_tenures` does `list(self.tenures.order_by("-start_date"))`, and because the ordering differs from what the prefetch cached, Django discards the cache and re-queries. Measured 4.67 queries per character *with* the prefetch in place.

Making it effective needs `Prefetch(queryset=...)` with matching ordering, which runs into the repo's rule about prefetch caches on `SharedMemoryModel` parents persisting across requests (`cached_tenures` is itself a `cached_property` on an idmapper-cached instance). That is a design call, not a mechanical fix, so I left the code untouched rather than ship a prefetch that looks like a fix and isn't.

It is weekly rather than daily, and its writes only fire for characters who actually change state, so it is the least urgent of the four.

## Testing

`world.conditions` 420 tests OK. `world.magic` 3193 tests — the 35 errors are pre-existing local environment gaps (missing `areas_areaclosure` / `codex_subjectbreadcrumb` matviews, plus 4 seed `IntegrityError`s), **verified by stashing my changes and reproducing them identically on a clean tree**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)