### PR TITLE
Hardcoded distinction slug lookups in code — should be data-driven effects

### DIFF
--- a/src/world/combat/AGENT_GLOSSARY.md
+++ b/src/world/combat/AGENT_GLOSSARY.md
@@ -149,8 +149,11 @@ accurate from inaccurate readings. One cached reading per (participant, opponent
 per encounter — no re-rolls (`ConsiderReading` model). An enhancement capability
 (`CovenantRole.enhances_assessment`, initially the Sage role) grants finer 9-band
 readings + health/condition axes; the check still gates accuracy. The
-`bias_direction()` seam is wired to the Overconfident distinction (always
-underestimates); the distinction also applies a -2 check penalty via a
+`bias_direction()` seam is data-driven via the "consider_bias_direction"
+`ModifierTarget` — the Overconfident distinction's `DistinctionEffect`
+(`value_per_rank=-1`) biases toward underestimates; any source can bias
+direction by writing a `CharacterModifier` against this target (#2752).
+The distinction also applies a -2 check penalty via a
 consider-scoped `ModifierTarget`, and `consider_opponent` routes through
 `collect_check_modifiers` (the central aggregator). Web-first REST endpoint on
 `CombatEncounterViewSet`; telnet `consider` command follows.

--- a/src/world/combat/consider.py
+++ b/src/world/combat/consider.py
@@ -274,6 +274,24 @@ def ensure_consider_check_type() -> CheckType:
         },
     )
 
+    # Create a ModifierTarget for the consider bias direction — the
+    # sign-interpreted directional bias on assessment (#2752). Negative
+    # total → underestimate (-1), positive → overestimate (+1), zero →
+    # random. Any source (distinction, condition, equipment) can bias
+    # direction by writing a CharacterModifier against this target.
+    bias_target, _ = ModifierTarget.objects.get_or_create(
+        name="consider_bias_direction",
+        category=check_category,
+        defaults={
+            "is_active": True,
+            "description": (
+                "Directional bias on consider assessment. "
+                "Negative → underestimate, positive → overestimate, "
+                "zero → random."
+            ),
+        },
+    )
+
     # Wire the Overconfident distinction's check penalty: a -2 per-rank
     # DistinctionEffect targeting the Consider-scoped ModifierTarget. Created
     # programmatically (not via fixture) because the ModifierTarget itself is
@@ -288,6 +306,19 @@ def ensure_consider_check_type() -> CheckType:
                 "value_per_rank": -2,
                 "description": (
                     "Applies a -2 penalty to Consider checks, making threat assessment harder."
+                ),
+            },
+        )
+        # Wire the Overconfident distinction's bias effect: -1 per rank
+        # biases toward underestimating threats (#2752). Same programmatic
+        # DistinctionEffect wiring pattern as the check penalty above.
+        DistinctionEffect.objects.get_or_create(
+            distinction=overconfident,
+            target=bias_target,
+            defaults={
+                "value_per_rank": -1,
+                "description": (
+                    "Biases consider assessment toward underestimating threats (direction -1)."
                 ),
             },
         )

--- a/src/world/combat/consider.py
+++ b/src/world/combat/consider.py
@@ -13,8 +13,6 @@ from typing import TYPE_CHECKING
 from world.traits.constants import PrimaryStat
 
 if TYPE_CHECKING:
-    from evennia.objects.models import ObjectDB
-
     from world.character_sheets.models import CharacterSheet
     from world.checks.models import CheckType
     from world.combat.models import CombatOpponent, CombatParticipant, ConsiderReading
@@ -84,22 +82,6 @@ _HEALTH_HALE = 75
 _HEALTH_WOUNDED = 50
 _HEALTH_BLOODIED = 25
 
-OVERCONFIDENT_SLUG = "overconfident"
-
-
-def _has_overconfident(character: ObjectDB) -> bool:
-    """True if the character holds the Overconfident distinction.
-
-    Uses ``character.id`` which equals the ``CharacterSheet`` pk (primary_key
-    O2O), matching the ``CharacterDistinction.character_id`` FK.
-    """
-    from world.distinctions.models import CharacterDistinction  # noqa: PLC0415
-
-    return CharacterDistinction.objects.filter(
-        character_id=character.id,
-        distinction__slug=OVERCONFIDENT_SLUG,
-    ).exists()
-
 
 def skew_for_success_level(success_level: int) -> int:
     """Return the skew magnitude for a given check success level.
@@ -119,35 +101,46 @@ def skew_for_success_level(success_level: int) -> int:
     return 3
 
 
-def bias_direction(true_index: int, skew: int, character: ObjectDB | None) -> int:  # noqa: ARG001
+def bias_direction(true_index: int, skew: int, sheet: CharacterSheet | None) -> int:  # noqa: ARG001
     """Return +1 or -1 — the direction to skew the reported band.
 
