### PR TITLE
Drop redundant joins through PK-sharing one-to-ones

### DIFF
--- a/src/actions/definitions/locations.py
+++ b/src/actions/definitions/locations.py
@@ -833,7 +833,7 @@ class RemoveFixtureAction(_RoomBuilderAction):
             return ActionResult(success=False, message=_no_room_message(kwargs))
         kind_name = (kwargs.get("kind") or "").strip()
         decoration = (
-            RoomDecoration.objects.filter(room_profile__objectdb=room, kind__name__iexact=kind_name)
+            RoomDecoration.objects.filter(room_profile_id=room.pk, kind__name__iexact=kind_name)
             .order_by("-placed_at")
             .first()
             if kind_name

--- a/src/actions/definitions/speaker_queue.py
+++ b/src/actions/definitions/speaker_queue.py
@@ -253,7 +253,7 @@ class SkipSpeakerAction(Action):
         from world.scenes.models import Persona  # noqa: PLC0415
 
         target_persona = Persona.objects.filter(
-            character_sheet__character=target,
+            character_sheet_id=target.pk,
         ).first()
         if target_persona is None:
             return ActionResult(success=False, message=f"{target_name} is not in line.")

--- a/src/actions/definitions/voyages.py
+++ b/src/actions/definitions/voyages.py
@@ -92,7 +92,7 @@ class StartVoyageAction(Action):
             return ActionResult(success=False, message="That destination doesn't exist.")
 
         try:
-            dest_hub = TravelHub.objects.get(room_profile__objectdb=dest_room)
+            dest_hub = TravelHub.objects.get(room_profile_id=dest_room.pk)
         except TravelHub.DoesNotExist:
             return ActionResult(success=False, message="That isn't a travel hub.")
 

--- a/src/commands/social/evidence.py
+++ b/src/commands/social/evidence.py
@@ -68,7 +68,7 @@ class CmdEvidence(ArxCommand):
         return list(
             CrimeEvidence.objects.filter(
                 state=EvidenceState.AT_SCENE,
-                room_profile__objectdb=room,
+                room_profile_id=room.pk,
                 deed__persona__character_sheet=sheet,
             )
         )

--- a/src/commands/social/grievance.py
+++ b/src/commands/social/grievance.py
@@ -26,7 +26,7 @@ _NO_IDENTITY = "You have no active character to register a grievance with."
 def _caller_entry(command: ArxCommand) -> RosterEntry:
     from world.roster.models import RosterEntry  # noqa: PLC0415
 
-    entry = RosterEntry.objects.filter(character_sheet__character=command.caller).first()
+    entry = RosterEntry.objects.filter(character_sheet_id=command.caller.pk).first()
     if entry is None:
         raise CommandError(_NO_IDENTITY)
     return entry

--- a/src/commands/social/tidings.py
+++ b/src/commands/social/tidings.py
@@ -97,7 +97,7 @@ class CmdTidings(ArxCommand):
         from world.roster.models import RosterEntry  # noqa: PLC0415
         from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
-        entry = RosterEntry.objects.filter(character_sheet__character=self.caller).first()
+        entry = RosterEntry.objects.filter(character_sheet_id=self.caller.pk).first()
         if entry is None:
             raise CommandError(_NO_IDENTITY)
         return active_persona_for_sheet(entry.character_sheet)

--- a/src/evennia_extensions/data_handlers/character_data.py
+++ b/src/evennia_extensions/data_handlers/character_data.py
@@ -89,7 +89,7 @@ class CharacterItemDataHandler(BaseItemDataHandler):
             from world.scenes.models import Persona
 
             self._personas_cache = list(
-                Persona.objects.filter(character_sheet__character=self.obj).order_by(
+                Persona.objects.filter(character_sheet_id=self.obj.pk).order_by(
                     "persona_type",
                     "name",
                 ),

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -252,9 +252,9 @@ def has_persistent_identity_references(objectdb: ObjectDB) -> bool:
 
     if CharacterSheet.objects.filter(character=objectdb).exists():
         return True
-    if Persona.objects.filter(character_sheet__character=objectdb).exists():
+    if Persona.objects.filter(character_sheet_id=objectdb.pk).exists():
         return True
-    if RosterEntry.objects.filter(character_sheet__character=objectdb).exists():
+    if RosterEntry.objects.filter(character_sheet_id=objectdb.pk).exists():
         return True
     return False
 

--- a/src/world/missions/services/rewards.py
+++ b/src/world/missions/services/rewards.py
@@ -507,8 +507,13 @@ def _resolve_contributor_persona(
     instance = deed.instance
     if instance.accepted_as_persona_id is not None:
         return instance.accepted_as_persona
+    # `recipient` IS the CharacterSheet (#2608 tranche 2 retargeted it off
+    # ObjectDB), so match the FK directly rather than traversing
+    # `character_sheet__character`. That traversal is correct — PK-sharing means
+    # Django resolves the sheet to the same id — but it reads as a type error and
+    # joins objects_objectdb to reach a value the FK already holds.
     return Persona.objects.filter(
-        character_sheet__character=line.recipient,
+        character_sheet=line.recipient,
         persona_type=PersonaType.PRIMARY,
     ).first()
 

--- a/src/world/missions/tests/test_services_apply_deed_rewards.py
+++ b/src/world/missions/tests/test_services_apply_deed_rewards.py
@@ -469,6 +469,39 @@ class ProjectSinkTests(TestCase):
         line.refresh_from_db()
         self.assertEqual(line.project_contribution, contrib)
 
+    def test_project_line_credits_recipient_when_no_accepted_persona(self) -> None:
+        """The fallback branch must credit the recipient's own primary persona.
+
+        Every other PROJECT test sets ``accepted_as_persona`` on the instance,
+        so ``_resolve_contributor_persona`` returns before its query ever runs.
+        A mission accepted without a presented persona (trigger-granted, or any
+        instance that never recorded one) takes the fallback, which was
+        previously untested — the branch resolves the recipient's own primary
+        persona and this pins that it credits the right character.
+        """
+        from world.projects.constants import ContributionKind
+        from world.projects.models import Contribution
+
+        self.deed.instance.accepted_as_persona = None
+        self.deed.instance.save(update_fields=["accepted_as_persona"])
+
+        MissionDeedRewardLineFactory(
+            deed=self.deed,
+            recipient=self.actor.sheet_data,
+            kind=DeedRewardKind.IMMEDIATE,
+            sink=DeedRewardSink.PROJECT,
+            amount=10,
+        )
+        self.deed.instance.target_project = self.project
+        self.deed.instance.save(update_fields=["target_project"])
+
+        result = apply_deed_rewards(self.deed)
+
+        self.assertEqual(len(result.project_skips), 0)
+        contrib = Contribution.objects.get(project=self.project)
+        self.assertEqual(contrib.kind, ContributionKind.MISSION)
+        self.assertEqual(contrib.contributor_persona, self.persona)
+
     def test_project_line_soft_skips_non_active_project(self) -> None:
         """A PROJECT line soft-skips when the project is COMPLETED (no raise)."""
         from world.projects.constants import ProjectStatus


### PR DESCRIPTION
Small pre-launch query cleanup. No migrations, no behaviour change — ten lookups stop emitting a JOIN they never needed.

`RoomProfile.objectdb`, `ExitProfile.objectdb`, `ObjectPosition.objectdb` and `CharacterSheet.character` are all `primary_key=True`. So `filter(room_profile__objectdb=room)` and `filter(room_profile_id=room.pk)` select exactly the same rows, but the first joins `objects_objectdb` — one of the largest tables in the schema — to reach a value it already has.

## Why this was less mechanical than it looked

**Nullability.** `filter(room_profile__objectdb=None)` is a valid `IS NULL` lookup; the rewritten `room.pk` raises `AttributeError` on `None`. A blanket find-and-replace here would quietly introduce crashes on empty paths. Only sites where non-`None` is provable are rewritten:

- four have an explicit `if x is None: return` immediately above the query (`locations`, `voyages`, `evidence`, `speaker_queue`)
- three take a value that is structurally always present (`command.caller`, `self.caller`, handler `self.obj`)
- two are inside `has_persistent_identity_references`, whose parameter is a non-optional `ObjectDB`
- one is `missions/services/rewards.py` (see below)

**The pattern is narrower than it reads.** Most `__character=` lookups traverse a *plain* FK to `CharacterSheet` and already pass a sheet — no PK-sharing hop, so no redundant join, and rewriting them would be wrong. The rule is that the **final** hop must be a `primary_key=True` O2O. I checked this per model: `CombatOpponent.objectdb` and `Companion.objectdb` are ordinary FKs and are deliberately untouched.

## A correction I want to be explicit about

I initially flagged `missions/services/rewards.py:510` as possibly **broken** — it filtered `character_sheet__character=line.recipient` when #2608 tranche 2 made `recipient` a `CharacterSheet`, which reads like a type error.

**It was not broken.** I verified by restoring the original lookup and re-running: everything passes, including a new test that exercises that exact branch and asserts the correct persona is credited. Django resolves the sheet by `pk`, which is correct precisely *because* `CharacterSheet.character` is `primary_key=True`. So it belongs in this PR as one more redundant join, nothing more.

I kept the new test anyway: every other PROJECT test sets `accepted_as_persona` on the instance, so `_resolve_contributor_persona` returns before its query ever runs. The fallback that credits the recipient's own primary persona had **no coverage at all**. It does now.

## Method

Sites were found with an AST scan over `filter`/`get`/`exclude`/`Q` kwargs rather than grep, so multi-line calls are covered and `select_related`/`prefetch_related` strings — which traverse the relation to genuinely *fetch* it, and would become N+1s if rewritten — are excluded by construction. Grep had estimated 11 candidates; the scan found ~17, of which only these 10 are real.

## Left for a follow-up

Several multi-hop paths whose nullability I did not establish (`ceremony_honoree__ceremony__location__objectdb`, `asset_persona__character_sheet__character`, the magic `effect_handlers` trio).

## Testing

`world.combat` + `commands` + `actions` + `world.locations`: 4840 tests, plus `world.missions.tests.test_services_apply_deed_rewards` 22 tests. The 337 errors are the known missing-matview gaps; the 2 failures are pre-existing composite-FK assertions on the partitioned interaction table. Both were reproduced identically with my changes stashed, so neither is mine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)