### PR TITLE
Audit: perform_check callers that bypass collect_check_modifiers

### DIFF
--- a/src/integration_tests/pipeline/test_battle_peril_rescue_e2e.py
+++ b/src/integration_tests/pipeline/test_battle_peril_rescue_e2e.py
@@ -101,7 +101,7 @@ class BattlePerilRescueE2EJourneyTest(TestCase):
             # exclusion). Assert this mock is never called — proves the exclusion holds,
             # not just that the stage happens to still read 1.
             patch(
-                "world.vitals.services.perform_check", return_value=_stub_check(-999)
+                "world.vitals.services.perform_check_with_modifiers", return_value=_stub_check(-999)
             ) as escalation_check_mock,
         ):
             _run(self.gm_char, "resolve")
@@ -115,7 +115,9 @@ class BattlePerilRescueE2EJourneyTest(TestCase):
         _run(self.gm_char, "round")
         # Only the rescuer declares (a SUPPORT no-op target isn't needed for this
         # assertion) -- the PC's own peril still ticks because afk_peril_override=True.
-        with patch("world.vitals.services.perform_check", return_value=_stub_check(-1)):
+        with patch(
+            "world.vitals.services.perform_check_with_modifiers", return_value=_stub_check(-1)
+        ):
             _run(self.gm_char, "resolve")
 
         instance.refresh_from_db()

