### PR TITLE
Design: CheckType naming shape — stat-defining vs skill-defining checks

### DIFF
--- a/docs/adr/0182-checks-are-skill-plus-situational-stat.md
+++ b/docs/adr/0182-checks-are-skill-plus-situational-stat.md
@@ -1,0 +1,47 @@
+# Checks are skill + situational stat
+
+Date: 2026-07-31
+Status: Accepted
+Supersedes: the "stat + skill" formulation in `docs/roadmap/design-tenets.md`
+
+## Context
+
+Issue #2757 identified that the CheckType catalog had two implicit shapes —
+skill-constant (Melee Attack = strength + Melee Combat) and stat/situation-constant
+(Break and Enter = strength + Athletics) — with no rule for which to use when
+authoring a new check. This ambiguity caused real damage: the #2691 legacy audit
+found 15 vaguely-named CheckTypes with no composition, and 142 of 191
+`ConditionCheckModifier` rows targeting checks nothing rolled.
+
+The deeper problem: the stat was fixed per CheckType, so a knife-fighter and a
+warhammer-wielder both rolled "Melee Attack = strength" — the character concept
+had no mechanical reflection.
+
+## Decision
+
+A CheckType's identity is its skill; the stat is situational. The calling system
+determines the stat from physical context (weapon type, barrier type) and passes
+it via a `stat_override` keyword-only parameter on `perform_check`.
+
+- `stat_override=None` (the default) is byte-identical to pre-#2757 behavior.
+- When set, `_calculate_trait_points` replaces the CheckType's STAT-type traits
+  with the override stat's value, borrowing the weight from the first STAT trait.
+- SKILL-type traits always contribute.
+- Valid only for checks with 0 or 1 STAT-type traits; 2+ stat checks log a warning.
+
+Physical-action checks merge to one-per-skill: "Melee Attack" + "Melee Defense"
+→ "Melee Combat"; "Break and Enter" + "Escape Through Window" → "Athletics".
+Social, investigation, resist, and multi-stat checks stay separate.
+
+## Consequences
+
+- One skill investment covers multiple stat situations (a Melee Combat specialist
+  fights with agility or strength depending on weapon).
+- Modifier targeting at the CheckType level covers all stat variants; stat-specific
+  targeting is covered by equipment-level and capability-level mechanisms.
+- The weapon→stat mapping is authored content, not engine logic — it can be
+  refined from the coarse initial `GearArchetype` mapping to a finer weapon-class
+  mapping in a content follow-up.
+- The GM ad-hoc check model (ADR-0110) uses the default stat — the question of
+  whether GMs should select from a stat palette or whether checks should emerge
+  from authored situations is a separate follow-up.

