### PR TITLE
Defined-parents narrowing: children of pinned parents work from the family look (#2815 follow-up)

### DIFF
--- a/docs/systems/kinship.md
+++ b/docs/systems/kinship.md
@@ -54,7 +54,11 @@ returns the legal child species (maternal always; paternal appended when his
 tier strictly exceeds hers; `chimeric_possible` when both are Grand+ and
 differ); `inherited_options` returns cross-line `FormTraitOption`s per trait
 (pins constrain, unpinned parents expose their species palette, own-palette
-overlap excluded so hidden ancestry stays hideable). Validation built on it
+overlap excluded so hidden ancestry stays hideable); `base_trait_options`
+narrows a child of fully-defined parents to the family look — when every
+parent line is pinned for a trait, options collapse to the same-species
+parents' pins, dominant line first (an unpinned side keeps the species
+palette open). Validation built on it
 is **one-directional and creation-time only** (ADR-0173): outcomes require
 supporting bands when created; parents may be retro-defined upward freely.
 Named "heredity" — NOT "lineage" (that word is taken three other ways).

--- a/src/world/character_creation/tests/test_heredity_cg.py
+++ b/src/world/character_creation/tests/test_heredity_cg.py
@@ -255,3 +255,74 @@ class FormOptionsEndpointTest(FinalizationTestMixin, TestCase):
         draft.save(update_fields=["account"])
         response = self._get(self.species.id, draft=draft.pk)
         self.assertEqual(response.status_code, 404)
+
+
+class DefinedParentsNarrowingTest(FinalizationTestMixin, TestCase):
+    """Children of fully-pinned parents work from the family look (#2815)."""
+
+    def setUp(self):
+        from rest_framework.test import APIClient
+
+        self._flush_common_caches()
+        self.account = AccountDB.objects.create(username="narrowuser")
+        self._setup_finalization_base(self, prefix="Narrow Test", height_min=700, height_max=800)
+        self.female, _ = Gender.objects.get_or_create(
+            key="female", defaults={"display_name": "Female"}
+        )
+        self.male, _ = Gender.objects.get_or_create(key="male", defaults={"display_name": "Male"})
+        self.hair = FormTraitFactory(name="hair_color")
+        self.black = FormTraitOptionFactory(trait=self.hair, name="black")
+        self.brown = FormTraitOptionFactory(trait=self.hair, name="brown")
+        self.white = FormTraitOptionFactory(trait=self.hair, name="white")
+        own_link = SpeciesFormTraitFactory(species=self.species, trait=self.hair)
+        own_link.allowed_options.set([self.black, self.brown, self.white])
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.account)
+
+    def _slot_with_pinned_parents(self):
+        from world.roster.factories import KinspersonFactory, ParentageEdgeFactory
+        from world.roster.models import KinspersonTraitValue
+
+        mother = KinspersonFactory(gender=self.female, species=self.species)
+        father = KinspersonFactory(gender=self.male, species=self.species)
+        KinspersonTraitValue.objects.create(kinsperson=mother, trait=self.hair, option=self.brown)
+        KinspersonTraitValue.objects.create(kinsperson=father, trait=self.hair, option=self.black)
+        slot = KinspersonFactory(name="Heir", is_appable=True)
+        ParentageEdgeFactory(child=slot, parent=mother)
+        ParentageEdgeFactory(child=slot, parent=father)
+        return slot
+
+    def test_validation_rejects_outside_family_look(self):
+        from world.character_creation.validators import get_appearance_errors
+
+        slot = self._slot_with_pinned_parents()
+        draft = self._create_base_draft(form_traits={"hair_color": self.white.pk})
+        draft.claimed_kin_slot = slot
+        draft.save(update_fields=["claimed_kin_slot"])
+        errors = get_appearance_errors(draft)
+        self.assertTrue(any("not available" in error for error in errors))
+        draft.draft_data["form_traits"] = {"hair_color": self.brown.pk}
+        draft.save(update_fields=["draft_data"])
+        self.assertEqual(get_appearance_errors(draft), [])
+
+    def test_endpoint_narrows_mother_first(self):
+        slot = self._slot_with_pinned_parents()
+        draft = self._create_base_draft()
+        draft.claimed_kin_slot = slot
+        draft.save(update_fields=["claimed_kin_slot"])
+        response = self.client.get(
+            f"/api/character-creation/form-options/{self.species.id}/", {"draft": draft.pk}
+        )
+        self.assertEqual(response.status_code, 200)
+        hair_entry = next(
+            entry for entry in response.data["traits"] if entry["trait"]["name"] == "hair_color"
+        )
+        self.assertEqual([opt["name"] for opt in hair_entry["options"]], ["brown", "black"])
+
+    def test_endpoint_without_draft_keeps_full_palette(self):
+        self._slot_with_pinned_parents()
+        response = self.client.get(f"/api/character-creation/form-options/{self.species.id}/")
+        hair_entry = next(
+            entry for entry in response.data["traits"] if entry["trait"]["name"] == "hair_color"
+        )
+        self.assertEqual(len(hair_entry["options"]), 3)

