### PR TITLE
Compose Resist Corruption + Medicine checks, wire into factories/seeds (#2747, #2748)

### DIFF
--- a/src/integration_tests/game_content/tests/test_magic_seed.py
+++ b/src/integration_tests/game_content/tests/test_magic_seed.py
@@ -183,10 +183,10 @@ class TestSeedMagicConfigIdempotency(TestCase):
         self.assertEqual(counts["mishap_pool_tiers"], 1)
         # Guard against orphan CheckType/CheckCategory rows leaking on re-run.
         # seed_magic_config() now delegates to ensure_magic_check_types() which
-        # seeds the five Magic CheckTypes (#709); count updated from 1 → 5.
+        # seeds the six Magic CheckTypes (#709, #2747); count updated from 1 → 6.
         self.assertEqual(
             counts["check_types"],
-            5,
+            6,
             "seed_magic_config() must not create extra CheckType rows on second call",
         )
         self.assertEqual(
@@ -1799,7 +1799,7 @@ class SeedMagicDevMagicChecksTests(TestCase):
 
     def test_seed_magic_dev_includes_magic_check_content(self):
         result = seed_magic_dev()
-        self.assertEqual(len(result.magic_checks.check_types), 5)
+        self.assertEqual(len(result.magic_checks.check_types), 6)
         self.assertEqual(len(result.magic_checks.skills), 3)
         self.assertEqual(len(result.magic_checks.configs), 5)
 

--- a/src/world/magic/factories.py
+++ b/src/world/magic/factories.py
@@ -2038,6 +2038,23 @@ def _make_magical_endurance_check_type():
     return CheckTypeFactory(name=MAGICAL_ENDURANCE_CHECK_TYPE_NAME, category=category)
 
 
+def _make_resist_corruption_check_type():
+    """Return a 'Resist Corruption' CheckType — factory-owned, not the gated #709 seed (#2698).
+
+    Mirrors ``_make_magical_endurance_check_type``: the seed is content-repo-gated
+    and may omit this key when SEED_SAMPLE_CONTENT is off, but a test factory must
+    always produce a valid object. Uses ``get_or_create`` so repeated calls share one row.
+    """
+    from world.checks.factories import CheckCategoryFactory, CheckTypeFactory
+    from world.magic.seeds_checks import (
+        MAGIC_CHECK_CATEGORY_NAME,
+        RESIST_CORRUPTION_CHECK_TYPE_NAME,
+    )
+
+    category = CheckCategoryFactory(name=MAGIC_CHECK_CATEGORY_NAME)
+    return CheckTypeFactory(name=RESIST_CORRUPTION_CHECK_TYPE_NAME, category=category)
+
+
 class CorruptionConditionTemplateFactory(factory.django.DjangoModelFactory):
     """Factory for a per-resonance Corruption ConditionTemplate with 5 stages.
 
@@ -2098,7 +2115,7 @@ class CorruptionConditionTemplateFactory(factory.django.DjangoModelFactory):
         thresholds = [50, 200, 500, 1000, 1500]
         is_abyssal = self.corruption_resonance.affinity.name.lower() == _ABYSSAL_AFFINITY_NAME
         difficulties = [12, 18, 25, 30, 35] if is_abyssal else [8, 12, 18, 22, 28]
-        check_type = _make_magical_endurance_check_type()
+        check_type = _make_resist_corruption_check_type()
 
         for i, (threshold, dc) in enumerate(zip(thresholds, difficulties, strict=True), start=1):
             ConditionStageFactory(

--- a/src/world/magic/seeds_checks.py
+++ b/src/world/magic/seeds_checks.py
@@ -49,6 +49,7 @@ ANIMA_RESTORATION_CHECK_TYPE_NAME = "Anima Restoration"
 SANCTUM_CONSECRATION_CHECK_TYPE_NAME = "Sanctum Consecration"
 SANCTUM_DISSOLUTION_CHECK_TYPE_NAME = "Sanctum Dissolution"
 MAGICAL_ENDURANCE_CHECK_TYPE_NAME = "Magical Endurance"
+RESIST_CORRUPTION_CHECK_TYPE_NAME = "Resist Corruption"
 ARCANA_ASPECT_NAME = "Arcana"
 
 # (name, description, display_order)
@@ -85,6 +86,11 @@ _MAGIC_CHECK_TYPES = [
         "Endurance check against the spiritual pressure of hallowed ground.",
         4,
     ),
+    (
+        RESIST_CORRUPTION_CHECK_TYPE_NAME,
+        "Resisting the pull of corruption when it crosses a stage threshold.",
+        5,
+    ),
 ]
 
 # (check_type_name, trait_name, weight)
@@ -103,6 +109,8 @@ _MAGIC_TRAIT_WEIGHTS = [
     (MAGICAL_ENDURANCE_CHECK_TYPE_NAME, "occult", "0.50"),
     (ENDURE_HALLOWED_GROUND_CHECK_TYPE_NAME, "willpower", "1.00"),
     (ENDURE_HALLOWED_GROUND_CHECK_TYPE_NAME, "theology", "0.50"),
+    (RESIST_CORRUPTION_CHECK_TYPE_NAME, "willpower", "1.00"),
+    (RESIST_CORRUPTION_CHECK_TYPE_NAME, "occult", "1.00"),
 ]
 
 # Stat trait defaults used only when the stat row doesn't exist yet.

--- a/src/world/magic/tests/test_reference_corruption_content.py
+++ b/src/world/magic/tests/test_reference_corruption_content.py
@@ -93,7 +93,7 @@ class TestCorruptionConditionTemplateFactory(TestCase):
         # All stages should have a resist_check_type
         for stage in template.stages.select_related("resist_check_type").order_by("stage_order"):
             self.assertIsNotNone(stage.resist_check_type, f"Stage {stage.stage_order} missing")
-            self.assertEqual(stage.resist_check_type.name, "Magical Endurance")
+            self.assertEqual(stage.resist_check_type.name, "Resist Corruption")
 
     def test_passive_decay_max_severity_is_none_for_primal(self) -> None:
         """Primal Corruption decays all the way to zero per Spec B §11 (tuning placeholder)."""

--- a/src/world/magic/tests/test_seeds_checks.py
+++ b/src/world/magic/tests/test_seeds_checks.py
@@ -45,9 +45,9 @@ class EnsureMagicSkillsTests(TestCase):
 
 @override_settings(SEED_SAMPLE_CONTENT=True)  # ensure_magic_check_types gates on #2698
 class EnsureMagicCheckTypesTests(TestCase):
-    def test_creates_five_composed_check_types(self):
+    def test_creates_six_composed_check_types(self):
         check_types = ensure_magic_check_types()
-        self.assertEqual(len(check_types), 5)
+        self.assertEqual(len(check_types), 6)
         category = CheckCategory.objects.get(name=MAGIC_CHECK_CATEGORY_NAME)
         arcana = Aspect.objects.get(name="Arcana")
         for ct in check_types.values():
@@ -91,7 +91,7 @@ class EnsureMagicCheckTypesTests(TestCase):
         ensure_magic_check_types()
         self.assertEqual(
             CheckType.objects.filter(category__name=MAGIC_CHECK_CATEGORY_NAME).count(),
-            5,
+            6,
         )
 
 

--- a/src/world/vitals/constants.py
+++ b/src/world/vitals/constants.py
@@ -98,6 +98,7 @@ AUTO_RETIRE_DAYS: int = 14
 
 ENDURANCE_CHECK_NAME: str = "Endurance"  # shared: knockout + permanent wound
 DEATH_CHECK_NAME: str = "Mortal Resolve"  # distinct, high-stakes (death)
+MEDICINE_CHECK_NAME: str = "Medicine"  # wound treatment (#2748)
 SURVIVABILITY_CHECK_CATEGORY: str = "Survival"
 
 # ---------------------------------------------------------------------------

--- a/src/world/vitals/seeds.py
+++ b/src/world/vitals/seeds.py
@@ -619,15 +619,11 @@ def ensure_default_wound_pool() -> ConsequencePool:
 def ensure_wound_treatment_content() -> None:
     """Seed one TreatmentTemplate per wound condition (#2644 — bounded HP mend).
 
-    **Check type — documented judgment call.** No Medicine/first-aid CheckType
-    exists anywhere in the codebase's seeded content (checked every production
-    seed file); authoring a new stat+skill composition (a Medicine Skill/Trait
-    plus its CheckType) is a bigger content-authoring lift than this mechanics-
-    vocabulary pass calls for. Reuses the vitals-owned ``Endurance`` CheckType
-    (Stamina resist check, already seeded by ``_ensure_endurance_check_type``)
-    per the spec's fallback clause ("reuse an existing broadly-applicable [check
-    type] and document") — a proper Medicine composition is a future authoring
-    pass; ``TreatmentTemplate.check_type`` just gets repointed, no schema change.
+    Uses the ``Medicine`` CheckType (intellect + Medicine skill, #2748) for the
+    treatment check. Previously fell back to the ``Endurance`` CheckType (stamina
+    resist) as a placeholder — now that Medicine is a composed check, treatment
+    rolls against it instead. ``TreatmentTemplate.check_type`` is a plain FK, so
+    repointing requires no schema change.
 
     Modest ``anima_cost`` (no bond thread requirement — unlike the Soulfray/
     Mage-Scar aftermath treatments, tending a physical wound doesn't require an
@@ -638,14 +634,14 @@ def ensure_wound_treatment_content() -> None:
     """
     from world.conditions.constants import TreatmentTargetKind  # noqa: PLC0415
     from world.conditions.models import TreatmentTemplate  # noqa: PLC0415
-    from world.vitals.services import _ensure_endurance_check_type  # noqa: PLC0415
+    from world.vitals.services import _ensure_medicine_check_type  # noqa: PLC0415
 
     lingering_ache, crippling_wound, bleeding_wound = ensure_wound_conditions()
-    check_type = _ensure_endurance_check_type()
+    check_type = _ensure_medicine_check_type()
     if check_type is None:
         # checks.CheckType is content-repo-owned (#2698); check_type is a
         # required FK on TreatmentTemplate, so every treatment template is
-        # skipped entirely when the Endurance CheckType isn't authored.
+        # skipped entirely when the Medicine CheckType isn't authored.
         return
 
     specs = [

--- a/src/world/vitals/services.py
+++ b/src/world/vitals/services.py
@@ -25,6 +25,7 @@ from world.vitals.constants import (
     DERIVED_STATUS_INCAPACITATED,
     ENDURANCE_CHECK_NAME,
     KNOCKOUT_HEALTH_THRESHOLD,
+    MEDICINE_CHECK_NAME,
     NEVER_TO_FULL_FRACTION,
     PERMANENT_WOUND_THRESHOLD,
     SURVIVABILITY_CHECK_CATEGORY,
@@ -275,6 +276,57 @@ def _ensure_endurance_check_type() -> CheckType | None:
     if stamina is not None:
         authored_or_sample(
             CheckTypeTrait, {"weight": Decimal("1.00")}, check_type=check, trait=stamina
+        )
+    return check
+
+
+def _ensure_medicine_check_type() -> CheckType | None:
+    """Look up (or sample) the Medicine CheckType + composition (#2748).
+
+    Composed as ``intellect`` stat + ``Medicine`` skill (stat + skill tenet).
+
+    Used for wound treatment checks (``TreatmentTemplate.check_type``).
+    ``checks.CheckCategory``/``CheckType``/``CheckTypeTrait``, ``traits.Trait``,
+    and ``skills.Skill`` are content-repo-owned (#2698) — looked up rather than
+    invented unless ``SEED_SAMPLE_CONTENT`` is on. Returns ``None`` when the
+    category or the check type itself isn't authored.
+    """
+    from decimal import Decimal  # noqa: PLC0415
+
+    from world.checks.models import CheckTypeTrait  # noqa: PLC0415
+    from world.seeds.sample_content import authored_or_sample  # noqa: PLC0415
+    from world.traits.models import Trait, TraitCategory, TraitType  # noqa: PLC0415
+
+    category = _ensure_survival_category()
+    if category is None:
+        return None
+    check = authored_or_sample(
+        CheckType,
+        {
+            "category": category,
+            "description": "Diagnosing and treating wounds, ailments, and poisons.",
+        },
+        name=MEDICINE_CHECK_NAME,
+    )
+    if check is None:
+        return None
+    intellect = authored_or_sample(
+        Trait,
+        {"trait_type": TraitType.STAT, "category": TraitCategory.MENTAL, "is_public": True},
+        name="intellect",
+    )
+    if intellect is not None:
+        authored_or_sample(
+            CheckTypeTrait, {"weight": Decimal("1.00")}, check_type=check, trait=intellect
+        )
+    medicine = authored_or_sample(
+        Trait,
+        {"trait_type": TraitType.SKILL, "category": TraitCategory.GENERAL, "is_public": True},
+        name="Medicine",
+    )
+    if medicine is not None:
+        authored_or_sample(
+            CheckTypeTrait, {"weight": Decimal("1.00")}, check_type=check, trait=medicine
         )
     return check
 


### PR DESCRIPTION
## What

Composes two previously-dead CheckTypes and wires them into their production code paths.

### Resist Corruption (#2747)

**Composition:** `willpower` (1.0) + `occult` (1.0) — mental fortitude against the corrupting pull + understanding of the corrupting force. Distinct from Magical Endurance (`stability` + `occult`), which keeps its soulfray/soul-tether rescue uses.

**Wiring:** Changed `CorruptionConditionTemplateFactory` to use Resist Corruption as the `resist_check_type` on all 5 corruption stages (was Magical Endurance). The factory already set `HOLD_OVERFLOW` + `resist_difficulty` — the only gap was the wrong check type being used.

**Result:** When corruption severity crosses a stage threshold, the character now rolls Resist Corruption (willpower + occult) at the stage's difficulty. The 4 `ConditionCheckModifier` rows targeting this check become live.

**Lore-repo PR:** Arx-Game/ArxII-lore#18 (CheckTypeTrait fixture rows)

### Medicine (#2748)

**Composition:** `intellect` (1.0) + `Medicine` skill (1.0) — diagnosis + treatment. New Medicine Trait + Skill authored in the lore repo. CheckType moved from Exploration to Survival category.

**Wiring:** Repointed `ensure_wound_treatment_content()` from the Endurance check (stamina) to the Medicine check (intellect + Medicine). The treatment seed's fallback clause explicitly anticipated this repointing — no schema change needed.

**Result:** Wound treatment now rolls intellect + Medicine instead of stamina.

**Lore-repo PR:** Arx-Game/ArxII-lore#18 (Trait, Skill, CheckTypeTrait fixture rows)

## Changes

**Arxii (this PR):**
- `world/magic/seeds_checks.py` — add `RESIST_CORRUPTION_CHECK_TYPE_NAME` constant + seed entries
- `world/magic/factories.py` — add `_make_resist_corruption_check_type()` helper, change corruption factory
- `world/vitals/constants.py` — add `MEDICINE_CHECK_NAME` constant
- `world/vitals/services.py` — add `_ensure_medicine_check_type()` function
- `world/vitals/seeds.py` — repoint treatment seed from Endurance to Medicine

**Lore repo (ArxII-lore#18):**
- `fixtures/checks/checktypetrait.json` — 4 new rows (2 Resist Corruption + 2 Medicine)
- `fixtures/traits/trait.json` — 1 new Medicine trait
- `fixtures/skills/skill.json` — 1 new Medicine skill
- `fixtures/checks/checktype.json` — Medicine moved to Survival category

## Tests

All vitals (219), corruption flow (18), and magic seed convergence (1) tests pass.

Closes #2747, closes #2748.