### PR TITLE
needs-design: dice/botch audit — Critical Failure is unreachable from every seeded result chart

### DIFF
--- a/src/integration_tests/game_content/tests/test_magic_seed.py
+++ b/src/integration_tests/game_content/tests/test_magic_seed.py
@@ -909,11 +909,14 @@ class SeedEndureHallowedGroundCheckTests(TestCase):
         _seed_endure_hallowed_ground_check()
         # The checks spine (world.seeds.checks) is the single authority for the
         # global resolution charts. The diff=0 chart carries the spine's even
-        # bands (Failure / Partial Success / Success), NOT the old placeholder.
+        # bands (Failure / Partial Success / Success / Critical Success), NOT
+        # the old placeholder.
         chart = ResultChart.objects.get(rank_difference=0)
         outcomes_for_chart = ResultChartOutcome.objects.filter(chart=chart)
         outcome_names = {ro.outcome.name for ro in outcomes_for_chart.select_related("outcome")}
-        self.assertEqual(outcome_names, {"Failure", "Partial Success", "Success"})
+        self.assertEqual(
+            outcome_names, {"Failure", "Partial Success", "Success", "Critical Success"}
+        )
         # The full outcome catalog the magic backfire pools fetch must exist.
         catalog = set(CheckOutcome.objects.values_list("name", flat=True))
         self.assertGreaterEqual(

--- a/src/world/checks/tests/test_chart_direction.py
+++ b/src/world/checks/tests/test_chart_direction.py
@@ -9,7 +9,7 @@ from django.test import TestCase
 
 from world.checks.services import chart_has_success_outcomes
 from world.seeds.checks import seed_check_resolution_tables
-from world.traits.models import CheckRank, ResultChart, ResultChartOutcome
+from world.traits.models import CheckOutcome, CheckRank, ResultChart, ResultChartOutcome
 
 
 def _success_share(roller_points: int, target_difficulty: int) -> int:
@@ -96,3 +96,84 @@ class ChartDirectionTests(TestCase):
         for rank_difference in (-5, -6, -50):
             with self.subTest(rank_difference=rank_difference):
                 self.assertTrue(chart_has_success_outcomes(rank_difference))
+
+    def test_botch_bands_present_only_on_negative_charts(self):
+        """Critical Failure bands exist at rank_diff -1 through -6, not at 0+."""
+        botch_outcome = CheckOutcome.objects.get(name="Critical Failure")
+        for rank_diff in range(-6, 0):
+            chart = ResultChart.get_chart_for_difference(rank_diff)
+            assert chart is not None
+            has_botch = ResultChartOutcome.objects.filter(
+                chart=chart, outcome=botch_outcome
+            ).exists()
+            self.assertTrue(
+                has_botch,
+                f"Chart at rank_diff={rank_diff} should have a Critical Failure band",
+            )
+        for rank_diff in range(7):
+            chart = ResultChart.get_chart_for_difference(rank_diff)
+            assert chart is not None
+            has_botch = ResultChartOutcome.objects.filter(
+                chart=chart, outcome=botch_outcome
+            ).exists()
+            self.assertFalse(
+                has_botch,
+                f"Chart at rank_diff={rank_diff} should NOT have a Critical Failure band",
+            )
+
+    def test_botch_share_monotonically_non_increasing(self):
+        """Botch share decays from worst chart to EVEN (10% -> 7% -> 5% -> 3% -> 2% -> 2% -> 0%)."""
+        botch_outcome = CheckOutcome.objects.get(name="Critical Failure")
+
+        def botch_share(rank_difference: int) -> int:
+            chart = ResultChart.get_chart_for_difference(rank_difference)
+            rows = ResultChartOutcome.objects.filter(chart=chart, outcome=botch_outcome)
+            return sum(row.max_roll - row.min_roll + 1 for row in rows)
+
+        shares = [botch_share(rd) for rd in range(-6, 1)]
+        self.assertEqual(shares, sorted(shares, reverse=True))
+        # Even footing and above: zero botch
+        self.assertEqual(botch_share(0), 0)
+
+    def test_all_charts_have_distinct_bands(self):
+        """No two rank_differences share the same set of outcome bands (#2760).
+
+        Today -4/-3 share identical bands, +1/+2 share, +3/+4 share, +5/+6 share.
+        After this change every chart must have distinct bands.
+        """
+        band_signatures: dict[frozenset, int] = {}
+        for rank_diff in range(-6, 7):
+            chart = ResultChart.get_chart_for_difference(rank_diff)
+            assert chart is not None
+            rows = ResultChartOutcome.objects.filter(chart=chart).select_related("outcome")
+            sig = frozenset((row.outcome.name, row.min_roll, row.max_roll) for row in rows)
+            self.assertNotIn(
+                sig,
+                band_signatures,
+                f"Chart at rank_diff={rank_diff} duplicates rank_diff={band_signatures.get(sig)}",
+            )
+            band_signatures[sig] = rank_diff
+
+    def test_partial_success_gradient(self):
+        """Partial Success bands exist on charts from -6 through +5, not on +6."""
+        partial_outcome = CheckOutcome.objects.get(name="Partial Success")
+        for rank_diff in range(-6, 6):
+            chart = ResultChart.get_chart_for_difference(rank_diff)
+            assert chart is not None
+            has_partial = ResultChartOutcome.objects.filter(
+                chart=chart, outcome=partial_outcome
+            ).exists()
+            self.assertTrue(
+                has_partial,
+                f"Chart at rank_diff={rank_diff} should have a Partial Success band",
+            )
+        # +6 (Inevitable) has no Partial — pure win
+        chart = ResultChart.get_chart_for_difference(6)
+        assert chart is not None
+        has_partial = ResultChartOutcome.objects.filter(
+            chart=chart, outcome=partial_outcome
+        ).exists()
+        self.assertFalse(
+            has_partial,
+            "Chart at rank_diff=+6 should NOT have a Partial Success band",
+        )

--- a/src/world/combat/tests/test_level_opposed_combat_journey.py
+++ b/src/world/combat/tests/test_level_opposed_combat_journey.py
@@ -158,7 +158,10 @@ class LevelOpposedOffenseJourneyTests(TestCase):
         self.assertGreaterEqual(success_level, 0)
 
     def test_high_level_attacker_lands_markedly_better_against_a_low_level_target(self) -> None:
-        rolls = [10, 50, 99]
+        # Rolls chosen to span the outcome tiers at rank_diff +3 (Very Easy)
+        # and rank_diff 0 (Even): roll 20 → Success vs Failure (diff 2),
+        # roll 50 → Success vs Partial, roll 85 → Crit vs Success.
+        rolls = [20, 50, 85]
         against_low_opp = [
             self._offense_success_level(pc_level=15, opp_level=1, roll=roll) for roll in rolls
         ]

--- a/src/world/seeds/checks.py
+++ b/src/world/seeds/checks.py
@@ -60,6 +60,7 @@ _CHECK_RANKS: tuple[tuple[int, int, str], ...] = (
 # CheckOutcome tier name constants — referenced in both _OUTCOMES and the band tuples.
 _OUTCOME_PARTIAL_SUCCESS = "Partial Success"
 _CRITICAL_SUCCESS = "Critical Success"
+_CRITICAL_FAILURE = "Critical Failure"
 
 # --- Outcome catalog (name -> success_level) ---
 # Initial sane defaults aligned with the integration-test setup. "Critical
@@ -67,7 +68,7 @@ _CRITICAL_SUCCESS = "Critical Success"
 # fetch a CheckOutcome named "Critical Failure") resolve against the canonical
 # spine rather than seeding their own outcome rows.
 _OUTCOMES: tuple[tuple[str, int], ...] = (
-    ("Critical Failure", -2),
+    (_CRITICAL_FAILURE, -2),
     ("Failure", -1),
     (_OUTCOME_PARTIAL_SUCCESS, 0),
     ("Success", 1),
@@ -78,67 +79,118 @@ _OUTCOMES: tuple[tuple[str, int], ...] = (
 # rank_difference is roller_rank MINUS target_rank, so POSITIVE means the roller is
 # stronger and must get the easier bands (#2707 — this mapping was inverted, making
 # better characters fail more; world/checks/tests/test_chart_direction.py guards it).
-_EASY_BANDS: tuple[tuple[str, int, int], ...] = (
-    ("Failure", 1, 20),
-    ("Success", 21, 90),
-    (_CRITICAL_SUCCESS, 91, 100),
-)
-_EVEN_BANDS: tuple[tuple[str, int, int], ...] = (
-    ("Failure", 1, 40),
-    (_OUTCOME_PARTIAL_SUCCESS, 41, 60),
-    ("Success", 61, 100),
-)
-_HARD_BANDS: tuple[tuple[str, int, int], ...] = (
-    ("Failure", 1, 70),
-    (_OUTCOME_PARTIAL_SUCCESS, 71, 85),
-    ("Success", 86, 100),
-)
-
-# Deep-gap bands (#2707). Design intent, stated because the numbers alone don't
-# show it: past a two-rung gap the FAILURE share stops growing — what degrades is
-# what you ACCOMPLISH. A party attacking something far above its level chips away
-# (Partial Success) instead of whiffing round after round; the chip-damage value
-# itself is an authored DamageSuccessLevelMultiplier row, not code.
-_DIRE_BANDS: tuple[tuple[str, int, int], ...] = (
-    ("Failure", 1, 55),
-    (_OUTCOME_PARTIAL_SUCCESS, 56, 98),
-    ("Success", 99, 100),
-)
-# A one-in-a-hundred Success keeps this chart out of chart_has_success_outcomes'
-# IMPOSSIBLE bucket (#2707 review): with an all-Failure/Partial-Success chart here,
-# world.mechanics.services reported DifficultyIndicator.IMPOSSIBLE for any rank
-# difference <= -5, and both approach-listing call sites (services.py:1408/:1657)
-# then dropped the action from the player's available-actions list entirely —
-# the exact inverse of "chip, not whiff, and still be offered" above.
-_HOPELESS_BANDS: tuple[tuple[str, int, int], ...] = (
-    ("Failure", 1, 45),
-    (_OUTCOME_PARTIAL_SUCCESS, 46, 99),
+#
+# 13 unique charts — one per rank_difference. Each gap has its own outcome
+# distribution; no two rank_differences share a chart (#2760). Previously 7
+# shared templates were reused across 13 slots via closest-match fallback.
+#
+# Botch (Critical Failure, success_level -2) appears at rank_diff <= -1 and
+# vanishes at EVEN — you can only botch when you're behind in rank, never on
+# even footing or better. Botch gradient: 10% at worst (-6) → 0% at EVEN.
+#
+# Partial Success is a smooth gradient present from -6 through +5, absent only
+# at +6 (pure win). The old design where Partial vanished entirely on EASY+ was
+# a mistake — it should be a smooth gradient.
+#
+# The -6 chart keeps a 1/100 success, preserving the "chip, don't whiff" design
+# (#2707) and keeping chart_has_success_outcomes True at every rank_difference
+# (so actions at the worst gap are still offered to the player, not dropped from
+# available-actions lists as IMPOSSIBLE).
+#
+# Deep-gap non-monotonicity (total negative outcomes peak at ~58% at -2/Hard,
+# then decline as Partial absorbs more at wider gaps) is intended — a party
+# attacking something far above its level chips away (partial success) instead
+# of whiffing round after round. The -6 "Crushing" chart is intentionally brutal
+# (89% negative); the non-monotonicity holds from -5 onward.
+_CRUSHING_BANDS: tuple[tuple[str, int, int], ...] = (
+    (_CRITICAL_FAILURE, 1, 10),
+    ("Failure", 11, 89),
+    (_OUTCOME_PARTIAL_SUCCESS, 90, 99),
     ("Success", 100, 100),
 )
-# Mirror bands for a roller far ABOVE the difficulty.
-_DOMINANT_BANDS: tuple[tuple[str, int, int], ...] = (
+_HOPELESS_BANDS: tuple[tuple[str, int, int], ...] = (
+    (_CRITICAL_FAILURE, 1, 7),
+    ("Failure", 8, 45),
+    (_OUTCOME_PARTIAL_SUCCESS, 46, 95),
+    ("Success", 96, 100),
+)
+_DIRE_BANDS: tuple[tuple[str, int, int], ...] = (
+    (_CRITICAL_FAILURE, 1, 5),
+    ("Failure", 6, 48),
+    (_OUTCOME_PARTIAL_SUCCESS, 49, 92),
+    ("Success", 93, 100),
+)
+_VERY_HARD_BANDS: tuple[tuple[str, int, int], ...] = (
+    (_CRITICAL_FAILURE, 1, 3),
+    ("Failure", 4, 45),
+    (_OUTCOME_PARTIAL_SUCCESS, 46, 88),
+    ("Success", 89, 100),
+)
+_HARD_BANDS: tuple[tuple[str, int, int], ...] = (
+    (_CRITICAL_FAILURE, 1, 2),
+    ("Failure", 3, 58),
+    (_OUTCOME_PARTIAL_SUCCESS, 59, 85),
+    ("Success", 86, 100),
+)
+_STEEP_BANDS: tuple[tuple[str, int, int], ...] = (
+    (_CRITICAL_FAILURE, 1, 2),
+    ("Failure", 3, 45),
+    (_OUTCOME_PARTIAL_SUCCESS, 46, 78),
+    ("Success", 79, 100),
+)
+_EVEN_BANDS: tuple[tuple[str, int, int], ...] = (
+    ("Failure", 1, 35),
+    (_OUTCOME_PARTIAL_SUCCESS, 36, 60),
+    ("Success", 61, 95),
+    (_CRITICAL_SUCCESS, 96, 100),
+)
+_FAVORABLE_BANDS: tuple[tuple[str, int, int], ...] = (
+    ("Failure", 1, 18),
+    (_OUTCOME_PARTIAL_SUCCESS, 19, 35),
+    ("Success", 36, 90),
+    (_CRITICAL_SUCCESS, 91, 100),
+)
+_EASY_BANDS: tuple[tuple[str, int, int], ...] = (
+    ("Failure", 1, 10),
+    (_OUTCOME_PARTIAL_SUCCESS, 11, 25),
+    ("Success", 26, 85),
+    (_CRITICAL_SUCCESS, 86, 100),
+)
+_VERY_EASY_BANDS: tuple[tuple[str, int, int], ...] = (
     ("Failure", 1, 5),
-    ("Success", 6, 55),
-    (_CRITICAL_SUCCESS, 56, 100),
+    (_OUTCOME_PARTIAL_SUCCESS, 6, 15),
+    ("Success", 16, 80),
+    (_CRITICAL_SUCCESS, 81, 100),
+)
+_DOMINANT_BANDS: tuple[tuple[str, int, int], ...] = (
+    ("Failure", 1, 3),
+    (_OUTCOME_PARTIAL_SUCCESS, 4, 10),
+    ("Success", 11, 75),
+    (_CRITICAL_SUCCESS, 76, 100),
 )
 _OVERWHELMING_BANDS: tuple[tuple[str, int, int], ...] = (
-    ("Success", 1, 30),
-    (_CRITICAL_SUCCESS, 31, 100),
+    (_OUTCOME_PARTIAL_SUCCESS, 1, 5),
+    ("Success", 6, 70),
+    (_CRITICAL_SUCCESS, 71, 100),
+)
+_INEVITABLE_BANDS: tuple[tuple[str, int, int], ...] = (
+    ("Success", 1, 50),
+    (_CRITICAL_SUCCESS, 51, 100),
 )
 _CHARTS: tuple[tuple[int, tuple[tuple[str, int, int], ...]], ...] = (
-    (-6, _HOPELESS_BANDS),
+    (-6, _CRUSHING_BANDS),
     (-5, _HOPELESS_BANDS),
     (-4, _DIRE_BANDS),
-    (-3, _DIRE_BANDS),
+    (-3, _VERY_HARD_BANDS),
     (-2, _HARD_BANDS),
-    (-1, _HARD_BANDS),
+    (-1, _STEEP_BANDS),
     (0, _EVEN_BANDS),
-    (1, _EASY_BANDS),
+    (1, _FAVORABLE_BANDS),
     (2, _EASY_BANDS),
-    (3, _DOMINANT_BANDS),
+    (3, _VERY_EASY_BANDS),
     (4, _DOMINANT_BANDS),
     (5, _OVERWHELMING_BANDS),
-    (6, _OVERWHELMING_BANDS),
+    (6, _INEVITABLE_BANDS),
 )
 
 


### PR DESCRIPTION
Closes #2760

## Summary

Replace 7 shared band templates with 13 unique result charts — one per rank difference. Add Critical Failure (success_level -2) botch bands at rank_diff ≤ -1, vanishing at EVEN. Botch gradient: 10% at worst (-6) → 0% at even footing. Partial Success stays as a smooth gradient present from -6 through +5, absent only at +6 (pure win). The -6 chart keeps a 1/100 success, preserving the 'chip, don't whiff' design.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2760 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Clean sync, no conflicts.

<!-- last-addressed-comment: 0 -->