### PR TITLE
Overconfident distinction — biases consider failures toward underestimating

### DIFF
--- a/src/world/combat/AGENT_GLOSSARY.md
+++ b/src/world/combat/AGENT_GLOSSARY.md
@@ -148,10 +148,12 @@ wrong** bands (off by 1–3 steps), not silence — the player can't distinguish
 accurate from inaccurate readings. One cached reading per (participant, opponent)
 per encounter — no re-rolls (`ConsiderReading` model). An enhancement capability
 (`CovenantRole.enhances_assessment`, initially the Sage role) grants finer 9-band
-readings + health/condition axes; the check still gates accuracy. A
-`bias_direction()` seam exists for the future Overconfident distinction (always
-underestimates). Web-first REST endpoint on `CombatEncounterViewSet`; telnet
-`consider` command follows.
+readings + health/condition axes; the check still gates accuracy. The
+`bias_direction()` seam is wired to the Overconfident distinction (always
+underestimates); the distinction also applies a -2 check penalty via a
+consider-scoped `ModifierTarget`, and `consider_opponent` routes through
+`collect_check_modifiers` (the central aggregator). Web-first REST endpoint on
+`CombatEncounterViewSet`; telnet `consider` command follows.
 _Avoid_: assess, appraise, threat-level (use **consider**), accuracy rating
 
 **Lieutenant** (#2642):

--- a/src/world/combat/consider.py
+++ b/src/world/combat/consider.py
@@ -84,6 +84,22 @@ _HEALTH_HALE = 75
 _HEALTH_WOUNDED = 50
 _HEALTH_BLOODIED = 25
 
+OVERCONFIDENT_SLUG = "overconfident"
+
+
+def _has_overconfident(character: ObjectDB) -> bool:
+    """True if the character holds the Overconfident distinction.
+
+    Uses ``character.id`` which equals the ``CharacterSheet`` pk (primary_key
+    O2O), matching the ``CharacterDistinction.character_id`` FK.
+    """
+    from world.distinctions.models import CharacterDistinction  # noqa: PLC0415
+
+    return CharacterDistinction.objects.filter(
+        character_id=character.id,
+        distinction__slug=OVERCONFIDENT_SLUG,
+    ).exists()
+
 
 def skew_for_success_level(success_level: int) -> int:
     """Return the skew magnitude for a given check success level.
@@ -110,19 +126,21 @@ def bias_direction(true_index: int, skew: int, character: ObjectDB | None) -> in
     ``participant.character_sheet.character``.
 
     Default: random.choice([-1, +1]).
-    Override point for the future Overconfident distinction, which
-    always returns -1 (toward 'weaker than you actually are').
+    Overconfident distinction: always returns -1 (toward 'weaker than you
+    actually are').
 
     Args:
         true_index: The correct band index.
         skew: The skew magnitude (from ``skew_for_success_level``).
-        character: The assessing character (for future distinction lookup).
+        character: The assessing character (for distinction lookup).
 
     Returns:
         +1, -1, or 0 (when skew is 0).
     """
     if skew == 0:
         return 0
+    if character is not None and _has_overconfident(character):
+        return -1
     return random.choice([-1, 1])  # noqa: S311
 
 
@@ -234,6 +252,45 @@ def ensure_consider_check_type() -> CheckType:
         ),
         defaults={"weight": Decimal("1.00")},
     )
+
+    # Create a scoped ModifierTarget so DistinctionEffect → CharacterModifier
+    # rows can target the Consider check specifically (#2742). Follows the
+    # same programmatic pattern as combat/factories.py penetration/flee
+    # targets — the CheckType is runtime get_or_created, so the ModifierTarget
+    # must be too.
+    from world.distinctions.models import Distinction, DistinctionEffect  # noqa: PLC0415
+    from world.mechanics.models import (  # noqa: PLC0415
+        ModifierCategory,
+        ModifierTarget,
+    )
+
+    check_category, _ = ModifierCategory.objects.get_or_create(name="check")
+    consider_target, _ = ModifierTarget.objects.get_or_create(
+        target_check_type=check_type,
+        defaults={
+            "name": "consider_check",
+            "category": check_category,
+            "is_active": True,
+        },
+    )
+
+    # Wire the Overconfident distinction's check penalty: a -2 per-rank
+    # DistinctionEffect targeting the Consider-scoped ModifierTarget. Created
+    # programmatically (not via fixture) because the ModifierTarget itself is
+    # programmatic — a fixture's natural-key FK can't resolve to a row that
+    # doesn't exist at loaddata time.
+    overconfident = Distinction.objects.filter(slug="overconfident").first()
+    if overconfident is not None:
+        DistinctionEffect.objects.get_or_create(
+            distinction=overconfident,
+            target=consider_target,
+            defaults={
+                "value_per_rank": -2,
+                "description": (
+                    "Applies a -2 penalty to Consider checks, making threat assessment harder."
+                ),
+            },
+        )
     return check_type
 
 