--- a/src/world/character_creation/validators.py
+++ b/src/world/character_creation/validators.py
@@ -242,8 +242,10 @@ def _get_form_trait_errors(draft: CharacterDraft) -> list[str]:
     inherited options a cross-species parent makes legal (pinned-aware).
     """
     from world.forms.models import SpeciesFormTrait  # noqa: PLC0415
-    from world.forms.services import get_cg_form_options  # noqa: PLC0415
-    from world.roster.services.heredity import inherited_options  # noqa: PLC0415
+    from world.roster.services.heredity import (  # noqa: PLC0415
+        base_trait_options,
+        inherited_options,
+    )
 
     species = draft.selected_species
     if species is None:
@@ -265,18 +267,20 @@ def _get_form_trait_errors(draft: CharacterDraft) -> list[str]:
 
     # Legality is scoped per offered trait: a trait the species has no
     # SpeciesFormTrait link for was never offered — finalize silently skips
-    # it (pre-#2815 behavior), so validation ignores it too.
-    own_palette = get_cg_form_options(species)
-    legal_by_trait: dict[str, set[int]] = {
-        trait.name: {opt.pk for opt in options} for trait, options in own_palette.items()
-    }
+    # it (pre-#2815 behavior), so validation ignores it too. Children of
+    # fully-defined parents work from the family look (base_trait_options
+    # narrows a trait to the parents' pins when every line carries one).
     lines = get_draft_parent_lines(draft)
+    base_palette = base_trait_options(species, lines)
+    legal_by_trait: dict[str, set[int]] = {
+        trait.name: {opt.pk for opt in options} for trait, options in base_palette.items()
+    }
     if lines:
         for entry in inherited_options(species, lines):
             legal_by_trait.setdefault(entry.trait.name, set()).update(
                 opt.pk for opt in entry.options
             )
-    trait_names = {trait.name: trait.display_name for trait in own_palette}
+    trait_names = {trait.name: trait.display_name for trait in base_palette}
     for trait_name, option_id in selections.items():
         legal = legal_by_trait.get(trait_name)
         if legal is None:

--- a/src/world/character_creation/views.py
+++ b/src/world/character_creation/views.py
@@ -1085,7 +1085,25 @@ class FormOptionsView(APIView):
                 status=status.HTTP_404_NOT_FOUND,
             )
 
-        form_options = get_cg_form_options(species)
+        draft = None
+        raw_draft_id = request.query_params.get("draft")  # noqa: USE_FILTERSET
+        if raw_draft_id:
+            try:
+                draft_id = int(raw_draft_id)
+            except (TypeError, ValueError):
+                draft_id = None
+            if draft_id is not None:
+                draft = get_object_or_404(CharacterDraft, pk=draft_id, account=request.user)
+
+        if draft is not None:
+            # Children of fully-defined parents work from the family look
+            # (#2815): base options narrow to the parents' pinned values.
+            from world.character_creation.validators import get_draft_parent_lines  # noqa: PLC0415
+            from world.roster.services.heredity import base_trait_options  # noqa: PLC0415
+
+            form_options = base_trait_options(species, get_draft_parent_lines(draft))
+        else:
+            form_options = get_cg_form_options(species)
         required_trait_ids = set(
             SpeciesFormTrait.objects.filter(
                 species=species, is_available_in_cg=True, is_required=True
@@ -1103,15 +1121,8 @@ class FormOptionsView(APIView):
             )
 
         payload: dict[str, object] = {"traits": result, "inherited": []}
-        raw_draft_id = request.query_params.get("draft")  # noqa: USE_FILTERSET
-        if raw_draft_id:
-            try:
-                draft_id = int(raw_draft_id)
-            except (TypeError, ValueError):
-                draft_id = None
-            if draft_id is not None:
-                draft = get_object_or_404(CharacterDraft, pk=draft_id, account=request.user)
-                payload["inherited"] = self._inherited_payload(draft, species)
+        if draft is not None:
+            payload["inherited"] = self._inherited_payload(draft, species)
         return Response(payload)
 
 

--- a/src/world/roster/AGENT_GLOSSARY.md
+++ b/src/world/roster/AGENT_GLOSSARY.md
@@ -37,7 +37,10 @@ kinship graph). Root terms live in `AGENT_GLOSSARY_MAP.md`.
   known appearance color. Written by CG approval back-inference (a child's
   off-palette pick is attributed to the cross-species parent) or staff
   authoring; the first child to draw on an unpinned trait defines it, and
-  pins constrain later siblings. _Avoid:_ heredity service named "lineage"
+  pins constrain later siblings. Children of *fully*-pinned parents work
+  from the family look (`base_trait_options`): a trait every parent line
+  has pinned collapses to the parents' values, mother's first; an unpinned
+  side keeps the palette open. _Avoid:_ heredity service named "lineage"
   (that word already means the CG stage, display-lineage, and roadmap
   lineage powers).
 - **Step-parent / in-law** — DERIVED relations (a parent's union partner

--- a/src/world/roster/services/heredity.py
+++ b/src/world/roster/services/heredity.py
@@ -43,6 +43,11 @@ CHIMERIC_MIN_TIER = DOMINANCE_TIER[PowerBand.GRAND]
 
 _HEREDITY_KINDS = (ParentageKind.BIOLOGICAL, ParentageKind.TREE_OF_SOULS)
 
+# Family-look narrowing needs both sides of the parentage recorded — a single
+# recorded parent means the other side is simply unknown, which keeps the
+# species palette open (lazy definition: unknown = free).
+_MIN_LINES_FOR_NARROWING = 2
+
 
 @dataclass(frozen=True)
 class ParentLine:
@@ -146,6 +151,58 @@ def derivable_species(lines: list[ParentLine], *, fallback_maternal: Species) ->
     return SpeciesDerivation(allowed=allowed, chimeric_possible=chimeric_possible)
 
 
+def _line_pins(line: ParentLine) -> dict[int, FormTraitOption]:
+    """A parent line's pinned values by trait pk (empty for undefined parents)."""
+    if line.kinsperson is None:
+        return {}
+    return {
+        pin.trait_id: pin.option
+        for pin in KinspersonTraitValue.objects.filter(kinsperson=line.kinsperson).select_related(
+            "option__trait"
+        )
+    }
+
+
+def base_trait_options(
+    child_species: Species, lines: list[ParentLine]
+) -> dict[FormTrait, list[FormTraitOption]]:
+    """The child's own-line options per trait, narrowed to the family look.
+
+    Children of *defined* parents work from their parents' actual colors,
+    defaulting to the mother's: when EVERY parent line carries a pin for a
+    trait, that trait's options collapse to the same-species parents' pinned
+    values (dominant line first — the UI's default ordering). An unpinned
+    side keeps the species palette open (lazy definition: unknown = free),
+    as does a family with fewer than two recorded parent lines.
+    Cross-species parents' pins are NOT folded in here — they surface via
+    ``inherited_options`` with their source label, so the UI grouping and
+    the no-duplicate invariant both hold.
+    """
+    palette = get_cg_form_options(child_species)
+    if len(lines) < _MIN_LINES_FOR_NARROWING:
+        return palette
+
+    ordered = sorted(lines, key=lambda line: not line.is_dominant_role)
+    pins_by_line = [(line, _line_pins(line)) for line in ordered]
+
+    result: dict[FormTrait, list[FormTraitOption]] = {}
+    for trait, options in palette.items():
+        pinned = [(line, pins.get(trait.pk)) for line, pins in pins_by_line]
+        if all(option is not None for _, option in pinned):
+            family_look: list[FormTraitOption] = []
+            for line, option in pinned:
+                if (
+                    option is not None
+                    and line.species == child_species
+                    and option not in family_look
+                ):
+                    family_look.append(option)
+            result[trait] = family_look or list(options)
+        else:
+            result[trait] = list(options)
+    return result
+
+
 def _parent_palette(
     line: ParentLine, trait_pins: dict[int, FormTraitOption]
 ) -> dict[FormTrait, list[FormTraitOption]]:
