### PR TITLE
General combatant-relationship model: should EngagementLock, Clash, and CombatMark share a base?

### DIFF
--- a/docs/adr/0178-combatant-relationships-remain-separate.md
+++ b/docs/adr/0178-combatant-relationships-remain-separate.md
@@ -1,0 +1,24 @@
+# Combatant relationship models remain separate — no shared base
+
+EngagementLock (pairing), Clash (metered contest), and CombatMark (round-scoped
+pointer) share column names (encounter + combatant FKs) but are three distinct
+concepts, not parallel implementations of one. The shared surface is too thin
+to carry behavior — the deletion test shows complexity vanishes if a
+hypothetical `CombatantRelationship` base is removed (it would be a one-field
+abstract base with no behavior), and no consumer ever cross-queries them as "all
+relationships for this encounter." Clash already carries its own internal
+`flavor` discriminator (CLASH/LOCK/WARD/BREAK) with iff-coupled fields and
+CheckConstraints; an outer `kind` discriminator would create a
+discriminator-on-discriminator. Even the FK targets differ: Clash's PC-side is
+`initiator`→CharacterSheet (who started, not exclusive), while the other two use
+`participant`→CombatParticipant (the exclusive combatant). A shared concrete
+table would be the GenericFK-adjacent pattern ADR-0015 rejects; forcing a base
+for distinct concepts is not the convergence ADR-0016 intends (its qualifier is
+"single concept," and ADR-0094 already established pairing ≠ struggle). The
+three alternatives considered and rejected: (1) Python abstract base — only
+`encounter` is truly shareable, a one-field base with no behavior; (2) single
+concrete table with `kind` discriminator — discriminator-on-discriminator,
+massive nullable column waste, every partial unique becomes kind-conditional;
+(3) keep separate — chosen.
+
+> Status: accepted · Source: #2674 (extends ADR-0094, ADR-0015, ADR-0016)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -79,6 +79,7 @@ treat those names as hints to confirm, not gospel.
 - [0101 — House aspects are catalog-only](0101-house-aspects-are-catalog-only.md)
 - [0107 — Solo darkness, not locked doors](0107-solo-darkness-not-locked-doors.md)
 - [0163 — Natural-key lookups are case-insensitive; a tuple→pk index removes the repeat query; whole-table warming is opt-in per model](0163-case-insensitive-natural-keys-and-opt-in-lookup-tables.md) (#2687; relates to ADR-0008)
+- [0178 — Combatant relationship models (EngagementLock, Clash, CombatMark) remain separate; no shared base](0178-combatant-relationships-remain-separate.md) (#2674; extends ADR-0094, ADR-0015, ADR-0016)
 
 ### Resolution
 - [0019 — Unified resolution: one roll path, data-sourced difficulty, graded outcomes](0019-unified-resolution-one-roll-path.md)

--- a/src/world/combat/models.py
+++ b/src/world/combat/models.py
@@ -3595,8 +3595,9 @@ class CombatMark(SharedMemoryModel):
     covenant-mates to focus. Vow content (perks, rungs) is lore-repo data that
     reads the mark via the ``TARGET_IS_MARKED_BY_ALLY`` situation evaluator.
 
-    Open seam: a general combatant-relationship model that could subsume
-    EngagementLock, Clash, and the mark is a ``needs-design`` follow-up.
+    EngagementLock, Clash, and CombatMark remain separate models — they are
+    three distinct concepts (pairing, struggle, mark), not parallel
+    implementations of one. See ADR-0178.
     """
 
     encounter = models.ForeignKey(


### PR DESCRIPTION
Closes #2674

## Summary

Resolves the #2674 design question: EngagementLock, Clash, and CombatMark are three distinct concepts (pairing, struggle, mark), not parallel implementations of one. The shared surface is too thin for a base class — the deletion test shows complexity vanishes, no consumer cross-queries them, and Clash already has its own internal flavor discriminator. Deliverable is ADR-0178 + CombatMark docstring cleanup.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2674 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Clean rebase, no conflicts.

<!-- last-addressed-comment: 0 -->