@@ -269,6 +326,7 @@ def consider_opponent(participant: CombatParticipant, opponent: CombatOpponent) 
         A ConsiderReading with the (possibly inaccurate) prose reading.
     """
     from world.checks.services import (  # noqa: PLC0415
+        collect_check_modifiers,
         level_opposition,
         perform_check,
     )
@@ -288,10 +346,20 @@ def consider_opponent(participant: CombatParticipant, opponent: CombatOpponent) 
 
     check_type = ensure_consider_check_type()
     difficulty = level_opposition(check_type, level=opponent.level, character=opponent.objectdb)
+
+    # Route through the central modifier aggregator so conditions, equipment,
+    # scene modifiers, fashion, and distinction-sourced check modifiers reach
+    # the consider check — matching every other check path (#2742).
+    modifier_breakdown = collect_check_modifiers(
+        sheet,
+        check_type,
+        scene=participant.encounter.scene,
+    )
     result = perform_check(
         character,
         check_type,
         target_difficulty=difficulty,
+        extra_modifiers=modifier_breakdown.total,
     )
     success_level = result.success_level
 

--- a/src/world/combat/tests/test_consider.py
+++ b/src/world/combat/tests/test_consider.py
@@ -91,6 +91,87 @@ class BiasDirectionTest(TestCase):
         self.assertEqual(bias_direction(2, 0, character=None), 0)
 
 
+class OverconfidentBiasDirectionTest(TestCase):
+    """bias_direction returns -1 for characters with the Overconfident distinction."""
+
+    def test_overconfident_always_underestimates(self) -> None:
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.distinctions.factories import (
+            CharacterDistinctionFactory,
+            DistinctionCategoryFactory,
+            DistinctionFactory,
+        )
+
+        sheet = CharacterSheetFactory()
+        category = DistinctionCategoryFactory(slug="personality")
+        distinction = DistinctionFactory(
+            slug="overconfident",
+            category=category,
+            cost_per_rank=-10,
+        )
+        CharacterDistinctionFactory(
+            character=sheet,
+            distinction=distinction,
+        )
+        # skew > 0, should always return -1 (underestimate)
+        result = bias_direction(2, 1, character=sheet.character)
+        self.assertEqual(result, -1)
+
+    def test_overconfident_with_higher_skew(self) -> None:
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.distinctions.factories import (
+            CharacterDistinctionFactory,
+            DistinctionCategoryFactory,
+            DistinctionFactory,
+        )
+
+        sheet = CharacterSheetFactory()
+        category = DistinctionCategoryFactory(slug="personality")
+        distinction = DistinctionFactory(
+            slug="overconfident",
+            category=category,
+        )
+        CharacterDistinctionFactory(
+            character=sheet,
+            distinction=distinction,
+        )
+        # skew = 3 (crit fail), should still return -1
+        result = bias_direction(2, 3, character=sheet.character)
+        self.assertEqual(result, -1)
+
+    def test_non_overconfident_uses_random(self) -> None:
+        from world.character_sheets.factories import CharacterSheetFactory
+
+        sheet = CharacterSheetFactory()
+        # No distinction — should fall through to random.choice
+        with patch("world.combat.consider.random.choice") as mock_choice:
+            mock_choice.return_value = 1
+            result = bias_direction(2, 1, character=sheet.character)
+            self.assertEqual(result, 1)
+
+    def test_overconfident_zero_skew_returns_zero(self) -> None:
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.distinctions.factories import (
+            CharacterDistinctionFactory,
+            DistinctionCategoryFactory,
+            DistinctionFactory,
+        )
+
+        sheet = CharacterSheetFactory()
+        category = DistinctionCategoryFactory(slug="personality")
+        distinction = DistinctionFactory(
+            slug="overconfident",
+            category=category,
+        )
+        CharacterDistinctionFactory(
+            character=sheet,
+            distinction=distinction,
+        )
+        # skew == 0 always returns 0, even with the distinction
+        result = bias_direction(2, 0, character=sheet.character)
+        self.assertEqual(result, 0)
+
+
 class ApplySkewTest(TestCase):
     """Skewed band indices clamp to valid range."""
 
@@ -257,6 +338,78 @@ class ConsiderOpponentServiceTest(TestCase):
         )
         reading = consider_opponent(self.participant, self.opponent)
         self.assertTrue(reading.is_enhanced)
+
+    def test_consider_picks_up_check_modifiers(self) -> None:
+        """consider_opponent routes through collect_check_modifiers (#2742).
+
+        Verifies the modifier aggregator is called by patching it and
+        confirming the patched value reaches perform_check.
+        """
+        from unittest.mock import MagicMock, patch
+
+        from world.checks.services import ModifierBreakdown, ModifierContribution
+        from world.combat.consider import consider_opponent
+
+        # Patch collect_check_modifiers to return a known breakdown.
+        fake_contribution = ModifierContribution(
+            source_kind="character",
+            source_label="Test modifier",
+            value=-42,
+        )
+        fake_breakdown = ModifierBreakdown(contributions=[fake_contribution])
+
+        # Patch perform_check to return a mock — we only care about call args.
+        fake_result = MagicMock()
+        fake_result.success_level = 0
+
+        with (
+            patch(
+                "world.checks.services.collect_check_modifiers",
+                return_value=fake_breakdown,
+            ) as mock_collect,
+            patch(
+                "world.checks.services.perform_check",
+                return_value=fake_result,
+            ) as mock_perform,
+        ):
+            consider_opponent(self.participant, self.opponent)
+
+            # collect_check_modifiers was called with the sheet.
+            mock_collect.assert_called_once()
+            call_args = mock_collect.call_args
+            self.assertEqual(call_args.args[0], self.participant.character_sheet)
+
+            # perform_check received extra_modifiers=-42 (the breakdown total).
+            mock_perform.assert_called_once()
+            perform_kwargs = mock_perform.call_args.kwargs
+            self.assertEqual(perform_kwargs["extra_modifiers"], -42)
+
+
+class EnsureConsiderCheckTypeTest(TestCase):
+    """ensure_consider_check_type creates the CheckType + scoped ModifierTarget."""
+
+    def test_creates_modifier_target_scoped_to_consider(self) -> None:
+        from world.combat.consider import ensure_consider_check_type
+
+        check_type = ensure_consider_check_type()
+        # The reverse OneToOne accessor should resolve to a ModifierTarget
+        # scoped to this CheckType.
+        target = check_type.modifier_target
+        self.assertIsNotNone(target)
+        self.assertEqual(target.target_check_type, check_type)
+        self.assertTrue(target.is_active)
+
+    def test_modifier_target_is_idempotent(self) -> None:
+        from world.combat.consider import ensure_consider_check_type
+        from world.mechanics.models import ModifierTarget
+
+        # Call twice — should not create a duplicate.
+        ensure_consider_check_type()
+        ensure_consider_check_type()
+        count = ModifierTarget.objects.filter(
+            target_check_type__name="Consider",
+        ).count()
+        self.assertEqual(count, 1)
 
 
 class ConsiderEndpointTest(TestCase):


### PR DESCRIPTION
Closes #2742

## Summary

Add an Overconfident personality flaw (-10 CP) that biases failed consider checks toward underestimating and applies a -2 check penalty. Routes consider_opponent through collect_check_modifiers, closing a pre-existing gap where conditions/equipment/scene modifiers never reached consider.

## Follow-ups filed

- #2750

## Notes

- Spec: reviewed & approved on #2742 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch was up to date with main; no conflicts.

<!-- last-addressed-comment: 0 -->