@@ -180,14 +237,7 @@ def inherited_options(
     for line in lines:
         if line.is_dominant_role or line.species is None or line.species == child_species:
             continue
-        trait_pins: dict[int, FormTraitOption] = {}
-        if line.kinsperson is not None:
-            trait_pins = {
-                pin.trait_id: pin.option
-                for pin in KinspersonTraitValue.objects.filter(
-                    kinsperson=line.kinsperson
-                ).select_related("option__trait")
-            }
+        trait_pins = _line_pins(line)
         has_real_name = line.kinsperson is not None and bool(
             line.kinsperson.name or line.kinsperson.sheet_id
         )

--- a/src/world/roster/tests/test_heredity.py
+++ b/src/world/roster/tests/test_heredity.py
@@ -18,6 +18,7 @@ from world.roster.factories import (
 from world.roster.models import KinspersonTraitValue
 from world.roster.services.heredity import (
     ParentLine,
+    base_trait_options,
     derivable_species,
     derive_lines_for_child,
     inherited_options,
@@ -272,3 +273,86 @@ class InheritedOptionsTest(TestCase):
         self.assertEqual(len(inherited), 1)
         self.assertEqual(set(inherited[0].options), {self.red, self.blonde})
         self.assertEqual(inherited[0].source, "Human parent")
+
+
+class BaseTraitOptionsTest(TestCase):
+    """Defined-parents narrowing: children work from the family look (#2815).
+
+    Narrowing triggers only when EVERY parent line is pinned for a trait; an
+    unpinned side (or a single recorded parent) keeps the palette open.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.khati = SpeciesFactory(name="Khati")
+        cls.human = SpeciesFactory(name="Human")
+        cls.hair = FormTraitFactory(name="hair_color")
+        cls.black = FormTraitOptionFactory(trait=cls.hair, name="black")
+        cls.brown = FormTraitOptionFactory(trait=cls.hair, name="brown")
+        cls.white = FormTraitOptionFactory(trait=cls.hair, name="white")
+        cls.red = FormTraitOptionFactory(trait=cls.hair, name="red")
+        khati_hair = SpeciesFormTraitFactory(species=cls.khati, trait=cls.hair)
+        khati_hair.allowed_options.set([cls.black, cls.brown, cls.white])
+        human_hair = SpeciesFormTraitFactory(species=cls.human, trait=cls.hair)
+        human_hair.allowed_options.set([cls.black, cls.brown, cls.red])
+
+    def _lines(self, mother, father):
+        return [
+            ParentLine(
+                kinsperson=mother,
+                species=mother.species if mother else None,
+                band=None,
+                is_dominant_role=True,
+            ),
+            ParentLine(
+                kinsperson=father,
+                species=father.species if father else None,
+                band=None,
+                is_dominant_role=False,
+            ),
+        ]
+
+    def test_both_parents_pinned_narrows_mother_first(self):
+        mother = KinspersonFactory(species=self.khati)
+        father = KinspersonFactory(species=self.khati)
+        KinspersonTraitValueFactory(kinsperson=mother, trait=self.hair, option=self.brown)
+        KinspersonTraitValueFactory(kinsperson=father, trait=self.hair, option=self.black)
+        base = base_trait_options(self.khati, self._lines(mother, father))
+        self.assertEqual(base[self.hair], [self.brown, self.black])
+
+    def test_unpinned_side_keeps_palette_open(self):
+        mother = KinspersonFactory(species=self.khati)
+        father = KinspersonFactory(species=self.khati)
+        KinspersonTraitValueFactory(kinsperson=mother, trait=self.hair, option=self.brown)
+        base = base_trait_options(self.khati, self._lines(mother, father))
+        self.assertEqual(set(base[self.hair]), {self.black, self.brown, self.white})
+
+    def test_single_line_keeps_palette(self):
+        mother = KinspersonFactory(species=self.khati)
+        KinspersonTraitValueFactory(kinsperson=mother, trait=self.hair, option=self.brown)
+        lines = self._lines(mother, None)[:1]
+        base = base_trait_options(self.khati, lines)
+        self.assertEqual(set(base[self.hair]), {self.black, self.brown, self.white})
+
+    def test_cross_species_pin_triggers_narrowing_but_rides_inherited(self):
+        # Mother khati pinned brown; father human pinned red (off khati palette).
+        # Base narrows to the mother's value only; red stays in the father's
+        # labeled inherited group — no duplicate between the two surfaces.
+        mother = KinspersonFactory(species=self.khati)
+        father = KinspersonFactory(species=self.human, name="Bob")
+        KinspersonTraitValueFactory(kinsperson=mother, trait=self.hair, option=self.brown)
+        KinspersonTraitValueFactory(kinsperson=father, trait=self.hair, option=self.red)
+        lines = self._lines(mother, father)
+        base = base_trait_options(self.khati, lines)
+        self.assertEqual(base[self.hair], [self.brown])
+        inherited = inherited_options(self.khati, lines)
+        self.assertEqual(len(inherited), 1)
+        self.assertEqual(inherited[0].options, [self.red])
+
+    def test_undefined_parents_keep_palette(self):
+        lines = [
+            ParentLine(kinsperson=None, species=self.khati, band=None, is_dominant_role=True),
+            ParentLine(kinsperson=None, species=self.human, band=None, is_dominant_role=False),
+        ]
+        base = base_trait_options(self.khati, lines)
+        self.assertEqual(set(base[self.hair]), {self.black, self.brown, self.white})


### PR DESCRIPTION
Per ApostateCD's ruling: someone making a CG off defined mothers and fathers works from their parents' characteristics, defaulting to the mother's.

`base_trait_options` in the heredity service: when EVERY parent line carries a pinned value for a trait, that trait's CG options collapse to the same-species parents' pins — dominant line (mother/ritual invoker) first, which the UI inherits as ordering. An unpinned side, or a single recorded parent, keeps the species palette open (lazy definition: unknown = free). Cross-species parents' pins stay in their labeled 'From your …' inherited groups, so nothing duplicates. Wired into CG validation and the parent-aware form-options endpoint; no frontend change needed. 5 new service tests + 3 CG integration tests.

Deliberate dials (flagged in the lore design doc): strict two-value family look (no throwback latitude yet — GMs widen by editing pins), and no same-species back-pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)