-    ``character`` is the ObjectDB resolved from
-    ``participant.character_sheet.character``.
+    ``sheet`` is the CharacterSheet of the assessing character.
 
-    Default: random.choice([-1, +1]).
-    Overconfident distinction: always returns -1 (toward 'weaker than you
-    actually are').
+    Default: random.choice([-1, +1]). A modifier against the
+    "consider_bias_direction" ModifierTarget biases the direction:
+    negative total → -1 (underestimate), positive → +1 (overestimate).
 
     Args:
         true_index: The correct band index.
         skew: The skew magnitude (from ``skew_for_success_level``).
-        character: The assessing character (for distinction lookup).
+        sheet: The assessing character's sheet (for modifier lookup).
 
     Returns:
         +1, -1, or 0 (when skew is 0).
     """
     if skew == 0:
         return 0
-    if character is not None and _has_overconfident(character):
-        return -1
+    if sheet is not None:
+        from world.mechanics.models import ModifierTarget  # noqa: PLC0415
+        from world.mechanics.services import get_modifier_total  # noqa: PLC0415
+
+        try:
+            bias_target = ModifierTarget.objects.get(name="consider_bias_direction")
+        except ModifierTarget.DoesNotExist:
+            # Target not yet seeded — fall back to random.
+            return random.choice([-1, 1])  # noqa: S311
+        total = get_modifier_total(sheet, bias_target)
+        if total < 0:
+            return -1
+        if total > 0:
+            return 1
     return random.choice([-1, 1])  # noqa: S311
 
 
 def apply_skew(
     true_index: int,
     skew: int,
-    character: ObjectDB | None,
+    sheet: CharacterSheet | None,
     *,
     max_index: int,
 ) -> int:
@@ -156,13 +149,13 @@ def apply_skew(
     Args:
         true_index: The correct band index.
         skew: The skew magnitude.
-        character: The assessing character.
+        sheet: The assessing character's sheet.
         max_index: The maximum valid band index (len(bands) - 1).
 
     Returns:
         The reported (possibly wrong) band index, clamped to [0, max_index].
     """
-    direction = bias_direction(true_index, skew, character)
+    direction = bias_direction(true_index, skew, sheet)
     reported = true_index + direction * skew
     return max(0, min(reported, max_index))
 
@@ -406,7 +399,7 @@ def consider_opponent(participant: CombatParticipant, opponent: CombatOpponent) 
 
     # Apply skew on failure.
     skew = skew_for_success_level(success_level)
-    reported_index = apply_skew(true_index, skew, character, max_index=max_index)
+    reported_index = apply_skew(true_index, skew, sheet, max_index=max_index)
 
     # Assemble prose.
     band_text = band_prose(reported_index, fine=fine)

--- a/src/world/combat/tests/test_consider.py
+++ b/src/world/combat/tests/test_consider.py
@@ -80,15 +80,15 @@ class BiasDirectionTest(TestCase):
     @patch("world.combat.consider.random.choice")
     def test_default_returns_plus_or_minus_one(self, mock_choice) -> None:
         mock_choice.return_value = 1
-        self.assertEqual(bias_direction(2, 1, character=None), 1)
+        self.assertEqual(bias_direction(2, 1, sheet=None), 1)
 
     @patch("world.combat.consider.random.choice")
     def test_default_can_return_negative(self, mock_choice) -> None:
         mock_choice.return_value = -1
-        self.assertEqual(bias_direction(2, 1, character=None), -1)
+        self.assertEqual(bias_direction(2, 1, sheet=None), -1)
 
     def test_zero_skew_returns_zero(self) -> None:
-        self.assertEqual(bias_direction(2, 0, character=None), 0)
+        self.assertEqual(bias_direction(2, 0, sheet=None), 0)
 
 
 class OverconfidentBiasDirectionTest(TestCase):
@@ -96,11 +96,13 @@ class OverconfidentBiasDirectionTest(TestCase):
 
     def test_overconfident_always_underestimates(self) -> None:
         from world.character_sheets.factories import CharacterSheetFactory
+        from world.combat.consider import ensure_consider_check_type
         from world.distinctions.factories import (
             CharacterDistinctionFactory,
             DistinctionCategoryFactory,
             DistinctionFactory,
         )
+        from world.mechanics.services import create_distinction_modifiers
 
         sheet = CharacterSheetFactory()
         category = DistinctionCategoryFactory(slug="personality")
@@ -109,21 +111,26 @@ class OverconfidentBiasDirectionTest(TestCase):
             category=category,
             cost_per_rank=-10,
         )
