### PR TITLE
world.magic signature-narration idmapper cache leak in test_signature_cast

### DIFF
--- a/src/world/scenes/tests/cast_test_helpers.py
+++ b/src/world/scenes/tests/cast_test_helpers.py
@@ -244,6 +244,12 @@ class CastScenarioMixin(TestCase):
         # seeded in the fast tier. Patch it for all cast tests.
         self.accrue_patcher = patch("world.scenes.action_services.accrue")
         self.mock_accrue = self.accrue_patcher.start()
+        # Invalidate the caster's threads handler between tests. The Character
+        # instance is shared across test methods via setUpTestData + the idmapper
+        # identity map; without this, a prior test's cast re-populates the
+        # handler's _all cached_property with Thread rows that are rolled back
+        # by the savepoint, leaving stale instances visible to the next test (#2718).
+        self.caster.character_sheet.character.threads.invalidate()
 
     def tearDown(self) -> None:
         self.accrue_patcher.stop()


### PR DESCRIPTION
Closes #2718

## Summary

Fix ordering-dependent test failure in test_signature_cast (#2718).

CastScenarioMixin uses setUpTestData, sharing the Character instance across test methods via the idmapper identity map. When a test signs a technique and casts, the cast re-populates CharacterThreadHandler._all with Thread rows that are then rolled back by the savepoint — but _all remains cached, leaving stale instances visible to the next test. On SQLite, autoincrement resets on rollback so the stale thread's target_technique_id matches the new unsigned technique's pk, causing the signature snippet to leak into the unsigned cast's pose.

Fix: invalidate the caster's threads handler in setUp. Test-hygiene only — no production code changes.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2718 (in the issue body)
- Brainstorm/plan: skipped
- Sync-with-main: clean rebase, no conflicts

<!-- last-addressed-comment: 0 -->