### PR TITLE
feat(tasking): actions layer + telnet 'network' command family (#2820 follow-up)

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2530,6 +2530,10 @@ consumers, not systems.
 - **API:** `/api/tasking/` — staff `templates/`+`routes/`; member `tasks/`
   (create/assign/accept), `roster/`, `posts/` (+collect), `counterplay/`;
   React `OperationsSection` (Roster/Postings/Operations) on `OrgPage`
+- **Actions + telnet:** 11 REGISTRY actions (`actions/definitions/tasking.py`)
+  are the ADR-0001 seam — viewsets dispatch through them; telnet `network`
+  family (`commands/network.py`: board/issue/assign/accept/post/collect/
+  sweep/clear/suppress/flip/plant)
 - **Boundary:** standing "stay until recalled" postings are `NPCAssignment`
   rows, never tasks — every task ends; prose is never a surveillance input
 - **Source:** `src/world/tasking/` · **Doc:** `docs/systems/tasking.md` ·

--- a/docs/systems/tasking.md
+++ b/docs/systems/tasking.md
@@ -80,9 +80,24 @@ agent (see `world/mechanics/effect_handlers.py::_apply_asset_status`).
 
 ## Frontend
 
-`frontend/src/tasking/` — API client, queries, and `OperationsSection` (read-only
-board panel rendered on `OrgPage`, hidden when empty). Issue/assign UI rides
-later phases.
+`frontend/src/tasking/` — API client, queries, and `OperationsSection`
+(Roster/Postings/Operations panels rendered on `OrgPage`, hidden when empty).
+
+## Actions layer + telnet (`network` family)
+
+Eleven REGISTRY actions in `actions/definitions/tasking.py` are the shared
+seam (ADR-0001): `list_org_tasks`, `issue_org_task`, `assign_task_agent`,
+`accept_org_task`, `post_listener`, `collect_harvest`, `suppress_listener`,
+`flip_listener`, `plant_red_herring`, `detect_listeners`,
+`clear_room_listeners`. The tasking viewsets dispatch through them (the web
+no longer calls the services directly for mutations), and telnet reaches the
+same actions via `CmdNetwork` (`network`, alias `spynet`,
+`commands/network.py`): `network` (board), `issue <template> org=<org>`,
+`assign <task-id> = <agent>`, `accept <task-id>`, `post <agent>`, `collect`,
+`sweep`, `clear`, `suppress`, `flip`, `plant <post-id> <char> = <lie>`.
+Location-contextual verbs act where the caller stands (the web passes
+explicit `room_id`/`post_id` anchors); name→pk resolution is the only work
+in the command.
 
 ## Covert-org layer (phase 2)
 

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -19564,13 +19564,7 @@ export interface paths {
      */
     get: operations['tasking_posts_list'];
     put?: never;
-    /**
-     * @description Standing listener posts (#2820 phase 3) — the board's Postings panel.
-     *
-     *     Visibility: your own posts (handler), plus posts whose agent is held by
-     *     an org you belong to or oversee. ``collect`` requires the handler's body
-     *     in the posted room — the visit is the exposure surface.
-     */
+    /** @description Post a listener — through PostListenerAction (ADR-0001). */
     post: operations['tasking_posts_create'];
     delete?: never;
     options?: never;
@@ -19610,7 +19604,7 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** @description Collect the oldest pending harvest, in person. */
+    /** @description Collect in person — through CollectHarvestAction (ADR-0001). */
     post: operations['tasking_posts_collect_create'];
     delete?: never;
     options?: never;
@@ -19689,7 +19683,7 @@ export interface paths {
     /** @description The org task board: list/inspect/issue/assign. */
     get: operations['tasking_tasks_list'];
     put?: never;
-    /** @description The org task board: list/inspect/issue/assign. */
+    /** @description Issue a task — dispatched through IssueOrgTaskAction (ADR-0001). */
     post: operations['tasking_tasks_create'];
     delete?: never;
     options?: never;
@@ -19740,7 +19734,7 @@ export interface paths {
     };
     get?: never;
     put?: never;
-    /** @description Dispatch one of the requester's own agents on this task. */
+    /** @description Dispatch an agent — through AssignTaskAgentAction (ADR-0001). */
     post: operations['tasking_tasks_assign_create'];
     delete?: never;
     options?: never;

--- a/src/actions/definitions/tasking.py
+++ b/src/actions/definitions/tasking.py
@@ -1,0 +1,580 @@
+"""Org-task and spy-network actions (#2820 telnet/actions layer).
+
+The action.run() seam for the tasking system — shared by the telnet
+``network`` command family and the web tasking viewsets (ADR-0001). Every
+action resolves the actor's active persona and delegates to the tasking
+service layer; no business logic lives here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from evennia.objects.models import ObjectDB
+
+from actions.base import Action
+from actions.constants import ActionCategory
+from actions.types import ActionResult, TargetType
+
+if TYPE_CHECKING:
+    from actions.types import ActionContext
+    from world.scenes.models import Persona
+
+_CATEGORY = "tasking"
+
+
+def _active_persona(actor: ObjectDB) -> Persona | None:
+    from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+    from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+    try:
+        sheet = actor.sheet_data
+    except (AttributeError, ObjectDoesNotExist):
+        return None
+    return active_persona_for_sheet(sheet)
+
+
+def _room_profile(actor: ObjectDB):
+    from evennia_extensions.models import RoomProfile  # noqa: PLC0415
+
+    if actor.location is None:
+        return None
+    return RoomProfile.objects.filter(objectdb=actor.location).first()
+
+
+def _sitting_post(room_profile):
+    from world.tasking.models import ListenerPost  # noqa: PLC0415
+
+    if room_profile is None:
+        return None
+    return ListenerPost.objects.filter(
+        assignment__room_id=room_profile.pk,
+        assignment__is_active=True,
+    ).first()
+
+
+_NO_PERSONA = ActionResult(success=False, message="You have no active persona.")
+
+
+@dataclass
+class ListOrgTasksAction(Action):
+    """The board hub: tasks, roster, and postings visible to the actor.
+
+    Kwargs:
+        org_id: Optional — narrow to one organization.
+    """
+
+    key: str = "list_org_tasks"
+    name: str = "Task Board"
+    icon: str = "clipboard-list"
+    category: str = _CATEGORY
+    action_category: ActionCategory = ActionCategory.SOCIAL
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.societies.models import OrganizationMembership  # noqa: PLC0415
+        from world.societies.office_services import overseen_org_ids  # noqa: PLC0415
+        from world.tasking.models import ListenerPost, OrgTask  # noqa: PLC0415
+
+        persona = _active_persona(actor)
+        if persona is None:
+            return _NO_PERSONA
+        member_org_ids = list(
+            OrganizationMembership.objects.filter(
+                persona=persona,
+                left_at__isnull=True,
+                exiled_at__isnull=True,
+            ).values_list("organization_id", flat=True)
+        )
+        allowed = set(member_org_ids) | set(overseen_org_ids(persona))
+        org_id = kwargs.get("org_id")
+        if org_id:
+            allowed &= {int(org_id)}
+
+        tasks = (
+            OrgTask.objects.filter(org_id__in=allowed)
+            .select_related("template", "org")
+            .order_by("-created_at")[:20]
+        )
+        posts = ListenerPost.objects.filter(
+            assignment__is_active=True,
+            assignment__npc_asset__promoter_org_id__in=allowed,
+        ).select_related("assignment__npc_asset__asset_persona") | ListenerPost.objects.filter(
+            assignment__is_active=True, handler=persona
+        ).select_related("assignment__npc_asset__asset_persona")
+
+        lines = [
+            f"#{task.pk} [{task.status}] {task.template.name} ({task.org.name})" for task in tasks
+        ]
+        for post in posts.distinct():
+            asset = post.assignment.npc_asset
+            agent = str(asset.asset_persona) if asset else "?"
+            pending = post.harvests.filter(collected_at__isnull=True).count()
+            ready = f" — {pending} to collect" if pending else ""
+            lines.append(
+                f"post #{post.pk}: {agent} listening (buzz {post.buzz}/{post.threshold}){ready}"
+            )
+        if not lines:
+            return ActionResult(success=True, message="Your networks report nothing.")
+        return ActionResult(success=True, message="\n".join(lines))
+
+
+@dataclass
+class IssueOrgTaskAction(Action):
+    """Issue a task from a template (org leadership only).
+
+    Kwargs:
+        template_id, org_id, and optional target_room_id / target_org_id /
+        target_domain_id / target_persona_id matching the template's kind.
+    """
+
+    key: str = "issue_org_task"
+    name: str = "Issue Task"
+    icon: str = "clipboard-plus"
+    category: str = _CATEGORY
+    action_category: ActionCategory = ActionCategory.SOCIAL
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from django.core.exceptions import ValidationError  # noqa: PLC0415
+
+        from evennia_extensions.models import RoomProfile  # noqa: PLC0415
+        from world.scenes.models import Persona  # noqa: PLC0415
+        from world.societies.houses.models import Domain  # noqa: PLC0415
+        from world.societies.houses.services import is_org_leader  # noqa: PLC0415
+        from world.societies.models import Organization  # noqa: PLC0415
+        from world.tasking.exceptions import TaskingError  # noqa: PLC0415
+        from world.tasking.models import TaskTemplate  # noqa: PLC0415
+        from world.tasking.services import create_task  # noqa: PLC0415
+
+        persona = _active_persona(actor)
+        if persona is None:
+            return _NO_PERSONA
+        template = TaskTemplate.objects.filter(pk=kwargs.get("template_id")).first()
+        org = Organization.objects.filter(pk=kwargs.get("org_id")).first()
+        if template is None or org is None:
+            return ActionResult(success=False, message="No such template or organization.")
+        if not is_org_leader(persona, org):
+            return ActionResult(
+                success=False,
+                message="Only the organization's leadership can issue tasks.",
+            )
+        try:
+            task = create_task(
+                template,
+                org,
+                persona,
+                target_room=RoomProfile.objects.filter(pk=kwargs.get("target_room_id")).first(),
+                target_org=Organization.objects.filter(pk=kwargs.get("target_org_id")).first(),
+                target_domain=Domain.objects.filter(pk=kwargs.get("target_domain_id")).first(),
+                target_persona=Persona.objects.filter(pk=kwargs.get("target_persona_id")).first(),
+            )
+        except TaskingError as exc:
+            return ActionResult(success=False, message=exc.user_message)
+        except ValidationError:
+            return ActionResult(
+                success=False,
+                message="That target does not fit the template's target kind.",
+            )
+        return ActionResult(
+            success=True,
+            message=f"Task #{task.pk} issued: {template.name}.",
+            data={"task_id": task.pk},
+        )
+
+
+@dataclass
+class AssignTaskAgentAction(Action):
+    """Dispatch an agent on an OPEN task (rolls your dispatch check).
+
+    Kwargs: task_id, npc_asset_id.
+    """
+
+    key: str = "assign_task_agent"
+    name: str = "Dispatch Agent"
+    icon: str = "send"
+    category: str = _CATEGORY
+    action_category: ActionCategory = ActionCategory.SOCIAL
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.assets.models import NPCAsset  # noqa: PLC0415
+        from world.tasking.exceptions import TaskingError  # noqa: PLC0415
+        from world.tasking.models import OrgTask  # noqa: PLC0415
+        from world.tasking.services import assign_agent  # noqa: PLC0415
+
+        persona = _active_persona(actor)
+        if persona is None:
+            return _NO_PERSONA
+        task = OrgTask.objects.filter(pk=kwargs.get("task_id")).first()
+        npc_asset = NPCAsset.objects.filter(pk=kwargs.get("npc_asset_id")).first()
+        if task is None or npc_asset is None:
+            return ActionResult(success=False, message="No such task or agent.")
+        try:
+            assign_agent(task, npc_asset, persona)
+        except TaskingError as exc:
+            return ActionResult(success=False, message=exc.user_message)
+        return ActionResult(
+            success=True,
+            message=(
+                f"{npc_asset.asset_persona} slips away on task #{task.pk}. "
+                f"They report back by {task.deadline:%Y-%m-%d %H:%M}."
+            ),
+        )
+
+
+@dataclass
+class AcceptOrgTaskAction(Action):
+    """Pick up a PC-fulfillable task yourself as a mission.
+
+    Kwargs: task_id.
+    """
+
+    key: str = "accept_org_task"
+    name: str = "Accept Task"
+    icon: str = "hand"
+    category: str = _CATEGORY
+    action_category: ActionCategory = ActionCategory.SOCIAL
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.tasking.exceptions import TaskingError  # noqa: PLC0415
+        from world.tasking.models import OrgTask  # noqa: PLC0415
+        from world.tasking.services import accept_task  # noqa: PLC0415
+
+        persona = _active_persona(actor)
+        if persona is None:
+            return _NO_PERSONA
+        task = OrgTask.objects.filter(pk=kwargs.get("task_id")).first()
+        if task is None:
+            return ActionResult(success=False, message="No such task.")
+        try:
+            fulfillment = accept_task(task, persona)
+        except TaskingError as exc:
+            return ActionResult(success=False, message=exc.user_message)
+        return ActionResult(
+            success=True,
+            message=(
+                f"You take task #{task.pk} yourself. "
+                f"See `mission` for your new run (#{fulfillment.mission_instance_id})."
+            ),
+            data={"mission_instance_id": fulfillment.mission_instance_id},
+        )
+
+
+@dataclass
+class PostListenerAction(Action):
+    """Post an agent as this room's listener.
+
+    Kwargs: npc_asset_id (room = your location).
+    """
+
+    key: str = "post_listener"
+    name: str = "Post Listener"
+    icon: str = "ear"
+    category: str = _CATEGORY
+    action_category: ActionCategory = ActionCategory.SOCIAL
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from evennia_extensions.models import RoomProfile  # noqa: PLC0415
+        from world.assets.models import NPCAsset  # noqa: PLC0415
+        from world.tasking.exceptions import TaskingError  # noqa: PLC0415
+        from world.tasking.listener_services import create_listener_post  # noqa: PLC0415
+
+        persona = _active_persona(actor)
+        if persona is None:
+            return _NO_PERSONA
+        # Explicit room_id is the web anchor; telnet posts where you stand.
+        room_id = kwargs.get("room_id")
+        if room_id:
+            room = RoomProfile.objects.filter(pk=room_id).first()
+        else:
+            room = _room_profile(actor)
+        if room is None:
+            return ActionResult(success=False, message="You're not in a room.")
+        npc_asset = NPCAsset.objects.filter(pk=kwargs.get("npc_asset_id")).first()
+        if npc_asset is None:
+            return ActionResult(success=False, message="No such agent.")
+        check_type = None
+        if kwargs.get("check_type_id"):
+            from world.checks.models import CheckType  # noqa: PLC0415
+
+            check_type = CheckType.objects.filter(pk=kwargs["check_type_id"]).first()
+        try:
+            post = create_listener_post(
+                npc_asset,
+                room,
+                persona,
+                check_type=check_type,
+                check_difficulty=int(kwargs.get("check_difficulty") or 0),
+            )
+        except TaskingError as exc:
+            return ActionResult(success=False, message=exc.user_message)
+        return ActionResult(
+            success=True,
+            message=f"{npc_asset.asset_persona} settles in here, ears open (post #{post.pk}).",
+            data={"post_id": post.pk},
+        )
+
+
+@dataclass
+class CollectHarvestAction(Action):
+    """Collect from your listener in this room (you must be present)."""
+
+    key: str = "collect_harvest"
+    name: str = "Collect"
+    icon: str = "inbox"
+    category: str = _CATEGORY
+    action_category: ActionCategory = ActionCategory.SOCIAL
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.tasking.exceptions import TaskingError  # noqa: PLC0415
+        from world.tasking.listener_services import collect_harvest  # noqa: PLC0415
+        from world.tasking.models import ListenerPost  # noqa: PLC0415
+
+        persona = _active_persona(actor)
+        if persona is None:
+            return _NO_PERSONA
+        # Explicit post_id is the web anchor; telnet collects where you stand.
+        post_id = kwargs.get("post_id")
+        if post_id:
+            post = ListenerPost.objects.filter(pk=post_id).first()
+        else:
+            post = _sitting_post(_room_profile(actor))
+        if post is None:
+            return ActionResult(success=False, message="None of your agents listen here.")
+        try:
+            clue = collect_harvest(post, persona)
+        except TaskingError as exc:
+            return ActionResult(success=False, message=exc.user_message)
+        if clue is None:
+            return ActionResult(
+                success=True,
+                message="Your agent has little of substance — talk, but nothing solid.",
+            )
+        return ActionResult(success=True, message=f"Your agent leans close: {clue.name}.")
+
+
+@dataclass
+class SuppressListenerAction(Action):
+    """Intimidate this room's sitting listener into silence."""
+
+    key: str = "suppress_listener"
+    name: str = "Suppress Listener"
+    icon: str = "volume-x"
+    category: str = _CATEGORY
+    action_category: ActionCategory = ActionCategory.SOCIAL
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.tasking.counterplay_services import suppress_listener  # noqa: PLC0415
+        from world.tasking.exceptions import TaskingError  # noqa: PLC0415
+
+        persona = _active_persona(actor)
+        if persona is None:
+            return _NO_PERSONA
+        post = _sitting_post(_room_profile(actor))
+        if post is None:
+            return ActionResult(success=False, message="No one here seems to be listening.")
+        try:
+            success = suppress_listener(persona, post)
+        except TaskingError as exc:
+            return ActionResult(success=False, message=exc.user_message)
+        if success:
+            return ActionResult(success=True, message="They go pale, and quiet.")
+        return ActionResult(success=False, message="They don't scare.")
+
+
+@dataclass
+class FlipListenerAction(Action):
+    """Seduce this room's sitting listener into a double allegiance."""
+
+    key: str = "flip_listener"
+    name: str = "Flip Listener"
+    icon: str = "repeat"
+    category: str = _CATEGORY
+    action_category: ActionCategory = ActionCategory.SOCIAL
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.tasking.counterplay_services import flip_listener  # noqa: PLC0415
+        from world.tasking.exceptions import TaskingError  # noqa: PLC0415
+
+        persona = _active_persona(actor)
+        if persona is None:
+            return _NO_PERSONA
+        post = _sitting_post(_room_profile(actor))
+        if post is None:
+            return ActionResult(success=False, message="No one here seems to be listening.")
+        try:
+            success = flip_listener(persona, post)
+        except TaskingError as exc:
+            return ActionResult(success=False, message=exc.user_message)
+        if success:
+            return ActionResult(
+                success=True,
+                message="Their loyalties quietly change hands. They are yours now.",
+            )
+        return ActionResult(success=False, message="They resist your charms.")
+
+
+@dataclass
+class PlantRedHerringAction(Action):
+    """Queue a false catch on a listener you control.
+
+    Kwargs: post_id, subject_sheet_id, content.
+    """
+
+    key: str = "plant_red_herring"
+    name: str = "Plant Red Herring"
+    icon: str = "fish"
+    category: str = _CATEGORY
+    action_category: ActionCategory = ActionCategory.SOCIAL
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.character_sheets.models import CharacterSheet  # noqa: PLC0415
+        from world.tasking.counterplay_services import plant_red_herring  # noqa: PLC0415
+        from world.tasking.exceptions import TaskingError  # noqa: PLC0415
+        from world.tasking.models import ListenerPost  # noqa: PLC0415
+
+        persona = _active_persona(actor)
+        if persona is None:
+            return _NO_PERSONA
+        post = ListenerPost.objects.filter(pk=kwargs.get("post_id")).first()
+        subject = CharacterSheet.objects.filter(pk=kwargs.get("subject_sheet_id")).first()
+        content = (kwargs.get("content") or "").strip()
+        if post is None or subject is None or not content:
+            return ActionResult(success=False, message="Plant what, about whom, where?")
+        try:
+            plant_red_herring(persona, post, subject_sheet=subject, content=content)
+        except TaskingError as exc:
+            return ActionResult(success=False, message=exc.user_message)
+        return ActionResult(
+            success=True,
+            message="The lie is seeded. Their next collection will carry it.",
+        )
+
+
+@dataclass
+class DetectListenersAction(Action):
+    """Sweep this room for informants (consentless, defensive)."""
+
+    key: str = "detect_listeners"
+    name: str = "Sweep for Listeners"
+    icon: str = "scan-eye"
+    category: str = _CATEGORY
+    action_category: ActionCategory = ActionCategory.SOCIAL
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.tasking.counterplay_services import detect_listeners  # noqa: PLC0415
+        from world.tasking.exceptions import TaskingError  # noqa: PLC0415
+
+        persona = _active_persona(actor)
+        if persona is None:
+            return _NO_PERSONA
+        room = _room_profile(actor)
+        if room is None:
+            return ActionResult(success=False, message="You're not in a room.")
+        try:
+            revealed = detect_listeners(persona, room)
+        except TaskingError as exc:
+            return ActionResult(success=False, message=exc.user_message)
+        if not revealed:
+            return ActionResult(success=True, message="You spot nothing out of place.")
+        names = ", ".join(r["agent_name"] or "someone" for r in revealed)
+        return ActionResult(
+            success=True,
+            message=f"Someone here is listening: {names}.",
+            data={"revealed": revealed},
+        )
+
+
+@dataclass
+class ClearRoomListenersAction(Action):
+    """Expel listeners from a room you hold authority over."""
+
+    key: str = "clear_room_listeners"
+    name: str = "Clear the Room"
+    icon: str = "door-open"
+    category: str = _CATEGORY
+    action_category: ActionCategory = ActionCategory.SOCIAL
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.tasking.counterplay_services import clear_room_listeners  # noqa: PLC0415
+        from world.tasking.exceptions import TaskingError  # noqa: PLC0415
+
+        persona = _active_persona(actor)
+        if persona is None:
+            return _NO_PERSONA
+        room = _room_profile(actor)
+        if room is None:
+            return ActionResult(success=False, message="You're not in a room.")
+        try:
+            count = clear_room_listeners(persona, room)
+        except TaskingError as exc:
+            return ActionResult(success=False, message=exc.user_message)
+        if count == 0:
+            return ActionResult(success=True, message="No hangers-on to usher out.")
+        return ActionResult(success=True, message=f"You clear the room ({count} ushered out).")

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -416,6 +416,19 @@ from actions.definitions.story_builder import (
     StoryRemoveRoomAction,
     StoryUnlinkRoomsAction,
 )
+from actions.definitions.tasking import (
+    AcceptOrgTaskAction,
+    AssignTaskAgentAction,
+    ClearRoomListenersAction,
+    CollectHarvestAction,
+    DetectListenersAction,
+    FlipListenerAction,
+    IssueOrgTaskAction,
+    ListOrgTasksAction,
+    PlantRedHerringAction,
+    PostListenerAction,
+    SuppressListenerAction,
+)
 from actions.definitions.technique_authoring import AuthorTechniqueAction
 from actions.definitions.threads import WeaveThreadAction
 from actions.definitions.traps import DisarmTrapAction
@@ -794,6 +807,18 @@ _ALL_ACTIONS: list[Action] = [
     AssignGuardAction(),
     UnassignGuardAction(),
     ListGuardAssignmentsAction(),
+    # #2820 — org tasking + spy networks (the `network` command family).
+    ListOrgTasksAction(),
+    IssueOrgTaskAction(),
+    AssignTaskAgentAction(),
+    AcceptOrgTaskAction(),
+    PostListenerAction(),
+    CollectHarvestAction(),
+    SuppressListenerAction(),
+    FlipListenerAction(),
+    PlantRedHerringAction(),
+    DetectListenersAction(),
+    ClearRoomListenersAction(),
     # #2287 — death & unconsciousness core slice.
     WakeAction(),
     # #2290 — dream realm.

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -454,6 +454,18 @@ class ActionRegistryTests(TestCase):
             "assign_guard",
             "unassign_guard",
             "list_guard_assignments",
+            # #2820 — org tasking + spy networks.
+            "list_org_tasks",
+            "issue_org_task",
+            "assign_task_agent",
+            "accept_org_task",
+            "post_listener",
+            "collect_harvest",
+            "suppress_listener",
+            "flip_listener",
+            "plant_red_herring",
+            "detect_listeners",
+            "clear_room_listeners",
             # #2287 — death & unconsciousness core slice.
             "wake",
             "retire",

--- a/src/actions/tests/test_tasking_actions.py
+++ b/src/actions/tests/test_tasking_actions.py
@@ -1,0 +1,115 @@
+"""Integration tests for the #2820 tasking actions (the telnet/web shared seam)."""
+
+from datetime import timedelta
+
+from django.test import TestCase
+
+from actions.registry import get_action
+from evennia_extensions.factories import RoomProfileFactory
+from world.assets.factories import NPCAssetFactory
+from world.checks.test_helpers import force_check_outcome
+from world.societies.factories import OrganizationFactory, OrganizationMembershipFactory
+from world.societies.models import OrganizationRank
+from world.tasking.constants import TaskStatus
+from world.tasking.factories import OrgTaskFactory, TaskTemplateFactory
+from world.tasking.models import ListenerPost, OrgTask
+from world.traits.factories import CheckOutcomeFactory
+
+
+class TaskingActionTestBase(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.org = OrganizationFactory()
+        cls.template = TaskTemplateFactory(duration=timedelta(days=1))
+        cls.win = CheckOutcomeFactory(name="action seam win", success_level=2)
+
+    def _member(self, *, leader: bool = False):
+        """A character whose ACTIVE (primary) persona is an org member (or leader).
+
+        Actions act as the actor's active persona, so the membership and the
+        agent must hang on the sheet's primary persona — not a sibling one.
+        """
+        from world.character_sheets.factories import CharacterSheetFactory
+
+        sheet = CharacterSheetFactory()
+        persona = sheet.primary_persona
+        asset = NPCAssetFactory(promoter_persona=persona)
+        rank = (
+            OrganizationRank.objects.filter(organization=self.org, can_manage_ranks=leader)
+            .order_by("tier")
+            .first()
+        )
+        OrganizationMembershipFactory(organization=self.org, persona=persona, rank=rank)
+        return sheet.character, persona, asset
+
+
+class IssueAndDispatchActionTests(TaskingActionTestBase):
+    def test_leader_issues_task_via_action(self):
+        character, _, _ = self._member(leader=True)
+        result = get_action("issue_org_task").run(
+            character, template_id=self.template.pk, org_id=self.org.pk
+        )
+        self.assertTrue(result.success)
+        task = OrgTask.objects.get(pk=result.data["task_id"])
+        self.assertEqual(task.status, TaskStatus.OPEN)
+
+    def test_non_leader_cannot_issue(self):
+        character, _, _ = self._member(leader=False)
+        result = get_action("issue_org_task").run(
+            character, template_id=self.template.pk, org_id=self.org.pk
+        )
+        self.assertFalse(result.success)
+        self.assertIn("leadership", result.message)
+
+    def test_member_assigns_own_agent_via_action(self):
+        character, persona, asset = self._member()
+        task = OrgTaskFactory(template=self.template, org=self.org, issued_by=persona)
+        with force_check_outcome(self.win):
+            result = get_action("assign_task_agent").run(
+                character, task_id=task.pk, npc_asset_id=asset.pk
+            )
+        self.assertTrue(result.success)
+        task.refresh_from_db()
+        self.assertEqual(task.status, TaskStatus.ASSIGNED)
+
+    def test_board_lists_org_tasks(self):
+        character, persona, _ = self._member()
+        task = OrgTaskFactory(template=self.template, org=self.org, issued_by=persona)
+        result = get_action("list_org_tasks").run(character)
+        self.assertTrue(result.success)
+        self.assertIn(f"#{task.pk}", result.message)
+
+
+class ListenerActionTests(TaskingActionTestBase):
+    def _posted(self):
+        character, persona, asset = self._member()
+        room = RoomProfileFactory()
+        character.db_location = room.objectdb
+        character.save()
+        result = get_action("post_listener").run(character, npc_asset_id=asset.pk)
+        return character, persona, room, result
+
+    def test_post_and_collect_where_you_stand(self):
+        character, _, room, post_result = self._posted()
+        self.assertTrue(post_result.success)
+        post = ListenerPost.objects.get(pk=post_result.data["post_id"])
+        self.assertEqual(post.assignment.room_id, room.pk)
+        # Nothing banked yet: collect fails with the service's message.
+        collect = get_action("collect_harvest").run(character)
+        self.assertFalse(collect.success)
+
+    def test_detect_reveals_the_listener(self):
+        from world.checks.factories import CheckTypeFactory
+
+        CheckTypeFactory(name="Perception")
+        from world.character_sheets.factories import CharacterSheetFactory
+
+        character, _, _, _ = self._posted()
+        # A different character sweeps the same room.
+        rival = CharacterSheetFactory().character
+        rival.db_location = character.db_location
+        rival.save()
+        with force_check_outcome(self.win):
+            result = get_action("detect_listeners").run(rival)
+        self.assertTrue(result.success)
+        self.assertIn("listening", result.message)

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -111,6 +111,7 @@ from commands.locations import CmdRoom
 from commands.market import CmdMarket
 from commands.missions import CmdMission
 from commands.motif import CmdMotif
+from commands.network import CmdNetwork  # #2820
 from commands.offer_response import CmdDecline
 from commands.organizations import CmdOrg
 from commands.outfit import CmdOutfit  # #1866
@@ -381,6 +382,9 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdRoom,
             # #2178 — NPC guard assignment (assign/unassign/list).
             CmdGuard,
+            # #2820 — org tasking + spy networks (board/issue/assign/accept/
+            # post/collect/sweep/clear/suppress/flip/plant).
+            CmdNetwork,
             # #1498 — staff set-the-stage: apply a position blueprint to the room.
             CmdSetStage,
             # #2450 — GM story rooms: spin up/close a temp scene room; join/leave a

--- a/src/commands/network.py
+++ b/src/commands/network.py
@@ -1,0 +1,203 @@
+"""Telnet command for org tasking + spy networks (#2820).
+
+    network                      - board hub: tasks, agents listening, harvests
+    network issue <template> org=<org> [target=<room|org|char>]
+    network assign <task-id> = <agent>
+    network accept <task-id>
+    network post <agent>         - post an agent as this room's listener
+    network collect              - collect from your listener here (in person)
+    network sweep                - search this room for informants
+    network clear                - usher listeners out (room authority)
+    network suppress             - intimidate this room's sitting listener
+    network flip                 - turn this room's sitting listener
+    network plant <post-id> <character> = <the lie>
+
+Thin over the REGISTRY actions in ``actions/definitions/tasking.py`` — the
+same seam the web tasking board uses. Name→pk resolution is the only work
+done here; all gating (leadership, membership, consent, presence, checks)
+lives in the actions and services.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from commands.command import ArxCommand
+
+if TYPE_CHECKING:
+    from world.assets.models import NPCAsset
+    from world.scenes.models import Persona
+
+_USAGE = (
+    "Usage: network | network issue <template> org=<org> | "
+    "network assign <task-id> = <agent> | network accept <task-id> | "
+    "network post <agent> | network collect | network sweep | network clear | "
+    "network suppress | network flip | network plant <post-id> <char> = <lie>"
+)
+
+
+class CmdNetwork(ArxCommand):
+    """Run your spy network: tasks, listeners, and counter-intelligence.
+
+    Usage:
+        network
+        network issue <template> org=<org>
+        network assign <task id> = <agent name>
+        network accept <task id>
+        network post <agent name>
+        network collect
+        network sweep
+        network clear
+        network suppress
+        network flip
+        network plant <post id> <character> = <the lie>
+
+    Bare `network` shows your board. Dispatching an agent rolls YOUR
+    handling check now; the agent's own roll resolves offscreen at the
+    deadline. Collection means going to your agent in person.
+    """
+
+    key = "network"
+    aliases = ("spynet",)
+    locks = "cmd:all()"
+    help_category = "Social"
+    action = None  # routes to multiple actions
+
+    def func(self) -> None:
+        args = (self.args or "").strip()
+        if not args:
+            self._run("list_org_tasks")
+            return
+        subverb, _, rest = args.partition(" ")
+        handler = {
+            "board": lambda r: self._run("list_org_tasks"),  # noqa: ARG005
+            "issue": self._issue,
+            "assign": self._assign,
+            "accept": self._accept,
+            "post": self._post,
+            "collect": lambda r: self._run("collect_harvest"),  # noqa: ARG005
+            "sweep": lambda r: self._run("detect_listeners"),  # noqa: ARG005
+            "clear": lambda r: self._run("clear_room_listeners"),  # noqa: ARG005
+            "suppress": lambda r: self._run("suppress_listener"),  # noqa: ARG005
+            "flip": lambda r: self._run("flip_listener"),  # noqa: ARG005
+            "plant": self._plant,
+        }.get(subverb.lower())
+        if handler is None:
+            self.msg(_USAGE)
+            return
+        handler(rest.strip())
+
+    def _run(self, action_key: str, **kwargs: Any) -> None:
+        from actions.registry import get_action  # noqa: PLC0415
+
+        result = get_action(action_key).run(self.caller, **kwargs)
+        self.msg(result.message)
+
+    def _issue(self, rest: str) -> None:
+        from world.societies.models import Organization  # noqa: PLC0415
+        from world.tasking.models import TaskTemplate  # noqa: PLC0415
+
+        head, _, org_part = rest.partition("org=")
+        template_name = head.strip()
+        org_name = org_part.strip()
+        if not template_name or not org_name:
+            self.msg("Usage: network issue <template> org=<org>")
+            return
+        template = self._by_pk_or_name(TaskTemplate, template_name)
+        org = self._by_pk_or_name(Organization, org_name)
+        if template is None or org is None:
+            self.msg("No such template or organization.")
+            return
+        self._run("issue_org_task", template_id=template.pk, org_id=org.pk)
+
+    def _assign(self, rest: str) -> None:
+        task_id, _, agent_name = rest.partition("=")
+        task_id = task_id.strip()
+        agent = self._resolve_agent(agent_name.strip())
+        if not task_id.isdigit() or agent is None:
+            self.msg("Usage: network assign <task id> = <agent name>")
+            return
+        self._run("assign_task_agent", task_id=int(task_id), npc_asset_id=agent.pk)
+
+    def _accept(self, rest: str) -> None:
+        if not rest.isdigit():
+            self.msg("Usage: network accept <task id>")
+            return
+        self._run("accept_org_task", task_id=int(rest))
+
+    def _post(self, rest: str) -> None:
+        agent = self._resolve_agent(rest)
+        if agent is None:
+            self.msg("Usage: network post <agent name> (one of your agents)")
+            return
+        self._run("post_listener", npc_asset_id=agent.pk)
+
+    def _plant(self, rest: str) -> None:
+        head, _, content = rest.partition("=")
+        post_id, _, char_name = head.strip().partition(" ")
+        content = content.strip()
+        char_name = char_name.strip()
+        if not post_id.isdigit() or not char_name or not content:
+            self.msg("Usage: network plant <post id> <character> = <the lie>")
+            return
+        target = self.caller.search(char_name, global_search=True, quiet=True)
+        target = target[0] if target else None
+        try:
+            sheet = target.sheet_data if target else None
+        except AttributeError:
+            sheet = None
+        if sheet is None:
+            self.msg("No such character.")
+            return
+        self._run(
+            "plant_red_herring",
+            post_id=int(post_id),
+            subject_sheet_id=sheet.pk,
+            content=content,
+        )
+
+    def _resolve_agent(self, name: str) -> NPCAsset | None:
+        """Resolve one of the caller's reachable agents by name or pk.
+
+        Own assets first, then assets held by orgs the caller belongs to.
+        """
+        from world.assets.constants import AssetStatus  # noqa: PLC0415
+        from world.assets.models import NPCAsset  # noqa: PLC0415
+        from world.societies.models import OrganizationMembership  # noqa: PLC0415
+
+        if not name:
+            return None
+        persona = self._active_persona()
+        if persona is None:
+            return None
+        reachable = NPCAsset.objects.filter(status=AssetStatus.ACTIVE)
+        member_org_ids = OrganizationMembership.objects.filter(
+            persona=persona,
+            left_at__isnull=True,
+            exiled_at__isnull=True,
+        ).values_list("organization_id", flat=True)
+        from django.db.models import Q  # noqa: PLC0415
+
+        reachable = reachable.filter(
+            Q(promoter_persona=persona) | Q(promoter_org_id__in=member_org_ids)
+        )
+        if name.isdigit():
+            return reachable.filter(pk=int(name)).first()
+        return reachable.filter(asset_persona__name__iexact=name).first()
+
+    def _active_persona(self) -> Persona | None:
+        from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+        from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
+
+        try:
+            sheet = self.caller.sheet_data
+        except (AttributeError, ObjectDoesNotExist):
+            return None
+        return active_persona_for_sheet(sheet)
+
+    @staticmethod
+    def _by_pk_or_name(model: type, token: str) -> Any:
+        if token.isdigit():
+            return model.objects.filter(pk=int(token)).first()
+        return model.objects.filter(name__iexact=token).first()

--- a/src/commands/tests/test_network_command.py
+++ b/src/commands/tests/test_network_command.py
@@ -1,0 +1,72 @@
+"""Routing tests for the ``network`` telnet command family (#2820)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from actions.types import ActionResult
+from commands.network import CmdNetwork
+
+
+def _make_cmd(caller, args: str) -> CmdNetwork:
+    cmd = CmdNetwork()
+    cmd.caller = caller
+    cmd.args = args
+    cmd.switches = []
+    cmd.raw_string = f"network {args}".strip()
+    return cmd
+
+
+def _messages(caller: MagicMock) -> list[str]:
+    return [str(c.args[0]) for c in caller.msg.call_args_list if c.args]
+
+
+class CmdNetworkRoutingTests(TestCase):
+    def setUp(self) -> None:
+        self.caller = MagicMock()
+        self.caller.msg = MagicMock()
+
+    def _run(self, args: str) -> list[str]:
+        cmd = _make_cmd(self.caller, args)
+        cmd.func()
+        return _messages(self.caller)
+
+    def test_unknown_subverb_shows_usage(self) -> None:
+        messages = self._run("skulk")
+        self.assertTrue(any("Usage" in m for m in messages))
+
+    @patch("actions.registry.get_action")
+    def test_bare_network_runs_board(self, get_action) -> None:
+        get_action.return_value.run.return_value = ActionResult(success=True, message="board")
+        self._run("")
+        get_action.assert_called_once_with("list_org_tasks")
+        get_action.return_value.run.assert_called_once_with(self.caller)
+
+    @patch("actions.registry.get_action")
+    def test_accept_parses_task_id(self, get_action) -> None:
+        get_action.return_value.run.return_value = ActionResult(success=True, message="ok")
+        self._run("accept 42")
+        get_action.assert_called_once_with("accept_org_task")
+        get_action.return_value.run.assert_called_once_with(self.caller, task_id=42)
+
+    @patch("actions.registry.get_action")
+    def test_sweep_routes_to_detect(self, get_action) -> None:
+        get_action.return_value.run.return_value = ActionResult(success=True, message="ok")
+        self._run("sweep")
+        get_action.assert_called_once_with("detect_listeners")
+
+    @patch.object(CmdNetwork, "_resolve_agent")
+    @patch("actions.registry.get_action")
+    def test_assign_parses_task_and_agent(self, get_action, resolve_agent) -> None:
+        resolve_agent.return_value = MagicMock(pk=7)
+        get_action.return_value.run.return_value = ActionResult(success=True, message="ok")
+        self._run("assign 42 = Alia the Barkeep")
+        resolve_agent.assert_called_once_with("Alia the Barkeep")
+        get_action.assert_called_once_with("assign_task_agent")
+        get_action.return_value.run.assert_called_once_with(self.caller, task_id=42, npc_asset_id=7)
+
+    def test_accept_rejects_non_numeric(self) -> None:
+        messages = self._run("accept soon")
+        self.assertTrue(any("Usage" in m for m in messages))

--- a/src/schema.json
+++ b/src/schema.json
@@ -32061,12 +32061,7 @@ paths:
           description: ''
     post:
       operationId: tasking_posts_create
-      description: |-
-        Standing listener posts (#2820 phase 3) — the board's Postings panel.
-
-        Visibility: your own posts (handler), plus posts whose agent is held by
-        an org you belong to or oversee. ``collect`` requires the handler's body
-        in the posted room — the visit is the exposure surface.
+      description: Post a listener — through PostListenerAction (ADR-0001).
       tags:
       - tasking
       requestBody:
@@ -32114,7 +32109,7 @@ paths:
   /api/tasking/posts/{id}/collect/:
     post:
       operationId: tasking_posts_collect_create
-      description: Collect the oldest pending harvest, in person.
+      description: Collect in person — through CollectHarvestAction (ADR-0001).
       parameters:
       - in: path
         name: id
@@ -32324,7 +32319,7 @@ paths:
           description: ''
     post:
       operationId: tasking_tasks_create
-      description: 'The org task board: list/inspect/issue/assign.'
+      description: Issue a task — dispatched through IssueOrgTaskAction (ADR-0001).
       tags:
       - tasking
       requestBody:
@@ -32390,7 +32385,7 @@ paths:
   /api/tasking/tasks/{id}/assign/:
     post:
       operationId: tasking_tasks_assign_create
-      description: Dispatch one of the requester's own agents on this task.
+      description: Dispatch an agent — through AssignTaskAgentAction (ADR-0001).
       parameters:
       - in: path
         name: id

--- a/src/world/tasking/views.py
+++ b/src/world/tasking/views.py
@@ -19,7 +19,6 @@ from rest_framework.pagination import PageNumberPagination
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 
-from world.tasking.exceptions import TaskingError
 from world.tasking.filters import (
     OrgRosterFilterSet,
     OrgTaskFilterSet,
@@ -35,7 +34,6 @@ from world.tasking.serializers import (
     TaskOutcomeRouteSerializer,
     TaskTemplateSerializer,
 )
-from world.tasking.services import assign_agent, create_task
 
 if TYPE_CHECKING:
     from rest_framework.request import Request
@@ -148,10 +146,9 @@ class ListenerPostViewSet(
         )
 
     def create(self, request: Request, *args, **kwargs) -> Response:
-        from evennia_extensions.models import RoomProfile  # noqa: PLC0415
-        from world.assets.models import NPCAsset  # noqa: PLC0415
-        from world.checks.models import CheckType  # noqa: PLC0415
-        from world.tasking.listener_services import create_listener_post  # noqa: PLC0415
+        """Post a listener — through PostListenerAction (ADR-0001)."""
+        from actions.registry import get_action  # noqa: PLC0415
+        from world.tasking.models import ListenerPost  # noqa: PLC0415
         from world.tasking.serializers import ListenerPostCreateSerializer  # noqa: PLC0415
 
         persona = active_persona_for_request(request)
@@ -160,46 +157,34 @@ class ListenerPostViewSet(
         payload = ListenerPostCreateSerializer(data=request.data)
         payload.is_valid(raise_exception=True)
         data = payload.validated_data
-        npc_asset = NPCAsset.objects.filter(pk=data["npc_asset"]).first()
-        room = RoomProfile.objects.filter(pk=data["room"]).first()
-        if npc_asset is None or room is None:
-            return Response(
-                {"detail": "Unknown agent or room."}, status=status.HTTP_400_BAD_REQUEST
-            )
-        check_type = None
-        if data.get("check_type"):
-            check_type = CheckType.objects.filter(pk=data["check_type"]).first()
-        try:
-            post = create_listener_post(
-                npc_asset,
-                room,
-                persona,
-                check_type=check_type,
-                check_difficulty=data.get("check_difficulty", 0),
-            )
-        except TaskingError as exc:
-            return Response({"detail": exc.user_message}, status=status.HTTP_400_BAD_REQUEST)
+        result = get_action("post_listener").run(
+            persona.character_sheet.character,
+            npc_asset_id=data["npc_asset"],
+            room_id=data["room"],
+            check_type_id=data.get("check_type"),
+            check_difficulty=data.get("check_difficulty", 0),
+        )
+        if not result.success:
+            return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
+        post = ListenerPost.objects.get(pk=result.data["post_id"])
         serializer = self.get_serializer(post)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
     @action(detail=True, methods=["post"])
     def collect(self, request: Request, pk: str | None = None) -> Response:
-        """Collect the oldest pending harvest, in person."""
-        from world.tasking.listener_services import collect_harvest  # noqa: PLC0415
+        """Collect in person — through CollectHarvestAction (ADR-0001)."""
+        from actions.registry import get_action  # noqa: PLC0415
 
         post = self.get_object()
         persona = active_persona_for_request(request)
         if persona is None:
             return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
-        try:
-            clue = collect_harvest(post, persona)
-        except TaskingError as exc:
-            return Response({"detail": exc.user_message}, status=status.HTTP_400_BAD_REQUEST)
-        if clue is None:
-            detail = "Your agent has little of substance — talk, but nothing solid."
-        else:
-            detail = f"Your agent leans close: {clue.name}."
-        return Response({"detail": detail, "clue": clue.pk if clue else None})
+        result = get_action("collect_harvest").run(
+            persona.character_sheet.character, post_id=post.pk
+        )
+        if not result.success:
+            return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
+        return Response({"detail": result.message})
 
 
 class CounterplayViewSet(viewsets.ViewSet):
@@ -213,112 +198,58 @@ class CounterplayViewSet(viewsets.ViewSet):
 
     permission_classes = [IsAuthenticated]
 
-    def _room_and_persona(self, request: Request):
-        from evennia_extensions.models import RoomProfile  # noqa: PLC0415
+    def _dispatch(self, request: Request, action_key: str, **kwargs) -> Response:
+        """Run a counterplay action as the requester's character (ADR-0001)."""
+        from actions.registry import get_action  # noqa: PLC0415
 
         persona = active_persona_for_request(request)
         if persona is None:
-            return None, None
-        character = persona.character_sheet.character
-        room = RoomProfile.objects.filter(pk=character.db_location_id).first()
-        return room, persona
-
-    def _sitting_post(self, room):
-        from world.tasking.models import ListenerPost  # noqa: PLC0415
-
-        return ListenerPost.objects.filter(
-            assignment__room_id=room.pk,
-            assignment__is_active=True,
-        ).first()
-
-    def _verb(self, request: Request, service) -> Response:
-        room, persona = self._room_and_persona(request)
-        if room is None:
             return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
-        post = self._sitting_post(room)
-        if post is None:
-            return Response(
-                {"detail": "No one here seems to be listening."},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
-        try:
-            success = service(persona, post)
-        except TaskingError as exc:
-            return Response({"detail": exc.user_message}, status=status.HTTP_400_BAD_REQUEST)
-        return Response({"success": success})
+        result = get_action(action_key).run(persona.character_sheet.character, **kwargs)
+        if not result.success:
+            return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
+        return Response({"detail": result.message, **(result.data or {})})
 
     @extend_schema(request=None, responses=OpenApiTypes.OBJECT)
     @action(detail=False, methods=["post"])
     def suppress(self, request: Request) -> Response:
         """Intimidate the room's sitting listener into silence."""
-        from world.tasking.counterplay_services import suppress_listener  # noqa: PLC0415
-
-        return self._verb(request, suppress_listener)
+        return self._dispatch(request, "suppress_listener")
 
     @extend_schema(request=None, responses=OpenApiTypes.OBJECT)
     @action(detail=False, methods=["post"])
     def flip(self, request: Request) -> Response:
         """Seduce the room's sitting listener into a double allegiance."""
-        from world.tasking.counterplay_services import flip_listener  # noqa: PLC0415
-
-        return self._verb(request, flip_listener)
+        return self._dispatch(request, "flip_listener")
 
     @extend_schema(request=OpenApiTypes.OBJECT, responses=OpenApiTypes.OBJECT)
     @action(detail=False, methods=["post"])
     def plant(self, request: Request) -> Response:
         """Queue a red herring on a listener you've flipped."""
-        from world.character_sheets.models import CharacterSheet  # noqa: PLC0415
-        from world.tasking.counterplay_services import plant_red_herring  # noqa: PLC0415
-        from world.tasking.models import ListenerPost  # noqa: PLC0415
         from world.tasking.serializers import PlantRedHerringSerializer  # noqa: PLC0415
 
-        persona = active_persona_for_request(request)
-        if persona is None:
-            return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
         payload = PlantRedHerringSerializer(data=request.data)
         payload.is_valid(raise_exception=True)
         data = payload.validated_data
-        post = ListenerPost.objects.filter(pk=data["post"]).first()
-        subject = CharacterSheet.objects.filter(pk=data["subject_sheet"]).first()
-        if post is None or subject is None:
-            return Response(
-                {"detail": "Unknown post or subject."}, status=status.HTTP_400_BAD_REQUEST
-            )
-        try:
-            plant_red_herring(persona, post, subject_sheet=subject, content=data["content"])
-        except TaskingError as exc:
-            return Response({"detail": exc.user_message}, status=status.HTTP_400_BAD_REQUEST)
-        return Response({"success": True})
+        return self._dispatch(
+            request,
+            "plant_red_herring",
+            post_id=data["post"],
+            subject_sheet_id=data["subject_sheet"],
+            content=data["content"],
+        )
 
     @extend_schema(request=None, responses=OpenApiTypes.OBJECT)
     @action(detail=False, methods=["post"])
     def detect(self, request: Request) -> Response:
         """Sweep the current room for informants. Consentless (defensive)."""
-        from world.tasking.counterplay_services import detect_listeners  # noqa: PLC0415
-
-        room, persona = self._room_and_persona(request)
-        if room is None:
-            return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
-        try:
-            revealed = detect_listeners(persona, room)
-        except TaskingError as exc:
-            return Response({"detail": exc.user_message}, status=status.HTTP_400_BAD_REQUEST)
-        return Response({"revealed": revealed})
+        return self._dispatch(request, "detect_listeners")
 
     @extend_schema(request=None, responses=OpenApiTypes.OBJECT)
     @action(detail=False, methods=["post"])
     def clear(self, request: Request) -> Response:
         """Expel listener assignments from a room you hold authority over."""
-        from world.tasking.counterplay_services import clear_room_listeners  # noqa: PLC0415
-
-        room, persona = self._room_and_persona(request)
-        if room is None:
-            return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
-        try:
-            count = clear_room_listeners(persona, room)
-        except TaskingError as exc:
-            return Response({"detail": exc.user_message}, status=status.HTTP_400_BAD_REQUEST)
-        return Response({"cleared": count})
+        return self._dispatch(request, "clear_room_listeners")
 
 
 class OrgTaskViewSet(
@@ -374,22 +305,27 @@ class OrgTaskViewSet(
         return Response(serializer.data)
 
     def create(self, request: Request, *args, **kwargs) -> Response:
+        """Issue a task — dispatched through IssueOrgTaskAction (ADR-0001)."""
+        from actions.registry import get_action  # noqa: PLC0415
+
         persona = active_persona_for_request(request)
         payload = OrgTaskCreateSerializer(data=request.data)
         payload.is_valid(raise_exception=True)
         data = payload.validated_data
-        try:
-            task = create_task(
-                data["template"],
-                data["org"],
-                persona,
-                target_room=data.get("target_room"),
-                target_org=data.get("target_org"),
-                target_domain=data.get("target_domain"),
-                target_persona=data.get("target_persona"),
-            )
-        except TaskingError as exc:
-            return Response({"detail": exc.user_message}, status=status.HTTP_400_BAD_REQUEST)
+        result = get_action("issue_org_task").run(
+            persona.character_sheet.character,
+            template_id=data["template"].pk,
+            org_id=data["org"].pk,
+            target_room_id=data.get("target_room").pk if data.get("target_room") else None,
+            target_org_id=data.get("target_org").pk if data.get("target_org") else None,
+            target_domain_id=data.get("target_domain").pk if data.get("target_domain") else None,
+            target_persona_id=(
+                data.get("target_persona").pk if data.get("target_persona") else None
+            ),
+        )
+        if not result.success:
+            return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
+        task = OrgTask.objects.get(pk=result.data["task_id"])
         serializer = self.get_serializer(task)
         return Response(serializer.data, status=status.HTTP_201_CREATED)
 
@@ -397,25 +333,27 @@ class OrgTaskViewSet(
     @action(detail=True, methods=["post"])
     def accept(self, request: Request, pk: str | None = None) -> Response:
         """Pick this task up yourself as a mission (#2820 phase 5)."""
-        from world.tasking.services import accept_task  # noqa: PLC0415
+
+        from actions.registry import get_action  # noqa: PLC0415
 
         task = self.get_object()
         persona = active_persona_for_request(request)
         if persona is None:
             return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
-        try:
-            fulfillment = accept_task(task, persona)
-        except TaskingError as exc:
-            return Response({"detail": exc.user_message}, status=status.HTTP_400_BAD_REQUEST)
+        result = get_action("accept_org_task").run(
+            persona.character_sheet.character, task_id=task.pk
+        )
+        if not result.success:
+            return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
         task.refresh_from_db()
         data = self.get_serializer(task).data
-        data["mission_instance"] = fulfillment.mission_instance_id
+        data["mission_instance"] = result.data["mission_instance_id"]
         return Response(data, status=status.HTTP_200_OK)
 
     @action(detail=True, methods=["post"])
     def assign(self, request: Request, pk: str | None = None) -> Response:
-        """Dispatch one of the requester's own agents on this task."""
-        from world.assets.models import NPCAsset  # noqa: PLC0415
+        """Dispatch an agent — through AssignTaskAgentAction (ADR-0001)."""
+        from actions.registry import get_action  # noqa: PLC0415
 
         task = self.get_object()
         persona = active_persona_for_request(request)
@@ -426,12 +364,12 @@ class OrgTaskViewSet(
             )
         payload = TaskAssignSerializer(data=request.data)
         payload.is_valid(raise_exception=True)
-        npc_asset = NPCAsset.objects.filter(pk=payload.validated_data["npc_asset"]).first()
-        if npc_asset is None:
-            return Response({"detail": "Unknown agent."}, status=status.HTTP_400_BAD_REQUEST)
-        try:
-            assign_agent(task, npc_asset, persona)
-        except TaskingError as exc:
-            return Response({"detail": exc.user_message}, status=status.HTTP_400_BAD_REQUEST)
+        result = get_action("assign_task_agent").run(
+            persona.character_sheet.character,
+            task_id=task.pk,
+            npc_asset_id=payload.validated_data["npc_asset"],
+        )
+        if not result.success:
+            return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
         task.refresh_from_db()
         return Response(self.get_serializer(task).data, status=status.HTTP_200_OK)


### PR DESCRIPTION
Part of #2820 (telnet parity follow-up; the umbrella's web/API surfaces merged in #2822/#2824).

## Summary

Closes the two halves of one gap: telnet players had no access to the spy-network surfaces, and the tasking viewsets bypassed the actions layer (the ADR-0001 'web bypasses actions' pattern). Eleven REGISTRY actions in `actions/definitions/tasking.py` (`list_org_tasks`, `issue_org_task`, `assign_task_agent`, `accept_org_task`, `post_listener`, `collect_harvest`, `suppress_listener`, `flip_listener`, `plant_red_herring`, `detect_listeners`, `clear_room_listeners`) become the shared seam: the tasking viewsets now dispatch through `action.run()`, and telnet reaches the same actions via one namespaced command family, `CmdNetwork` (`network`, alias `spynet`): board / issue / assign / accept / post / collect / sweep / clear / suppress / flip / plant. Location-contextual verbs act where the caller stands; the web passes explicit room/post anchors. Name→pk resolution is the only work in the command — all gating (leadership, membership, consent, presence, checks) stays in actions/services. Docs updated in tandem (systems doc + INDEX).

## Notes

- Spec: #2820 (approved); this is the deferred-by-spec telnet layer
- Tests: actions registry exact-match updated; action integration tests + command routing tests + full tasking suite green locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)