-        CharacterDistinctionFactory(
+        # Wire the bias DistinctionEffect now that the distinction exists.
+        ensure_consider_check_type()
+        cd = CharacterDistinctionFactory(
             character=sheet,
             distinction=distinction,
         )
+        create_distinction_modifiers(cd)
         # skew > 0, should always return -1 (underestimate)
-        result = bias_direction(2, 1, character=sheet.character)
+        result = bias_direction(2, 1, sheet=sheet)
         self.assertEqual(result, -1)
 
     def test_overconfident_with_higher_skew(self) -> None:
         from world.character_sheets.factories import CharacterSheetFactory
+        from world.combat.consider import ensure_consider_check_type
         from world.distinctions.factories import (
             CharacterDistinctionFactory,
             DistinctionCategoryFactory,
             DistinctionFactory,
         )
+        from world.mechanics.services import create_distinction_modifiers
 
         sheet = CharacterSheetFactory()
         category = DistinctionCategoryFactory(slug="personality")
@@ -131,31 +138,37 @@ class OverconfidentBiasDirectionTest(TestCase):
             slug="overconfident",
             category=category,
         )
-        CharacterDistinctionFactory(
+        ensure_consider_check_type()
+        cd = CharacterDistinctionFactory(
             character=sheet,
             distinction=distinction,
         )
+        create_distinction_modifiers(cd)
         # skew = 3 (crit fail), should still return -1
-        result = bias_direction(2, 3, character=sheet.character)
+        result = bias_direction(2, 3, sheet=sheet)
         self.assertEqual(result, -1)
 
     def test_non_overconfident_uses_random(self) -> None:
         from world.character_sheets.factories import CharacterSheetFactory
+        from world.combat.consider import ensure_consider_check_type
 
+        ensure_consider_check_type()
         sheet = CharacterSheetFactory()
         # No distinction — should fall through to random.choice
         with patch("world.combat.consider.random.choice") as mock_choice:
             mock_choice.return_value = 1
-            result = bias_direction(2, 1, character=sheet.character)
+            result = bias_direction(2, 1, sheet=sheet)
             self.assertEqual(result, 1)
 
     def test_overconfident_zero_skew_returns_zero(self) -> None:
         from world.character_sheets.factories import CharacterSheetFactory
+        from world.combat.consider import ensure_consider_check_type
         from world.distinctions.factories import (
             CharacterDistinctionFactory,
             DistinctionCategoryFactory,
             DistinctionFactory,
         )
+        from world.mechanics.services import create_distinction_modifiers
 
         sheet = CharacterSheetFactory()
         category = DistinctionCategoryFactory(slug="personality")
@@ -163,40 +176,97 @@ class OverconfidentBiasDirectionTest(TestCase):
             slug="overconfident",
             category=category,
         )