--- a/src/world/agriculture/services/collection.py
+++ b/src/world/agriculture/services/collection.py
@@ -209,7 +209,7 @@ def _roll_collection_check(character, pool_bonus: int, difficulty_modifier: int)
     """
     from world.agriculture.constants import FOOD_COLLECTION_CHECK_NAME  # noqa: PLC0415
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
     from world.scenes.action_constants import (  # noqa: PLC0415
         DIFFICULTY_VALUES,
         DifficultyChoice,
@@ -224,7 +224,7 @@ def _roll_collection_check(character, pool_bonus: int, difficulty_modifier: int)
     )
     effective_difficulty = min(effective_difficulty, DIFFICULTY_VALUES[DifficultyChoice.HARROWING])
     effective_difficulty = max(effective_difficulty, DIFFICULTY_VALUES[DifficultyChoice.TRIVIAL])
-    result = perform_check(
+    result = perform_check_with_modifiers(
         character,
         check_type,
         target_difficulty=effective_difficulty,

--- a/src/world/agriculture/tests/test_collection_events.py
+++ b/src/world/agriculture/tests/test_collection_events.py
@@ -148,7 +148,7 @@ class FoodPreCollectEventTests(TestCase):
 
         with (
             patch("flows.emit.emit_event", side_effect=emit_side_effect),
-            patch("world.checks.services.perform_check") as mock_check,
+            patch("world.checks.services.perform_check_with_modifiers") as mock_check,
         ):
             mock_check.return_value = MagicMock(success_level=0)
 
@@ -188,7 +188,7 @@ class FoodCollectedEventTests(TestCase):
 
         with (
             patch("flows.emit.emit_event", side_effect=_uncancelled_stack) as mock_emit,
-            patch("world.checks.services.perform_check") as mock_check,
+            patch("world.checks.services.perform_check_with_modifiers") as mock_check,
         ):
             # success_level=-2 → below the last band floor (-1) → catastrophe
             mock_check.return_value = MagicMock(success_level=-2)

--- a/src/world/assets/effects.py
+++ b/src/world/assets/effects.py
@@ -49,7 +49,7 @@ def _promote_functionary(
     from world.areas.services import get_room_profile  # noqa: PLC0415
     from world.assets.models import NPCAsset  # noqa: PLC0415
     from world.character_sheets.services import create_character_with_sheet  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
     from world.npc_services.functionaries import remove_functionary  # noqa: PLC0415
     from world.npc_services.models import Functionary  # noqa: PLC0415
 
@@ -80,7 +80,7 @@ def _promote_functionary(
             message="This offer has no capability check configured. (Authoring error.)",
         )
 
-    check_result = perform_check(
+    check_result = perform_check_with_modifiers(
         character, offer.check_type, target_difficulty=offer.check_difficulty
     )
     if check_result.success_level <= 0:
@@ -179,7 +179,7 @@ def run_asset_intel_task(offer: NPCServiceOffer, persona: Persona) -> EffectResu
         AssetTaskIntelDetails,
         NPCAsset,
     )
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
     from world.clues.models import CharacterClue  # noqa: PLC0415
     from world.roster.models import RosterEntry  # noqa: PLC0415
 
@@ -207,7 +207,7 @@ def run_asset_intel_task(offer: NPCServiceOffer, persona: Persona) -> EffectResu
     # Roll the check — the PC rolls (they're directing the task).
     character = persona.character_sheet.character
     if offer.check_type_id is not None:
-        check_result = perform_check(
+        check_result = perform_check_with_modifiers(
             character, offer.check_type, target_difficulty=offer.check_difficulty
         )
         if check_result.success_level <= 0:

--- a/src/world/battles/tests/test_resolution.py
+++ b/src/world/battles/tests/test_resolution.py
@@ -1985,7 +1985,10 @@ class EscalationTickTests(TestCase):
                 "world.battles.resolution.resolve_battle_technique",
                 return_value=_success_result(3),
             ),
-            patch("world.vitals.services.perform_check", return_value=_failure_result(-1)),
+            patch(
+                "world.vitals.services.perform_check_with_modifiers",
+                return_value=_failure_result(-1),
+            ),
         ):
             resolve_battle_round(battle_round=battle_round)
 
@@ -2005,7 +2008,9 @@ class EscalationTickTests(TestCase):
         battle_round = begin_battle_round(battle=battle)
         # No declaration this round; battle.afk_peril_override defaults False.
 
-        with patch("world.vitals.services.perform_check", return_value=_failure_result(-1)):
+        with patch(
+            "world.vitals.services.perform_check_with_modifiers", return_value=_failure_result(-1)
+        ):
             resolve_battle_round(battle_round=battle_round)
 
         instance = get_active_conditions(
@@ -2025,7 +2030,9 @@ class EscalationTickTests(TestCase):
         participant = self._surrounded_participant(battle, side)
         battle_round = begin_battle_round(battle=battle)
 
-        with patch("world.vitals.services.perform_check", return_value=_failure_result(-1)):
+        with patch(
+            "world.vitals.services.perform_check_with_modifiers", return_value=_failure_result(-1)
+        ):
             resolve_battle_round(battle_round=battle_round)
 
         instance = get_active_conditions(

--- a/src/world/ceremonies/leak.py
+++ b/src/world/ceremonies/leak.py
@@ -103,13 +103,13 @@ def _observer_senses_twist(  # noqa: PLR0913
     *, observer, observer_sheet, officiant_sheet, check_type, difficulty, worship_secret
 ) -> bool:
     """One witness: consent gate → hidden Search roll → clue mint on success."""
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
     from world.clues.services import acquire_clue  # noqa: PLC0415
     from world.roster.models import RosterEntry  # noqa: PLC0415
 
     if not _may_investigate(observer_sheet, officiant_sheet):
         return False
-    result = perform_check(observer, check_type, target_difficulty=difficulty)
+    result = perform_check_with_modifiers(observer, check_type, target_difficulty=difficulty)
     if result.outcome is None or result.outcome.success_level <= 0:
         return False
     entry = RosterEntry.objects.filter(character_sheet=observer_sheet).first()

--- a/src/world/ceremonies/services.py
+++ b/src/world/ceremonies/services.py
@@ -203,7 +203,7 @@ def record_speech(
     """Recognize a speaker; their Performance/Oratory roll shapes the tally."""
     _require_open(ceremony)
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
     from world.skills.models import Specialization  # noqa: PLC0415
 
     check_type = CheckType.objects.filter(name=SPEECH_CHECK_TYPE_NAME).first()
@@ -213,7 +213,7 @@ def record_speech(
             name=SPEECH_SPECIALIZATION_NAME,
             parent_skill__trait__name=SPEECH_CHECK_TYPE_NAME,
         ).first()
-        result = perform_check(
+        result = perform_check_with_modifiers(
             speaker_persona.character_sheet.character,
             check_type,
             specialization=oratory,
@@ -232,7 +232,7 @@ def finish_ceremony(*, ceremony: Ceremony) -> Ceremony:
     """Close the rite: quality roll, renown tallies, worship, funeral effects."""
     _require_open(ceremony)
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
     from world.worship.services import bump_devotion  # noqa: PLC0415
 
     config = get_ceremony_config()
@@ -243,7 +243,7 @@ def finish_ceremony(*, ceremony: Ceremony) -> Ceremony:
     if check_type is not None:
         # The rite follows the TRUE being's forms (Decision 10) — its tradition
         # specialization applies even when the presentation claims another god.
-        result = perform_check(
+        result = perform_check_with_modifiers(
             officiant_sheet.character,
             check_type,
             specialization=ceremony.being.tradition.rites_specialization,

--- a/src/world/checks/CLAUDE.md
+++ b/src/world/checks/CLAUDE.md
@@ -20,6 +20,7 @@ The checks app defines types of checks (Stealth, Diplomacy, Perception, etc.) an
 
 ### `services.py`
 - **`perform_check(character, check_type, target_difficulty, extra_modifiers)`**: Main resolution function. Returns CheckResult.
+- **`perform_check_with_modifiers(character, check_type, ..., *, scene=None)`** (#2750): Thin wrapper around `perform_check` that resolves `character.character_sheet`, guards `None` for sheet-less actors (GM puppets, companions), calls `collect_check_modifiers`, and forwards `breakdown.total` additively to `perform_check`. Use this for any check that should honor conditions, equipment, fashion, capability, and distinction modifiers. Mirrors `perform_check`'s exact signature plus a keyword-only `scene` param.
 - **`get_rollmod(character)`**: Public function that sums character and account rollmod values. Used by both checks and attempts apps.
 
 ### `consequence_resolution.py`

--- a/src/world/checks/services.py
+++ b/src/world/checks/services.py
@@ -134,6 +134,75 @@ def perform_check(  # noqa: PLR0913 - optional effort/fatigue params extend exis
     return _check_result(check_type, outcome, breakdown)
 
 
+def perform_check_with_modifiers(  # noqa: PLR0913 - mirrors perform_check signature
+    character: "ObjectDB",
+    check_type: "CheckType",
+    target_difficulty: int = 0,
+    extra_modifiers: int = 0,
+    effort_level: str | None = None,
+    fatigue_penalty: int = 0,
+    specialization: "Specialization | None" = None,
+    *,
+    situation_ctx: "SituationContext | None" = None,
+    level_override: int | None = None,
+    scene: "Scene | None" = None,
+) -> CheckResult:
+    """Run a check with all character modifiers gathered automatically.
+
+    Thin wrapper around :func:`perform_check` that resolves the character's
+    ``CharacterSheet`` and calls :func:`collect_check_modifiers` to gather
+    condition, rollmod, scene, equipment, character, fashion, and capability
+    contributions. The aggregator's ``.total`` is added to any caller-supplied
+    ``extra_modifiers`` (additive, not replacing).
+
+    For sheet-less actors (GM puppets, companions with no ``CharacterSheet``),
+    forwards to ``perform_check`` unchanged — no crash, no modifiers applied.
+
+    Args:
+        character: The character performing the check.
+        check_type: The type of check being resolved.
+        target_difficulty: Target difficulty in points.
+        extra_modifiers: Additional modifiers from the caller. Added to the
+            aggregator's total when a sheet exists.
+        effort_level: Optional EffortLevel value.
+        fatigue_penalty: Penalty from fatigue zone (typically negative).
+        specialization: Optional skill specialization.
+        situation_ctx: Optional SituationContext for situational perks.
+        level_override: Optional level override (substitutes for resolved level).
+        scene: Optional Scene — when provided, scene modifiers and the
+            perception-relative fashion bonus apply. Omit when the check is
+            performed outside an active scene.
+
+    Returns:
+        CheckResult from perform_check.
+    """
+    sheet = character.character_sheet
+    if sheet is None:
+        return perform_check(
+            character,
+            check_type,
+            target_difficulty=target_difficulty,
+            extra_modifiers=extra_modifiers,
+            effort_level=effort_level,
+            fatigue_penalty=fatigue_penalty,
+            specialization=specialization,
+            situation_ctx=situation_ctx,
+            level_override=level_override,
+        )
+    breakdown = collect_check_modifiers(sheet, check_type, scene=scene)
+    return perform_check(
+        character,
+        check_type,
+        target_difficulty=target_difficulty,
+        extra_modifiers=extra_modifiers + breakdown.total,
+        effort_level=effort_level,
+        fatigue_penalty=fatigue_penalty,
+        specialization=specialization,
+        situation_ctx=situation_ctx,
+        level_override=level_override,
+    )
+
+
 def _build_forced_check_result(  # noqa: PLR0913 - mirrors perform_check signature for test seam
     character: "ObjectDB",
     check_type: "CheckType",

--- a/src/world/checks/tests/test_perform_check_with_modifiers.py
+++ b/src/world/checks/tests/test_perform_check_with_modifiers.py
@@ -1,0 +1,113 @@
+"""Tests for perform_check_with_modifiers() — the sheet-resolving wrapper.
+
+Verifies that the helper resolves CharacterSheet, guards None for sheet-less
+actors, calls collect_check_modifiers, and forwards breakdown.total
+additively to perform_check.
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from evennia_extensions.factories import ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.factories import CheckTypeFactory
+from world.checks.services import perform_check_with_modifiers
+
+
+class PerformCheckWithModifiersTest(TestCase):
+    """Tests for the perform_check_with_modifiers wrapper."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.check_type = CheckTypeFactory(name="wrapper-test-check")
+
+    def setUp(self):
+        self.target = ObjectDBFactory(db_key="WrapperTarget")
+        self.sheet = CharacterSheetFactory(character=self.target)
+
+    def test_sheet_present_calls_aggregator_and_adds_total(self):
+        """When sheet exists, collect_check_modifiers is called and its total
+        is added to extra_modifiers before forwarding to perform_check."""
+        with (
+            patch("world.checks.services.collect_check_modifiers") as mock_collect,
+            patch("world.checks.services.perform_check") as mock_perform,
+        ):
+            mock_collect.return_value.total = 5
+            perform_check_with_modifiers(
+                self.target,
+                self.check_type,
+                target_difficulty=10,
+                extra_modifiers=3,
+            )
+            # Aggregator was called with the sheet and check_type.
+            mock_collect.assert_called_once_with(self.sheet, self.check_type, scene=None)
+            # perform_check received extra_modifiers=3+5=8.
+            call_kwargs = mock_perform.call_args
+            assert call_kwargs.kwargs["extra_modifiers"] == 8
+
+    def test_sheet_none_forwards_without_aggregator(self):
+        """When character has no sheet (sheet-less actor), forward to
+        perform_check with extra_modifiers unchanged; do NOT call the
+        aggregator."""
+        sheetless = ObjectDBFactory(db_key="SheetlessNPC")
+        # Ensure no CharacterSheet exists for this object.
+        from world.character_sheets.models import CharacterSheet
+
+        CharacterSheet.objects.filter(character=sheetless).delete()
+
+        with (
+            patch("world.checks.services.collect_check_modifiers") as mock_collect,
+            patch("world.checks.services.perform_check") as mock_perform,
+        ):
+            perform_check_with_modifiers(
+                sheetless,
+                self.check_type,
+                target_difficulty=5,
+                extra_modifiers=7,
+            )
+            mock_collect.assert_not_called()
+            call_kwargs = mock_perform.call_args
+            assert call_kwargs.kwargs["extra_modifiers"] == 7
+
+    def test_scene_passed_to_aggregator(self):
+        """When scene= is supplied, it reaches collect_check_modifiers."""
+        from world.scenes.factories import SceneFactory
+
+        scene = SceneFactory()
+        with (
+            patch("world.checks.services.collect_check_modifiers") as mock_collect,
+            patch("world.checks.services.perform_check"),
+        ):
+            mock_collect.return_value.total = 0
+            perform_check_with_modifiers(self.target, self.check_type, scene=scene)
+            mock_collect.assert_called_once_with(self.sheet, self.check_type, scene=scene)
+
+    def test_all_params_forwarded(self):
+        """specialization, situation_ctx, effort_level, fatigue_penalty,
+        and level_override all reach perform_check unchanged."""
+        from world.skills.factories import SpecializationFactory
+
+        spec = SpecializationFactory()
+        with (
+            patch("world.checks.services.collect_check_modifiers") as mock_collect,
+            patch("world.checks.services.perform_check") as mock_perform,
+        ):
+            mock_collect.return_value.total = 0
+            perform_check_with_modifiers(
+                self.target,
+                self.check_type,
+                target_difficulty=10,
+                extra_modifiers=2,
+                effort_level="STANDARD",
+                fatigue_penalty=-1,
+                specialization=spec,
+                situation_ctx=None,
+                level_override=5,
+            )
+            call = mock_perform.call_args
+            assert call.kwargs["target_difficulty"] == 10
+            assert call.kwargs["effort_level"] == "STANDARD"
+            assert call.kwargs["fatigue_penalty"] == -1
+            assert call.kwargs["specialization"] == spec
+            assert call.kwargs["level_override"] == 5

--- a/src/world/clues/services.py
+++ b/src/world/clues/services.py
@@ -270,7 +270,7 @@ def search_room(
     caller (the Search action) charges AP + fatigue and resolves which check type to use.
     Returns the clues found this search (empty if the searcher has no roster entry).
     """
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
 
     roster_entry = _roster_entry_for(character)
     if roster_entry is None:
@@ -289,7 +289,7 @@ def search_room(
             continue
         if not _placement_passes_eligibility(placement, character, context_holder):
             continue
-        result = perform_check(
+        result = perform_check_with_modifiers(
             character, search_check_type, target_difficulty=placement.detect_difficulty
         )
         if result.outcome is None or result.outcome.success_level < 0:

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -34,7 +34,7 @@ from flows.models.triggers import Trigger
 from world.achievements.constants import ConditionEventType
 from world.checks.constants import ModifierSourceKind
 from world.checks.models import CheckType
-from world.checks.services import perform_check
+from world.checks.services import perform_check_with_modifiers
 from world.checks.types import ModifierContribution
 from world.conditions.constants import (
     POISON_CATEGORY_NAME,
@@ -611,7 +611,7 @@ def _check_application_resist(
     """
     if template.resist_check_type is None:
         return False
-    result = perform_check(
+    result = perform_check_with_modifiers(
         character=target,
         check_type=template.resist_check_type,
         target_difficulty=template.resist_difficulty,
@@ -2913,7 +2913,7 @@ def _perform_advancement_resist_check(
             location=location,
         )
 
-    result = perform_check(
+    result = perform_check_with_modifiers(
         character=instance.target,
         check_type=next_stage.resist_check_type,
         target_difficulty=payload.base_difficulty,
@@ -3668,7 +3668,6 @@ def perform_treatment(  # noqa: PLR0912, PLR0913, PLR0915, C901
     from django.db import IntegrityError  # noqa: PLC0415
     from django.utils import timezone as tz  # noqa: PLC0415
 
-    from world.checks.services import perform_check  # noqa: PLC0415
     from world.conditions.exceptions import (  # noqa: PLC0415
         HelperEngagedForTreatment,
         NoSupportingBondThread,
@@ -3802,7 +3801,7 @@ def perform_treatment(  # noqa: PLR0912, PLR0913, PLR0915, C901
     # ------------------------------------------------------------------
     # Execute: perform check
     # ------------------------------------------------------------------
-    check_result = perform_check(
+    check_result = perform_check_with_modifiers(
         helper,
         check_type=treatment.check_type,
         target_difficulty=treatment.target_difficulty,

--- a/src/world/conditions/tests/test_advance_resist.py
+++ b/src/world/conditions/tests/test_advance_resist.py
@@ -69,7 +69,7 @@ class TestAdvanceConditionSeverityResistCheck(TestCase):
         self.assertEqual(result.outcome, AdvancementOutcome.ADVANCED)
         self.assertTrue(result.stage_changed)
 
-    @patch("world.conditions.services.perform_check")
+    @patch("world.conditions.services.perform_check_with_modifiers")
     def test_hold_overflow_with_resist_check_holds_on_pass(self, mock_perform_check):
         """HOLD_OVERFLOW + resist check passes → outcome=HELD, stage unchanged."""
         self.stage2.advancement_resist_failure_kind = AdvancementResistFailureKind.HOLD_OVERFLOW
@@ -89,7 +89,7 @@ class TestAdvanceConditionSeverityResistCheck(TestCase):
         self.instance.refresh_from_db()
         self.assertEqual(self.instance.current_stage, self.stage1)
 
-    @patch("world.conditions.services.perform_check")
+    @patch("world.conditions.services.perform_check_with_modifiers")
     def test_hold_overflow_with_resist_check_advances_on_fail(self, mock_perform_check):
         """HOLD_OVERFLOW + resist check fails → outcome=ADVANCED."""
         self.stage2.advancement_resist_failure_kind = AdvancementResistFailureKind.HOLD_OVERFLOW

--- a/src/world/conditions/tests/test_apply_resist_check.py
+++ b/src/world/conditions/tests/test_apply_resist_check.py
@@ -32,7 +32,7 @@ class ApplyConditionResistCheckTest(TestCase):
         )
         fake_result = SimpleNamespace(success_level=1)
         with patch(
-            "world.conditions.services.perform_check", return_value=fake_result
+            "world.conditions.services.perform_check_with_modifiers", return_value=fake_result
         ) as mock_check:
             result = apply_condition(self.target, template)
 
@@ -54,7 +54,9 @@ class ApplyConditionResistCheckTest(TestCase):
             resist_difficulty=15,
         )
         fake_result = SimpleNamespace(success_level=0)
-        with patch("world.conditions.services.perform_check", return_value=fake_result):
+        with patch(
+            "world.conditions.services.perform_check_with_modifiers", return_value=fake_result
+        ):
             result = apply_condition(self.target, template)
 
         self.assertTrue(result.success)
@@ -63,7 +65,7 @@ class ApplyConditionResistCheckTest(TestCase):
     def test_null_resist_check_type_applies_unconditionally(self) -> None:
         """When resist_check_type is None (default), no check is rolled at all."""
         template = ConditionTemplateFactory(name="UnresistibleCondition")
-        with patch("world.conditions.services.perform_check") as mock_check:
+        with patch("world.conditions.services.perform_check_with_modifiers") as mock_check:
             result = apply_condition(self.target, template)
 
         mock_check.assert_not_called()
@@ -91,7 +93,7 @@ class BulkApplyConditionsResistCheckTest(TestCase):
         # target_a resists (SL=1), target_b does not (SL=0) — SimpleNamespace side_effect
         # returns results in call order: target_a is processed first (insertion order).
         with patch(
-            "world.conditions.services.perform_check",
+            "world.conditions.services.perform_check_with_modifiers",
             side_effect=[SimpleNamespace(success_level=1), SimpleNamespace(success_level=0)],
         ):
             results = bulk_apply_conditions(
@@ -110,7 +112,7 @@ class BulkApplyConditionsResistCheckTest(TestCase):
     def test_null_resist_check_type_applies_unconditionally_in_bulk(self) -> None:
         """A template with no resist_check_type applies normally via bulk_apply_conditions."""
         template = ConditionTemplateFactory(name="BulkUnresistibleCondition")
-        with patch("world.conditions.services.perform_check") as mock_check:
+        with patch("world.conditions.services.perform_check_with_modifiers") as mock_check:
             results = bulk_apply_conditions(
                 [BulkConditionApplication(target=self.target_a, template=template)]
             )

--- a/src/world/currency/services.py
+++ b/src/world/currency/services.py
@@ -534,7 +534,7 @@ def collect_org_income(*, organization: Organization, character) -> CollectionRe
     here).
     """
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
     from world.currency.constants import TAX_COLLECTION_CHECK_NAME  # noqa: PLC0415
     from world.scenes.action_constants import DIFFICULTY_VALUES, DifficultyChoice  # noqa: PLC0415
 
@@ -574,7 +574,7 @@ def collect_org_income(*, organization: Organization, character) -> CollectionRe
     check_type = CheckType.objects.filter(name__iexact=TAX_COLLECTION_CHECK_NAME).first()
     success_level = 0  # unseeded world: every collection is an unremarkable partial
     if check_type is not None:
-        result = perform_check(
+        result = perform_check_with_modifiers(
             character,
             check_type,
             target_difficulty=DIFFICULTY_VALUES[DifficultyChoice.NORMAL],
@@ -777,7 +777,7 @@ def collect_asset_income(*, asset, character_sheet) -> CollectionResult:
         ValidationError: If the pool is empty (nothing to collect).
     """
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
     from world.currency.constants import TAX_COLLECTION_CHECK_NAME  # noqa: PLC0415
     from world.scenes.action_constants import (  # noqa: PLC0415
         DIFFICULTY_VALUES,
@@ -794,7 +794,7 @@ def collect_asset_income(*, asset, character_sheet) -> CollectionResult:
     check_type = CheckType.objects.filter(name__iexact=TAX_COLLECTION_CHECK_NAME).first()
     success_level = 0  # unseeded world: every collection is an unremarkable partial
     if check_type is not None:
-        result = perform_check(
+        result = perform_check_with_modifiers(
             character_sheet.character,
             check_type,
             target_difficulty=DIFFICULTY_VALUES[DifficultyChoice.NORMAL],
@@ -830,7 +830,7 @@ def improve_org_domain(*, organization: Organization, character) -> ImprovementR
     All magnitudes PLACEHOLDER.
     """
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
     from world.currency.constants import (  # noqa: PLC0415
         DOMAIN_INVESTMENT_CHECK_NAME,
         IMPROVEMENT_GRAFT_STEP,
@@ -841,7 +841,7 @@ def improve_org_domain(*, organization: Organization, character) -> ImprovementR
     check_type = CheckType.objects.filter(name__iexact=DOMAIN_INVESTMENT_CHECK_NAME).first()
     success_level = -1  # unseeded world: investment simply fails, nothing moves
     if check_type is not None:
-        result = perform_check(
+        result = perform_check_with_modifiers(
             character,
             check_type,
             target_difficulty=DIFFICULTY_VALUES[DifficultyChoice.NORMAL],
@@ -1323,7 +1323,7 @@ def work_chore(employment: CharacterEmployment, *, ap_spent: int) -> int:
     (fail 1×, success 1.5×, strong success 2×). Returns coppers paid.
     """
     from world.action_points.models import ActionPointPool  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
 
     if not employment.active:
         msg = "You do not hold that job."
@@ -1339,7 +1339,7 @@ def work_chore(employment: CharacterEmployment, *, ap_spent: int) -> int:
 
     multiplier = CHORE_MULTIPLIER_FAIL
     if employment.profession.chore_check_type is not None:
-        result = perform_check(
+        result = perform_check_with_modifiers(
             employment.character_sheet.character,
             employment.profession.chore_check_type,
         )

--- a/src/world/fatigue/services.py
+++ b/src/world/fatigue/services.py
@@ -16,7 +16,7 @@ from world.action_points.models import ActionPointPool
 from world.character_creation.constants import STAT_MAX_VALUE
 from world.character_sheets.models import CharacterSheet
 from world.checks.models import CheckCategory, CheckType, CheckTypeTrait
-from world.checks.services import perform_check
+from world.checks.services import perform_check_with_modifiers
 from world.fatigue.constants import (
     CAPACITY_STAT_MULTIPLIER,
     CAPACITY_WILLPOWER_MULTIPLIER,
@@ -419,7 +419,7 @@ def attempt_endurance_check(character_sheet: CharacterSheet, category: str) -> b
     # Scale difficulty: at 81% it's moderate, at 150%+ it's very hard
     target_difficulty = int((percentage - 60) * 3)
 
-    result = perform_check(
+    result = perform_check_with_modifiers(
         character=character_sheet.character,
         check_type=check_type,
         target_difficulty=target_difficulty,
@@ -456,7 +456,7 @@ def attempt_power_through(
 
     target_difficulty = 50 + (strain_damage * 3)
 
-    result = perform_check(
+    result = perform_check_with_modifiers(
         character=character_sheet.character,
         check_type=check_type,
         target_difficulty=target_difficulty,

--- a/src/world/fatigue/tests/test_services.py
+++ b/src/world/fatigue/tests/test_services.py
@@ -568,7 +568,7 @@ class AttemptEnduranceCheckTests(TestCase):
         pool.set_current("physical", fatigue)
         pool.save()
 
-    @patch("world.fatigue.services.perform_check")
+    @patch("world.fatigue.services.perform_check_with_modifiers")
     def test_endurance_pass_when_check_succeeds(self, mock_perform_check):
         """Endurance check passes when perform_check returns positive success_level."""
         self._setup_character(stamina_internal=30, willpower_internal=20, fatigue=29)
@@ -577,7 +577,7 @@ class AttemptEnduranceCheckTests(TestCase):
         assert result is True
         mock_perform_check.assert_called_once()
 
-    @patch("world.fatigue.services.perform_check")
+    @patch("world.fatigue.services.perform_check_with_modifiers")
     def test_endurance_fail_when_check_fails(self, mock_perform_check):
         """Endurance check fails when perform_check returns zero success_level."""
         self._setup_character(stamina_internal=10, willpower_internal=10, fatigue=11)
@@ -585,7 +585,7 @@ class AttemptEnduranceCheckTests(TestCase):
         result = attempt_endurance_check(self.sheet, ActionCategory.PHYSICAL)
         assert result is False
 
-    @patch("world.fatigue.services.perform_check")
+    @patch("world.fatigue.services.perform_check_with_modifiers")
     def test_endurance_fail_when_negative_success(self, mock_perform_check):
         """Endurance check fails when perform_check returns negative success_level."""
         self._setup_character(stamina_internal=50, willpower_internal=50, fatigue=0)
@@ -593,7 +593,7 @@ class AttemptEnduranceCheckTests(TestCase):
         result = attempt_endurance_check(self.sheet, ActionCategory.PHYSICAL)
         assert result is False
 
-    @patch("world.fatigue.services.perform_check")
+    @patch("world.fatigue.services.perform_check_with_modifiers")
     def test_endurance_difficulty_scales_with_fatigue(self, mock_perform_check):
         """Target difficulty should scale with fatigue percentage."""
         # Capacity = 1*10 + 1*3 = 13. fatigue=26 -> 200%
@@ -624,7 +624,7 @@ class AttemptPowerThroughTests(TestCase):
         pool.set_current("physical", fatigue)
         pool.save()
 
-    @patch("world.fatigue.services.perform_check")
+    @patch("world.fatigue.services.perform_check_with_modifiers")
     def test_power_through_pass_when_check_succeeds(self, mock_perform_check):
         """Power through succeeds when perform_check returns positive success_level."""
         # Capacity = 3*10 + 5*3 = 45. fatigue=46 -> over_ratio = 1/45 = 0.022
@@ -635,7 +635,7 @@ class AttemptPowerThroughTests(TestCase):
         assert succeeded is True
         assert strain_damage == 1
 
-    @patch("world.fatigue.services.perform_check")
+    @patch("world.fatigue.services.perform_check_with_modifiers")
     def test_power_through_fail_when_check_fails(self, mock_perform_check):
         """Power through fails when perform_check returns zero success_level."""
         self._setup_character(stamina_internal=50, willpower_internal=50, fatigue=70)
@@ -643,7 +643,7 @@ class AttemptPowerThroughTests(TestCase):
         succeeded, _strain_damage = attempt_power_through(self.sheet, ActionCategory.PHYSICAL)
         assert succeeded is False
 
-    @patch("world.fatigue.services.perform_check")
+    @patch("world.fatigue.services.perform_check_with_modifiers")
     def test_power_through_pass_when_high_success(self, mock_perform_check):
         """Power through succeeds with high success_level."""
         self._setup_character(stamina_internal=10, willpower_internal=10, fatigue=50)
@@ -651,7 +651,7 @@ class AttemptPowerThroughTests(TestCase):
         succeeded, _strain_damage = attempt_power_through(self.sheet, ActionCategory.PHYSICAL)
         assert succeeded is True
 
-    @patch("world.fatigue.services.perform_check")
+    @patch("world.fatigue.services.perform_check_with_modifiers")
     def test_power_through_strain_scales_with_over_capacity(self, mock_perform_check):
         """Strain damage increases as fatigue exceeds capacity."""
         # Capacity = 1*10 + 1*3 = 13. fatigue=26 -> over_ratio = 13/13 = 1.0

--- a/src/world/forms/services/identification.py
+++ b/src/world/forms/services/identification.py
@@ -367,7 +367,7 @@ def attempt_identification(
     logic isn't duplicated.
     """
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
     from world.forms.constants import IDENTIFICATION_CHECK_TYPE_NAME  # noqa: PLC0415
     from world.scenes.services import persona_discovery_between  # noqa: PLC0415
 
@@ -412,6 +412,8 @@ def attempt_identification(
 
     target_difficulty = _target_difficulty(odds, guess_name, true_persona)
     check_type = CheckType.objects.get(name=IDENTIFICATION_CHECK_TYPE_NAME)
-    result = perform_check(viewer_character, check_type, target_difficulty=target_difficulty)
+    result = perform_check_with_modifiers(
+        viewer_character, check_type, target_difficulty=target_difficulty
+    )
 
     return _roll_outcome_result(result, presented_persona, true_persona, viewer_sheet)

--- a/src/world/items/crafting/services.py
+++ b/src/world/items/crafting/services.py
@@ -22,7 +22,7 @@ from world.checks.consequence_resolution import (
     apply_resolution,
     select_consequence_from_result,
 )
-from world.checks.services import perform_check
+from world.checks.services import perform_check_with_modifiers
 from world.checks.types import ResolutionContext
 from world.items.crafting.constants import CraftingRecipeKind
 from world.items.crafting.cost import consume_cost, stage_and_assert_affordable
@@ -537,7 +537,9 @@ def run_crafting_recipe(  # noqa: PLR0913
     )
 
     # --- 5. Roll ---
-    check_result = perform_check(crafter_character, recipe.check_type, recipe.base_difficulty)
+    check_result = perform_check_with_modifiers(
+        crafter_character, recipe.check_type, recipe.base_difficulty
+    )
 
     # --- 6. Station wear (#1234) — unconditional, regardless of roll outcome ---
     _apply_station_wear(station)

--- a/src/world/items/gems/services.py
+++ b/src/world/items/gems/services.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING
 
 from django.db import transaction
 
-from world.checks.services import perform_check
+from world.checks.services import perform_check_with_modifiers
 from world.items.exceptions import (
     AdornmentCapacityExceeded,
     CraftingCostUnaffordable,
@@ -145,7 +145,7 @@ def pry_adornment(  # noqa: PLR0913 — keyword-only adornment + crafter + check
         host.lore_value = max(0, (host.lore_value or 0) - worth)
         host.save(update_fields=["lore_value"])
 
-        check_result = perform_check(crafter_character, check_type, base_difficulty)
+        check_result = perform_check_with_modifiers(crafter_character, check_type, base_difficulty)
         if check_result.success_level < min_success_level:
             gem_instance.delete()  # CASCADE removes the Adornment + GemInstanceDetails
             return PryResult(shattered=True, freed_gem=None, worth_removed=worth)
@@ -215,7 +215,9 @@ def cut_gem(
             msg = f"You need {ap_cost} action points but only have {pool.current}."
             raise CraftingCostUnaffordable(msg)
 
-    check_result = perform_check(crafter_character, recipe.check_type, recipe.base_difficulty)
+    check_result = perform_check_with_modifiers(
+        crafter_character, recipe.check_type, recipe.base_difficulty
+    )
 
     if check_result.success_level < recipe.min_success_level:
         worth_lost = compute_gem_worth(gem)

--- a/src/world/items/services/reclamation.py
+++ b/src/world/items/services/reclamation.py
@@ -196,14 +196,14 @@ def advance_trace(claim: ReclamationClaim, *, check_level: int | None = None) ->
 
 def _roll_trace_check(claim: ReclamationClaim) -> int:
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
 
     sheet = claim.claimant_sheet
     character = sheet.character if sheet is not None else None
     check_type = CheckType.objects.filter(name=TRACE_CHECK_TYPE_NAME).first()
     if character is None or check_type is None:
         return 1  # unseeded world: the floor never hard-blocks
-    result = perform_check(character, check_type)
+    result = perform_check_with_modifiers(character, check_type)
     return result.outcome.success_level if result.outcome else 0
 
 

--- a/src/world/items/tests/test_crafting_query_counts.py
+++ b/src/world/items/tests/test_crafting_query_counts.py
@@ -256,7 +256,9 @@ class CraftAttachFacetQueryCountTests(TestCase):
             # per-instance .save(update_fields=["quantity"]) — the test setup
             # uses quantity=2 materials with quantity=1 requirements, so the
             # common case is now a partial-consume (save, not delete). The band
-            # dropped from 91-94 to 74-76.
+            # dropped from 91-94 to 74-76, then rose to 79-81 after #2750 routed
+            # the crafting check through collect_check_modifiers (adding ~5
+            # queries for condition/equipment/character/capability contributions).
             with CaptureQueriesContext(connection) as ctx:
                 result = craft_attach_facet(
                     crafter_account=self.account,
@@ -266,9 +268,9 @@ class CraftAttachFacetQueryCountTests(TestCase):
                 )
             executed = len(ctx.captured_queries)
             self.assertTrue(
-                74 <= executed <= 76,
-                f"{executed} queries executed, expected 75 ±1 identity-map "
-                f"wobble (band 74-76). A jump of >=3 means a per-row N+1.",
+                79 <= executed <= 81,
+                f"{executed} queries executed, expected 80 ±1 identity-map "
+                f"wobble (band 79-81). A jump of >=3 means a per-row N+1.",
             )
 
         self.assertTrue(result.attached)

--- a/src/world/justice/case_file.py
+++ b/src/world/justice/case_file.py
@@ -98,7 +98,7 @@ def examine_evidence(character: ObjectDB, evidence: CrimeEvidence) -> EvidenceRe
     and success simply confirms nothing is off.
     """
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
 
     if evidence.state != EvidenceState.PRODUCED:
         raise EvidenceError(_NOT_EXAMINABLE)
@@ -109,7 +109,7 @@ def examine_evidence(character: ObjectDB, evidence: CrimeEvidence) -> EvidenceRe
         evidence.tamper_quality if evidence.tamper_quality is not None else evidence.quality
     )
     check_type = CheckType.objects.get(name=SCRUTINIZE_EVIDENCE_CHECK_NAME)
-    result = perform_check(character, check_type, target_difficulty=difficulty)
+    result = perform_check_with_modifiers(character, check_type, target_difficulty=difficulty)
     if result.success_level < 0:
         return EvidenceResult(success=False, evidence_id=evidence.pk)
     if evidence.tamper_quality is not None:

--- a/src/world/justice/evidence.py
+++ b/src/world/justice/evidence.py
@@ -79,7 +79,7 @@ def gather_evidence(character: ObjectDB, evidence: CrimeEvidence) -> EvidenceRes
     On success the evidence becomes a physical inventory item (holdable, givable,
     stealable); on failure it stays where it lies.
     """
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
     from world.items.services.materialize import materialize_item_game_object  # noqa: PLC0415
 
     if evidence.state != EvidenceState.AT_SCENE:
@@ -87,7 +87,9 @@ def gather_evidence(character: ObjectDB, evidence: CrimeEvidence) -> EvidenceRes
     if character.location != evidence.room_profile.objectdb:
         raise EvidenceError(_NOT_AT_SCENE)
 
-    result = perform_check(character, _gather_check_type(), target_difficulty=evidence.quality)
+    result = perform_check_with_modifiers(
+        character, _gather_check_type(), target_difficulty=evidence.quality
+    )
     if result.success_level < 0:
         return EvidenceResult(success=False, evidence_id=evidence.pk)
 
@@ -112,14 +114,16 @@ def dispose_evidence(character: ObjectDB, evidence: CrimeEvidence) -> EvidenceRe
     Disposal is why the dampener in ``accrue_for_deed_knowledge`` exists: a deed
     whose every evidence row is DISPOSED spreads far less pursuit heat.
     """
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
 
     if evidence.state != EvidenceState.GATHERED:
         raise EvidenceError(_NOT_DISPOSABLE)
     if not _holds_evidence(character, evidence):
         raise EvidenceError(_NOT_HOLDER)
 
-    result = perform_check(character, _gather_check_type(), target_difficulty=evidence.quality)
+    result = perform_check_with_modifiers(
+        character, _gather_check_type(), target_difficulty=evidence.quality
+    )
     if result.success_level < 0:
         return EvidenceResult(success=False, evidence_id=evidence.pk)
 

--- a/src/world/justice/lifecycle.py
+++ b/src/world/justice/lifecycle.py
@@ -124,7 +124,7 @@ def attempt_bribe(persona: Persona, area: Area) -> dict:
     ``bribery`` crime with its own heat.
     """
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
     from world.currency.services import get_or_create_purse  # noqa: PLC0415
     from world.justice.services import accrue_heat  # noqa: PLC0415
 
@@ -150,7 +150,7 @@ def attempt_bribe(persona: Persona, area: Area) -> dict:
         msg = f"purse {purse.pk} below bribe cost {cost}"
         raise HeatLifecycleError(msg, user_message="You cannot afford that bribe.")
 
-    result = perform_check(character, check_type)
+    result = perform_check_with_modifiers(character, check_type)
     level = result.outcome.success_level if result.outcome else 0
 
     if level > 0:

--- a/src/world/justice/pipeline.py
+++ b/src/world/justice/pipeline.py
@@ -133,14 +133,14 @@ def _resolve_evasion_level(encounter: GuardEncounter, check_level: int | None) -
     if check_level is not None:
         return check_level
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
 
     sheet = encounter.persona.character_sheet
     character = sheet.character if sheet is not None else None
     check_type = CheckType.objects.filter(name=EVASION_CHECK_TYPE_NAME).first()
     if character is None or check_type is None:
         return 1  # unseeded world / bodiless persona: escape clean
-    result = perform_check(character, check_type)
+    result = perform_check_with_modifiers(character, check_type)
     return result.outcome.success_level if result.outcome else 0
 
 
@@ -371,7 +371,7 @@ def initiate_trial(
 
 def _argument_levels(participants: list[Persona]) -> list[int]:
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
 
     check_type = CheckType.objects.filter(name=ADVOCACY_CHECK_TYPE_NAME).first()
     levels: list[int] = []
@@ -381,7 +381,7 @@ def _argument_levels(participants: list[Persona]) -> list[int]:
         if check_type is None or character is None:
             levels.append(0)
             continue
-        result = perform_check(character, check_type)
+        result = perform_check_with_modifiers(character, check_type)
         levels.append(result.outcome.success_level if result.outcome else 0)
     return levels
 

--- a/src/world/magic/services/anima.py
+++ b/src/world/magic/services/anima.py
@@ -98,7 +98,7 @@ def perform_anima_ritual(
     first at ritual_severity_cost_per_point per point, then refill anima
     with leftover budget. Crit always tops anima to max regardless.
     """
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
     from world.magic.exceptions import (  # noqa: PLC0415
         CharacterEngagedForRitual,
         NoRitualConfigured,
@@ -126,10 +126,11 @@ def perform_anima_ritual(
     if AnimaRitualPerformance.objects.filter(ritual=ritual, scene=scene).exists():
         raise RitualAlreadyPerformedThisScene
 
-    check_result = perform_check(
+    check_result = perform_check_with_modifiers(
         character,
         check_type=config.check_type,
         target_difficulty=config.target_difficulty,
+        scene=scene,
     )
     outcome = check_result.outcome
 

--- a/src/world/magic/services/cast_observation.py
+++ b/src/world/magic/services/cast_observation.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass
 import logging
 from typing import TYPE_CHECKING
 
-from world.checks.services import level_opposition, perform_check
+from world.checks.services import level_opposition, perform_check_with_modifiers
 from world.magic.constants import CAST_DETECTION_ATTRIBUTION_LEVEL, DETECT_CAST_CHECK_NAME
 
 if TYPE_CHECKING:
@@ -153,7 +153,7 @@ def resolve_cast_audience(
         persona = _persona_for(observer)
         if persona is None:
             continue
-        result = perform_check(observer, check_type, target_difficulty=difficulty)
+        result = perform_check_with_modifiers(observer, check_type, target_difficulty=difficulty)
         if result.success_level >= CAST_DETECTION_ATTRIBUTION_LEVEL:
             full.append(persona)
         elif result.success_level >= 1:

--- a/src/world/magic/services/condition_application.py
+++ b/src/world/magic/services/condition_application.py
@@ -12,7 +12,7 @@ from collections.abc import Iterable
 import logging
 from typing import TYPE_CHECKING
 
-from world.checks.services import perform_check
+from world.checks.services import perform_check_with_modifiers
 from world.conditions.services import (
     bulk_apply_conditions,
     get_condition_instance,
@@ -189,7 +189,8 @@ def remove_technique_conditions(
       2. ``can_be_dispelled`` hard gate: a condition whose template has
          ``can_be_dispelled=False`` is a no-op (skipped, never an error).
       3. Opposed cure check: when ``row.condition.cure_check_type`` is set, rolls
-         ``perform_check(source_character, cure_check_type, cure_difficulty)``. Removal
+         ``perform_check_with_modifiers(source_character, cure_check_type,
+         cure_difficulty)``. Removal
          succeeds iff ``check_result.success_level > 0``; otherwise it is resisted (no-op
          for that target, cast continues). When ``cure_check_type`` is null, removal
          proceeds unconditionally (uncontested dispel).
@@ -258,7 +259,7 @@ def _attempt_removal(
     # Gate 3: opposed cure check (only when the condition defines one).
     cure_check_type = condition.cure_check_type
     if cure_check_type is not None:
-        check_result = perform_check(
+        check_result = perform_check_with_modifiers(
             source_character,
             cure_check_type,
             condition.cure_difficulty,

--- a/src/world/magic/services/fury.py
+++ b/src/world/magic/services/fury.py
@@ -161,13 +161,13 @@ def run_fury_for_action(
     if fury_commitment is None:
         return None
 
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
 
     cfg = _config()
     check_type = _ensure_fury_check_type(cfg.check_trait)
     ease = provocation_ease(character, fury_anchor)
     target_diff = max(fury_commitment.base_check_difficulty - ease, 0)
-    check = perform_check(character, check_type, target_difficulty=target_diff)
+    check = perform_check_with_modifiers(character, check_type, target_difficulty=target_diff)
     fury_res = resolve_fury(
         character=character, tier=fury_commitment, anchor=fury_anchor, check_result=check
     )

--- a/src/world/magic/services/resonance_environment.py
+++ b/src/world/magic/services/resonance_environment.py
@@ -14,7 +14,7 @@ from world.areas.models import AreaClosure
 from world.checks.consequence_resolution import apply_resolution, select_consequence_from_result
 from world.checks.constants import EffectType
 from world.checks.models import CheckType
-from world.checks.services import perform_check
+from world.checks.services import perform_check_with_modifiers
 from world.checks.types import ResolutionContext
 from world.conditions.services import apply_condition, remove_condition
 from world.locations.constants import KeyType
@@ -682,7 +682,7 @@ def resonance_environment_for_cast(
 
     # Perform the endurance check at the config-derived difficulty.
     check_type = _get_endure_hallowed_ground_check_type()
-    check_result = perform_check(caster, check_type, effect.backfire_difficulty)
+    check_result = perform_check_with_modifiers(caster, check_type, effect.backfire_difficulty)
 
     # Select from the pool using the existing check result (pool holds WeightedConsequence).
     weighted_consequences = pool.cached_consequences

--- a/src/world/magic/services/soul_tether.py
+++ b/src/world/magic/services/soul_tether.py
@@ -1397,11 +1397,11 @@ def _perform_rescue_check(sineater_sheet: CharacterSheet) -> Any:
         CheckResult dataclass from perform_check.
     """
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
     from world.magic.seeds_checks import MAGICAL_ENDURANCE_CHECK_TYPE_NAME  # noqa: PLC0415
 
     check_type = CheckType.objects.get(name=MAGICAL_ENDURANCE_CHECK_TYPE_NAME)
-    return perform_check(
+    return perform_check_with_modifiers(
         sineater_sheet.character,
         check_type=check_type,
         target_difficulty=0,

--- a/src/world/magic/services/technique_training.py
+++ b/src/world/magic/services/technique_training.py
@@ -11,7 +11,7 @@ from decimal import Decimal
 import math
 from typing import TYPE_CHECKING
 
-from world.checks.services import compute_check_rating, perform_check
+from world.checks.services import compute_check_rating, perform_check_with_modifiers
 from world.magic.models import TrainingOutcomeAward
 from world.magic.services.gift_acquisition import get_gift_acquisition_config
 from world.magic.services.technique_progress import contribute_to_technique_progress
@@ -81,7 +81,7 @@ def resolve_training_check(
     target_difficulty = max(0, target_difficulty - teacher_skill_bonus)
 
     # 3. Resolve the check.
-    check_result = perform_check(
+    check_result = perform_check_with_modifiers(
         learner.character,
         check_type,
         target_difficulty=target_difficulty,

--- a/src/world/magic/tests/services/test_cast_observation.py
+++ b/src/world/magic/tests/services/test_cast_observation.py
@@ -103,7 +103,7 @@ def _forced_success_level(level: int) -> Iterator[MagicMock]:
     Must patch world.magic.services.cast_observation.perform_check — the name as
     imported into the service's own module namespace — not world.checks.services.
     """
-    with patch("world.magic.services.cast_observation.perform_check") as rolled:
+    with patch("world.magic.services.cast_observation.perform_check_with_modifiers") as rolled:
         rolled.return_value = _check_result_with_success_level(level)
         yield rolled
 
@@ -122,7 +122,7 @@ class ResolveCastAudienceTests(TestCase):
         """
         caster = _caster_on_path_with_style(cast_concealment=0)
         _observer_in_room_with(caster)
-        with patch("world.magic.services.cast_observation.perform_check") as rolled:
+        with patch("world.magic.services.cast_observation.perform_check_with_modifiers") as rolled:
             audience = resolve_cast_audience(caster=caster)
         self.assertFalse(audience.concealed)
         rolled.assert_not_called()
@@ -174,7 +174,7 @@ class ResolveCastAudienceTests(TestCase):
         caster = _caster_on_path_with_style(cast_concealment=25, level=4)
         _observer_in_room_with(caster)
         with (
-            patch("world.magic.services.cast_observation.perform_check") as rolled,
+            patch("world.magic.services.cast_observation.perform_check_with_modifiers") as rolled,
             patch("world.magic.services.cast_observation.level_opposition", return_value=20),
         ):
             rolled.return_value = _check_result_with_success_level(0)

--- a/src/world/magic/tests/test_condition_application.py
+++ b/src/world/magic/tests/test_condition_application.py
@@ -327,7 +327,9 @@ class ApplyTechniqueConditionsResistCheckTest(TestCase):
             minimum_success_level=1,
         )
         fake_result = SimpleNamespace(success_level=1)
-        with patch("world.conditions.services.perform_check", return_value=fake_result):
+        with patch(
+            "world.conditions.services.perform_check_with_modifiers", return_value=fake_result
+        ):
             results = apply_technique_conditions(
                 technique=self.technique,
                 success_level=2,
@@ -358,7 +360,9 @@ class ApplyTechniqueConditionsResistCheckTest(TestCase):
             minimum_success_level=1,
         )
         fake_result = SimpleNamespace(success_level=0)
-        with patch("world.conditions.services.perform_check", return_value=fake_result):
+        with patch(
+            "world.conditions.services.perform_check_with_modifiers", return_value=fake_result
+        ):
             results = apply_technique_conditions(
                 technique=self.technique,
                 success_level=2,
@@ -413,7 +417,7 @@ class RemoveTechniqueConditionsTest(TestCase):
         )
         with (
             patch("world.magic.services.condition_application.remove_condition") as mock_remove,
-            patch("world.magic.services.condition_application.perform_check"),
+            patch("world.magic.services.condition_application.perform_check_with_modifiers"),
         ):
             result = remove_technique_conditions(
                 technique=self.technique,
@@ -502,7 +506,8 @@ class RemoveTechniqueConditionsTest(TestCase):
         fake_result = SimpleNamespace(success_level=0)
         with (
             patch(
-                "world.magic.services.condition_application.perform_check", return_value=fake_result
+                "world.magic.services.condition_application.perform_check_with_modifiers",
+                return_value=fake_result,
             ),
             patch("world.magic.services.condition_application.remove_condition") as mock_remove,
             patch("world.magic.services.condition_application.get_condition_instance") as mock_get,
@@ -542,7 +547,8 @@ class RemoveTechniqueConditionsTest(TestCase):
         fake_result = SimpleNamespace(success_level=2)
         with (
             patch(
-                "world.magic.services.condition_application.perform_check", return_value=fake_result
+                "world.magic.services.condition_application.perform_check_with_modifiers",
+                return_value=fake_result,
             ),
             patch("world.magic.services.condition_application.remove_condition") as mock_remove,
             patch("world.magic.services.condition_application.get_condition_instance") as mock_get,
@@ -572,7 +578,9 @@ class RemoveTechniqueConditionsTest(TestCase):
             target_kind=ConditionTargetKind.ALLY,
         )
         with (
-            patch("world.magic.services.condition_application.perform_check") as mock_check,
+            patch(
+                "world.magic.services.condition_application.perform_check_with_modifiers"
+            ) as mock_check,
             patch("world.magic.services.condition_application.remove_condition") as mock_remove,
             patch("world.magic.services.condition_application.get_condition_instance") as mock_get,
         ):

--- a/src/world/magic/tests/test_pending_stage_advance_offer.py
+++ b/src/world/magic/tests/test_pending_stage_advance_offer.py
@@ -380,7 +380,7 @@ class SoulTetherStageAdvancePromptWritesPendingRowTests(TestCase):
     def tearDown(self) -> None:
         _pending_stage_advance_offers.clear()
 
-    @patch("world.conditions.services.perform_check")
+    @patch("world.conditions.services.perform_check_with_modifiers")
     def test_subscriber_writes_pending_row(self, mock_check: object) -> None:
         """Advancing severity over the stage threshold writes one PendingStageAdvanceOffer row."""
         from world.conditions.services import advance_condition_severity
@@ -403,7 +403,7 @@ class SoulTetherStageAdvancePromptWritesPendingRowTests(TestCase):
             ).exists()
         )
 
-    @patch("world.conditions.services.perform_check")
+    @patch("world.conditions.services.perform_check_with_modifiers")
     def test_pending_row_expires_at_within_ttl(self, mock_check: object) -> None:
         """The expires_at is approximately now + STAGE_ADVANCE_OFFER_TTL."""
         from world.conditions.services import advance_condition_severity
@@ -422,7 +422,7 @@ class SoulTetherStageAdvancePromptWritesPendingRowTests(TestCase):
         self.assertGreaterEqual(row.expires_at, expected_min)
         self.assertLessEqual(row.expires_at, expected_max)
 
-    @patch("world.conditions.services.perform_check")
+    @patch("world.conditions.services.perform_check_with_modifiers")
     def test_pending_row_has_correct_commit_units_max(self, mock_check: object) -> None:
         """commit_units_max equals the Sinner's hollow_current at prompt time."""
         from world.conditions.services import advance_condition_severity
@@ -436,7 +436,7 @@ class SoulTetherStageAdvancePromptWritesPendingRowTests(TestCase):
         )
         self.assertEqual(row.commit_units_max, 5)  # Thread.hollow_current was 5
 
-    @patch("world.conditions.services.perform_check")
+    @patch("world.conditions.services.perform_check_with_modifiers")
     def test_pending_row_resonance_matches(self, mock_check: object) -> None:
         """PendingStageAdvanceOffer.resonance matches the Corruption condition's resonance."""
         from world.conditions.services import advance_condition_severity
@@ -527,7 +527,7 @@ class SoulTetherStageAdvancePromptNoSharedSceneTests(TestCase):
     def tearDown(self) -> None:
         _pending_stage_advance_offers.clear()
 
-    @patch("world.conditions.services.perform_check")
+    @patch("world.conditions.services.perform_check_with_modifiers")
     def test_no_pending_row_when_no_shared_scene(self, mock_check: object) -> None:
         """When no shared SceneParticipation exists, no PendingStageAdvanceOffer is written."""
         from world.conditions.services import advance_condition_severity
@@ -544,7 +544,7 @@ class SoulTetherStageAdvancePromptNoSharedSceneTests(TestCase):
             "A PendingStageAdvanceOffer row must NOT be written when there is no shared scene.",
         )
 
-    @patch("world.conditions.services.perform_check")
+    @patch("world.conditions.services.perform_check_with_modifiers")
     def test_in_memory_offer_still_recorded_when_no_shared_scene(self, mock_check: object) -> None:
         """Even without a shared scene, the in-memory offer is recorded."""
         from world.conditions.services import advance_condition_severity

--- a/src/world/magic/tests/test_resonance_environment_service.py
+++ b/src/world/magic/tests/test_resonance_environment_service.py
@@ -367,7 +367,7 @@ class ResonanceCastOpposedBackfireTest(ResonanceCacheIsolationMixin, TestCase):
         # Force perform_check to return the failure outcome
         check_result = _make_check_result(self.outcome_failure)
         with patch(
-            "world.magic.services.resonance_environment.perform_check",
+            "world.magic.services.resonance_environment.perform_check_with_modifiers",
             return_value=check_result,
         ):
             result = resonance_environment_for_cast(
@@ -391,7 +391,7 @@ class ResonanceCastOpposedBackfireTest(ResonanceCacheIsolationMixin, TestCase):
         """OPPOSED + success outcome → success consequence's condition applied to caster."""
         check_result = _make_check_result(self.outcome_success)
         with patch(
-            "world.magic.services.resonance_environment.perform_check",
+            "world.magic.services.resonance_environment.perform_check_with_modifiers",
             return_value=check_result,
         ):
             result = resonance_environment_for_cast(
@@ -451,7 +451,7 @@ class ResonanceCastOpposedBackfireTest(ResonanceCacheIsolationMixin, TestCase):
 
         check_result = _make_check_result(self.outcome_failure)
         with patch(
-            "world.magic.services.resonance_environment.perform_check",
+            "world.magic.services.resonance_environment.perform_check_with_modifiers",
             return_value=check_result,
         ):
             result = resonance_environment_for_cast(
@@ -581,7 +581,7 @@ class AppliedNameParenthesisRegressionTest(ResonanceCacheIsolationMixin, TestCas
         """result.applied must contain the EXACT full name 'Singed (light)', not truncated."""
         check_result = _make_check_result(self.outcome_failure)
         with patch(
-            "world.magic.services.resonance_environment.perform_check",
+            "world.magic.services.resonance_environment.perform_check_with_modifiers",
             return_value=check_result,
         ):
             result = resonance_environment_for_cast(
@@ -889,7 +889,7 @@ class UseTechniqueResonanceEnvironmentIntegrationTest(ResonanceCacheIsolationMix
         """
         check_result = _make_check_result(self.outcome_failure)
         with patch(
-            "world.magic.services.resonance_environment.perform_check",
+            "world.magic.services.resonance_environment.perform_check_with_modifiers",
             return_value=check_result,
         ):
             result = use_technique(
@@ -957,7 +957,7 @@ class UseTechniqueResonanceEnvironmentIntegrationTest(ResonanceCacheIsolationMix
         check_result = _make_check_result(self.outcome_failure)
         with (
             patch(
-                "world.magic.services.resonance_environment.perform_check",
+                "world.magic.services.resonance_environment.perform_check_with_modifiers",
                 return_value=check_result,
             ),
             patch(

--- a/src/world/magic/tests/test_soul_tether_subscribers.py
+++ b/src/world/magic/tests/test_soul_tether_subscribers.py
@@ -633,7 +633,7 @@ class StageAdvancePromptFiresWhenSineaterInSceneTests(TestCase):
     def tearDown(self) -> None:
         _pending_stage_advance_offers.clear()
 
-    @patch("world.conditions.services.perform_check")
+    @patch("world.conditions.services.perform_check_with_modifiers")
     def test_prompt_offer_recorded_when_sineater_in_scene(self, mock_check: object) -> None:
         """Advancing severity over stage2 threshold records a StageAdvanceBonusOffer."""
         mock_check.return_value = _make_check_result(success_level=-1)  # Fail = advances
@@ -645,7 +645,7 @@ class StageAdvancePromptFiresWhenSineaterInSceneTests(TestCase):
         # The handler should have recorded one offer.
         self.assertEqual(len(_pending_stage_advance_offers), 1)
 
-    @patch("world.conditions.services.perform_check")
+    @patch("world.conditions.services.perform_check_with_modifiers")
     def test_offer_has_correct_sinner_and_sineater(self, mock_check: object) -> None:
         """The recorded offer references the correct Sinner and Sineater sheets."""
         mock_check.return_value = _make_check_result(success_level=-1)
@@ -656,7 +656,7 @@ class StageAdvancePromptFiresWhenSineaterInSceneTests(TestCase):
         self.assertEqual(offer.sinner_sheet, self.sinner)
         self.assertEqual(offer.sineater_sheet, self.sineater)
 
-    @patch("world.conditions.services.perform_check")
+    @patch("world.conditions.services.perform_check_with_modifiers")
     def test_offer_max_hollow_reflects_thread_capacity(self, mock_check: object) -> None:
         """max_hollow_to_spend equals the Sinner's Thread's current hollow_current."""
         mock_check.return_value = _make_check_result(success_level=-1)
@@ -666,7 +666,7 @@ class StageAdvancePromptFiresWhenSineaterInSceneTests(TestCase):
         offer = next(iter(_pending_stage_advance_offers.values()))
         self.assertEqual(offer.max_hollow_to_spend, 5)  # Thread.hollow_current=5
 
-    @patch("world.conditions.services.perform_check")
+    @patch("world.conditions.services.perform_check_with_modifiers")
     def test_sineater_receives_notification(self, mock_check: object) -> None:
         """The Sineater's ObjectDB.msg() is called with the offer details."""
         mock_check.return_value = _make_check_result(success_level=-1)
@@ -715,7 +715,7 @@ class StageAdvancePromptNoSineaterInSceneTests(TestCase):
     def tearDown(self) -> None:
         _pending_stage_advance_offers.clear()
 
-    @patch("world.conditions.services.perform_check")
+    @patch("world.conditions.services.perform_check_with_modifiers")
     def test_no_offer_when_sineater_in_different_room(self, mock_check: object) -> None:
         """Sineater in a different room → no offer recorded."""
         mock_check.return_value = _make_check_result(success_level=-1)
@@ -724,7 +724,7 @@ class StageAdvancePromptNoSineaterInSceneTests(TestCase):
 
         self.assertEqual(len(_pending_stage_advance_offers), 0)
 
-    @patch("world.conditions.services.perform_check")
+    @patch("world.conditions.services.perform_check_with_modifiers")
     def test_resist_check_proceeds_without_offer(self, mock_check: object) -> None:
         """Check still fires (mock called) even with no Sineater in scene."""
         mock_check.return_value = _make_check_result(success_level=1)  # Pass = HELD
@@ -792,7 +792,7 @@ class StageAdvancePromptNonCorruptionConditionTests(TestCase):
     def tearDown(self) -> None:
         _pending_stage_advance_offers.clear()
 
-    @patch("world.conditions.services.perform_check")
+    @patch("world.conditions.services.perform_check_with_modifiers")
     def test_non_corruption_condition_skipped(self, mock_check: object) -> None:
         """Handler returns immediately for non-Corruption conditions — no offer recorded."""
         mock_check.return_value = _make_check_result(success_level=-1)
@@ -841,7 +841,7 @@ class StageAdvanceBonusAcceptTests(TestCase):
 
     def _fire_prompt_and_get_offer_id(self) -> str:
         """Trigger the stage-advance check (mocked to fail) and return the offer_id."""
-        with patch("world.conditions.services.perform_check") as mock_check:
+        with patch("world.conditions.services.perform_check_with_modifiers") as mock_check:
             mock_check.return_value = _make_check_result(success_level=-1)
             advance_condition_severity(self.condition_instance, 5)
 
@@ -937,7 +937,7 @@ class StageAdvanceBonusDeclineTests(TestCase):
         _pending_stage_advance_offers.clear()
 
     def _fire_and_get_offer_id(self) -> str:
-        with patch("world.conditions.services.perform_check") as mock_check:
+        with patch("world.conditions.services.perform_check_with_modifiers") as mock_check:
             mock_check.return_value = _make_check_result(success_level=-1)
             advance_condition_severity(self.condition_instance, 5)
         return next(iter(_pending_stage_advance_offers.keys()))

--- a/src/world/magic/tests/test_technique_training.py
+++ b/src/world/magic/tests/test_technique_training.py
@@ -207,7 +207,7 @@ class ResolveTrainingCheckTest(TestCase):
             )
 
         with patch(
-            "world.magic.services.technique_training.perform_check",
+            "world.magic.services.technique_training.perform_check_with_modifiers",
             side_effect=capture_check,
         ):
             resolve_training_check(self.sheet, high_progress, ap_to_invest=20)
@@ -239,7 +239,7 @@ class ResolveTrainingCheckTest(TestCase):
         mock_teacher = type("MockTeacher", (), {"character": self.sheet.character})()
 
         with patch(
-            "world.magic.services.technique_training.perform_check",
+            "world.magic.services.technique_training.perform_check_with_modifiers",
             side_effect=capture_check,
         ):
             with patch(

--- a/src/world/missions/services/report.py
+++ b/src/world/missions/services/report.py
@@ -152,7 +152,7 @@ def _run_embellish_check(
 ) -> bool:
     """Roll the manipulation check against the giver. Raises if the reporter can't embellish."""
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
 
     if not reporter_can_embellish(reporter):
         msg = "You lack the Persuasion to embellish your account."
@@ -161,7 +161,7 @@ def _run_embellish_check(
     if check_type is None:
         msg = "There is no one here who will hear an embellished account."
         raise MissionReportError(msg)
-    result = perform_check(
+    result = perform_check_with_modifiers(
         reporter,
         check_type,
         target_difficulty=_embellish_difficulty(functionary),
@@ -183,7 +183,7 @@ def _run_consequence_dodge_check(
     fail closed (falls back to the bare Persuasion check when Con is absent).
     """
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
 
     check_type = (
         CheckType.objects.filter(name__iexact="Con").first()
@@ -191,7 +191,7 @@ def _run_consequence_dodge_check(
     )
     if check_type is None:
         return False  # unseeded world: the dodge simply fails, consequences apply.
-    result = perform_check(
+    result = perform_check_with_modifiers(
         reporter,
         check_type,
         target_difficulty=_embellish_difficulty(functionary),
@@ -215,7 +215,7 @@ def _apply_masked_deed_association(
     harsh (association happens without a roll) — consistent with the dodge failing closed.
     """
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
     from world.justice.services import associate_heat  # noqa: PLC0415
     from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
 
@@ -231,7 +231,7 @@ def _apply_masked_deed_association(
         or CheckType.objects.filter(name__iexact="Persuasion").first()
     )
     if check_type is not None:
-        result = perform_check(
+        result = perform_check_with_modifiers(
             reporter,
             check_type,
             target_difficulty=_embellish_difficulty(functionary),

--- a/src/world/npc_services/guard_services.py
+++ b/src/world/npc_services/guard_services.py
@@ -78,10 +78,10 @@ def check_guard_detection(character: ObjectDB, room: ObjectDB) -> None:
 
     # Roll the intruder's Stealth against the guard's detection difficulty.
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
 
     stealth_check = CheckType.objects.get(name="Stealth")
-    result = perform_check(
+    result = perform_check_with_modifiers(
         character=character,
         check_type=stealth_check,
         target_difficulty=GUARD_DETECTION_DIFFICULTY,

--- a/src/world/npc_services/services.py
+++ b/src/world/npc_services/services.py
@@ -27,7 +27,7 @@ from django.db import transaction
 from django.db.models import F
 from django.utils import timezone
 
-from world.checks.services import perform_check
+from world.checks.services import perform_check_with_modifiers
 from world.missions.constants import MissionStatus
 from world.missions.models import MissionInstance
 from world.missions.services.visibility import template_visible_to
@@ -630,7 +630,7 @@ def _apply_check(
     """
     if offer.check_type_id is None:
         return offer.rapport_delta_success, True
-    result = perform_check(
+    result = perform_check_with_modifiers(
         character,
         offer.check_type,
         target_difficulty=offer.check_difficulty,

--- a/src/world/projects/services.py
+++ b/src/world/projects/services.py
@@ -223,7 +223,7 @@ def contribute_check_to_project(
     spend rolls back with the contribution if anything downstream fails.
     """
     from world.action_points.models import ActionPointPool  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
 
     if project.status != ProjectStatus.ACTIVE:
         msg = f"Project #{project.pk} is not accepting contributions."
@@ -239,7 +239,7 @@ def contribute_check_to_project(
                 msg = "You don't have enough action points for that."
                 raise ContributionMethodError(msg)
 
-        result = perform_check(actor, method.check_type)
+        result = perform_check_with_modifiers(actor, method.check_type)
         if result.outcome is None:
             msg = "The check could not be resolved."
             raise ContributionMethodError(msg)

--- a/src/world/secrets/gossip.py
+++ b/src/world/secrets/gossip.py
@@ -132,9 +132,9 @@ def _roster_entry(character: ObjectDB):
 
 def _check_tier(character: ObjectDB) -> int:
     """Run the Gossip check; return its ``success_level`` (>=1 success, >=2 special)."""
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
 
-    return perform_check(character, _gossip_check_type()).success_level
+    return perform_check_with_modifiers(character, _gossip_check_type()).success_level
 
 
 def _delta_for(tier: int, regular: int, special: int) -> int:
@@ -274,7 +274,7 @@ def refute_accusation(character: ObjectDB, secret: Secret, *, room: ObjectDB) ->
     Tom/Bob/Fred rule: defending the accused is open; only naming-and-attacking the
     author (denounce) needs the author's hostile-consent opt-in.
     """
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
     from world.secrets.constants import (  # noqa: PLC0415
         REFUTE_BASE_DIFFICULTY,
         REFUTE_DIFFICULTY_PER_LEVEL,
@@ -295,7 +295,9 @@ def refute_accusation(character: ObjectDB, secret: Secret, *, room: ObjectDB) ->
         raise GossipError(_ALREADY_REFUTED)
 
     difficulty = REFUTE_BASE_DIFFICULTY + secret.level * REFUTE_DIFFICULTY_PER_LEVEL
-    result = perform_check(character, _gossip_check_type(), target_difficulty=difficulty)
+    result = perform_check_with_modifiers(
+        character, _gossip_check_type(), target_difficulty=difficulty
+    )
     succeeded = result.success_level >= 1
     AccusationRebuttal.objects.create(
         secret=secret, refuter_sheet=refuter_sheet, succeeded=succeeded

--- a/src/world/societies/scandal.py
+++ b/src/world/societies/scandal.py
@@ -214,7 +214,7 @@ def reduce_witnesses_by_stealth(
     worlds (no Stealth CheckType) change nothing.
     """
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
 
     if not characters:
         return witnesses, False
@@ -225,7 +225,7 @@ def reduce_witnesses_by_stealth(
     outsider_count = sum(1 for w in witnesses if w.pk not in actor_pks)
     worst: int | None = None
     for character in characters:
-        result = perform_check(
+        result = perform_check_with_modifiers(
             character,
             check_type,
             target_difficulty=_containment_difficulty(outsider_count),
@@ -261,7 +261,7 @@ def _run_containment_check(
     (nothing to roll → the scandal leaks).
     """
     from world.checks.models import CheckType  # noqa: PLC0415
-    from world.checks.services import perform_check  # noqa: PLC0415
+    from world.checks.services import perform_check_with_modifiers  # noqa: PLC0415
 
     check_type = None
     declared = _approach_for_key(approach_key)
@@ -282,7 +282,7 @@ def _run_containment_check(
         )
     if check_type is None:
         return False
-    result = perform_check(
+    result = perform_check_with_modifiers(
         character,
         check_type,
         target_difficulty=_containment_difficulty(witness_count),

--- a/src/world/vitals/services.py
+++ b/src/world/vitals/services.py
@@ -15,7 +15,7 @@ from django.db import transaction
 from django.utils import timezone
 
 from world.checks.models import CheckCategory, CheckType
-from world.checks.services import collect_check_modifiers, perform_check
+from world.checks.services import collect_check_modifiers, perform_check_with_modifiers
 from world.vitals.constants import (
     DEATH_CHECK_NAME,
     DEATH_HEALTH_THRESHOLD,
@@ -1235,7 +1235,7 @@ def _advance_staged_peril_condition(
                 return True
             continue
 
-        result = perform_check(
+        result = perform_check_with_modifiers(
             character,
             stage.resist_check_type,
             target_difficulty=stage.resist_difficulty,
@@ -1467,7 +1467,7 @@ def attempt_wake(  # noqa: PLR0911 - one return per resolved wake-attempt outcom
         return WakeResult(
             attempted=False, woke=False, message="You strain, but nothing answers the effort."
         )
-    result = perform_check(character, check_type, target_difficulty=difficulty)
+    result = perform_check_with_modifiers(character, check_type, target_difficulty=difficulty)
     if int(result.success_level) >= 0:
         remove_condition(character, instance.condition)
         _maybe_move_to_destination(character, destination_room)


### PR DESCRIPTION
Closes #2750

## Summary

Introduces perform_check_with_modifiers — a thin wrapper that resolves character.character_sheet, guards None for sheet-less actors, calls collect_check_modifiers, and forwards breakdown.total additively to perform_check. Migrates 46 simple call sites that previously passed extra_modifiers=0 without calling the aggregator, so conditions, equipment, fashion, capability, and distinction modifiers now reach these checks.

## Follow-ups filed

- #2758

## Notes

- Spec: reviewed & approved on #2750 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased on origin/main — no conflicts.

<!-- last-addressed-comment: 0 -->