--- a/docs/roadmap/design-tenets.md
+++ b/docs/roadmap/design-tenets.md
@@ -370,21 +370,32 @@ sheet navigation. Corollary: "more findable places is a feature" — a
 main-sheet identity link complements a dedicated section, never replaces it.
 (Apostate, #1446.)
 
-### Checks are stat + skill (+ specialization), rarely stat + stat
+### Checks are skill + situational stat (+ specialization)
 
-A check's composition defaults to a **stat + the relevant skill**, plus a **specialization
-when the character owns one** (e.g. *Charm + Persuasion + Seduction*; *Charm + Persuasion +
-Gossip*). **stat + stat is the rare exception, not the norm** — a check resolving on two raw
-attributes with no trained skill must be a deliberate choice, never a default. Character
-identity (the trained skill, the owned specialization) should almost always matter to the
-roll. Specializations compose as **parent skill + specialization** and require the
-spec-in-checks engine foundation (#1688) before they can participate in a `CheckType`.
+A check's composition defaults to **the relevant skill + a situational stat**,
+plus a **specialization when the character owns one** (e.g. *Charm + Persuasion
++ Seduction*; *Charm + Persuasion + Gossip*). The skill is the CheckType's
+identity; the stat is determined by the calling system from situation context
+(weapon type, barrier type, approach). A check's STAT-type `CheckTypeTrait`
+rows carry the default stat; the calling system may override it via
+`stat_override`. **stat + stat is the rare exception, not the norm** — a check
+resolving on two raw attributes with no trained skill must be a deliberate
+choice, never a default. Character identity (the trained skill, the owned
+specialization) should almost always matter to the roll. Specializations compose
+as **parent skill + specialization** and require the spec-in-checks engine
+foundation (#1688) before they can participate in a `CheckType`.
+
+Single-stat resist checks (Endurance, Mortal Resolve, Reflexes, Escalation Pace)
+and fixed multi-stat checks (penetration, flee) are the documented exceptions —
+they do not use situational stats. See ADR-0182.
 
 Auto-scaffolded check seeds are **PLACEHOLDER** until a real composition pass: the social
 `CheckType`s (Intimidation/Persuasion/Deception/Seduction/Performance/Presence) shipped as
 stat+stat boilerplate and were redesigned to stat + skill (+ spec) (#1689); the combat + vitals
 checks (penetration/flee retrofitted, Reflexes/Endurance/Mortal Resolve/Escalation Pace seeded,
-Melee Combat skill catalog + the combat offense check added) followed in #1706. The resist-style
+Melee Combat skill catalog + the combat offense check added) followed in #1706. #2757 merged
+Melee Attack + Melee Defense into a single "Melee Combat" CheckType with a situational stat,
+and Break and Enter + Escape Through Window into "Athletics". The resist-style
 checks (single-stat) are the tenet-permitted exception.
 
 ---

--- a/docs/systems/checks.md
+++ b/docs/systems/checks.md
@@ -376,7 +376,7 @@ Check compositions are authored as seed data (the design tenet: **stat + skill (
 
 | Cluster | Checks | Composition |
 |---------|--------|-------------|
-| `combat_checks` (#1706) | `Melee Attack` | strength + Melee Combat (+ Small/Medium/Heavy Weapons spec) |
+| `combat_checks` (#1706, #2757) | `Melee Combat` | Melee Combat (skill) + situational stat (default: strength; combat system passes `stat_override` from weapon) |
 | `combat` | `penetration` | willpower + intellect + Melee Combat |
 | `combat` | `flee` | agility + wits + Melee Combat |
 | `combat` | `Escalation Pace` | wits (single-stat resist) |
@@ -388,7 +388,8 @@ Check compositions are authored as seed data (the design tenet: **stat + skill (
 | `investigation` (#1705) | `Search` | perception + Investigation |
 | `governance` (#930) | Tax/Investment checks | stat + Scholarship/Economics |
 | `stealth` (#1464) | `Stealth` | agility + Stealth |
-| `security` (#2180) | `Lockpick` / `Break and Enter` / `Escape Through Window` / `Guard Detection` | wits+Skulduggery / strength+Athletics / agility+Athletics / perception+Investigation |
+| `security` (#2180, #2757) | `Athletics` | Athletics (skill) + situational stat (default: strength; `resolve_security_check` passes `stat_override` from `SecurityCheckKind`) |
+| `security` | `Lockpick` / `Guard Detection` | wits+Skulduggery / perception+Investigation |
 
 **Resist checks** (Reflexes, Escalation Pace, Endurance, Mortal Resolve) are the tenet-permitted single-stat exception — they seed exactly one `CheckTypeTrait`. The `Melee Combat` skill catalog (with weapon-class specializations aligned to `progression.services.scene_integration`'s `weapon_map`) is seeded by the `combat_checks` cluster; the penetration/flee retrofits depend on it.
 
@@ -396,27 +397,30 @@ Check compositions are authored as seed data (the design tenet: **stat + skill (
 
 ---
 
-## Security Checks (#2180)
+## Security Checks (#2180, #2757)
 
-Five security-domain check types seeded via the `"security"` cluster
+Security-domain check types seeded via the `"security"` cluster
 (`world/seeds/security_checks.py`):
 
 | CheckType | Category | Composition | Used by |
 |---|---|---|---|
 | Stealth | Physical | agility + Stealth | Sneaking past guards (reuses #1464 seed) |
 | Lockpick | Physical | wits + Skulduggery (+ Lockpicking) | Picking locks (#2176, renamed from Larceny #1825) |
-| Break and Enter | Physical | strength + Athletics | Forcing barriers (#2176) |
-| Escape Through Window | Physical | agility + Athletics (+ Climbing) | Fleeing via window (#2175) |
+| Athletics | Physical | Athletics (skill) + situational stat (default: strength) | Forcing barriers / fleeing via window (#2757 merge) |
 | Guard Detection | Exploration | perception + Investigation | Guard NPC spotting intruders (#2178) |
 
 **`SecurityCheckKind`** (`world/checks/constants.py`) maps each kind to its
-CheckType name via `SECURITY_CHECK_TYPE_NAMES`.
+CheckType name via `SECURITY_CHECK_TYPE_NAMES`, and to its stat override via
+`SECURITY_CHECK_STAT_OVERRIDE` (#2757). Both `BREAK_AND_ENTER` and
+`ESCAPE_THROUGH_WINDOW` resolve to the "Athletics" CheckType — the former
+passes `stat_override="strength"`, the latter `stat_override="agility"`.
 
 **`resolve_security_check(kind, actor, *, target_difficulty, extra_modifiers)`**
 (`world/checks/security_services.py`) is the helper entry point. It looks up the
-CheckType by name and delegates to `perform_check`. The caller computes
-`target_difficulty` from domain context (lock level, guard level, window height).
+CheckType by name, resolves the stat_override from the kind, and delegates to
+`perform_check`. The caller computes `target_difficulty` from domain context
+(lock level, guard level, window height).
 
-Two new skills: **Larceny** (fine manipulation — locks, pockets) and **Athletics**
+Two skills: **Larceny** (fine manipulation — locks, pockets) and **Athletics**
 (running, climbing, force). Specializations: **Lockpicking** (under Larceny) and
 **Climbing** (under Athletics). All weights PLACEHOLDER (1.0).

--- a/src/world/checks/constants.py
+++ b/src/world/checks/constants.py
@@ -103,7 +103,19 @@ class SecurityCheckKind(models.TextChoices):
 SECURITY_CHECK_TYPE_NAMES: dict[SecurityCheckKind, str] = {
     SecurityCheckKind.SNEAK: "Stealth",
     SecurityCheckKind.LOCKPICK: "Lockpick",
-    SecurityCheckKind.BREAK_AND_ENTER: "Break and Enter",
-    SecurityCheckKind.ESCAPE_THROUGH_WINDOW: "Escape Through Window",
+    SecurityCheckKind.BREAK_AND_ENTER: "Athletics",
+    SecurityCheckKind.ESCAPE_THROUGH_WINDOW: "Athletics",
     SecurityCheckKind.GUARD_DETECTION: "Guard Detection",
+}
+
+# #2757: stat_override per security kind. None = use the check's default stat.
+# BREAK_AND_ENTER and ESCAPE_THROUGH_WINDOW both resolve to the "Athletics"
+# CheckType but override the stat from the situation (strength for breaking,
+# agility for escaping).
+SECURITY_CHECK_STAT_OVERRIDE: dict[SecurityCheckKind, str | None] = {
+    SecurityCheckKind.SNEAK: None,
+    SecurityCheckKind.LOCKPICK: None,
+    SecurityCheckKind.BREAK_AND_ENTER: "strength",
+    SecurityCheckKind.ESCAPE_THROUGH_WINDOW: "agility",
+    SecurityCheckKind.GUARD_DETECTION: None,
 }

--- a/src/world/checks/security_services.py
+++ b/src/world/checks/security_services.py
@@ -10,7 +10,11 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-from world.checks.constants import SECURITY_CHECK_TYPE_NAMES, SecurityCheckKind
+from world.checks.constants import (
+    SECURITY_CHECK_STAT_OVERRIDE,
+    SECURITY_CHECK_TYPE_NAMES,
+    SecurityCheckKind,
+)
 from world.checks.services import perform_check
 
 if TYPE_CHECKING:
@@ -55,9 +59,11 @@ def resolve_security_check(
             "is not seeded or not active. Run the 'security' seed cluster."
         )
         raise ValueError(msg)
+    stat_override = SECURITY_CHECK_STAT_OVERRIDE.get(kind)
     return perform_check(
         actor,
         check_type,
         target_difficulty=target_difficulty,
         extra_modifiers=extra_modifiers,
+        stat_override=stat_override,
     )

--- a/src/world/checks/services.py
+++ b/src/world/checks/services.py
@@ -1,6 +1,7 @@
 """Check resolution service functions."""
 
 from decimal import Decimal
+import logging
 import random
 from typing import TYPE_CHECKING, NamedTuple, cast
 
@@ -39,6 +40,8 @@ if TYPE_CHECKING:
     from world.skills.models import Specialization
     from world.traits.handlers import TraitHandler
 
+logger = logging.getLogger(__name__)
+
 
 def perform_check(  # noqa: PLR0913 - optional effort/fatigue params extend existing signature
     character: "ObjectDB",
@@ -51,6 +54,7 @@ def perform_check(  # noqa: PLR0913 - optional effort/fatigue params extend exis
     *,
     situation_ctx: "SituationContext | None" = None,
     level_override: int | None = None,
+    stat_override: str | None = None,
 ) -> CheckResult:
     """
     Main check resolution function.
@@ -111,6 +115,7 @@ def perform_check(  # noqa: PLR0913 - optional effort/fatigue params extend exis
             specialization=specialization,
             situation_ctx=situation_ctx,
             level_override=level_override,
+            stat_override=stat_override,
         )
 
     breakdown = _compute_check_breakdown(
@@ -123,6 +128,7 @@ def perform_check(  # noqa: PLR0913 - optional effort/fatigue params extend exis
         specialization=specialization,
         situation_ctx=situation_ctx,
         level_override=level_override,
+        stat_override=stat_override,
     )
 
     roll = random.randint(1, 100)  # noqa: S311
@@ -148,6 +154,7 @@ def perform_check_with_modifiers(  # noqa: PLR0913 - mirrors perform_check signa
     scene: "Scene | None" = None,
     extra_contributions: "list[ModifierContribution] | None" = None,
     skip_fashion: bool = False,
+    stat_override: str | None = None,
 ) -> CheckResult:
     """Run a check with all character modifiers gathered automatically.
 
@@ -197,6 +204,7 @@ def perform_check_with_modifiers(  # noqa: PLR0913 - mirrors perform_check signa
             specialization=specialization,
             situation_ctx=situation_ctx,
             level_override=level_override,
+            stat_override=stat_override,
         )
     breakdown = collect_check_modifiers(
         sheet,
@@ -215,6 +223,7 @@ def perform_check_with_modifiers(  # noqa: PLR0913 - mirrors perform_check signa
         specialization=specialization,
         situation_ctx=situation_ctx,
         level_override=level_override,
+        stat_override=stat_override,
     )
 
 
@@ -229,6 +238,7 @@ def _build_forced_check_result(  # noqa: PLR0913 - mirrors perform_check signatu
     specialization: "Specialization | None" = None,
     situation_ctx: "SituationContext | None" = None,
     level_override: int | None = None,
+    stat_override: str | None = None,
 ) -> CheckResult:
     """Build a synthetic CheckResult for the test-rig forced-outcome path.
 
@@ -251,6 +261,7 @@ def _build_forced_check_result(  # noqa: PLR0913 - mirrors perform_check signatu
         specialization=specialization,
         situation_ctx=situation_ctx,
         level_override=level_override,
+        stat_override=stat_override,
     )
     outcome = _apply_outcome_guarantees(character, forced_outcome, breakdown.chart, situation_ctx)
     return _check_result(check_type, outcome, breakdown)
@@ -282,6 +293,7 @@ def _compute_check_breakdown(  # noqa: PLR0913 - keyword-only check params mirro
     specialization: "Specialization | None",
     situation_ctx: "SituationContext | None" = None,
     level_override: int | None = None,
+    stat_override: str | None = None,
 ) -> _CheckBreakdown:
     """Compute stat + skill + specialization + aspect + level points, ranks, and chart
 
@@ -306,7 +318,7 @@ def _compute_check_breakdown(  # noqa: PLR0913 - keyword-only check params mirro
         level = get_character_path_level(character)
     effort_modifier = EFFORT_CHECK_MODIFIER.get(effort_level, 0) if effort_level else 0
 
-    trait_points = _calculate_trait_points(handler, check_type)
+    trait_points = _calculate_trait_points(handler, check_type, stat_override=stat_override)
     specialization_points = _calculate_specialization_points(character, check_type, specialization)
     aspect_bonus = _calculate_aspect_bonus(character, check_type, level)
     level_points = LEVEL_POINTS_PER_LEVEL * level
@@ -644,6 +656,7 @@ def compute_check_rating(
     extra_modifiers: int = 0,
     *,
     level_override: int | None = None,
+    stat_override: str | None = None,
 ) -> int:
     """Return *character*'s pre-roll rating (total points) for *check_type* — no dice roll.
 
@@ -667,6 +680,7 @@ def compute_check_rating(
         fatigue_penalty=0,
         specialization=None,
         level_override=level_override,
+        stat_override=stat_override,
     )
     return breakdown.total_points
 
@@ -735,16 +749,38 @@ def _calculate_aspect_bonus(
     return bonus
 
 
-def _calculate_trait_points(handler: "TraitHandler", check_type: "CheckType") -> int:
-    """
-    Calculate weighted trait points for a check type.
+def _calculate_trait_points(
+    handler: "TraitHandler",
+    check_type: "CheckType",
+    *,
+    stat_override: str | None = None,
+) -> int:
+    """Calculate weighted trait points for a check type.
 
     For each CheckTypeTrait, multiply raw trait value by weight (truncated to int),
     then convert the weighted value to points via PointConversionRange, and sum.
+
+    When ``stat_override`` is set (#2757), STAT-type CheckTypeTrait rows are
+    skipped and the override stat's value is substituted in their place —
+    borrowing the weight from the check's first STAT-type trait so authored
+    stat weighting is preserved regardless of which stat is selected.
+    SKILL-type traits always contribute. ``None`` (the default) is
+    byte-identical to the pre-#2757 behavior. A check with 2+ STAT-type
+    traits logs a warning and ignores the override (the substitution would
+    lose a stat).
     """
     check_type_traits = check_type.traits.select_related("trait").all()  # type: ignore[attr-defined] — reverse FK manager from CheckTypeTrait
-    total = 0
 
+    if stat_override is not None:
+        overridden = _calculate_trait_points_with_override(
+            handler, check_type, check_type_traits, stat_override
+        )
+        if overridden is not None:
+            return overridden
+        # stat_count > 1: warning already logged, fall through to default.
+
+    # Default path: stat_override is None or was ignored — byte-identical to pre-#2757.
+    total = 0
     for ct_trait in check_type_traits:
         trait = cast(Trait, ct_trait.trait)
         trait_value = handler.get_trait_value(cast(str, trait.name))
@@ -752,7 +788,60 @@ def _calculate_trait_points(handler: "TraitHandler", check_type: "CheckType") ->
             weighted_value = int(trait_value * ct_trait.weight)
             if weighted_value > 0:
                 total += PointConversionRange.calculate_points(trait.trait_type, weighted_value)
+    return total
 
+
+def _calculate_trait_points_with_override(  # noqa: C901
+    handler: "TraitHandler",
+    check_type: "CheckType",
+    check_type_traits,
+    stat_override: str,
+) -> int | None:
+    """Compute trait points when a stat_override is active (#2757).
+
+    Returns the substituted total, or ``None`` when the override should be
+    ignored (the check has 2+ STAT-type traits — the substitution would lose
+    a stat). In the latter case a warning is logged and the caller falls
+    through to the default path.
+    """
+    # Count STAT traits and borrow the first STAT weight for the override.
+    stat_weight: Decimal = Decimal("1.0")
+    stat_count = 0
+    for ct_trait in check_type_traits:
+        trait = cast(Trait, ct_trait.trait)
+        if trait.trait_type == TraitType.STAT:
+            stat_count += 1
+            if stat_count == 1:
+                stat_weight = ct_trait.weight
+
+    if stat_count > 1:
+        logger.warning(
+            "stat_override=%r passed for check %r with %d STAT-type traits — "
+            "override ignored (would lose a stat).",
+            stat_override,
+            check_type.name,
+            stat_count,
+        )
+        return None
+
+    total = 0
+    # Substitute the override stat (borrowed weight if a STAT trait existed,
+    # or weight 1.0 if the check had no STAT traits).
+    override_value = handler.get_trait_value(stat_override)
+    if override_value > 0:
+        weighted_value = int(override_value * stat_weight)
+        if weighted_value > 0:
+            total += PointConversionRange.calculate_points(TraitType.STAT, weighted_value)
+    # Add all non-STAT (SKILL) traits from the check's own composition.
+    for ct_trait in check_type_traits:
+        trait = cast(Trait, ct_trait.trait)
+        if trait.trait_type == TraitType.STAT:
+            continue
+        trait_value = handler.get_trait_value(cast(str, trait.name))
+        if trait_value > 0:
+            weighted_value = int(trait_value * ct_trait.weight)
+            if weighted_value > 0:
+                total += PointConversionRange.calculate_points(trait.trait_type, weighted_value)
     return total
 
 
@@ -966,6 +1055,7 @@ def compute_resist_increment(
     resist_effort_level: str,
     *,
     level_override: int | None = None,
+    stat_override: str | None = None,
 ) -> int:
     """Compute how much a defender's active resistance raises difficulty.
 
@@ -1030,6 +1120,7 @@ def compute_resist_increment(
         composure_check_type,
         extra_modifiers=modifier,
         level_override=level_override,
+        stat_override=stat_override,
     )
     return max(0, rating)
 
@@ -1039,6 +1130,8 @@ def preview_check_difficulty(
     check_type: "CheckType",
     target_difficulty: int = 0,
     extra_modifiers: int = 0,
+    *,
+    stat_override: str | None = None,
 ) -> int:
     """
     Preview the rank difference for a check without rolling.
@@ -1060,6 +1153,7 @@ def preview_check_difficulty(
         effort_level=None,
         fatigue_penalty=0,
         specialization=None,
+        stat_override=stat_override,
     )
     return breakdown.rank_difference
 

--- a/src/world/checks/tests/test_security.py
+++ b/src/world/checks/tests/test_security.py
@@ -77,7 +77,7 @@ class ResolveSecurityCheckTests(TestCase):
                 SecurityCheckKind.BREAK_AND_ENTER, self.character, target_difficulty=0
             )
         assert capture.check_type is not None
-        assert capture.check_type.name == "Break and Enter"
+        assert capture.check_type.name == "Athletics"  # #2757: merged from "Break and Enter"
 
     def test_escape_through_window_resolves(self):
         success = CheckOutcome.objects.filter(success_level__gt=0).first()
@@ -88,7 +88,7 @@ class ResolveSecurityCheckTests(TestCase):
                 target_difficulty=0,
             )
         assert capture.check_type is not None
-        assert capture.check_type.name == "Escape Through Window"
+        assert capture.check_type.name == "Athletics"  # #2757: merged from "Escape Through Window"
 
     def test_guard_detection_resolves(self):
         success = CheckOutcome.objects.filter(success_level__gt=0).first()

--- a/src/world/checks/tests/test_stat_override.py
+++ b/src/world/checks/tests/test_stat_override.py
@@ -1,0 +1,190 @@
+"""Tests for the stat_override parameter on perform_check (#2757).
+
+stat_override lets the calling system replace the CheckType's STAT-type
+traits with a different stat, determined from situational context (weapon
+type, barrier type). SKILL-type traits always contribute. None (the
+default) is byte-identical to pre-#2757 behavior.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+import logging
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.factories import (
+    CheckCategoryFactory,
+    CheckTypeFactory,
+    CheckTypeTraitFactory,
+)
+from world.checks.services import compute_check_rating, perform_check
+from world.traits.factories import CheckSystemSetupFactory
+from world.traits.models import (
+    CharacterTraitValue,
+    CheckRank,
+    PointConversionRange,
+    ResultChart,
+    Trait,
+    TraitCategory,
+    TraitType,
+)
+
+
+class StatOverrideTests(TestCase):
+    """Core stat_override behavior: substitution, byte-identical, guards."""
+
+    @classmethod
+    def setUpTestData(cls):
+        Trait.flush_instance_cache()
+        CheckSystemSetupFactory.create()
+        for trait_type in (TraitType.STAT, TraitType.SKILL):
+            PointConversionRange.objects.get_or_create(
+                trait_type=trait_type,
+                min_value=1,
+                defaults={"max_value": 100, "points_per_level": 1},
+            )
+        for rank_val, min_pts, name in [
+            (0, 0, "SO0"),
+            (1, 10, "SO1"),
+            (2, 25, "SO2"),
+            (3, 50, "SO3"),
+        ]:
+            CheckRank.objects.get_or_create(
+                rank=rank_val, defaults={"min_points": min_pts, "name": name}
+            )
+
+        cls.character = CharacterSheetFactory().character
+        cls.strength, _ = Trait.objects.get_or_create(
+            name="stat_override_strength",
+            defaults={"trait_type": TraitType.STAT, "category": TraitCategory.PHYSICAL},
+        )
+        cls.agility, _ = Trait.objects.get_or_create(
+            name="stat_override_agility",
+            defaults={"trait_type": TraitType.STAT, "category": TraitCategory.PHYSICAL},
+        )
+        cls.willpower, _ = Trait.objects.get_or_create(
+            name="stat_override_willpower",
+            defaults={"trait_type": TraitType.STAT, "category": TraitCategory.MENTAL},
+        )
+        cls.intellect, _ = Trait.objects.get_or_create(
+            name="stat_override_intellect",
+            defaults={"trait_type": TraitType.STAT, "category": TraitCategory.MENTAL},
+        )
+        cls.melee_skill, _ = Trait.objects.get_or_create(
+            name="stat_override_melee_combat",
+            defaults={"trait_type": TraitType.SKILL, "category": TraitCategory.COMBAT},
+        )
+
+        cls.category = CheckCategoryFactory(name="stat_override_test")
+
+    def setUp(self):
+        Trait.flush_instance_cache()
+        CharacterTraitValue.flush_instance_cache()
+        ResultChart.clear_cache()
+
+    def _make_combat_check(self) -> object:
+        """A check with strength (stat) + Melee Combat (skill)."""
+        ct = CheckTypeFactory(name="stat_override_melee", category=self.category)
+        CheckTypeTraitFactory(check_type=ct, trait=self.strength, weight=Decimal("1.0"))
+        CheckTypeTraitFactory(check_type=ct, trait=self.melee_skill, weight=Decimal("1.0"))
+        return ct
+
+    def _make_multistat_check(self) -> object:
+        """A check with willpower + intellect (two stats) + Melee Combat (skill)."""
+        ct = CheckTypeFactory(name="stat_override_multi", category=self.category)
+        CheckTypeTraitFactory(check_type=ct, trait=self.willpower, weight=Decimal("1.0"))
+        CheckTypeTraitFactory(check_type=ct, trait=self.intellect, weight=Decimal("1.0"))
+        CheckTypeTraitFactory(check_type=ct, trait=self.melee_skill, weight=Decimal("1.0"))
+        return ct
+
+    def test_none_is_byte_identical_to_default(self):
+        """stat_override=None must produce identical results to not passing it."""
+        ct = self._make_combat_check()
+        CharacterTraitValue.objects.create(
+            character=self.character.sheet_data, trait=self.strength, value=30
+        )
+        CharacterTraitValue.objects.create(
+            character=self.character.sheet_data, trait=self.melee_skill, value=20
+        )
+
+        result_default = perform_check(self.character, ct)
+        result_explicit_none = perform_check(self.character, ct, stat_override=None)
+        self.assertEqual(result_default.total_points, result_explicit_none.total_points)
+        self.assertEqual(result_default.trait_points, result_explicit_none.trait_points)
+
+    def test_stat_replaced_skill_preserved(self):
+        """Overriding strength→agility: agility value used, skill still contributes."""
+        ct = self._make_combat_check()
+        CharacterTraitValue.objects.create(
+            character=self.character.sheet_data, trait=self.strength, value=50
+        )
+        CharacterTraitValue.objects.create(
+            character=self.character.sheet_data, trait=self.agility, value=20
+        )
+        CharacterTraitValue.objects.create(
+            character=self.character.sheet_data, trait=self.melee_skill, value=30
+        )
+
+        result_strength = perform_check(self.character, ct)
+        result_agility = perform_check(self.character, ct, stat_override="stat_override_agility")
+
+        # Strength (50) > agility (20), so overriding to agility lowers trait_points.
+        self.assertGreater(result_strength.trait_points, result_agility.trait_points)
+        # But the skill portion is still there — total isn't zero.
+        self.assertGreater(result_agility.trait_points, 0)
+
+    def test_override_to_missing_stat_is_zero_stat(self):
+        """Overriding to a stat the character doesn't have: 0 stat points, no crash."""
+        ct = self._make_combat_check()
+        CharacterTraitValue.objects.create(
+            character=self.character.sheet_data, trait=self.strength, value=30
+        )
+        CharacterTraitValue.objects.create(
+            character=self.character.sheet_data, trait=self.melee_skill, value=20
+        )
+
+        result = perform_check(self.character, ct, stat_override="nonexistent_stat")
+        # Only skill contributes (20 points), stat is 0
+        self.assertGreaterEqual(result.trait_points, 0)
+        self.assertGreaterEqual(result.total_points, 0)
+
+    def test_two_stat_check_logs_warning(self):
+        """stat_override on a 2+ stat check logs a warning and ignores the override."""
+        ct = self._make_multistat_check()
+        CharacterTraitValue.objects.create(
+            character=self.character.sheet_data, trait=self.willpower, value=30
+        )
+        CharacterTraitValue.objects.create(
+            character=self.character.sheet_data, trait=self.intellect, value=30
+        )
+        CharacterTraitValue.objects.create(
+            character=self.character.sheet_data, trait=self.melee_skill, value=20
+        )
+
+        with self.assertLogs(logger="world.checks.services", level=logging.WARNING) as logs:
+            perform_check(self.character, ct, stat_override="stat_override_agility")
+        self.assertTrue(any("stat_override" in msg for msg in logs.output))
+
+    def test_compute_check_rating_accepts_stat_override(self):
+        """compute_check_rating also accepts stat_override."""
+        ct = self._make_combat_check()
+        CharacterTraitValue.objects.create(
+            character=self.character.sheet_data, trait=self.strength, value=50
+        )
+        CharacterTraitValue.objects.create(
+            character=self.character.sheet_data, trait=self.agility, value=20
+        )
+        CharacterTraitValue.objects.create(
+            character=self.character.sheet_data, trait=self.melee_skill, value=30
+        )
+
+        rating_default = compute_check_rating(self.character, ct)
+        rating_override = compute_check_rating(
+            self.character, ct, stat_override="stat_override_agility"
+        )
+        # Strength (50) > agility (20), so default rating is higher
+        self.assertGreater(rating_default, rating_override)
+        # But the skill portion keeps the override rating positive
+        self.assertGreater(rating_override, 0)

--- a/src/world/combat/factories.py
+++ b/src/world/combat/factories.py
@@ -1224,8 +1224,9 @@ def wire_melee_attack_action_template():
 
     The combat-flavored sibling of the magic standalone cast template
     (``seeds_cast.ensure_technique_cast_content``). Carries the seeded
-    'Melee Attack' CheckType so physical techniques roll a combat check
-    (strength + Melee Combat) instead of the magic fallback. Also carries the
+    'Melee Combat' CheckType so physical techniques roll a combat check
+    (skill + situational stat, default strength + Melee Combat) instead
+    of the magic fallback (#2757: formerly 'Melee Attack'). Also carries the
     seeded 'Combat: Melee Offense' base ConsequencePool (#1995) — the combat
     sibling of the magic 'Magic: Technique Cast' base pool — so a standalone
     melee cast with no flavor chosen still resolves graded consequences rather
@@ -1244,7 +1245,7 @@ def wire_melee_attack_action_template():
     from world.combat.seeds_offense import ensure_melee_offense_pool
     from world.seeds.sample_content import authored_or_sample
 
-    # Resolve the 'Melee Attack' CheckType: prefer the authored seed
+    # Resolve the 'Melee Combat' CheckType: prefer the authored seed
     # (seed_combat_check_content writes the full composition); fall back to a
     # gated lookup so the wire function is self-sufficient in test setups
     # that haven't run the combat_checks seed (mirrors how
@@ -1254,8 +1255,8 @@ def wire_melee_attack_action_template():
         return None
     check_type = authored_or_sample(
         CheckType,
-        {"description": "A melee attack roll: strength + Melee Combat."},
-        name="Melee Attack",
+        {"description": "A melee combat roll: skill + situational stat (default strength)."},
+        name="Melee Combat",
         category=category,
     )
     if check_type is None:

--- a/src/world/combat/interpose_content.py
+++ b/src/world/combat/interpose_content.py
@@ -52,12 +52,12 @@ logger = logging.getLogger(__name__)
 INTERPOSE_CHALLENGE_NAME: str = "Interpose"
 INTERPOSABLE_PROPERTY_NAME: str = "interposable"
 
-# The "Melee Defense" CheckType is seeded by world.seeds.combat_checks
-# (ensure_melee_defense_check_type, #1994) — this module only looks it up
-# (mirrors the cross-module CheckType reference idiom in
-# world.seeds.social_actions._MELEE_DEFENSE_CHECK_NAME) and never creates it,
-# so a re-seed never risks a duplicate row under a different CheckCategory.
-MELEE_DEFENSE_CHECK_TYPE_NAME: str = "Melee Defense"
+# The "Melee Combat" CheckType is seeded by world.seeds.combat_checks
+# (ensure_melee_combat_check_type) — this module only looks it up
+# and never creates it, so a re-seed never risks a duplicate row under
+# a different CheckCategory. #2757: Melee Defense merged into Melee Combat;
+# the constant name is kept for backward compat but now resolves to "Melee Combat".
+MELEE_DEFENSE_CHECK_TYPE_NAME: str = "Melee Combat"  # #2757: merged with Melee Attack
 
 # Authored difficulty of the interpose challenge. Lives on
 # ChallengeTemplate.severity — never as a literal target_difficulty in engine code.
@@ -150,17 +150,18 @@ def _ensure_interpose_check_type() -> CheckType | None:
 
 
 def _get_melee_defense_check_type() -> CheckType | None:
-    """Look up the "Melee Defense" CheckType seeded by world.seeds.combat_checks.
+    """Look up the "Melee Combat" CheckType seeded by world.seeds.combat_checks.
 
     Returns None (never creates) when it hasn't been seeded yet — the twin
     approaches are skipped for that run rather than risking a duplicate
     CheckType row under the wrong CheckCategory (CheckType.name is only unique
-    together with category, not globally).
+    together with category, not globally). #2757: Melee Defense merged into
+    Melee Combat; the stat is agility via stat_override for defense.
     """
     check_type = CheckType.objects.filter(name=MELEE_DEFENSE_CHECK_TYPE_NAME).first()
     if check_type is None:
         logger.warning(
-            "Melee Defense CheckType not seeded; interpose best-of twins skipped "
+            "Melee Combat CheckType not seeded; interpose best-of twins skipped "
             "(run world.seeds.combat_checks.seed_combat_check_content() first)."
         )
     return check_type

--- a/src/world/combat/seeds_offense.py
+++ b/src/world/combat/seeds_offense.py
@@ -78,7 +78,7 @@ def get_melee_offense_pool() -> ConsequencePool | None:
 
     ``checks.CheckType`` is content-repo-owned (#2698) — returns ``None``
     when ``wire_melee_attack_action_template()`` returns ``None`` (the
-    'Melee Attack' CheckType isn't authored).
+    'Melee Combat' CheckType isn't authored).
     """
     from world.combat.factories import wire_melee_attack_action_template  # noqa: PLC0415
 

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -478,6 +478,9 @@ class CombatTechniqueResolver:
             if focused is not None
             else 0
         )
+        from world.combat.stat_mapping import weapon_stat_override  # noqa: PLC0415
+
+        stat_override = weapon_stat_override(character)
         return check_fn(
             character,
             self.offense_check_type,
@@ -485,6 +488,7 @@ class CombatTechniqueResolver:
             extra_modifiers=extra_modifiers,
             fatigue_penalty=penalty,
             situation_ctx=situation_ctx,
+            stat_override=stat_override,
         )
 
     def _sum_intensity_bump_pulls(self) -> int:
@@ -6427,6 +6431,8 @@ def resolve_npc_attack(
     # aspect match on this defense check) that sets the difficulty -- the
     # inverse of the offense/penetration sites, where the difficulty is
     # sourced from the side being acted upon.
+    from world.combat.stat_mapping import DEFENSE_STAT  # noqa: PLC0415
+
     result: CheckResult = perform_check_fn(
         character,
         check_type,
@@ -6437,6 +6443,7 @@ def resolve_npc_attack(
         ),
         extra_modifiers=breakdown.total,
         situation_ctx=situation_ctx,
+        stat_override=DEFENSE_STAT,
     )
 
     multiplier = _damage_multiplier_for_success(result.success_level)

--- a/src/world/combat/stat_mapping.py
+++ b/src/world/combat/stat_mapping.py
@@ -1,0 +1,52 @@
+"""Weapon→stat mapping for combat checks (#2757).
+
+The calling system determines which stat a combat check rolls from the
+equipped weapon's archetype. This is authored content — a simple mapping
+from ``GearArchetype`` to stat name. ``None`` means "use the check's
+default stat" (no override).
+
+The mapping is intentionally coarse: ``GearArchetype`` distinguishes
+one-handed from two-handed, not light/rapier from heavy/warhammer. A
+finer weapon-class→stat mapping (keyed on a weapon-class property or
+specialization) is a content follow-up. The initial mapping favors
+agility for one-handed weapons (the common case: swords, daggers,
+rapiers) and strength for two-handed weapons.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from world.items.constants import GearArchetype
+
+if TYPE_CHECKING:
+    from typeclasses.characters import Character as CharacterType
+
+# GearArchetype → stat name. None = use the check's default stat.
+WEAPON_ARCHETYPE_STAT_MAP: dict[str, str | None] = {
+    GearArchetype.MELEE_ONE_HAND: "agility",
+    GearArchetype.MELEE_TWO_HAND: "strength",
+    GearArchetype.RANGED: "agility",
+    GearArchetype.THROWN: "strength",
+    GearArchetype.LANCE: "strength",
+    GearArchetype.OTHER: None,
+}
+
+# Defense is always agility-based (dodging/parrying, not striking).
+DEFENSE_STAT: str = "agility"
+
+
+def weapon_stat_override(character: CharacterType) -> str | None:
+    """Return the stat name for the character's equipped weapon, or None.
+
+    Looks up the character's strongest equipped weapon's ``gear_archetype``
+    and maps it to a stat name via ``WEAPON_ARCHETYPE_STAT_MAP``. Returns
+    ``None`` when the character has no weapon or the archetype isn't in
+    the map — the caller then uses the check's default stat.
+    """
+    from world.combat.services import _equipped_weapon_archetype  # noqa: PLC0415
+
+    archetype = _equipped_weapon_archetype(character)
+    if archetype is None:
+        return None
+    return WEAPON_ARCHETYPE_STAT_MAP.get(archetype)

--- a/src/world/combat/tests/test_guardian_reactions.py
+++ b/src/world/combat/tests/test_guardian_reactions.py
@@ -81,8 +81,8 @@ class InterposeBestOfCheckRealPathTest(TestCase):
         idmapper_models.flush_cache()
 
         # ensure_interpose_content() must run AFTER seed_combat_check_content()
-        # so its Melee-Defense twin approaches aren't skipped (interpose_content
-        # warns + no-ops without a seeded "Melee Defense" CheckType).
+        # so its Melee Combat twin approaches aren't skipped (interpose_content
+        # warns + no-ops without a seeded "Melee Combat" CheckType).
         seed_combat_check_content()
         ensure_interpose_content()
 
@@ -250,8 +250,8 @@ class InterposeBestOfCheckRealPathTest(TestCase):
         )
         self.assertEqual(
             duelist_check_type,
-            "Melee Defense",
-            "a duelist-statted guardian must roll the Melee-Defense twin, not Reflexes",
+            "Melee Combat",
+            "a duelist-statted guardian must roll Melee Combat (agility override), not Reflexes",
         )
 
         # Reflexes-statted guardian: high wits, low agility/Melee Combat.

--- a/src/world/combat/tests/test_stat_override.py
+++ b/src/world/combat/tests/test_stat_override.py
@@ -1,0 +1,64 @@
+"""Tests for combat stat_override wiring (#2757)."""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.stat_mapping import DEFENSE_STAT, weapon_stat_override
+from world.items.constants import BodyRegion, EquipmentLayer, GearArchetype
+from world.items.factories import ItemInstanceFactory, ItemTemplateFactory
+from world.items.models import EquippedItem
+
+
+class WeaponStatMappingTests(TestCase):
+    """The weapon→stat mapping maps GearArchetype to a stat name."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.character = CharacterSheetFactory().character
+
+    def _equip_weapon(self, archetype: str, name: str = "test_weapon"):
+        template = ItemTemplateFactory(
+            gear_archetype=archetype,
+            base_weapon_damage=5,
+            name=name,
+            max_durability=30,
+        )
+        inst = ItemTemplateFactory
+        inst = ItemInstanceFactory(template=template, durability=30)
+        EquippedItem.objects.create(
+            character=self.character.sheet_data,
+            item_instance=inst,
+            body_region=BodyRegion.RIGHT_HAND,
+            equipment_layer=EquipmentLayer.BASE,
+        )
+        self.character.equipped_items.invalidate()
+        return inst
+
+    def test_two_handed_maps_to_strength(self):
+        self._equip_weapon(GearArchetype.MELEE_TWO_HAND, "warhammer")
+        self.assertEqual(weapon_stat_override(self.character), "strength")
+
+    def test_one_handed_maps_to_agility(self):
+        self._equip_weapon(GearArchetype.MELEE_ONE_HAND, "rapier")
+        self.assertEqual(weapon_stat_override(self.character), "agility")
+
+    def test_ranged_maps_to_agility(self):
+        self._equip_weapon(GearArchetype.RANGED, "bow")
+        self.assertEqual(weapon_stat_override(self.character), "agility")
+
+    def test_thrown_maps_to_strength(self):
+        self._equip_weapon(GearArchetype.THROWN, "javelin")
+        self.assertEqual(weapon_stat_override(self.character), "strength")
+
+    def test_lance_maps_to_strength(self):
+        self._equip_weapon(GearArchetype.LANCE, "lance")
+        self.assertEqual(weapon_stat_override(self.character), "strength")
+
+    def test_no_weapon_returns_none(self):
+        # Fresh character with no equipped weapon
+        self.assertIsNone(weapon_stat_override(self.character))
+
+    def test_defense_stat_is_agility(self):
+        self.assertEqual(DEFENSE_STAT, "agility")

--- a/src/world/seeds/combat_checks.py
+++ b/src/world/seeds/combat_checks.py
@@ -26,7 +26,7 @@ from decimal import Decimal
 # (specialization name) — weapon-class specs under Melee Combat.
 _WEAPON_SPECIALIZATIONS: list[str] = ["Small Weapons", "Medium Weapons", "Heavy Weapons"]
 
-_MELEE_ATTACK_CHECK_TYPE_NAME = "Melee Attack"
+_MELEE_COMBAT_CHECK_TYPE_NAME = "Melee Combat"
 _MELEE_SKILL_NAME = "Melee Combat"
 _MELEE_SKILL_TOOLTIP = "Fighting with melee weapons — the trained combat skill."
 
@@ -92,14 +92,18 @@ def ensure_weapon_specializations(skill) -> dict:
     return specs
 
 
-def ensure_melee_attack_check_type(skill, specs) -> object | None:
-    """Look up (or sample) the Melee Attack CheckType: strength + Melee Combat.
+def ensure_melee_combat_check_type(skill, specs) -> object | None:
+    """Look up (or sample) the Melee Combat CheckType: skill + default stat (strength).
 
     ``checks.checktype``/``checktypetrait`` are content-repo-owned (#2698) —
     returns ``None`` (logged by ``authored_or_sample``) when the category or
     the check type itself isn't authored. The skill's trait leg is skipped
     (not fatal) when ``skill`` is ``None`` — the CheckType may still be
     authored content the lore repo composes with its own trait rows.
+
+    The stat is situational (#2757): the calling system passes ``stat_override``
+    based on the equipped weapon. The default stat (strength) is used when no
+    override is given (GM ad-hoc, legacy callers).
     """
     from world.checks.models import (  # noqa: PLC0415
         CheckType,
@@ -114,8 +118,8 @@ def ensure_melee_attack_check_type(skill, specs) -> object | None:
         return None
     check_type = authored_or_sample(
         CheckType,
-        {"description": "A melee attack roll: strength + Melee Combat."},
-        name=_MELEE_ATTACK_CHECK_TYPE_NAME,
+        {"description": "A melee combat roll: skill + situational stat (default strength)."},
+        name=_MELEE_COMBAT_CHECK_TYPE_NAME,
         category=category,
     )
     if check_type is None:
@@ -131,57 +135,14 @@ def ensure_melee_attack_check_type(skill, specs) -> object | None:
         authored_or_sample(
             CheckTypeTrait, {"weight": weight}, check_type=check_type, trait=strength
         )
-    if skill is not None:
-        authored_or_sample(
-            CheckTypeTrait, {"weight": weight}, check_type=check_type, trait=skill.trait
-        )
-    for spec in specs.values():
-        CheckTypeSpecialization.objects.get_or_create(
-            check_type=check_type, specialization=spec, defaults={"weight": weight}
-        )
-    return check_type
-
-
-_MELEE_DEFENSE_CHECK_TYPE_NAME = "Melee Defense"
-
-
-def ensure_melee_defense_check_type(skill, specs) -> object | None:
-    """Look up (or sample) the Melee Defense CheckType: agility + Melee Combat.
-
-    Mirrors ``ensure_melee_attack_check_type`` but with ``agility`` as the stat
-    (evasion) instead of ``strength`` (attack). Reuses the same ``Melee Combat``
-    skill + weapon specializations from #1706 — one skill investment covers
-    offense and defense. See ``ensure_melee_attack_check_type`` for the
-    skip-on-missing-content contract.
-    """
-    from world.checks.models import (  # noqa: PLC0415
-        CheckType,
-        CheckTypeSpecialization,
-        CheckTypeTrait,
-    )
-    from world.seeds.sample_content import authored_or_sample  # noqa: PLC0415
-    from world.traits.models import Trait, TraitCategory, TraitType  # noqa: PLC0415
-
-    category = _ensure_combat_category()
-    if category is None:
-        return None
-    check_type = authored_or_sample(
-        CheckType,
-        {"description": "A melee defense roll: agility + Melee Combat."},
-        name=_MELEE_DEFENSE_CHECK_TYPE_NAME,
-        category=category,
-    )
-    if check_type is None:
-        return None
-
-    weight = Decimal("1.00")
-    agility = authored_or_sample(
+    # Ensure agility exists as a stat_override target for Melee Combat (#2757):
+    # the combat system passes stat_override="agility" for light-weapon offense
+    # and defense. The Trait row must exist so handler.get_trait_value works.
+    authored_or_sample(
         Trait,
         {"trait_type": TraitType.STAT, "category": TraitCategory.PHYSICAL, "is_public": True},
         name="agility",
     )
-    if agility is not None:
-        authored_or_sample(CheckTypeTrait, {"weight": weight}, check_type=check_type, trait=agility)
     if skill is not None:
         authored_or_sample(
             CheckTypeTrait, {"weight": weight}, check_type=check_type, trait=skill.trait
@@ -194,8 +155,7 @@ def ensure_melee_defense_check_type(skill, specs) -> object | None:
 
 
 def seed_combat_check_content() -> None:
-    """Cluster entry — seed Melee Combat skill catalog + Attack/Defense checks."""
+    """Cluster entry — seed Melee Combat skill catalog + Melee Combat check."""
     skill = ensure_melee_combat_skill()
     specs = ensure_weapon_specializations(skill)
-    ensure_melee_attack_check_type(skill, specs)
-    ensure_melee_defense_check_type(skill, specs)
+    ensure_melee_combat_check_type(skill, specs)

--- a/src/world/seeds/security_checks.py
+++ b/src/world/seeds/security_checks.py
@@ -48,10 +48,11 @@ _SECURITY_SPECIALIZATIONS: list[tuple[str, str]] = [
 
 # CheckType name -> (stat trait name, parent skill name, specialization | None, category name).
 # Stat categories: wits=MENTAL, strength=PHYSICAL, agility=PHYSICAL, perception=META.
+# #2757: "Break and Enter" and "Escape Through Window" merged into "Athletics" —
+# the stat_override is passed by resolve_security_check from SecurityCheckKind.
 _SECURITY_CHECK_COMPOSITION: dict[str, tuple[str, str, str | None, str]] = {
     "Lockpick": ("wits", "Skulduggery", "Lockpicking", "Physical"),
-    "Break and Enter": ("strength", "Athletics", None, "Physical"),
-    "Escape Through Window": ("agility", "Athletics", "Climbing", "Physical"),
+    "Athletics": ("strength", "Athletics", "Climbing", "Physical"),
     "Guard Detection": ("perception", "Investigation", None, "Exploration"),
     # #1825 accusation counter-play — the evidence pipeline's three checks.
     "Forge Evidence": ("wits", "Skulduggery", "Forgery", "Physical"),

--- a/src/world/seeds/social_actions.py
+++ b/src/world/seeds/social_actions.py
@@ -119,7 +119,7 @@ _SMITTEN_EXPLOITABLE_TIERS = 2
 _SMITTEN_DEFENSE_PENALTY = -10
 _SMITTEN_DAMAGE_TYPE = "Force"
 _SMITTEN_DAMAGE_BONUS_PCT = 100
-_MELEE_DEFENSE_CHECK_NAME = "Melee Defense"
+_MELEE_DEFENSE_CHECK_NAME = "Melee Combat"  # #2757: merged with Melee Attack
 
 # Automatic affection shifts on success (#1697) — the first instances of the generic
 # valence-signed SHIFT_AFFECTION family. PLACEHOLDER magnitudes (#1699 scale: bump 1,

--- a/src/world/seeds/tests/test_clusters.py
+++ b/src/world/seeds/tests/test_clusters.py
@@ -66,8 +66,8 @@ class TestClusterRegistry(TestCase):
         self.assertLess(keys.index("magic"), keys.index("character_creation"))
 
     def test_reactive_challenges_cluster_registered_after_combat_checks(self) -> None:
-        # Interpose's Melee-Defense twin approaches look up the "Melee Defense"
-        # CheckType seeded by the combat_checks cluster (#2636).
+        # Interpose's Melee Combat twin approaches look up the "Melee Combat"
+        # CheckType seeded by the combat_checks cluster (#2636, #2757 merge).
         keys = list(CLUSTER_SEEDERS)
         assert "reactive_challenges" in keys
         self.assertLess(keys.index("combat_checks"), keys.index("reactive_challenges"))

--- a/src/world/seeds/tests/test_combat_checks.py
+++ b/src/world/seeds/tests/test_combat_checks.py
@@ -31,7 +31,7 @@ class CombatCheckSeedTests(TestCase):
         )
 
         seed_combat_check_content()
-        ct = CheckType.objects.get(name="Melee Attack")
+        ct = CheckType.objects.get(name="Melee Combat")
         trait_names = {t.trait.name for t in ct.traits.all()}  # type: ignore[attr-defined]
         self.assertEqual(trait_names, {"strength", "Melee Combat"})
         spec_names = {
@@ -45,21 +45,13 @@ class CombatCheckSeedTests(TestCase):
 
         seed_combat_check_content()
         seed_combat_check_content()  # re-run
-        self.assertEqual(CheckType.objects.filter(name="Melee Attack").count(), 1)
+        self.assertEqual(CheckType.objects.filter(name="Melee Combat").count(), 1)
 
-    def test_melee_defense_composition(self):
+    def test_melee_combat_is_single_check(self):
+        """#2757: Melee Attack + Melee Defense merged into one 'Melee Combat' CheckType."""
         from world.checks.models import CheckType
 
         seed_combat_check_content()
-        ct = CheckType.objects.get(name="Melee Defense")
-        trait_names = {t.trait.name for t in ct.traits.all()}
-        self.assertEqual(trait_names, {"agility", "Melee Combat"})
-        spec_names = {s.specialization.name for s in ct.specializations.all()}
-        self.assertEqual(spec_names, {"Small Weapons", "Medium Weapons", "Heavy Weapons"})
-
-    def test_melee_defense_idempotent(self):
-        from world.checks.models import CheckType
-
-        seed_combat_check_content()
-        seed_combat_check_content()
-        self.assertEqual(CheckType.objects.filter(name="Melee Defense").count(), 1)
+        # No separate Melee Defense CheckType exists anymore
+        self.assertFalse(CheckType.objects.filter(name="Melee Defense").exists())
+        self.assertEqual(CheckType.objects.filter(name="Melee Combat").count(), 1)

--- a/src/world/seeds/tests/test_security_checks.py
+++ b/src/world/seeds/tests/test_security_checks.py
@@ -120,30 +120,27 @@ class SecurityCheckSeedTests(TestCase):
         assert not CheckTypeSpecialization.objects.filter(check_type=ct).exists()
         assert ct.category.name == "Exploration"
 
-    def test_break_and_enter_composition(self):
+    def test_athletics_composition(self):
+        """#2757: Break and Enter + Escape Through Window merged into Athletics."""
         from world.checks.models import CheckTypeSpecialization, CheckTypeTrait
 
-        ct = CheckType.objects.get(name="Break and Enter")
+        ct = CheckType.objects.get(name="Athletics")
         trait_names = set(
             CheckTypeTrait.objects.filter(check_type=ct).values_list("trait__name", flat=True)
         )
+        # Default stat is strength; agility comes via stat_override at call time
         assert trait_names == {"strength", "Athletics"}
-        assert not CheckTypeSpecialization.objects.filter(check_type=ct).exists()
-
-    def test_escape_through_window_composition(self):
-        from world.checks.models import CheckTypeSpecialization, CheckTypeTrait
-
-        ct = CheckType.objects.get(name="Escape Through Window")
-        trait_names = set(
-            CheckTypeTrait.objects.filter(check_type=ct).values_list("trait__name", flat=True)
-        )
-        assert trait_names == {"agility", "Athletics"}
         spec_names = set(
             CheckTypeSpecialization.objects.filter(check_type=ct).values_list(
                 "specialization__name", flat=True
             )
         )
         assert spec_names == {"Climbing"}
+
+    def test_no_separate_break_and_enter_or_escape_checks(self):
+        """#2757: merged CheckTypes no longer exist as separate rows."""
+        assert not CheckType.objects.filter(name="Break and Enter").exists()
+        assert not CheckType.objects.filter(name="Escape Through Window").exists()
 
     def test_guard_detection_composition(self):
         from world.checks.models import CheckTypeSpecialization, CheckTypeTrait
@@ -192,8 +189,7 @@ class SecurityCheckSeedTests(TestCase):
         seed_security_check_content()
         seed_security_check_content()
         assert CheckType.objects.filter(name="Lockpick").count() == 1
-        assert CheckType.objects.filter(name="Break and Enter").count() == 1
-        assert CheckType.objects.filter(name="Escape Through Window").count() == 1
+        assert CheckType.objects.filter(name="Athletics").count() == 1  # #2757: merged
         assert CheckType.objects.filter(name="Guard Detection").count() == 1
         assert CheckType.objects.filter(name="Forge Evidence").count() == 1
         assert CheckType.objects.filter(name="Gather Evidence").count() == 1


### PR DESCRIPTION
Closes #2757

## Summary

Add stat_override parameter to perform_check so the stat in a check is situational — determined by the calling system from physical context (weapon type, barrier type) rather than fixed per CheckType. Merge Melee Attack + Melee Defense into Melee Combat; Break and Enter + Escape Through Window into Athletics. Social, investigation, resist, and multi-stat checks stay separate.

## Follow-ups filed

- #2857
- #2858

## Notes

- Spec: reviewed & approved on #2757 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Clean rebase onto main (no conflicts)

<!-- last-addressed-comment: 0 -->