-        CharacterDistinctionFactory(
+        ensure_consider_check_type()
+        cd = CharacterDistinctionFactory(
             character=sheet,
             distinction=distinction,
         )
+        create_distinction_modifiers(cd)
         # skew == 0 always returns 0, even with the distinction
-        result = bias_direction(2, 0, character=sheet.character)
+        result = bias_direction(2, 0, sheet=sheet)
         self.assertEqual(result, 0)
+
+
+class BiasDirectionModifierTest(TestCase):
+    """bias_direction reads get_modifier_total and interprets the sign."""
+
+    def setUp(self) -> None:
+        from world.combat.consider import ensure_consider_check_type
+
+        ensure_consider_check_type()
+
+    def test_direct_negative_modifier_biases_underestimate(self) -> None:
+        """A CharacterModifier directly against the bias target (not via
+        a distinction) also biases direction — proves multi-source principle."""
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.mechanics.models import (
+            CharacterModifier,
+            ModifierSource,
+            ModifierTarget,
+        )
+
+        sheet = CharacterSheetFactory()
+        target = ModifierTarget.objects.get(name="consider_bias_direction")
+        # achievement_reward=True marks the source as a recognized non-distinction
+        # source so get_modifier_breakdown includes it in other_mods (#909).
+        source = ModifierSource.objects.create(achievement_reward=True)
+        CharacterModifier.objects.create(
+            character=sheet,
+            target=target,
+            value=-1,
+            source=source,
+        )
+        result = bias_direction(2, 1, sheet=sheet)
+        self.assertEqual(result, -1)
+
+    def test_positive_modifier_biases_overestimate(self) -> None:
+        """A positive modifier returns +1 (overestimate) — proves sign
+        interpretation works both ways."""
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.mechanics.models import (
+            CharacterModifier,
+            ModifierSource,
+            ModifierTarget,
+        )
+
+        sheet = CharacterSheetFactory()
+        target = ModifierTarget.objects.get(name="consider_bias_direction")
+        source = ModifierSource.objects.create(achievement_reward=True)
+        CharacterModifier.objects.create(
+            character=sheet,
+            target=target,
+            value=1,
+            source=source,
+        )
+        result = bias_direction(2, 1, sheet=sheet)
+        self.assertEqual(result, 1)
 
 
 class ApplySkewTest(TestCase):
     """Skewed band indices clamp to valid range."""
 
     def test_no_skew_returns_true_index(self) -> None:
-        self.assertEqual(apply_skew(2, 0, character=None, max_index=4), 2)
+        self.assertEqual(apply_skew(2, 0, sheet=None, max_index=4), 2)
 
     @patch("world.combat.consider.random.choice")
     def test_skew_up(self, mock_choice) -> None:
         mock_choice.return_value = 1
-        self.assertEqual(apply_skew(2, 1, character=None, max_index=4), 3)
+        self.assertEqual(apply_skew(2, 1, sheet=None, max_index=4), 3)
 
     @patch("world.combat.consider.random.choice")
     def test_skew_down(self, mock_choice) -> None:
         mock_choice.return_value = -1
-        self.assertEqual(apply_skew(2, 1, character=None, max_index=4), 1)
+        self.assertEqual(apply_skew(2, 1, sheet=None, max_index=4), 1)
 
     @patch("world.combat.consider.random.choice")
     def test_clamp_at_max(self, mock_choice) -> None:
         mock_choice.return_value = 1
-        self.assertEqual(apply_skew(4, 2, character=None, max_index=4), 4)
+        self.assertEqual(apply_skew(4, 2, sheet=None, max_index=4), 4)
 
     @patch("world.combat.consider.random.choice")
     def test_clamp_at_zero(self, mock_choice) -> None:
         mock_choice.return_value = -1
-        self.assertEqual(apply_skew(0, 2, character=None, max_index=4), 0)
+        self.assertEqual(apply_skew(0, 2, sheet=None, max_index=4), 0)
 
 
 class HealthBandTest(TestCase):

--- a/src/world/combat/tests/test_consider.py
+++ b/src/world/combat/tests/test_consider.py
@@ -411,6 +411,26 @@ class EnsureConsiderCheckTypeTest(TestCase):
         ).count()
         self.assertEqual(count, 1)
 
+    def test_creates_bias_direction_modifier_target(self) -> None:
+        """ensure_consider_check_type also creates the bias-direction target."""
+        from world.combat.consider import ensure_consider_check_type
+        from world.mechanics.models import ModifierTarget
+
+        ensure_consider_check_type()
+        target = ModifierTarget.objects.get(name="consider_bias_direction")
+        self.assertTrue(target.is_active)
+        self.assertEqual(target.category.name, "check")
+
+    def test_bias_direction_target_is_idempotent(self) -> None:
+        """Calling ensure_consider_check_type twice does not duplicate the bias target."""
+        from world.combat.consider import ensure_consider_check_type
+        from world.mechanics.models import ModifierTarget
+
+        ensure_consider_check_type()
+        ensure_consider_check_type()
+        count = ModifierTarget.objects.filter(name="consider_bias_direction").count()
+        self.assertEqual(count, 1)
+
 
 class ConsiderEndpointTest(TestCase):
     """GET /api/combat/encounters/<pk>/consider/<opp_pk>/ returns prose only."""

--- a/src/world/distinctions/CLAUDE.md
+++ b/src/world/distinctions/CLAUDE.md
@@ -43,7 +43,9 @@ are the only other writers — no in-play caller re-implements the create/rank-u
 (`EffectType.GRANT_DISTINCTION` on `checks.ConsequenceEffect`), `ENDORSEMENT_THRESHOLD`
 (`DistinctionResonanceRankThreshold` in `world.magic`, fired from sustained-endorsement resonance
 gain), and — as of #2441 Task 8 — `GAMEPLAY` (`world.magic.services.tradition_membership.
-leave_tradition` re-applying the Unbound drawback; previously vestigial/unassigned). Full
+leave_tradition` re-applying the traditionless-default drawback, identified by
+the `traditionless-default` `DistinctionTag` rather than a hardcoded slug, #2752;
+previously vestigial/unassigned). Full
 per-source detail: `docs/systems/distinctions.md` "Post-CG acquisition" section.
 
 **The removal counterpart is `remove_distinction` (#2628/#2631).** It requires an APPROVED

--- a/src/world/magic/services/tradition_membership.py
+++ b/src/world/magic/services/tradition_membership.py
@@ -31,19 +31,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-#: Drawback-distinction slugs that mark a character as traditionless-in-play
-#: (#2441 ruling 4). "orphaned-tradition" is seeded today
-#: (``world.seeds.character_creation.ensure_orphaned_tradition_distinction``, #2428
-#: Task 5); "unbound" is Task 9's addition — this constant tolerates its absence
-#: (see ``_shed_traditionless_drawbacks``). Both are removed on joining a
-#: non-orphaned tradition.
-_SHED_ON_JOIN_SLUGS = ("unbound", "orphaned-tradition")
-
-#: Only "unbound" is re-applied on leave — an ex-Orphaned-Tradition-drawback
-#: character who leaves their (already orphaned) tradition becomes plain Unbound,
-#: not doubly-drawbacked with a stale Orphaned-Tradition row pointing at a
-#: tradition they no longer belong to.
-_REAPPLY_ON_LEAVE_SLUG = "unbound"
+#: DistinctionTag slugs for traditionless categorization (#2752).
+_TRADITIONLESS_DRAWBACK_TAG = "traditionless-drawback"
+_TRADITIONLESS_DEFAULT_TAG = "traditionless-default"
+_ORPHANED_TRADITION_MARKER_TAG = "orphaned-tradition-marker"
 
 
 def _active_tradition_row(sheet: CharacterSheet) -> CharacterTradition | None:
@@ -56,57 +47,55 @@ def _active_tradition_row(sheet: CharacterSheet) -> CharacterTradition | None:
 def _tradition_is_orphaned(tradition: Tradition) -> bool:
     """Whether ``tradition`` currently has no living teachers (#2441).
 
-    Task 5 (#2428) modeled "orphaned" as a CG-selection gate, not a live field on
-    ``Tradition``: a ``BeginningTradition`` row requires the "Orphaned Tradition"
-    drawback distinction (``required_distinction``) before a tradition with no
-    living trainers can be picked at CG (see ``world.seeds.character_creation.
-    ensure_orphaned_tradition_distinction``/``seed_metallic_order_tradition``). That
-    authored gate is the only place "this tradition lacks teachers" is recorded
-    anywhere in the schema, so it doubles as the live-game truth read here — the
-    smallest truthful check available without inventing a parallel field Task 5
-    didn't build (verified: no "orphan"/"is_orphaned" surface exists anywhere in
-    ``world.magic`` or ``world.npc_services``). A lazy import keeps ``magic`` from
-    taking a module-level dependency on ``character_creation`` (documented as a
-    "CG-only concern" on ``BeginningTradition`` itself — this is the one read that
-    deliberately reaches back across that boundary for a live-game answer).
+    Checks whether the tradition's ``BeginningTradition`` row has a
+    ``required_distinction`` tagged ``'orphaned-tradition-marker'`` (#2752 —
+    was a hardcoded slug lookup, now tag-driven). That authored gate is the
+    only place "this tradition lacks teachers" is recorded anywhere in the
+    schema, so it doubles as the live-game truth read here. A lazy import
+    keeps ``magic`` from taking a module-level dependency on
+    ``character_creation`` (documented as a "CG-only concern" on
+    ``BeginningTradition`` itself — this is the one read that deliberately
+    reaches back across that boundary for a live-game answer).
     """
     from world.character_creation.models import BeginningTradition  # noqa: PLC0415
 
     return BeginningTradition.objects.filter(
         tradition=tradition,
-        required_distinction__slug="orphaned-tradition",
+        required_distinction__tags__slug=_ORPHANED_TRADITION_MARKER_TAG,
     ).exists()
 
 
 def _shed_traditionless_drawbacks(sheet: CharacterSheet) -> None:
-    """Delete any held unbound/orphaned-tradition drawback CharacterDistinction rows.
+    """Delete any held traditionless-drawback CharacterDistinction rows.
 
-    Direct queryset delete — ``world.distinctions.services`` has no removal
-    counterpart to ``grant_distinction`` (verified for #2441 Task 8: the only
-    writers of ``CharacterDistinction`` are ``grant_distinction``, CG
-    finalization, and Django admin; nothing in the codebase revokes one). A
-    drawback flag carries no story-significant history worth preserving as a row
-    (contrast ``CharacterTradition`` itself, which is ``left_at``-preserved) — a
-    plain delete mirrors how other short-lived/no-longer-true rows are cleaned up
-    elsewhere in this codebase (e.g. expired offer rows). Tolerates either/both
-    slugs being absent (Task 9 seeds "unbound"; this task only ships
-    "orphaned-tradition").
+    Queries by the ``'traditionless-drawback'`` DistinctionTag instead of
+    hardcoded slugs (#2752). Direct queryset delete —
+    ``world.distinctions.services`` has no removal counterpart to
+    ``grant_distinction`` (verified for #2441 Task 8: the only writers of
+    ``CharacterDistinction`` are ``grant_distinction``, CG finalization, and
+    Django admin; nothing in the codebase revokes one). A drawback flag carries
+    no story-significant history worth preserving as a row (contrast
+    ``CharacterTradition`` itself, which is ``left_at``-preserved) — a plain
+    delete mirrors how other short-lived/no-longer-true rows are cleaned up
+    elsewhere in this codebase (e.g. expired offer rows).
     """
     from world.distinctions.models import CharacterDistinction  # noqa: PLC0415
 
     CharacterDistinction.objects.filter(
         character=sheet,
-        distinction__slug__in=_SHED_ON_JOIN_SLUGS,
+        distinction__tags__slug=_TRADITIONLESS_DRAWBACK_TAG,
     ).delete()
 
 
 def _reapply_unbound_drawback(sheet: CharacterSheet) -> None:
-    """Re-grant the "unbound" drawback distinction on leaving a tradition (#2441 ruling 4).
+    """Re-grant the traditionless-default drawback on leaving a tradition (#2441 ruling 4).
 
-    Defensive skip (logged) if the "unbound" Distinction row doesn't exist yet —
-    Task 9 seeds it, and this task's ``leave_tradition`` must not hard-fail on a
-    DB that hasn't run that seed yet. Catches ``DistinctionExclusionError`` and
-    skips (logs) rather than propagating, per the ``grant_distinction`` seam's
+    Queries by the ``'traditionless-default'`` DistinctionTag instead of
+    the hardcoded ``'unbound'`` slug (#2752).
+
+    Defensive skip (logged) if no distinction carries that tag yet — the
+    seed may not have run. Catches ``DistinctionExclusionError`` and skips
+    (logs) rather than propagating, per the ``grant_distinction`` seam's
     documented contract for non-GM/telnet callers (see
     ``world/distinctions/CLAUDE.md``: "every in-play caller except the GM
     action/telnet path catches it and skips just that grant").
@@ -123,12 +112,14 @@ def _reapply_unbound_drawback(sheet: CharacterSheet) -> None:
     from world.distinctions.services import grant_distinction  # noqa: PLC0415
     from world.distinctions.types import DistinctionOrigin  # noqa: PLC0415
 
-    distinction = Distinction.objects.filter(slug=_REAPPLY_ON_LEAVE_SLUG).first()
+    distinction = Distinction.objects.filter(
+        tags__slug=_TRADITIONLESS_DEFAULT_TAG,
+    ).first()
     if distinction is None:
         logger.info(
-            "leave_tradition: %r drawback distinction not seeded yet (#2441 Task 9) "
-            "— skipping re-application for character sheet #%s.",
-            _REAPPLY_ON_LEAVE_SLUG,
+            "leave_tradition: no distinction tagged %r found "
+            "(not seeded yet?) — skipping re-application for character sheet #%s.",
+            _TRADITIONLESS_DEFAULT_TAG,
             sheet.pk,
         )
         return
@@ -142,9 +133,9 @@ def _reapply_unbound_drawback(sheet: CharacterSheet) -> None:
         )
     except DistinctionExclusionError:
         logger.warning(
-            "leave_tradition: re-applying %r blocked by exclusion conflict on "
-            "character sheet #%s — skipping.",
-            _REAPPLY_ON_LEAVE_SLUG,
+            "leave_tradition: re-applying distinction tagged %r blocked by "
+            "exclusion conflict on character sheet #%s — skipping.",
+            _TRADITIONLESS_DEFAULT_TAG,
             sheet.pk,
         )
 

--- a/src/world/magic/tests/test_tradition_membership.py
+++ b/src/world/magic/tests/test_tradition_membership.py
@@ -25,6 +25,28 @@ class JoinTraditionTests(TestCase):
         self.unbound = TraditionFactory(name="Unbound")
         self.caretakers = TraditionFactory(name="The Caretakers")
 
+    @staticmethod
+    def _tag_traditionless_distinctions() -> None:
+        """Tag unbound + orphaned-tradition distinctions for tag-based queries (#2752)."""
+        from world.distinctions.models import DistinctionTag
+
+        drawback_tag, _ = DistinctionTag.objects.get_or_create(
+            slug="traditionless-drawback",
+            defaults={"name": "Traditionless Drawback"},
+        )
+        default_tag, _ = DistinctionTag.objects.get_or_create(
+            slug="traditionless-default",
+            defaults={"name": "Traditionless Default"},
+        )
+        marker_tag, _ = DistinctionTag.objects.get_or_create(
+            slug="orphaned-tradition-marker",
+            defaults={"name": "Orphaned Tradition Marker"},
+        )
+        unbound = DistinctionFactory(slug="unbound", cost_per_rank=-2)
+        orphaned = DistinctionFactory(slug="orphaned-tradition", cost_per_rank=-2)
+        unbound.tags.add(drawback_tag, default_tag)
+        orphaned.tags.add(drawback_tag, marker_tag)
+
     def test_first_join_creates_active_row(self) -> None:
         row = join_tradition(self.sheet, self.unbound)
 
@@ -52,9 +74,12 @@ class JoinTraditionTests(TestCase):
             join_tradition(self.sheet, self.unbound)
 
     def test_join_removes_unbound_and_orphaned_drawbacks_for_living_tradition(self) -> None:
+        self._tag_traditionless_distinctions()
+        from world.distinctions.models import Distinction
+
         CharacterTraditionFactory(character=self.sheet, tradition=self.unbound)
-        unbound_drawback = DistinctionFactory(slug="unbound", cost_per_rank=-2)
-        orphaned_drawback = DistinctionFactory(slug="orphaned-tradition", cost_per_rank=-2)
+        unbound_drawback = Distinction.objects.get(slug="unbound")
+        orphaned_drawback = Distinction.objects.get(slug="orphaned-tradition")
         CharacterDistinctionFactory(
             character=self.sheet,
             distinction=unbound_drawback,
@@ -87,7 +112,10 @@ class JoinTraditionTests(TestCase):
         ).exists()
 
     def test_join_orphaned_tradition_keeps_drawback(self) -> None:
-        orphaned_drawback = DistinctionFactory(slug="orphaned-tradition", cost_per_rank=-2)
+        self._tag_traditionless_distinctions()
+        from world.distinctions.models import Distinction
+
+        orphaned_drawback = Distinction.objects.get(slug="orphaned-tradition")
         metallic_order = TraditionFactory(name="Metallic Order")
         BeginningTraditionFactory(
             tradition=metallic_order,
@@ -104,6 +132,27 @@ class JoinTraditionTests(TestCase):
 
         assert CharacterDistinction.objects.filter(
             character=self.sheet, distinction=orphaned_drawback
+        ).exists()
+
+    def test_join_sheds_third_tagged_drawback(self) -> None:
+        """A third distinction tagged 'traditionless-drawback' is also shed (#2752)."""
+        from world.distinctions.models import DistinctionTag
+
+        self._tag_traditionless_distinctions()
+        drawback_tag = DistinctionTag.objects.get(slug="traditionless-drawback")
+        third = DistinctionFactory(slug="some-new-drawback", cost_per_rank=-2)
+        third.tags.add(drawback_tag)
+        CharacterDistinctionFactory(
+            character=self.sheet,
+            distinction=third,
+            origin=DistinctionOrigin.CHARACTER_CREATION,
+        )
+        CharacterTraditionFactory(character=self.sheet, tradition=self.unbound)
+
+        join_tradition(self.sheet, self.caretakers)
+
+        assert not CharacterDistinction.objects.filter(
+            character=self.sheet, distinction=third
         ).exists()
 
     def test_learned_techniques_untouched_on_join(self) -> None:
@@ -134,13 +183,20 @@ class LeaveTraditionTests(TestCase):
             leave_tradition(self.sheet)
 
     def test_leave_reapplies_unbound_when_seeded(self) -> None:
-        DistinctionFactory(slug="unbound", cost_per_rank=-2)
+        from world.distinctions.models import DistinctionTag
+
+        unbound = DistinctionFactory(slug="unbound", cost_per_rank=-2)
+        default_tag, _ = DistinctionTag.objects.get_or_create(
+            slug="traditionless-default",
+            defaults={"name": "Traditionless Default"},
+        )
+        unbound.tags.add(default_tag)
         CharacterTraditionFactory(character=self.sheet, tradition=self.tradition)
 
         leave_tradition(self.sheet)
 
         grant = CharacterDistinction.objects.filter(
-            character=self.sheet, distinction__slug="unbound"
+            character=self.sheet, distinction=unbound
         ).first()
         assert grant is not None
         assert grant.origin == DistinctionOrigin.GAMEPLAY

--- a/src/world/seeds/character_creation.py
+++ b/src/world/seeds/character_creation.py
@@ -420,6 +420,11 @@ _ORPHANED_TRADITION_DISTINCTION_SLUG = "orphaned-tradition"
 #: keep in sync if this ever changes.
 _UNBOUND_DRAWBACK_DISTINCTION_SLUG = UNBOUND_DRAWBACK_DISTINCTION_SLUG
 
+#: DistinctionTag slugs for traditionless categorization (#2752).
+_TRADITIONLESS_DRAWBACK_TAG = "traditionless-drawback"
+_TRADITIONLESS_DEFAULT_TAG = "traditionless-default"
+_ORPHANED_TRADITION_MARKER_TAG = "orphaned-tradition-marker"
+
 #: Name for the one example orphaned Arx tradition seeded alongside the
 #: drawback (#2428 Task 5). Richer lore ("ancient Traditions for the Metallic
 #: Order and the Fractals of the Abyss" per the #2428 vision) is a lore-repo
@@ -547,6 +552,20 @@ def ensure_unbound_drawback_distinction():
             distinction=distinction,
             target=target,
         )
+    # Attach traditionless tags so tradition_membership can identify this
+    # distinction by tag instead of hardcoded slug (#2752).
+    if distinction is not None:
+        from world.distinctions.models import DistinctionTag  # noqa: PLC0415
+
+        drawback_tag, _ = DistinctionTag.objects.get_or_create(
+            slug=_TRADITIONLESS_DRAWBACK_TAG,
+            defaults={"name": "Traditionless Drawback"},
+        )
+        default_tag, _ = DistinctionTag.objects.get_or_create(
+            slug=_TRADITIONLESS_DEFAULT_TAG,
+            defaults={"name": "Traditionless Default"},
+        )
+        distinction.tags.add(drawback_tag, default_tag)
     return distinction
 
 
@@ -761,7 +780,7 @@ def ensure_orphaned_tradition_distinction():
     )
     if category is None:
         return None
-    return authored_or_sample(
+    distinction = authored_or_sample(
         Distinction,
         {
             "name": "Orphaned Tradition",
@@ -777,6 +796,21 @@ def ensure_orphaned_tradition_distinction():
         },
         slug=_ORPHANED_TRADITION_DISTINCTION_SLUG,
     )
+    # Attach traditionless tags so tradition_membership can identify this
+    # distinction by tag instead of hardcoded slug (#2752).
+    if distinction is not None:
+        from world.distinctions.models import DistinctionTag  # noqa: PLC0415
+
+        drawback_tag, _ = DistinctionTag.objects.get_or_create(
+            slug=_TRADITIONLESS_DRAWBACK_TAG,
+            defaults={"name": "Traditionless Drawback"},
+        )
+        marker_tag, _ = DistinctionTag.objects.get_or_create(
+            slug=_ORPHANED_TRADITION_MARKER_TAG,
+            defaults={"name": "Orphaned Tradition Marker"},
+        )
+        distinction.tags.add(drawback_tag, marker_tag)
+    return distinction
 
 
 def seed_metallic_order_tradition():

--- a/src/world/seeds/tests/test_character_creation_magic_seed.py
+++ b/src/world/seeds/tests/test_character_creation_magic_seed.py
@@ -230,6 +230,16 @@ class EnsureUnboundDrawbackDistinctionTests(TestCase):
         db_value = Distinction.objects.filter(slug="unbound").values("description").get()
         self.assertEqual(db_value["description"], "staff-edited description")
 
+    def test_unbound_distinction_has_traditionless_tags(self) -> None:
+        """The Unbound distinction carries both traditionless tags (#2752)."""
+        from world.distinctions.models import Distinction
+
+        ensure_unbound_drawback_distinction()
+        distinction = Distinction.objects.get(slug="unbound")
+        tag_slugs = set(distinction.tags.values_list("slug", flat=True))
+        self.assertIn("traditionless-drawback", tag_slugs)
+        self.assertIn("traditionless-default", tag_slugs)
+
 
 @override_settings(SEED_SAMPLE_CONTENT=True)
 class SeedBeginningTraditionsTests(TestCase):
@@ -429,6 +439,16 @@ class EnsureOrphanedTraditionDistinctionTests(TestCase):
 
         db_value = Distinction.objects.filter(slug="orphaned-tradition").values("description").get()
         self.assertEqual(db_value["description"], "staff-edited description")
+
+    def test_orphaned_tradition_distinction_has_traditionless_tags(self) -> None:
+        """The Orphaned Tradition distinction carries the drawback + marker tags (#2752)."""
+        from world.distinctions.models import Distinction
+
+        ensure_orphaned_tradition_distinction()
+        distinction = Distinction.objects.get(slug="orphaned-tradition")
+        tag_slugs = set(distinction.tags.values_list("slug", flat=True))
+        self.assertIn("traditionless-drawback", tag_slugs)
+        self.assertIn("orphaned-tradition-marker", tag_slugs)
 
 
 @override_settings(SEED_SAMPLE_CONTENT=True)


### PR DESCRIPTION
Closes #2752

## Summary

Replace three hardcoded distinction-slug lookups with data-driven mechanisms:
1. bias_direction() now reads get_modifier_total against a 'consider_bias_direction' ModifierTarget (sign-interpreted) instead of querying CharacterDistinction by slug.
2. tradition_membership functions query by DistinctionTag instead of hardcoded slug constants.
3. predicates: no change (already correct pattern).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2752 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: clean — branch up to date with main, no conflicts

<!-- last-addressed-comment: 0 -->