### PR TITLE
Moon/lycan arc: moon-pull control checks, shared Berserk with real compulsion, Wolf's Fury content (#2845)

### DIFF
--- a/docs/adr/0183-moon-control-shared-berserk-and-real-compulsion.md
+++ b/docs/adr/0183-moon-control-shared-berserk-and-real-compulsion.md
@@ -1,0 +1,39 @@
+# ADR-0183: Moon control rides one shared Berserk, and Berserk finally compels
+
+**Status:** Accepted (built #2845; extends ADR-0179)
+
+**Decision.** The moon is a *control* pressure, not an exposure damage ladder: a
+moon-bound character (tag-anchored `Moon-Bound` distinction, ADR-0179 — Lycans
+innately via the "The Wolf's Fury" `SpeciesGiftGrant`) under a felt pull
+(`illumination × sky exposure − shade`; clouds ride the ADR-0180 radiant-shelter
+rows with zero moon-side code; clothing/magic never enter an instinct read) rolls
+`moon_control` (willpower 1.0 + composure 0.5 — both existing stats, no new
+skill) each reconcile window. Difficulty scales with pull and down with character
+level, and gift-thread level; at level 6+ the check fires only while impaired
+(condition-driven willpower a full tier down — drink, drugs, despair). Failure
+forces the battle-form shift through the existing `trigger_transformation` seam
+with `instance_value` = a moon-clarity multiplier (voluntary shifts get the same
+multiplier — the moon empowers the form regardless of who chose the shift), and
+applies the **same Berserk condition the fury engine applies** — one shared row
+(now production-seeded with a healing ensure; it previously existed only as a
+test factory plus a miscategorized dormant fixture), so revert-blocking, the
+compulsion below, and the Restore to Sense break-out serve every producer (fury,
+moon, future demonic rage). Berserk also gains real **compulsion**: an
+auto-declared simplest-damaging-technique attack at the NPC-selection fallback
+each combat round (steerable, not refusable), flee/parley/leave refusal, and an
+out-of-combat rampage window that seeds a real encounter against the nearest NPC
+through the ordinary hostile-cast seam. Restore to Sense — wired since #567 but
+content-free — gets its production seed (Persuasion roll removes Berserk),
+closing the talk-the-beast-down loop. Cani (the umbrella subspecies — khati
+stay umbrella families, no per-animal rows) feel a flavor-only Moonlit Unease
+under the open night moon.
+
+**Rejected alternatives.** (a) A moon-specific rage condition — a second
+loss-of-control state would fork the revert-block/break-out machinery and
+orphan fury's Berserk. (b) A clock-driven battle-form stat engine — the built
+`instance_value` snapshot at shift time gets the clear-full-moon peak without
+any recompute machinery. (c) Consent-side gating for the in-combat compulsion —
+everyone in an encounter already passed the entry gates; out-of-combat rampage
+simply never grabs PCs in v1. (d) A `Lupi` wolf subspecies for the unease —
+per-animal khati rows balloon uncontrollably (ruled); the Cani umbrella carries
+it.

--- a/docs/roadmap/world-clock.md
+++ b/docs/roadmap/world-clock.md
@@ -64,7 +64,9 @@ The central time engine that drives the living world. An anchor-based game clock
   cycle PLACEHOLDER 30 IC days, fixed epoch — no state, no cron writer; staff
   time-skips move the moon). Surfaced via the weather `Conditions` read + widget
   (night only). Astrological conjunctions remain deferred; the lycan consumer is
-  the #2845 follow-on spec.
+  **built (#2845, ADR-0183)**: `felt_moon_pull` (illumination × sky − shade) drives
+  the `moon_control` window (`species.moon_reconcile` cron, 5-min DRAIN) — forced
+  battle-form shift + shared Berserk on failure, Cani Moonlit Unease as flavor.
 - **Consumer note (#2846, ADR-0179):** the sunlight bane/allergy system reads
   `get_ic_phase()` for its base-sun gate (full at DAY, reduced DAWN/DUSK, zero
   NIGHT) and registers the `species.sun_reconcile` cron (5-min, DRAIN band) —

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -772,6 +772,16 @@ Species/race definitions with stat bonuses, language assignments, and species-gi
   `tasks.sun_reconcile_tick` (`species.sun_reconcile` cron), factories
   `ensure_sunlight_exposure_content` (staged template) + `ensure_sunlight_distinctions`
   (Bane/Allergy: Sunlight anchor rows); PLACEHOLDER constants in `sun_constants.py`.
+  Moon control (#2845, ADR-0183): `moon_pull.felt_moon_pull`/`moon_clarity_instance_value`,
+  `moon_sensitivity.reconcile_moon_pull` (control window: `moon_control` check →
+  forced shift + shared Berserk) + `reconcile_cani_unease` (umbrella flavor state),
+  `moon_provisioning.ensure_lycan_battle_form` (lazy battle-form provisioning),
+  `tasks.moon_reconcile_tick` (`species.moon_reconcile` cron), factories
+  `ensure_moon_bound_distinction`/`ensure_moonlit_unease_condition`; seeded content in
+  `_seed_moon_content` ("The Wolf's Fury" grant); Berserk production seed + Restore-to-Sense
+  removal effect in `world/conditions/berserk_content.py`; compulsion in
+  `world/combat/berserk_compulsion.py` (auto-attack fallback, disengage refusal,
+  out-of-combat rampage); PLACEHOLDER constants in `moon_constants.py`.
 - **Key Methods:** `Species.get_stat_bonuses_dict()`, `Species.is_subspecies`
 - **Integrates with:** character_creation (Beginnings.allowed_species, CG points
   breakdown), forms (physical traits — per-species palettes + `is_required`

--- a/docs/systems/species.md
+++ b/docs/systems/species.md
@@ -127,6 +127,28 @@ ADR. `ensure_appetite_distinctions` / `ensure_ravenous_condition` /
 seeded content routes through `authored_or_sample` in `_seed_appetite_content`
 (Vesperi is the eighth khati subspecies).
 
+## Moon Control & Lycans (#2845, ADR-0183)
+
+The moon is a *control* pressure, not exposure damage. `world.species.moon_pull`
+computes the felt pull (`illumination × sky exposure − radiant shade`; NIGHT
+only; cloud cover rides ADR-0180 shelter rows for free — clothing/magic never
+enter an instinct read) plus `moon_clarity_instance_value` (the battle-form
+stat multiplier at shift time — voluntary and forced alike).
+`world.species.moon_sensitivity` runs the control window: `Moon-Bound`
+tag-anchored holders (Lycans innately, via "The Wolf's Fury" SpeciesGiftGrant
+seeded in `_seed_moon_content`) above the pull threshold roll `moon_control`
+(willpower + composure; ADR-0171 config prerequisite); difficulty scales with
+pull, down with level and Wolf's-Fury thread level; level 6+ exempt unless
+impaired (condition-driven willpower ≥1 tier down). Failure = forced shift
+(`trigger_transformation(cause="moon")`, battle form lazily provisioned by
+`world.species.moon_provisioning.ensure_lycan_battle_form`) + the shared
+**Berserk** condition (production seed + Restore-to-Sense removal effect in
+`world.conditions.berserk_content`; compulsion in
+`world.combat.berserk_compulsion` — auto-attack fallback at round resolution,
+disengage refusal, out-of-combat rampage; see the INDEX combat entry). Cani (the
+umbrella subspecies) get the flavor-only Moonlit Unease under the open night
+moon (`reconcile_cani_unease`). Cron: `species.moon_reconcile` (5-min DRAIN).
+
 ---
 
 ## Key Methods

--- a/src/actions/definitions/forms.py
+++ b/src/actions/definitions/forms.py
@@ -81,9 +81,14 @@ class ShiftFormAction(Action):
         # web path). Routes through ``trigger_transformation`` (the cause-path
         # seam) so the at-will command shares the audit hook + variance path
         # with the technique/trigger cause-paths (#1604); ``instance_value``
-        # defaults to 1.0 (the at-will baseline needs no per-instance scaling).
+        # defaults to 1.0 — except for a moon-bound shifter (#2845), whose form
+        # drinks the moonlight: a shift under a clear full moon scales the whole
+        # stat suite up (voluntary and forced shifts alike, ruled 2026-07-31).
+        instance_value = self._moon_instance_value(actor, sheet)
         try:
-            active = trigger_transformation(sheet, alt, cause="command")
+            active = trigger_transformation(
+                sheet, alt, cause="command", instance_value=instance_value
+            )
         except AlternateSelfActiveError as exc:
             # A different alt-self is already active — revert it first.
             return ActionResult(success=False, message=exc.user_message)
@@ -96,6 +101,16 @@ class ShiftFormAction(Action):
             message=f"You assume {alt.display_name or 'an alternate self'}.",
             data={"active_alternate_self_id": active.pk, "alternate_self_id": alt.pk},
         )
+
+    @staticmethod
+    def _moon_instance_value(actor: ObjectDB, sheet: Any) -> float:
+        """Moon-clarity multiplier for moon-bound shifters; 1.0 for everyone else."""
+        from world.species.moon_pull import moon_clarity_instance_value  # noqa: PLC0415
+        from world.species.moon_sensitivity import is_moon_bound  # noqa: PLC0415
+
+        if not is_moon_bound(sheet):
+            return 1.0
+        return moon_clarity_instance_value(actor, actor.location)
 
 
 @dataclass

--- a/src/world/combat/berserk_compulsion.py
+++ b/src/world/combat/berserk_compulsion.py
@@ -1,0 +1,255 @@
+"""Berserk compulsion (#2845): a berserker genuinely goes uncontrolled.
+
+Before this module, Berserk was a state flag — it derived ``in_control=False``
+(blocking form-revert) but nothing made the character act. These seams add the
+teeth, for EVERY Berserk producer (fury, the moon, future demonic sources):
+
+- **In combat** (`select_berserk_actions`): each round, a Berserk participant
+  with no declared action gets their simplest damaging technique auto-declared
+  against the first active opponent — a sibling of the NPC auto-selection
+  fallback, invoked at the same DECLARING→RESOLVING boundary. Every opponent in
+  an encounter already passed the gates to be there (risk acknowledgement,
+  hostile-cast entry), so targeting them raises no new consent question. The
+  player may steer the rage by declaring their own attack first; they cannot
+  opt out except through the break-out loop (Restore to Sense / stage decay).
+- **Retreat/parley refusal** (`reject_if_berserk`): flee, parley, and leaving
+  the encounter are refused while raging.
+- **Out of combat** (`berserk_rampage_window`): at each reconcile window a
+  Berserk character auto-engages the nearest NPC in the room through the same
+  hostile-cast seeding a deliberate attack uses; with nobody to grab, they
+  rage harmlessly. PC targets are NOT grabbed outside combat in v1 — a PC
+  becomes a valid rampage target only by entering the fight.
+
+The compulsion is deliberately modest — lowest-level pure-damage technique,
+medium effort, no combos — so round pacing keeps the pre-kill grace window
+real: nothing dies to the first swing, and bystanders get rounds to talk the
+beast down.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from evennia.objects.models import ObjectDB
+
+    from world.character_sheets.models import CharacterSheet
+    from world.combat.models import (
+        CombatEncounter,
+        CombatOpponent,
+        CombatParticipant,
+        CombatRoundAction,
+    )
+    from world.magic.models import Technique
+    from world.scenes.models import Scene
+
+logger = logging.getLogger(__name__)
+
+BERSERK_CONDITION_NAME = "Berserk"
+
+RAMPAGE_EMIT = (
+    "{name} rages at nothing and everything — claws raking the air, hunting for something to break."
+)
+BERSERK_REFUSAL = "The rage does not retreat."
+
+
+def is_berserk(character: ObjectDB) -> bool:
+    """Whether the character has an active Berserk condition."""
+    from world.conditions.services import get_active_conditions  # noqa: PLC0415
+
+    return any(
+        instance.condition.name == BERSERK_CONDITION_NAME
+        for instance in get_active_conditions(character)
+    )
+
+
+def reject_if_berserk(participant: CombatParticipant, verb: str) -> None:
+    """Raise ValueError when a Berserk participant tries to disengage.
+
+    Called by ``declare_flee`` / ``declare_parley`` / ``leave_encounter`` —
+    the rage neither retreats nor negotiates (#2845).
+    """
+    character = participant.character_sheet.character
+    if character is not None and is_berserk(character):
+        msg = f"Cannot {verb}: {BERSERK_REFUSAL.lower()}"
+        raise ValueError(msg)
+
+
+def compulsion_technique_for(sheet: CharacterSheet) -> Technique | None:
+    """The technique the rage swings with: the simplest damaging one known.
+
+    Lowest-level pure-damage pick (basic-attack-only compulsion, ruled) —
+    granted battle-form techniques qualify like any other known technique.
+    """
+    from world.magic.models.techniques import CharacterTechnique  # noqa: PLC0415
+
+    row = (
+        CharacterTechnique.objects.filter(
+            character=sheet,
+            technique__effect_type__base_power__isnull=False,
+        )
+        .select_related("technique")
+        .order_by("technique__level", "technique__pk")
+        .first()
+    )
+    return row.technique if row is not None else None
+
+
+def select_berserk_actions(encounter: CombatEncounter) -> list[CombatRoundAction]:
+    """Auto-declare attacks for Berserk participants with no declared action.
+
+    Idempotent within a round (skips participants who already declared —
+    steering their own rage counts). A participant whose declaration fails
+    validation (no anima, no target, incapacitated) simply doesn't act this
+    round; the failure is logged, never raised — the sweep must not abort
+    round resolution.
+    """
+    from world.combat.constants import OpponentStatus, ParticipantStatus  # noqa: PLC0415
+    from world.combat.models import (  # noqa: PLC0415
+        CombatOpponent,
+        CombatParticipant,
+        CombatRoundAction,
+    )
+
+    declared: list[CombatRoundAction] = []
+    participants = CombatParticipant.objects.filter(
+        encounter=encounter,
+        status=ParticipantStatus.ACTIVE,
+    ).select_related("character_sheet")
+    for participant in participants:
+        character = participant.character_sheet.character
+        if character is None or not is_berserk(character):
+            continue
+        already = CombatRoundAction.objects.filter(
+            participant=participant,
+            round_number=encounter.round_number,
+        ).exists()
+        if already:
+            continue
+        target = (
+            CombatOpponent.objects.filter(
+                encounter=encounter,
+                status=OpponentStatus.ACTIVE,
+            )
+            .exclude(objectdb=character)
+            .order_by("pk")
+            .first()
+        )
+        technique = compulsion_technique_for(participant.character_sheet)
+        if target is None or technique is None:
+            continue
+        action = _declare_rage_attack(participant, technique, target)
+        if action is not None:
+            declared.append(action)
+    return declared
+
+
+def _declare_rage_attack(
+    participant: CombatParticipant,
+    technique: Technique,
+    target: CombatOpponent,
+) -> CombatRoundAction | None:
+    """One compelled declaration; validation failures skip, never abort."""
+    from world.combat.services import declare_action  # noqa: PLC0415
+    from world.fatigue.constants import EffortLevel  # noqa: PLC0415
+
+    try:
+        return declare_action(
+            participant,
+            focused_action=technique,
+            focused_category=technique.action_category,
+            effort_level=EffortLevel.MEDIUM,
+            focused_opponent_target=target,
+            confirm_soulfray_risk=True,
+        )
+    except ValueError as exc:
+        logger.info(
+            "Berserk compulsion could not declare for participant pk=%s: %s",
+            participant.pk,
+            exc,
+        )
+        return None
+
+
+def berserk_rampage_window(character: ObjectDB) -> None:
+    """One out-of-combat rampage window for a Berserk character (#2845).
+
+    Auto-engages the nearest NPC in the room through the hostile-cast seeding
+    seam (the same entry a deliberate attack uses, so evidence, stakes, and
+    risk plumbing all ride along). With no NPC present, the rage vents
+    harmlessly — bystander PCs are never grabbed outside combat in v1.
+    """
+    from world.scenes.interaction_services import get_active_scene  # noqa: PLC0415
+
+    if not is_berserk(character):
+        return
+    if _in_uncompleted_encounter(character):
+        return
+    room = character.location
+    if room is None:
+        return
+    sheet = character.character_sheet
+    technique = compulsion_technique_for(sheet) if sheet is not None else None
+    victim_sheet = _nearest_npc_sheet(character, room)
+    scene = get_active_scene(room)
+    if sheet is None or technique is None or victim_sheet is None or scene is None:
+        room.msg_contents(RAMPAGE_EMIT.format(name=character.key))
+        return
+    _seed_rampage_encounter(sheet, victim_sheet, technique, scene, room)
+
+
+def _seed_rampage_encounter(
+    sheet: CharacterSheet,
+    victim_sheet: CharacterSheet,
+    technique: Technique,
+    scene: Scene,
+    room: ObjectDB,
+) -> None:
+    """Open (or feed) the encounter; seeding failures emit rather than raise."""
+    from world.combat.cast_seed import seed_or_feed_encounter_from_cast  # noqa: PLC0415
+
+    try:
+        seed_or_feed_encounter_from_cast(
+            caster_sheet=sheet,
+            target_sheet=victim_sheet,
+            technique=technique,
+            scene=scene,
+            room=room,
+        )
+    except ValueError as exc:
+        logger.info("Berserk rampage could not seed encounter: %s", exc)
+        room.msg_contents(RAMPAGE_EMIT.format(name=sheet.character.key))
+
+
+def _nearest_npc_sheet(character: ObjectDB, room: ObjectDB) -> CharacterSheet | None:
+    """The first living sheeted NPC co-located with the berserker."""
+    from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+    from world.vitals.services import can_act  # noqa: PLC0415
+
+    for obj in room.contents:
+        if obj == character:
+            continue
+        try:
+            if obj.db_account is not None:
+                continue
+            sheet = obj.character_sheet
+        except (AttributeError, ObjectDoesNotExist):
+            continue
+        if sheet is not None and can_act(sheet):
+            return sheet
+    return None
+
+
+def _in_uncompleted_encounter(character: ObjectDB) -> bool:
+    """Whether the character already participates in an uncompleted encounter."""
+    from world.combat.models import CombatParticipant  # noqa: PLC0415
+
+    sheet = character.character_sheet
+    if sheet is None:
+        return False
+    return CombatParticipant.objects.filter(
+        character_sheet=sheet,
+        encounter__completed_at__isnull=True,
+    ).exists()

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -1548,6 +1548,9 @@ def leave_encounter(participant: CombatParticipant) -> None:
     - the encounter type is not OPEN_ENCOUNTER, or
     - the participant is not ACTIVE.
     """
+    from world.combat.berserk_compulsion import reject_if_berserk  # noqa: PLC0415
+
+    reject_if_berserk(participant, "leave")
     enc = CombatEncounter.objects.select_for_update().get(pk=participant.encounter_id)
     if enc.status != RoundStatus.BETWEEN_ROUNDS:
         msg = (
@@ -1585,8 +1588,10 @@ def declare_flee(participant: CombatParticipant) -> CombatRoundAction:
     round resolution (_resolve_flee); the participant remains ACTIVE until
     the check succeeds.
     """
+    from world.combat.berserk_compulsion import reject_if_berserk  # noqa: PLC0415
     from world.vitals.services import is_dead  # noqa: PLC0415
 
+    reject_if_berserk(participant, "flee")
     encounter = participant.encounter
 
     # Encounter status check
@@ -2329,8 +2334,10 @@ def declare_parley(
     decisive success, calms the opponent (Calm condition → NEUTRAL allegiance).
     This function only records the declaration.
     """
+    from world.combat.berserk_compulsion import reject_if_berserk  # noqa: PLC0415
     from world.vitals.services import is_dead  # noqa: PLC0415
 
+    reject_if_berserk(participant, "parley")
     encounter = participant.encounter
     if encounter.status != RoundStatus.DECLARING:
         msg = (
@@ -10212,6 +10219,13 @@ def resolve_round(  # noqa: PLR0915 - orchestration function; already at the
     )
     if not already_selected:
         select_npc_actions(enc)
+
+    # Berserk compulsion (#2845): rage-driven participants who declared nothing
+    # get their simplest damaging technique auto-declared. Idempotent — a
+    # participant who steered their own rage (declared an attack) is skipped.
+    from world.combat.berserk_compulsion import select_berserk_actions  # noqa: PLC0415
+
+    select_berserk_actions(enc)
 
     enc.status = RoundStatus.RESOLVING
     enc.save(update_fields=["status"])

--- a/src/world/combat/tests/test_berserk_compulsion.py
+++ b/src/world/combat/tests/test_berserk_compulsion.py
@@ -1,0 +1,185 @@
+"""Berserk compulsion (#2845). SQLite tier — condition state is patched via
+``is_berserk`` (apply_condition is PG-only); declaration plumbing is observed
+at the ``_declare_rage_attack`` seam where full validation isn't the subject."""
+
+from unittest.mock import MagicMock, patch
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.combat.berserk_compulsion import (
+    berserk_rampage_window,
+    compulsion_technique_for,
+    reject_if_berserk,
+    select_berserk_actions,
+)
+from world.combat.factories import (
+    CombatEncounterFactory,
+    CombatOpponentFactory,
+    CombatParticipantFactory,
+    CombatRoundActionFactory,
+)
+from world.magic.factories import EffectTypeFactory, TechniqueFactory
+from world.magic.models.techniques import CharacterTechnique
+
+
+def _berserk_only(*characters):
+    """Patch is_berserk to be True only for the given characters."""
+    pks = {c.pk for c in characters}
+    return patch(
+        "world.combat.berserk_compulsion.is_berserk",
+        side_effect=lambda c: c is not None and c.pk in pks,
+    )
+
+
+class CompulsionTechniqueTest(TestCase):
+    def test_picks_the_simplest_damaging_technique(self):
+        sheet = CharacterSheetFactory()
+        heavy = TechniqueFactory(effect_type=EffectTypeFactory(base_power=8), level=5)
+        light = TechniqueFactory(effect_type=EffectTypeFactory(base_power=2), level=1)
+        harmless = TechniqueFactory(effect_type=EffectTypeFactory(base_power=None), level=1)
+        for technique in (heavy, light, harmless):
+            CharacterTechnique.objects.create(character=sheet, technique=technique)
+        self.assertEqual(compulsion_technique_for(sheet), light)
+
+    def test_no_damaging_technique_yields_none(self):
+        sheet = CharacterSheetFactory()
+        CharacterTechnique.objects.create(
+            character=sheet,
+            technique=TechniqueFactory(effect_type=EffectTypeFactory(base_power=None)),
+        )
+        self.assertIsNone(compulsion_technique_for(sheet))
+
+
+class SelectBerserkActionsTest(TestCase):
+    def setUp(self):
+        self.encounter = CombatEncounterFactory()
+        self.participant = CombatParticipantFactory(encounter=self.encounter)
+        self.opponent = CombatOpponentFactory(encounter=self.encounter)
+        self.character = self.participant.character_sheet.character
+        technique = TechniqueFactory(effect_type=EffectTypeFactory(base_power=3), level=1)
+        CharacterTechnique.objects.create(
+            character=self.participant.character_sheet, technique=technique
+        )
+        self.technique = technique
+
+    def test_non_berserk_participants_are_left_alone(self):
+        with (
+            _berserk_only(),
+            patch("world.combat.berserk_compulsion._declare_rage_attack") as declare,
+        ):
+            select_berserk_actions(self.encounter)
+        declare.assert_not_called()
+
+    def test_berserk_participant_gets_an_auto_attack(self):
+        with (
+            _berserk_only(self.character),
+            patch("world.combat.berserk_compulsion._declare_rage_attack") as declare,
+        ):
+            select_berserk_actions(self.encounter)
+        declare.assert_called_once()
+        _participant, technique, target = declare.call_args.args
+        self.assertEqual(technique, self.technique)
+        self.assertEqual(target, self.opponent)
+
+    def test_steered_rage_is_not_overridden(self):
+        """A berserk participant who declared their own attack keeps it."""
+        CombatRoundActionFactory(
+            participant=self.participant, round_number=self.encounter.round_number
+        )
+        with (
+            _berserk_only(self.character),
+            patch("world.combat.berserk_compulsion._declare_rage_attack") as declare,
+        ):
+            select_berserk_actions(self.encounter)
+        declare.assert_not_called()
+
+
+class RejectIfBerserkTest(TestCase):
+    def setUp(self):
+        self.participant = CombatParticipantFactory()
+        self.character = self.participant.character_sheet.character
+
+    def test_berserk_cannot_disengage(self):
+        with _berserk_only(self.character), self.assertRaises(ValueError) as caught:
+            reject_if_berserk(self.participant, "flee")
+        self.assertIn("rage does not retreat", str(caught.exception))
+
+    def test_lucid_participant_passes(self):
+        with _berserk_only():
+            reject_if_berserk(self.participant, "flee")
+
+    def test_flee_service_carries_the_guard(self):
+        from world.combat.services import declare_flee
+
+        with _berserk_only(self.character), self.assertRaises(ValueError) as caught:
+            declare_flee(self.participant)
+        self.assertIn("rage does not retreat", str(caught.exception))
+
+
+class RampageWindowTest(TestCase):
+    def setUp(self):
+        self.sheet = CharacterSheetFactory()
+        self.character = self.sheet.character
+        technique = TechniqueFactory(effect_type=EffectTypeFactory(base_power=3), level=1)
+        CharacterTechnique.objects.create(character=self.sheet, technique=technique)
+
+    def _room_with(self, *contents):
+        room = MagicMock()
+        room.contents = [self.character, *contents]
+        return room
+
+    def test_lucid_character_never_rampages(self):
+        room = self._room_with()
+        with (
+            _berserk_only(),
+            patch.object(type(self.character), "location", room, create=True),
+        ):
+            berserk_rampage_window(self.character)
+        room.msg_contents.assert_not_called()
+
+    def test_no_target_vents_harmlessly(self):
+        room = self._room_with()
+        with (
+            _berserk_only(self.character),
+            patch.object(type(self.character), "location", room, create=True),
+            patch(
+                "world.scenes.interaction_services.get_active_scene",
+                return_value=None,
+            ),
+        ):
+            berserk_rampage_window(self.character)
+        room.msg_contents.assert_called_once()
+
+    def test_npc_present_seeds_the_encounter(self):
+        npc_sheet = CharacterSheetFactory()
+        npc = npc_sheet.character
+        room = self._room_with(npc)
+        scene = MagicMock()
+        with (
+            _berserk_only(self.character),
+            patch.object(type(self.character), "location", room, create=True),
+            patch.object(type(npc), "db_account", None, create=True),
+            patch("world.vitals.services.can_act", return_value=True),
+            patch(
+                "world.scenes.interaction_services.get_active_scene",
+                return_value=scene,
+            ),
+            patch("world.combat.cast_seed.seed_or_feed_encounter_from_cast") as seed,
+        ):
+            berserk_rampage_window(self.character)
+        seed.assert_called_once()
+        self.assertEqual(seed.call_args.kwargs["target_sheet"], npc_sheet)
+
+    def test_already_fighting_defers_to_combat_compulsion(self):
+        room = self._room_with()
+        with (
+            _berserk_only(self.character),
+            patch.object(type(self.character), "location", room, create=True),
+            patch(
+                "world.combat.berserk_compulsion._in_uncompleted_encounter",
+                return_value=True,
+            ),
+        ):
+            berserk_rampage_window(self.character)
+        room.msg_contents.assert_not_called()

--- a/src/world/conditions/berserk_content.py
+++ b/src/world/conditions/berserk_content.py
@@ -15,6 +15,11 @@ Control category so `CharacterSheet.in_control` derives False while raging.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from world.conditions.models import ConditionTemplate
+
 BERSERK_CONDITION_NAME = "Berserk"
 CONTROL_CATEGORY_NAME = "Control"
 
@@ -73,5 +78,46 @@ def ensure_berserk_content() -> None:
             ),
             "rounds_to_next": None,
             "severity_multiplier": "1.00",
+        },
+    )
+    ensure_restore_to_sense_effect(template)
+
+
+def ensure_restore_to_sense_effect(berserk_template: ConditionTemplate) -> None:
+    """Seed the Restore-to-Sense removal effect targeting Berserk (#2845).
+
+    The `restore_sense` Action and its remove-condition-on-check machinery have
+    been wired since #567 but the production content never existed — only a
+    test factory. This seeds the ActionEnhancement (sourced on the Berserk
+    ConditionTemplate itself — the enhancement source only satisfies the
+    one-FK constraint; dispatch is by ``base_action_key``) and the
+    ``RemoveConditionOnCheckConfig`` rolling Persuasion. The "Restore to
+    Sense" ActionTemplate row itself rides the social-actions seeder.
+    """
+    from actions.constants import EnhancementSourceType  # noqa: PLC0415
+    from actions.models import ActionEnhancement  # noqa: PLC0415
+    from actions.models.effect_configs import RemoveConditionOnCheckConfig  # noqa: PLC0415
+    from world.checks.models import CheckType  # noqa: PLC0415
+
+    check_type = CheckType.objects.filter(name="Persuasion", is_active=True).first()
+    if check_type is None:
+        return
+    enhancement, _ = ActionEnhancement.objects.get_or_create(
+        base_action_key="restore_sense",
+        variant_name="Restore to Sense",
+        defaults={
+            "is_involuntary": False,
+            "source_type": EnhancementSourceType.CONDITION,
+            "condition": berserk_template,
+        },
+    )
+    RemoveConditionOnCheckConfig.objects.get_or_create(
+        enhancement=enhancement,
+        condition=berserk_template,
+        defaults={
+            "check_type": check_type,
+            "resistance_check_type": None,
+            "target_difficulty": None,
+            "execution_order": 0,
         },
     )

--- a/src/world/conditions/berserk_content.py
+++ b/src/world/conditions/berserk_content.py
@@ -1,0 +1,77 @@
+"""Production Berserk condition content (#2845, ADR-0171 config rows).
+
+Berserk is resolved BY NAME at runtime by every producer — the fury engine
+(`world.magic.services.fury.run_fury_for_action`) and the moon control check
+(`world.species.moon_sensitivity`) — so the row is load-bearing config, not
+optional content. Until #2845 it existed only as a test factory
+(`world.magic.factories.BerserkConditionTemplateFactory`, whose shape this
+seed mirrors exactly) plus a gitignored local fixture whose copy sits in an
+`alters_behavior=False` category and would silently fail to block form-revert.
+
+`ensure_berserk_content` therefore also HEALS a pre-existing row: whatever
+category a hand-loaded Berserk row landed in, it is re-anchored onto the
+Control category so `CharacterSheet.in_control` derives False while raging.
+"""
+
+from __future__ import annotations
+
+BERSERK_CONDITION_NAME = "Berserk"
+CONTROL_CATEGORY_NAME = "Control"
+
+
+def ensure_berserk_content() -> None:
+    """Idempotently seed (and heal) the Control category + Berserk template."""
+    from world.conditions.constants import DurationType  # noqa: PLC0415
+    from world.conditions.models import (  # noqa: PLC0415
+        ConditionCategory,
+        ConditionStage,
+        ConditionTemplate,
+    )
+
+    category, _ = ConditionCategory.objects.get_or_create(
+        name=CONTROL_CATEGORY_NAME,
+        defaults={
+            "description": (
+                "Conditions that change how a character behaves — compulsion, "
+                "charm, fear, rage — rather than only their capabilities or stats."
+            ),
+            "is_negative": True,
+            "alters_behavior": True,
+            "display_order": 20,
+        },
+    )
+    if not category.alters_behavior:
+        category.alters_behavior = True
+        category.save(update_fields=["alters_behavior"])
+
+    template, _ = ConditionTemplate.objects.get_or_create(
+        name=BERSERK_CONDITION_NAME,
+        defaults={
+            "category": category,
+            "description": (
+                "Lost to primal rage — unable to distinguish friend from foe, "
+                "and unable to let go of the shape the rage wears."
+            ),
+            "default_duration_type": DurationType.ROUNDS,
+            "default_duration_value": 3,
+            "has_progression": True,
+            "is_stackable": False,
+            "can_be_dispelled": False,
+        },
+    )
+    if template.category_id != category.pk:
+        template.category = category
+        template.save(update_fields=["category"])
+
+    ConditionStage.objects.get_or_create(
+        condition=template,
+        stage_order=1,
+        defaults={
+            "name": "Uncontrolled Rage",
+            "description": (
+                "Consumed by uncontrolled rage, lashing out at any target within reach."
+            ),
+            "rounds_to_next": None,
+            "severity_multiplier": "1.00",
+        },
+    )

--- a/src/world/conditions/services.py
+++ b/src/world/conditions/services.py
@@ -4136,6 +4136,7 @@ def ensure_conditions_content() -> None:
     Aggregates the existing poison seed with the charm/calm seed so callers have
     a single entry point for the condition content required by multiple systems.
     """
+    from world.conditions.berserk_content import ensure_berserk_content  # noqa: PLC0415
     from world.conditions.capability_content import (  # noqa: PLC0415
         ensure_at_will_shifting_capability,
     )
@@ -4143,4 +4144,5 @@ def ensure_conditions_content() -> None:
 
     ensure_poison_content()
     ensure_charm_content()
+    ensure_berserk_content()
     ensure_at_will_shifting_capability()

--- a/src/world/seeds/character_creation.py
+++ b/src/world/seeds/character_creation.py
@@ -1077,6 +1077,7 @@ def seed_character_creation_dev() -> None:
     ensure_somehow_always_broke_distinction()
     _seed_sun_sensitive_species()
     _seed_appetite_content()
+    _seed_moon_content()
     if not settings.SEED_SAMPLE_CONTENT:
         return
     # Named world content — authored in the content repo by maintainers, so
@@ -1429,6 +1430,79 @@ def _seed_appetite_content() -> None:
             species=species,
             gift=gift,
         )
+
+
+def _seed_moon_content() -> None:
+    """Moon-bound distinction + The Wolf's Fury Lycan gift grant (#2845).
+
+    Mirrors the appetite seeder: tag-anchored drawback distinction (ADR-0179),
+    MINOR gift, and a SpeciesGiftGrant stamping both on Lycans at CG. The gift
+    name was ruled by ApostateCD (TehomCD may rename in his species-gift pass).
+    """
+    from world.distinctions.models import (  # noqa: PLC0415
+        Distinction,
+        DistinctionCategory,
+        DistinctionTag,
+    )
+    from world.magic.constants import GiftKind  # noqa: PLC0415
+    from world.magic.models.gifts import Gift  # noqa: PLC0415
+    from world.seeds.sample_content import authored_or_sample  # noqa: PLC0415
+    from world.species.models import SpeciesGiftGrant  # noqa: PLC0415
+    from world.species.moon_constants import (  # noqa: PLC0415
+        MOON_BOUND_SLUG,
+        MOON_BOUND_TAG,
+        WOLFS_FURY_GIFT_NAME,
+    )
+
+    category = authored_or_sample(
+        DistinctionCategory,
+        {
+            "name": "Drawbacks",
+            "description": "PLACEHOLDER: disadvantages that reimburse CG points.",
+        },
+        slug="drawbacks",
+    )
+    if category is None:
+        return
+    tag_row = authored_or_sample(DistinctionTag, {"name": "Moon-Bound"}, slug=MOON_BOUND_TAG)
+    distinction = authored_or_sample(
+        Distinction,
+        {
+            "name": "Moon-Bound",
+            "description": (
+                "PLACEHOLDER: the moon pulls at the beast in you — under a bright "
+                "open night sky, control is a thing you must hold, not a thing you have."
+            ),
+            "category": category,
+            "cost_per_rank": 0,
+            "max_rank": 1,
+        },
+        slug=MOON_BOUND_SLUG,
+    )
+    if distinction is not None and tag_row is not None:
+        distinction.tags.add(tag_row)
+    lycan = Species.objects.filter(name="Lycan").first()
+    if lycan is None or distinction is None:
+        return
+    gift = authored_or_sample(
+        Gift,
+        {
+            "kind": GiftKind.MINOR,
+            "description": (
+                "PLACEHOLDER: the shapeshifter's gift — the battle form, and "
+                "mastery over the moon's pull as it is threaded up."
+            ),
+        },
+        name=WOLFS_FURY_GIFT_NAME,
+    )
+    if gift is None:
+        return
+    authored_or_sample(
+        SpeciesGiftGrant,
+        {"drawback_distinction": distinction, "cg_point_cost": 0},
+        species=lycan,
+        gift=gift,
+    )
 
 
 def _seed_cg_explanations() -> None:

--- a/src/world/seeds/config_prerequisites.py
+++ b/src/world/seeds/config_prerequisites.py
@@ -57,6 +57,15 @@ def _fury_rows() -> None:
     _ensure_fury_check_type(get_fury_config().check_trait)
 
 
+def _moon_rows() -> None:
+    """The `moon_control` CheckType `reconcile_moon_pull` rolls by name (#2845)."""
+    from world.species.moon_sensitivity import (  # noqa: PLC0415
+        _ensure_moon_control_check_type,
+    )
+
+    _ensure_moon_control_check_type()
+
+
 def _spread_rows() -> None:
     """Performance/Persuasion Traits + Skills the `spread a tale` deed needs."""
     from world.societies.spread_services import ensure_spread_skills  # noqa: PLC0415
@@ -165,6 +174,7 @@ CONFIG_PREREQUISITES: dict[str, Callable[[], None]] = {
     "technique_cast": _technique_cast_rows,
     "fatigue": _fatigue_rows,
     "fury": _fury_rows,
+    "moon": _moon_rows,
     "spread": _spread_rows,
     "vitals": _vitals_rows,
     "conditions": _conditions_rows,

--- a/src/world/seeds/social_actions.py
+++ b/src/world/seeds/social_actions.py
@@ -41,6 +41,10 @@ _SOCIAL_ACTION_TEMPLATES = [
     ("Feed", "Seduction", "single", "droplet", 1),
     ("Drain", "Seduction", "single", "sparkles", 1),
     ("Seduce", "Seduction", "single", "flame", 1),
+    # #2845 — talk a berserk ally down through force of personality and connection.
+    # The removal effect itself is seeded by conditions.berserk_content (the
+    # ActionEnhancement + RemoveConditionOnCheckConfig targeting Berserk).
+    ("Restore to Sense", "Persuasion", "single", "sunrise", 0),
     ("Perform", "Performance", "area", "music", 0),
     ("Entrance", "Presence", "area", "sparkles", 0),
 ]
@@ -88,6 +92,11 @@ _POOL_CONSEQUENCES: dict[str, list[tuple[str, str, int]]] = {
         ("Failure", "Advance rebuffed", 1),
         ("Partial Success", "Interest piqued but guarded", 2),
         ("Success", "Charm lands completely", 1),
+    ],
+    "Restore to Sense": [
+        ("Failure", "The beast does not hear you", 1),
+        ("Partial Success", "A flicker of the person behind the rage", 2),
+        ("Success", "Sense restored — the rage lets go", 1),
     ],
     "Seduce": [
         ("Failure", "Seduction rebuffed", 1),

--- a/src/world/species/AGENT_GLOSSARY.md
+++ b/src/world/species/AGENT_GLOSSARY.md
@@ -55,3 +55,19 @@ Domain-local vocabulary for `world.species`. Root terms live in
   and drives feeding restraint checks. In the desc footer it folds into the
   single worst-wins depletion clause. _Avoid:_ separate per-condition hunger
   lines (spam).
+- **Moon pull** — the felt instinct pressure on a moon-bound character
+  (`moon_pull.felt_moon_pull`: illumination × sky exposure − radiant shade;
+  NIGHT only). Only occlusion dampens it — clothing and modifier magic never
+  enter an instinct read. _Avoid:_ "moon exposure" (it is not a damage ladder).
+- **Moon-Bound** — the control-pressure anchor Distinction (`moon-bound` tag,
+  #2845/ADR-0183): holders roll `moon_control` (willpower + composure) under a
+  strong pull; failure forces the battle-form shift + shared Berserk. Lycans
+  innately via "The Wolf's Fury" grant. _Avoid:_ species-probed lycanthropy.
+- **Battle form** — a lycan's ALTERNATE `CharacterForm` + `FormCombatProfile`
+  stat suite (`moon_provisioning.ensure_lycan_battle_form`, lazily provisioned);
+  moon clarity scales the whole suite at shift time via `instance_value`, and
+  Wolf's-Fury thread level feeds `tuning_value`. _Avoid:_ a bespoke
+  transformation mechanic (it IS the forms alternate-self machinery).
+- **Moonlit Unease** — the Cani umbrella's flavor-only alertness condition under
+  the open night moon (`reconcile_cani_unease`). _Avoid:_ wolf-specific khati
+  subspecies (umbrella families only, ruled 2026-07-31).

--- a/src/world/species/factories.py
+++ b/src/world/species/factories.py
@@ -357,6 +357,38 @@ def ensure_appetite_distinctions() -> tuple:
     return blood, essence
 
 
+def ensure_moonlit_unease_condition() -> "ConditionTemplate":
+    """Idempotently seed the Cani Moonlit Unease condition (#2845).
+
+    A heightened-alert flavor state — mechanically inert in v1 (PLACEHOLDER);
+    applied/removed by the moon reconcile sweep while a Cani stands under the
+    open night moon.
+    """
+    from world.conditions.constants import DurationType
+    from world.conditions.models import ConditionCategory, ConditionTemplate
+    from world.species.moon_constants import MOONLIT_UNEASE_NAME
+
+    category, _created = ConditionCategory.objects.get_or_create(
+        name="Instinct",
+        defaults={"description": "Instinctive species states.", "is_negative": False},
+    )
+    template, _created = ConditionTemplate.objects.get_or_create(
+        name=MOONLIT_UNEASE_NAME,
+        defaults={
+            "category": category,
+            "description": "PLACEHOLDER: the moon watches, and the blood remembers (#2845).",
+            "player_description": (
+                "The moonlight prickles along your spine — something in you "
+                "will not settle while it watches."
+            ),
+            "observer_description": "is restless and watchful under the moonlight.",
+            "default_duration_type": DurationType.UNTIL_CURED,
+            "is_stackable": False,
+        },
+    )
+    return template
+
+
 def ensure_moon_bound_distinction() -> "Distinction":
     """Idempotently seed the Moon-Bound distinction (#2845).
 

--- a/src/world/species/factories.py
+++ b/src/world/species/factories.py
@@ -357,6 +357,48 @@ def ensure_appetite_distinctions() -> tuple:
     return blood, essence
 
 
+def ensure_moon_bound_distinction() -> "Distinction":
+    """Idempotently seed the Moon-Bound distinction (#2845).
+
+    Tag-identified anchor (ADR-0179 pattern): Lycans stamp it innately via
+    ``SpeciesGiftGrant.drawback_distinction``. Cost 0 — the moon's price is
+    the control check, not CG points.
+    """
+    from world.distinctions.models import (
+        Distinction,
+        DistinctionCategory,
+        DistinctionTag,
+    )
+    from world.species.moon_constants import MOON_BOUND_SLUG, MOON_BOUND_TAG
+
+    category, _created = DistinctionCategory.objects.get_or_create(
+        slug="drawbacks",
+        defaults={
+            "name": "Drawbacks",
+            "description": "PLACEHOLDER: disadvantages that reimburse CG points.",
+        },
+    )
+    tag, _created = DistinctionTag.objects.get_or_create(
+        slug=MOON_BOUND_TAG, defaults={"name": "Moon-Bound"}
+    )
+    distinction, _created = Distinction.objects.get_or_create(
+        slug=MOON_BOUND_SLUG,
+        defaults={
+            "name": "Moon-Bound",
+            "description": (
+                "PLACEHOLDER: the moon pulls at the beast in you — under a bright "
+                "open night sky, control is a thing you must hold, not a thing "
+                "you have."
+            ),
+            "category": category,
+            "cost_per_rank": 0,
+            "max_rank": 1,
+        },
+    )
+    distinction.tags.add(tag)
+    return distinction
+
+
 def ensure_ravenous_condition() -> "ConditionTemplate":
     """Idempotently seed the Ravenous hunger condition (#2853).
 

--- a/src/world/species/moon_constants.py
+++ b/src/world/species/moon_constants.py
@@ -1,0 +1,63 @@
+"""Tuning constants for the moon pull and lycan control checks (#2845).
+
+Every magnitude here is a PLACEHOLDER author pass — the shapes are the design,
+the numbers are first-cut values arranged to satisfy the #2845 tuning
+invariants (see world/species/tests/test_moon_pull.py and the spec on the
+issue):
+
+- Only a bright moon under an open night sky pulls at all; clouds dampen it.
+- A fresh lycan under a clear full moon faces a genuinely hard control check.
+- A mid-tier lycan (level 3) finds the same moon manageable.
+- At level 6+ the check never fires unless the character is impaired
+  (condition-driven willpower a full tier down — drink, drugs, despair).
+- A shift under a clear full moon is more fearsome than a daytime shift.
+"""
+
+# --- Base moonlight ---
+# Full-moon base at NIGHT under an open sky; scaled by illumination (0..1).
+BASE_MOON_FULL = 10
+
+# --- Pull → check gate ---
+# The control check fires only when the felt pull reaches this. A half moon
+# (base 5) never triggers; a clear full moon (10) always does; cloud shelter
+# can drag a full moon below the line.
+MOON_PULL_CHECK_THRESHOLD = 6
+
+# --- Control check difficulty ---
+# difficulty = BASE + pull × PER_PULL − level × RELIEF_PER_LEVEL − thread relief
+MOON_CONTROL_BASE_DIFFICULTY = 20
+MOON_CONTROL_DIFFICULTY_PER_PULL = 5
+MOON_CONTROL_RELIEF_PER_LEVEL = 10
+# Gift-thread mastery: relief per level of the character's thread on the
+# species gift, capped so authored content stays the ceiling.
+MOON_THREAD_RELIEF_PER_LEVEL = 5
+MOON_THREAD_RELIEF_CAP = 30
+
+# --- Tier exemption (ruled 2026-07-31) ---
+# At/above this character level the check fires only while impaired:
+# condition-driven willpower shifted a full tier (or more) below base.
+MOON_EXEMPT_LEVEL = 6
+MOON_IMPAIRMENT_WILLPOWER_DROP = 10
+
+# --- Failure consequences ---
+MOON_BERSERK_SEVERITY = 3
+MOON_BERSERK_DURATION_ROUNDS = 3
+
+# --- Battle-form clarity scaling ---
+# instance_value multiplier at shift time: 1.0 baseline (day/indoors), rising
+# with felt moonlight to 1.0 + MOON_FORM_CLARITY_MAX_BONUS under a clear full
+# moon. Applies to voluntary shifts too — the moon empowers the form
+# regardless of who chose the shift.
+MOON_FORM_CLARITY_MAX_BONUS = 0.5
+
+# --- Distinction anchoring (#2752 tag pattern; mirrors sun/appetites) ---
+MOON_BOUND_TAG = "moon-bound"
+MOON_BOUND_SLUG = "moon-bound"
+
+# --- Species gift (named by ApostateCD 2026-07-31; TehomCD may rename) ---
+WOLFS_FURY_GIFT_NAME = "The Wolf's Fury"
+
+# --- Check content (config rows named by code, ADR-0171) ---
+MOON_CONTROL_CHECK_NAME = "moon_control"
+MOON_CONTROL_WILLPOWER_WEIGHT = "1.00"
+MOON_CONTROL_COMPOSURE_WEIGHT = "0.50"

--- a/src/world/species/moon_constants.py
+++ b/src/world/species/moon_constants.py
@@ -57,6 +57,10 @@ MOON_BOUND_SLUG = "moon-bound"
 # --- Species gift (named by ApostateCD 2026-07-31; TehomCD may rename) ---
 WOLFS_FURY_GIFT_NAME = "The Wolf's Fury"
 
+# --- Cani unease (ruled 2026-07-31: the Cani umbrella carries it) ---
+CANI_SPECIES_NAME = "Cani"
+MOONLIT_UNEASE_NAME = "Moonlit Unease"
+
 # --- Check content (config rows named by code, ADR-0171) ---
 MOON_CONTROL_CHECK_NAME = "moon_control"
 MOON_CONTROL_WILLPOWER_WEIGHT = "1.00"

--- a/src/world/species/moon_provisioning.py
+++ b/src/world/species/moon_provisioning.py
@@ -1,0 +1,119 @@
+"""Lycan battle-form provisioning (#2845): the shape The Wolf's Fury wears.
+
+The battle form rides the built alternate-self machinery whole: a
+``CharacterForm`` (ALTERNATE), a ``FormCombatProfile`` stat suite, and an
+``AlternateSelf`` binding them — all per-character rows, provisioned lazily
+and idempotently. The moon reconcile calls this before a forced shift, so a
+moon-bound character self-heals a missing battle form the first time the moon
+takes them; a CG-time provisioning hook can call the same seam later.
+
+Stat magnitudes are a PLACEHOLDER author pass (sequence with TehomCD's
+species-gift content work). ``tuning_value`` bakes gift-thread mastery into
+the suite (10 = baseline; each thread level adds), refreshed on every ensure.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from world.species.moon_constants import WOLFS_FURY_GIFT_NAME
+
+if TYPE_CHECKING:
+    from world.character_sheets.models import CharacterSheet
+    from world.forms.models import AlternateSelf
+
+logger = logging.getLogger(__name__)
+
+BATTLE_FORM_NAME = "Battle Form"
+# PLACEHOLDER stat suite: (stat trait name, modifier value).
+BATTLE_FORM_STAT_SUITE = (
+    ("strength", 2),
+    ("agility", 2),
+    ("stamina", 2),
+)
+TUNING_BASELINE = 10
+TUNING_PER_THREAD_LEVEL = 1
+
+
+def ensure_lycan_battle_form(sheet: CharacterSheet) -> AlternateSelf:
+    """Idempotently provision *sheet*'s battle form; refresh thread tuning."""
+    from world.forms.models import (  # noqa: PLC0415
+        AlternateSelf,
+        CharacterForm,
+        FormCombatProfile,
+        FormCombatProfileEffect,
+        FormType,
+    )
+
+    form, _created = CharacterForm.objects.get_or_create(
+        character=sheet,
+        name=BATTLE_FORM_NAME,
+        form_type=FormType.ALTERNATE,
+    )
+    profile, _created = FormCombatProfile.objects.get_or_create(
+        form=form,
+        defaults={"display_name": WOLFS_FURY_GIFT_NAME},
+    )
+    for trait_name, value in BATTLE_FORM_STAT_SUITE:
+        target = _stat_modifier_target(trait_name)
+        if target is None:
+            continue
+        FormCombatProfileEffect.objects.get_or_create(
+            profile=profile,
+            target=target,
+            defaults={"value": value},
+        )
+    alt, _created = AlternateSelf.objects.get_or_create(
+        character=sheet,
+        form=form,
+        defaults={
+            "combat_profile": profile,
+            "display_name": BATTLE_FORM_NAME,
+        },
+    )
+    tuning = TUNING_BASELINE + _gift_thread_level(sheet) * TUNING_PER_THREAD_LEVEL
+    if alt.tuning_value != tuning or alt.combat_profile_id != profile.pk:
+        alt.tuning_value = tuning
+        alt.combat_profile = profile
+        alt.save(update_fields=["tuning_value", "combat_profile"])
+    return alt
+
+
+def _stat_modifier_target(trait_name: str):
+    """The stat-category ModifierTarget for *trait_name*, get-or-created.
+
+    Tolerant of a missing Trait row (skip, don't invent) — stat Traits are
+    content-fixture rows, mirroring fury's check-type pattern.
+    """
+    from world.mechanics.models import ModifierCategory, ModifierTarget  # noqa: PLC0415
+    from world.traits.models import Trait, TraitType  # noqa: PLC0415
+
+    trait = Trait.objects.filter(name=trait_name, trait_type=TraitType.STAT).first()
+    if trait is None:
+        return None
+    category, _created = ModifierCategory.objects.get_or_create(
+        name="stat",
+        defaults={"description": "Stat modifiers."},
+    )
+    target, _created = ModifierTarget.objects.get_or_create(
+        name=trait_name,
+        category=category,
+        defaults={"target_trait": trait},
+    )
+    if target.target_trait_id is None:
+        target.target_trait = trait
+        target.save(update_fields=["target_trait"])
+    return target
+
+
+def _gift_thread_level(sheet: CharacterSheet) -> int:
+    """Thread level on the species gift (0 when unwoven)."""
+    from world.magic.models import Thread  # noqa: PLC0415
+
+    thread = Thread.objects.filter(
+        owner=sheet,
+        target_gift__name=WOLFS_FURY_GIFT_NAME,
+        retired_at__isnull=True,
+    ).first()
+    return thread.level if thread is not None else 0

--- a/src/world/species/moon_pull.py
+++ b/src/world/species/moon_pull.py
@@ -1,0 +1,69 @@
+"""Felt moon pull (#2845) — the graded read behind lycan control checks.
+
+The instinctual sibling of ``felt_sun_exposure``, deliberately simpler: the
+pull is about what reaches the sky-exposed character, so mundane clothing and
+modifier magic never enter it — only real occlusion (roof, shade, cloud
+cover) dampens the moon:
+
+    pull = max(0, base(illumination, NIGHT, sky) - shade)
+
+Cloud cover needs no moon-side code: weather materializes area-wide shelter
+rows on the radiant damage-type axis (ADR-0180), and the same read that
+shades the sun shades the moon.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+from world.game_clock.constants import TimePhase
+from world.game_clock.services import get_ic_phase, get_moon_illumination
+from world.species.moon_constants import BASE_MOON_FULL, MOON_FORM_CLARITY_MAX_BONUS
+from world.species.sun_exposure import _shade_value, _sky_exposed
+
+
+class MoonPull(NamedTuple):
+    """Component breakdown of the moon's felt pull on one character in one room."""
+
+    base: int
+    shade: int
+    pull: int
+
+
+_NO_PULL = MoonPull(0, 0, 0)
+
+
+def felt_moon_pull(character, room) -> MoonPull:
+    """Compute *character*'s felt moon pull in *room* with full breakdown."""
+    base = _base_moonlight(room)
+    if base <= 0:
+        return _NO_PULL
+    shade = _shade_value(character, room)
+    return MoonPull(base=base, shade=shade, pull=max(0, base - shade))
+
+
+def _base_moonlight(room) -> int:
+    """Moonlight reaching *room*'s occupants before shade — NIGHT only."""
+    if not _sky_exposed(room):
+        return 0
+    if get_ic_phase() != TimePhase.NIGHT:
+        return 0
+    illumination = get_moon_illumination()
+    if illumination is None:
+        return 0
+    return round(illumination * BASE_MOON_FULL)
+
+
+def moon_clarity_instance_value(character, room) -> float:
+    """The battle-form ``instance_value`` multiplier for a shift here and now.
+
+    1.0 baseline (day, indoors, new moon); rises linearly with the felt pull
+    to ``1.0 + MOON_FORM_CLARITY_MAX_BONUS`` under a clear full moon. Applies
+    to voluntary and forced shifts alike — the moon empowers the form
+    regardless of who chose the shift (ruled 2026-07-31).
+    """
+    exposure = felt_moon_pull(character, room)
+    if exposure.pull <= 0:
+        return 1.0
+    fraction = min(1.0, exposure.pull / BASE_MOON_FULL)
+    return 1.0 + fraction * MOON_FORM_CLARITY_MAX_BONUS

--- a/src/world/species/moon_sensitivity.py
+++ b/src/world/species/moon_sensitivity.py
@@ -1,0 +1,224 @@
+"""Lycan moon-control checks (#2845): the pull, the roll, and the loss.
+
+A moon-bound character (holds a distinction carrying the ``moon-bound``
+DistinctionTag — Lycans innately, ADR-0179 anchoring) under a strong felt
+moon pull rolls a control check each reconcile window. Failure forces the
+battle-form shift (`trigger_transformation`, the built involuntary seam) and
+applies the shared **Berserk** condition — the same row the fury engine
+applies, so the not-in-control derivation, the revert block, and the Restore
+to Sense break-out all compose with zero moon-specific state.
+
+Mastery axes (ruled 2026-07-31): character level (tier), thread level on the
+species gift, and raw willpower/composure growth. At ``MOON_EXEMPT_LEVEL``+
+the check fires only while impaired — condition-driven willpower a full tier
+below base (drink, drugs, despair-class conditions).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from world.species.moon_constants import (
+    MOON_BERSERK_DURATION_ROUNDS,
+    MOON_BERSERK_SEVERITY,
+    MOON_BOUND_TAG,
+    MOON_CONTROL_BASE_DIFFICULTY,
+    MOON_CONTROL_CHECK_NAME,
+    MOON_CONTROL_COMPOSURE_WEIGHT,
+    MOON_CONTROL_DIFFICULTY_PER_PULL,
+    MOON_CONTROL_RELIEF_PER_LEVEL,
+    MOON_CONTROL_WILLPOWER_WEIGHT,
+    MOON_EXEMPT_LEVEL,
+    MOON_IMPAIRMENT_WILLPOWER_DROP,
+    MOON_PULL_CHECK_THRESHOLD,
+    MOON_THREAD_RELIEF_CAP,
+    MOON_THREAD_RELIEF_PER_LEVEL,
+    WOLFS_FURY_GIFT_NAME,
+)
+from world.species.moon_pull import felt_moon_pull, moon_clarity_instance_value
+
+if TYPE_CHECKING:
+    from world.character_sheets.models import CharacterSheet
+    from world.checks.models import CheckType
+
+logger = logging.getLogger(__name__)
+
+BERSERK_CONDITION_NAME = "Berserk"
+
+
+def is_moon_bound(sheet: CharacterSheet) -> bool:
+    """Whether *sheet* holds any distinction tagged ``moon-bound``."""
+    from world.distinctions.models import CharacterDistinction  # noqa: PLC0415
+
+    return CharacterDistinction.objects.filter(
+        character=sheet, distinction__tags__slug=MOON_BOUND_TAG
+    ).exists()
+
+
+def reconcile_moon_pull(character) -> None:
+    """One moon-bound character's control-check window (#2845).
+
+    No-ops for the unbound, the already-Berserk, and anyone below the pull
+    threshold. Failure = forced battle-form shift + shared Berserk.
+    """
+    sheet = character.character_sheet
+    if sheet is None or not is_moon_bound(sheet):
+        return
+    if _active_berserk_instance(character) is not None:
+        return
+    exposure = felt_moon_pull(character, character.location)
+    if exposure.pull < MOON_PULL_CHECK_THRESHOLD:
+        return
+    level = sheet.current_level
+    if level >= MOON_EXEMPT_LEVEL and not _is_impaired(sheet):
+        return
+    if _control_holds(character, sheet, exposure.pull, level):
+        return
+    _lose_control(character, sheet)
+
+
+def reconcile_moon_pull_safely(character) -> None:
+    """Best-effort moon reconcile for cron call sites (#2845)."""
+    from world.species.services import run_reconcile_safely  # noqa: PLC0415
+
+    run_reconcile_safely(character, reconcile_moon_pull, "moon-pull")
+
+
+def _control_holds(character, sheet: CharacterSheet, pull: int, level: int) -> bool:
+    """Roll the moon control check. Fail-open when the check type is missing."""
+    from world.checks.services import perform_check  # noqa: PLC0415
+
+    check_type = _ensure_moon_control_check_type()
+    if check_type is None:
+        logger.warning("moon_control check type unavailable; control holds by default.")
+        return True
+    difficulty = max(
+        0,
+        MOON_CONTROL_BASE_DIFFICULTY
+        + pull * MOON_CONTROL_DIFFICULTY_PER_PULL
+        - level * MOON_CONTROL_RELIEF_PER_LEVEL
+        - _thread_relief(sheet),
+    )
+    result = perform_check(character, check_type, difficulty)
+    return result.success_level > 0
+
+
+def _thread_relief(sheet: CharacterSheet) -> int:
+    """Mastery relief from the character's thread on the species gift."""
+    from world.magic.models import Thread  # noqa: PLC0415
+
+    thread = Thread.objects.filter(
+        owner=sheet,
+        target_gift__name=WOLFS_FURY_GIFT_NAME,
+        retired_at__isnull=True,
+    ).first()
+    if thread is None:
+        return 0
+    return min(MOON_THREAD_RELIEF_CAP, thread.level * MOON_THREAD_RELIEF_PER_LEVEL)
+
+
+def _is_impaired(sheet: CharacterSheet) -> bool:
+    """Condition-driven willpower a full tier (or more) below base (ruled 2026-07-31)."""
+    from world.conditions.services import get_condition_modifier_total  # noqa: PLC0415
+    from world.mechanics.models import ModifierTarget  # noqa: PLC0415
+
+    target = ModifierTarget.objects.filter(target_trait__name__iexact="willpower").first()
+    if target is None:
+        return False
+    return get_condition_modifier_total(sheet, target) <= -MOON_IMPAIRMENT_WILLPOWER_DROP
+
+
+def _lose_control(character, sheet: CharacterSheet) -> None:
+    """Failure consequences: forced shift into the battle form, then Berserk."""
+    _force_battle_form_shift(character, sheet)
+    _apply_berserk(character)
+    character.msg(
+        "|rThe moon's pull crests and something older than you answers it — "
+        "the beast takes the reins.|n"
+    )
+    location = character.location
+    if location is not None:
+        location.msg_contents(
+            f"|r{character.key} convulses under the moonlight — and what rises is "
+            "not entirely them anymore.|n",
+            exclude=[character],
+        )
+
+
+def _force_battle_form_shift(character, sheet: CharacterSheet) -> None:
+    """Shift into the battle form via the built involuntary seam, moon-scaled.
+
+    Skips silently when no battle form is provisioned (Berserk still lands) or
+    when an alternate self is already active (a voluntary shift preempts the
+    forced one — the rage simply takes over the shape they already wear).
+    """
+    from world.forms.models import ActiveAlternateSelf, AlternateSelf  # noqa: PLC0415
+    from world.forms.services.transformation import trigger_transformation  # noqa: PLC0415
+
+    if ActiveAlternateSelf.objects.filter(character=sheet).exists():
+        return
+    alt = AlternateSelf.objects.filter(character=sheet, combat_profile__isnull=False).first()
+    if alt is None:
+        return
+    clarity = moon_clarity_instance_value(character, character.location)
+    trigger_transformation(sheet, alt, cause="moon", instance_value=clarity)
+
+
+def _apply_berserk(character) -> None:
+    """Apply the shared Berserk condition (the same row fury applies)."""
+    from world.conditions.models import ConditionTemplate  # noqa: PLC0415
+    from world.conditions.services import apply_condition  # noqa: PLC0415
+
+    template = ConditionTemplate.objects.filter(name=BERSERK_CONDITION_NAME).first()
+    if template is None:
+        logger.warning("Berserk template missing; moon control loss applied no condition.")
+        return
+    apply_condition(
+        character,
+        template,
+        severity=MOON_BERSERK_SEVERITY,
+        duration_rounds=MOON_BERSERK_DURATION_ROUNDS,
+        source_character=character,
+    )
+
+
+def _active_berserk_instance(character):
+    """The character's active Berserk ConditionInstance, if any."""
+    from world.conditions.services import get_active_conditions  # noqa: PLC0415
+
+    for instance in get_active_conditions(character):
+        if instance.condition.name == BERSERK_CONDITION_NAME:
+            return instance
+    return None
+
+
+def _ensure_moon_control_check_type() -> CheckType | None:
+    """Lazy-ensure the ``moon_control`` CheckType (willpower + composure).
+
+    Config row named by a code literal (ADR-0171) — also registered in
+    ``world.seeds.config_prerequisites`` so it exists after a press.
+    """
+    from world.checks.models import CheckCategory, CheckType, CheckTypeTrait  # noqa: PLC0415
+    from world.traits.services import ensure_stat_trait  # noqa: PLC0415
+
+    category, _ = CheckCategory.objects.get_or_create(
+        name="Species",
+        defaults={"description": "Species instinct-control checks", "display_order": 97},
+    )
+    check_type, _ = CheckType.objects.get_or_create(
+        name=MOON_CONTROL_CHECK_NAME,
+        defaults={
+            "category": category,
+            "description": "Holding the self against the moon's pull (#2845).",
+        },
+    )
+    for trait_name, weight in (
+        ("willpower", MOON_CONTROL_WILLPOWER_WEIGHT),
+        ("composure", MOON_CONTROL_COMPOSURE_WEIGHT),
+    ):
+        trait = ensure_stat_trait(trait_name)
+        CheckTypeTrait.objects.get_or_create(
+            check_type=check_type, trait=trait, defaults={"weight": weight}
+        )
+    return check_type

--- a/src/world/species/moon_sensitivity.py
+++ b/src/world/species/moon_sensitivity.py
@@ -38,6 +38,11 @@ from world.species.moon_constants import (
 )
 from world.species.moon_pull import felt_moon_pull, moon_clarity_instance_value
 
+CANI_UNEASE_MESSAGE = (
+    "|wThe moonlight prickles along your spine — something old in your blood "
+    "stirs and will not settle while the moon watches.|n"
+)
+
 if TYPE_CHECKING:
     from world.character_sheets.models import CharacterSheet
     from world.checks.models import CheckType
@@ -161,7 +166,9 @@ def _force_battle_form_shift(character, sheet: CharacterSheet) -> None:
         return
     alt = AlternateSelf.objects.filter(character=sheet, combat_profile__isnull=False).first()
     if alt is None:
-        return
+        from world.species.moon_provisioning import ensure_lycan_battle_form  # noqa: PLC0415
+
+        alt = ensure_lycan_battle_form(sheet)
     clarity = moon_clarity_instance_value(character, character.location)
     trigger_transformation(sheet, alt, cause="moon", instance_value=clarity)
 
@@ -230,3 +237,55 @@ def _ensure_moon_control_check_type() -> CheckType | None:
             check_type=check_type, trait=trait, defaults={"weight": weight}
         )
     return check_type
+
+
+def reconcile_cani_unease(character) -> None:
+    """Apply/remove the Cani Moonlit Unease with the open night moon (#2845).
+
+    Ruled 2026-07-31: the Cani umbrella (wolves, hounds, all canine-touched)
+    carries the unease — khati subspecies stay umbrella families, so no
+    wolf-specific subspecies exists or should. Mechanically inert flavor state
+    in v1 (PLACEHOLDER); the message fires once, on application.
+    """
+    from world.conditions.services import (  # noqa: PLC0415
+        apply_condition,
+        get_active_conditions,
+        remove_condition,
+    )
+    from world.species.factories import ensure_moonlit_unease_condition  # noqa: PLC0415
+    from world.species.moon_constants import MOONLIT_UNEASE_NAME  # noqa: PLC0415
+
+    sheet = character.character_sheet
+    if sheet is None or not _is_cani(sheet):
+        return
+    exposure = felt_moon_pull(character, character.location)
+    active = None
+    for instance in get_active_conditions(character):
+        if instance.condition.name == MOONLIT_UNEASE_NAME:
+            active = instance
+            break
+    if exposure.pull > 0 and active is None:
+        template = ensure_moonlit_unease_condition()
+        apply_condition(character, template, severity=1, source_character=character)
+        character.msg(CANI_UNEASE_MESSAGE)
+    elif exposure.pull <= 0 and active is not None:
+        remove_condition(character, active.condition)
+
+
+def _is_cani(sheet: CharacterSheet) -> bool:
+    """Whether the sheet's species is (or descends from) the Cani umbrella."""
+    from world.species.moon_constants import CANI_SPECIES_NAME  # noqa: PLC0415
+
+    species = sheet.species
+    while species is not None:
+        if species.name == CANI_SPECIES_NAME:
+            return True
+        species = species.parent
+    return False
+
+
+def reconcile_cani_unease_safely(character) -> None:
+    """Best-effort unease reconcile for the cron sweep (#2845)."""
+    from world.species.services import run_reconcile_safely  # noqa: PLC0415
+
+    run_reconcile_safely(character, reconcile_cani_unease, "cani-unease")

--- a/src/world/species/moon_sensitivity.py
+++ b/src/world/species/moon_sensitivity.py
@@ -66,6 +66,7 @@ def reconcile_moon_pull(character) -> None:
     if sheet is None or not is_moon_bound(sheet):
         return
     if _active_berserk_instance(character) is not None:
+        _rampage_window(character)
         return
     exposure = felt_moon_pull(character, character.location)
     if exposure.pull < MOON_PULL_CHECK_THRESHOLD:
@@ -181,6 +182,13 @@ def _apply_berserk(character) -> None:
         duration_rounds=MOON_BERSERK_DURATION_ROUNDS,
         source_character=character,
     )
+
+
+def _rampage_window(character) -> None:
+    """One out-of-combat rampage window while the moon-swept character rages."""
+    from world.combat.berserk_compulsion import berserk_rampage_window  # noqa: PLC0415
+
+    berserk_rampage_window(character)
 
 
 def _active_berserk_instance(character):

--- a/src/world/species/services.py
+++ b/src/world/species/services.py
@@ -22,12 +22,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def reconcile_sun_exposure_safely(character) -> None:
-    """Best-effort reconcile for hook/cron call sites (#2846).
+def run_reconcile_safely(character, reconcile, label: str) -> None:
+    """Best-effort celestial reconcile for hook/cron call sites (#2846/#2845).
 
     Skips non-characters cheaply; isolates any reconcile failure so an equip,
     position change, or cron sweep never breaks on a bad row. Log-and-continue
-    is the interim policy (#1164) — never a silent suppress.
+    is the interim policy (#1164) — never a silent suppress. Shared by the sun
+    and moon wrappers so the broad guard exists exactly once.
     """
     try:
         sheet = character.character_sheet
@@ -36,9 +37,18 @@ def reconcile_sun_exposure_safely(character) -> None:
     if sheet is None:
         return
     try:
-        reconcile_sunlight_exposure(character, character.location)
+        reconcile(character)
     except Exception:  # the ONE ratcheted broad guard shared by every hook site
-        logger.exception("sun-exposure reconcile failed for character pk=%s", character.pk)
+        logger.exception("%s reconcile failed for character pk=%s", label, character.pk)
+
+
+def reconcile_sun_exposure_safely(character) -> None:
+    """Best-effort sun reconcile for hook/cron call sites (#2846)."""
+    run_reconcile_safely(
+        character,
+        lambda c: reconcile_sunlight_exposure(c, c.location),
+        "sun-exposure",
+    )
 
 
 def reconcile_sunlight_exposure(character, room) -> None:

--- a/src/world/species/tasks.py
+++ b/src/world/species/tasks.py
@@ -80,6 +80,31 @@ def _reconcile_safely(character) -> None:
     reconcile_sun_exposure_safely(character)
 
 
+def moon_reconcile_tick() -> None:
+    """Roll moon-control windows for every moon-bound character (#2845).
+
+    Sibling of ``sun_reconcile_tick``: sweeps holders of any ``moon-bound``
+    tagged distinction and runs their control-check window. All gating (night,
+    sky exposure, pull threshold, tier exemption, already-Berserk) lives in
+    ``reconcile_moon_pull`` — the sweep is deliberately dumb. Volume is
+    proportional to moon-bound PCs, not the grid.
+    """
+    from world.distinctions.models import CharacterDistinction  # noqa: PLC0415
+    from world.species.moon_constants import MOON_BOUND_TAG  # noqa: PLC0415
+    from world.species.moon_sensitivity import reconcile_moon_pull_safely  # noqa: PLC0415
+
+    seen: set[int] = set()
+    holder_rows = CharacterDistinction.objects.filter(
+        distinction__tags__slug=MOON_BOUND_TAG,
+    ).select_related("character")
+    for row in holder_rows:
+        character = row.character.character
+        if character is None or character.pk in seen:
+            continue
+        seen.add(character.pk)
+        reconcile_moon_pull_safely(character)
+
+
 def register_all_tasks() -> None:
     """Register species cron tasks with the game-clock scheduler."""
     register_task(
@@ -91,6 +116,18 @@ def register_all_tasks() -> None:
             description=(
                 "Reconcile sunlight exposure for sun-sensitive characters "
                 "(stationary dawn pickup + sustained-exposure escalation, #2846)."
+            ),
+        )
+    )
+    register_task(
+        CronDefinition(
+            task_key="species.moon_reconcile",
+            callable=moon_reconcile_tick,
+            interval=timedelta(minutes=5),
+            phase=CronPhase.DRAIN,
+            description=(
+                "Moon control-check windows for moon-bound characters "
+                "(forced shift + Berserk on failure, #2845)."
             ),
         )
     )

--- a/src/world/species/tasks.py
+++ b/src/world/species/tasks.py
@@ -89,9 +89,16 @@ def moon_reconcile_tick() -> None:
     ``reconcile_moon_pull`` — the sweep is deliberately dumb. Volume is
     proportional to moon-bound PCs, not the grid.
     """
+    from world.character_sheets.models import CharacterSheet  # noqa: PLC0415
     from world.distinctions.models import CharacterDistinction  # noqa: PLC0415
-    from world.species.moon_constants import MOON_BOUND_TAG  # noqa: PLC0415
-    from world.species.moon_sensitivity import reconcile_moon_pull_safely  # noqa: PLC0415
+    from world.species.moon_constants import (  # noqa: PLC0415
+        CANI_SPECIES_NAME,
+        MOON_BOUND_TAG,
+    )
+    from world.species.moon_sensitivity import (  # noqa: PLC0415
+        reconcile_cani_unease_safely,
+        reconcile_moon_pull_safely,
+    )
 
     seen: set[int] = set()
     holder_rows = CharacterDistinction.objects.filter(
@@ -103,6 +110,17 @@ def moon_reconcile_tick() -> None:
             continue
         seen.add(character.pk)
         reconcile_moon_pull_safely(character)
+    # Cani unease (ruled 2026-07-31): the umbrella subspecies feels the open
+    # night moon — a flavor condition + one-time message, applied/removed here.
+    cani_sheets = CharacterSheet.objects.filter(
+        species__name=CANI_SPECIES_NAME,
+    ) | CharacterSheet.objects.filter(species__parent__name=CANI_SPECIES_NAME)
+    for sheet in cani_sheets:
+        character = sheet.character
+        if character is None or character.pk in seen:
+            continue
+        seen.add(character.pk)
+        reconcile_cani_unease_safely(character)
 
 
 def register_all_tasks() -> None:

--- a/src/world/species/tests/test_moon_pull.py
+++ b/src/world/species/tests/test_moon_pull.py
@@ -1,7 +1,7 @@
 """Moon pull + lycan control checks (#2845). SQLite tier — apply_condition is
 PG-only, so consequence application is patched where the reconcile would reach it."""
 
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
@@ -198,3 +198,140 @@ class BerserkContentTest(TestCase):
         template = ConditionTemplate.objects.get(name="Berserk")
         self.assertTrue(template.category.alters_behavior)
         self.assertEqual(template.category.name, "Control")
+
+
+class LycanBattleFormProvisioningTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        from world.species.moon_provisioning import BATTLE_FORM_STAT_SUITE
+        from world.traits.factories import TraitFactory
+        from world.traits.models import TraitType
+
+        for trait_name, _value in BATTLE_FORM_STAT_SUITE:
+            TraitFactory(name=trait_name, trait_type=TraitType.STAT)
+
+    def test_provisions_form_profile_effects_and_alt_idempotently(self):
+        from world.forms.models import AlternateSelf, FormCombatProfileEffect
+        from world.species.moon_provisioning import (
+            BATTLE_FORM_STAT_SUITE,
+            TUNING_BASELINE,
+            ensure_lycan_battle_form,
+        )
+
+        sheet = CharacterSheetFactory()
+        alt = ensure_lycan_battle_form(sheet)
+        again = ensure_lycan_battle_form(sheet)
+        self.assertEqual(alt.pk, again.pk)
+        self.assertEqual(AlternateSelf.objects.filter(character=sheet).count(), 1)
+        self.assertIsNotNone(alt.combat_profile)
+        self.assertEqual(
+            FormCombatProfileEffect.objects.filter(profile=alt.combat_profile).count(),
+            len(BATTLE_FORM_STAT_SUITE),
+        )
+        self.assertEqual(alt.tuning_value, TUNING_BASELINE)
+
+    def test_thread_level_feeds_tuning(self):
+        from world.species.moon_provisioning import (
+            TUNING_BASELINE,
+            ensure_lycan_battle_form,
+        )
+
+        sheet = CharacterSheetFactory()
+        with patch("world.species.moon_provisioning._gift_thread_level", return_value=3):
+            alt = ensure_lycan_battle_form(sheet)
+        self.assertEqual(alt.tuning_value, TUNING_BASELINE + 3)
+
+
+class CaniUneaseTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        from world.species.factories import SpeciesFactory
+
+        cls.cani = SpeciesFactory(name="Cani")
+
+    def setUp(self):
+        self.sheet = CharacterSheetFactory(species=self.cani)
+        self.character = self.sheet.character
+        self.room = RoomProfileFactory(is_outdoor=True).objectdb
+        self.character.location = self.room
+
+    def test_moonlit_cani_gains_unease_with_message(self):
+        from world.species.moon_sensitivity import reconcile_cani_unease
+
+        with (
+            _night_full_moon(),
+            patch("world.conditions.services.apply_condition") as apply,
+            patch("world.conditions.services.get_active_conditions", return_value=[]),
+            patch.object(self.character, "msg") as msg,
+        ):
+            reconcile_cani_unease(self.character)
+        apply.assert_called_once()
+        msg.assert_called_once()
+
+    def test_non_cani_never_gains_unease(self):
+        from world.species.moon_sensitivity import reconcile_cani_unease
+
+        other = CharacterSheetFactory()
+        other.character.location = self.room
+        with (
+            _night_full_moon(),
+            patch("world.conditions.services.apply_condition") as apply,
+        ):
+            reconcile_cani_unease(other.character)
+        apply.assert_not_called()
+
+    def test_unease_clears_out_of_the_moonlight(self):
+        from world.species.factories import ensure_moonlit_unease_condition
+        from world.species.moon_sensitivity import reconcile_cani_unease
+
+        template = ensure_moonlit_unease_condition()
+        instance = MagicMock()
+        instance.condition = template
+        with (
+            patch("world.species.moon_pull.get_ic_phase", return_value=TimePhase.DAY),
+            patch(
+                "world.conditions.services.get_active_conditions",
+                return_value=[instance],
+            ),
+            patch("world.conditions.services.remove_condition") as remove,
+        ):
+            reconcile_cani_unease(self.character)
+        remove.assert_called_once()
+
+
+class RestoreToSenseContentTest(TestCase):
+    def test_seed_creates_enhancement_and_removal_config(self):
+        from actions.models import ActionEnhancement
+        from actions.models.effect_configs import RemoveConditionOnCheckConfig
+        from world.checks.models import CheckCategory, CheckType
+        from world.conditions.berserk_content import ensure_berserk_content
+
+        category, _ = CheckCategory.objects.get_or_create(name="Social")
+        CheckType.objects.get_or_create(name="Persuasion", defaults={"category": category})
+        ensure_berserk_content()
+        enhancement = ActionEnhancement.objects.get(base_action_key="restore_sense")
+        config = RemoveConditionOnCheckConfig.objects.get(enhancement=enhancement)
+        self.assertEqual(config.condition.name, "Berserk")
+        self.assertEqual(config.check_type.name, "Persuasion")
+
+
+class VoluntaryShiftMoonScalingTest(TestCase):
+    def test_unbound_shifter_gets_baseline(self):
+        from actions.definitions.forms import ShiftFormAction
+
+        sheet = CharacterSheetFactory()
+        value = ShiftFormAction._moon_instance_value(sheet.character, sheet)
+        self.assertEqual(value, 1.0)
+
+    def test_moon_bound_shifter_drinks_the_moonlight(self):
+        from actions.definitions.forms import ShiftFormAction
+
+        sheet = CharacterSheetFactory()
+        CharacterDistinction.objects.create(
+            character=sheet, distinction=ensure_moon_bound_distinction()
+        )
+        room = RoomProfileFactory(is_outdoor=True).objectdb
+        sheet.character.location = room
+        with _night_full_moon():
+            value = ShiftFormAction._moon_instance_value(sheet.character, sheet)
+        self.assertAlmostEqual(value, 1.0 + MOON_FORM_CLARITY_MAX_BONUS)

--- a/src/world/species/tests/test_moon_pull.py
+++ b/src/world/species/tests/test_moon_pull.py
@@ -1,0 +1,200 @@
+"""Moon pull + lycan control checks (#2845). SQLite tier — apply_condition is
+PG-only, so consequence application is patched where the reconcile would reach it."""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from evennia_extensions.factories import RoomProfileFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.distinctions.models import CharacterDistinction
+from world.game_clock.constants import TimePhase
+from world.species.factories import ensure_moon_bound_distinction
+from world.species.moon_constants import (
+    MOON_EXEMPT_LEVEL,
+    MOON_FORM_CLARITY_MAX_BONUS,
+    MOON_PULL_CHECK_THRESHOLD,
+)
+from world.species.moon_pull import felt_moon_pull, moon_clarity_instance_value
+from world.species.moon_sensitivity import reconcile_moon_pull
+
+
+def _night_full_moon():
+    return patch.multiple(
+        "world.species.moon_pull",
+        get_ic_phase=lambda: TimePhase.NIGHT,
+        get_moon_illumination=lambda: 1.0,
+    )
+
+
+class FeltMoonPullTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.sheet = CharacterSheetFactory()
+        cls.room = RoomProfileFactory(is_outdoor=True).objectdb
+
+    def test_daytime_pulls_nothing(self):
+        with patch("world.species.moon_pull.get_ic_phase", return_value=TimePhase.DAY):
+            exposure = felt_moon_pull(self.sheet.character, self.room)
+        self.assertEqual(exposure.pull, 0)
+
+    def test_clear_full_moon_pulls_at_full_base(self):
+        with _night_full_moon():
+            exposure = felt_moon_pull(self.sheet.character, self.room)
+        self.assertEqual(exposure.base, 10)
+        self.assertEqual(exposure.pull, 10)
+        self.assertGreaterEqual(exposure.pull, MOON_PULL_CHECK_THRESHOLD)
+
+    def test_half_moon_stays_below_the_check_threshold(self):
+        with patch.multiple(
+            "world.species.moon_pull",
+            get_ic_phase=lambda: TimePhase.NIGHT,
+            get_moon_illumination=lambda: 0.5,
+        ):
+            exposure = felt_moon_pull(self.sheet.character, self.room)
+        self.assertLess(exposure.pull, MOON_PULL_CHECK_THRESHOLD)
+
+    def test_cloud_shade_dampens_the_pull(self):
+        with (
+            _night_full_moon(),
+            patch("world.species.moon_pull._shade_value", return_value=3),
+        ):
+            exposure = felt_moon_pull(self.sheet.character, self.room)
+        self.assertEqual(exposure.pull, 7)
+
+    def test_indoors_pulls_nothing(self):
+        indoor = RoomProfileFactory(is_outdoor=False).objectdb
+        with _night_full_moon():
+            exposure = felt_moon_pull(self.sheet.character, indoor)
+        self.assertEqual(exposure.pull, 0)
+
+    def test_clarity_multiplier_scales_with_pull(self):
+        with _night_full_moon():
+            clarity = moon_clarity_instance_value(self.sheet.character, self.room)
+        self.assertAlmostEqual(clarity, 1.0 + MOON_FORM_CLARITY_MAX_BONUS)
+        with patch("world.species.moon_pull.get_ic_phase", return_value=TimePhase.DAY):
+            self.assertEqual(moon_clarity_instance_value(self.sheet.character, self.room), 1.0)
+
+
+class MoonReconcileTest(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.distinction = ensure_moon_bound_distinction()
+
+    def setUp(self):
+        self.sheet = CharacterSheetFactory()
+        self.character = self.sheet.character
+        self.room = RoomProfileFactory(is_outdoor=True).objectdb
+        self.character.location = self.room
+
+    def _bind(self):
+        CharacterDistinction.objects.create(character=self.sheet, distinction=self.distinction)
+
+    def test_unbound_character_never_checks(self):
+        with (
+            _night_full_moon(),
+            patch("world.species.moon_sensitivity._control_holds") as check,
+        ):
+            reconcile_moon_pull(self.character)
+        check.assert_not_called()
+
+    def test_weak_pull_never_checks(self):
+        self._bind()
+        with (
+            patch.multiple(
+                "world.species.moon_pull",
+                get_ic_phase=lambda: TimePhase.NIGHT,
+                get_moon_illumination=lambda: 0.4,
+            ),
+            patch("world.species.moon_sensitivity._control_holds") as check,
+        ):
+            reconcile_moon_pull(self.character)
+        check.assert_not_called()
+
+    def test_failed_check_forces_shift_and_berserk(self):
+        self._bind()
+        with (
+            _night_full_moon(),
+            patch("world.species.moon_sensitivity._control_holds", return_value=False),
+            patch("world.species.moon_sensitivity._force_battle_form_shift") as shift,
+            patch("world.species.moon_sensitivity._apply_berserk") as berserk,
+        ):
+            reconcile_moon_pull(self.character)
+        shift.assert_called_once()
+        berserk.assert_called_once()
+
+    def test_held_check_changes_nothing(self):
+        self._bind()
+        with (
+            _night_full_moon(),
+            patch("world.species.moon_sensitivity._control_holds", return_value=True),
+            patch("world.species.moon_sensitivity._lose_control") as lost,
+        ):
+            reconcile_moon_pull(self.character)
+        lost.assert_not_called()
+
+    def test_high_tier_exempt_unless_impaired(self):
+        self._bind()
+        with (
+            _night_full_moon(),
+            patch.object(
+                type(self.sheet),
+                "current_level",
+                new_callable=lambda: property(lambda _self: MOON_EXEMPT_LEVEL),
+            ),
+            patch("world.species.moon_sensitivity._is_impaired", return_value=False),
+            patch("world.species.moon_sensitivity._control_holds") as check,
+        ):
+            reconcile_moon_pull(self.character)
+        check.assert_not_called()
+        with (
+            _night_full_moon(),
+            patch.object(
+                type(self.sheet),
+                "current_level",
+                new_callable=lambda: property(lambda _self: MOON_EXEMPT_LEVEL),
+            ),
+            patch("world.species.moon_sensitivity._is_impaired", return_value=True),
+            patch("world.species.moon_sensitivity._control_holds", return_value=True) as check,
+        ):
+            reconcile_moon_pull(self.character)
+        check.assert_called_once()
+
+    def test_already_berserk_skips_the_window(self):
+        self._bind()
+        with (
+            _night_full_moon(),
+            patch(
+                "world.species.moon_sensitivity._active_berserk_instance",
+                return_value=object(),
+            ),
+            patch("world.species.moon_sensitivity._control_holds") as check,
+        ):
+            reconcile_moon_pull(self.character)
+        check.assert_not_called()
+
+
+class BerserkContentTest(TestCase):
+    def test_seed_creates_control_category_berserk(self):
+        from world.conditions.berserk_content import ensure_berserk_content
+        from world.conditions.models import ConditionTemplate
+
+        ensure_berserk_content()
+        template = ConditionTemplate.objects.get(name="Berserk")
+        self.assertTrue(template.category.alters_behavior)
+        self.assertTrue(template.has_progression)
+        self.assertEqual(template.stages.count(), 1)
+
+    def test_seed_heals_a_miscategorized_row(self):
+        """A hand-loaded Berserk in a non-behavioral category gets re-anchored."""
+        from world.conditions.berserk_content import ensure_berserk_content
+        from world.conditions.models import ConditionCategory, ConditionTemplate
+
+        wrong = ConditionCategory.objects.create(name="Emotional", alters_behavior=False)
+        ConditionTemplate.objects.create(
+            name="Berserk", category=wrong, description="fixture-shaped impostor"
+        )
+        ensure_berserk_content()
+        template = ConditionTemplate.objects.get(name="Berserk")
+        self.assertTrue(template.category.alters_behavior)
+        self.assertEqual(template.category.name, "Control")


### PR DESCRIPTION
Closes #2845

The moon/lycan arc — the last unchecked box on the umbrella (spec in the issue body, approved by ApostateCD 2026-07-31). Three commits:

## 1. Moon pull + control checks + production Berserk

- **`felt_moon_pull`** mirrors felt sun exposure, simpler by design: `illumination × sky exposure − radiant shade`, NIGHT only. Only real occlusion dampens an instinct read — clothing and modifier magic never enter it. **Cloud cover costs zero moon-side code**: weather shelter rows land on the radiant axis (ADR-0180) and the same shade read serves sun and moon.
- **Control window** (`species.moon_reconcile`, 5-min DRAIN cron): `Moon-Bound` tag-anchored holders (ADR-0179 pattern) above the pull threshold roll **`moon_control`** — willpower 1.0 + composure 0.5, both existing stats, **no new skill needed** (registered as an ADR-0171 config prerequisite). Difficulty scales with pull, down with character level and Wolf's-Fury thread level; **level 6+ exempt unless impaired** (condition-driven willpower a full tier down — the drink/drugs/despair predicate, ruled; #2852's intoxication states become its consumers when they land).
- **Failure** = forced battle-form shift via the built `trigger_transformation` seam (`cause="moon"`, `instance_value` = moon clarity — a clear full moon makes a stronger form) + the **shared Berserk condition**.
- **Berserk production seed** (`berserk_content`): the same row fury applies by name finally exists outside test factories, in a Control category with `alters_behavior=True` so `in_control` derives False and revert blocks. The seed **heals** a hand-loaded miscategorized row (the dormant emotional-ladder fixture copy would silently fail to block revert).

## 2. Berserk compulsion — a berserker genuinely goes uncontrolled

Berserk was a state flag with no behavioral teeth. Now, for **every** producer (fury, moon, future demonic rage):

- **In combat**: a Berserk participant with no declared action gets their simplest damaging technique auto-declared at the first active opponent — a sibling of the NPC auto-selection fallback at the same DECLARING→RESOLVING boundary. Steering allowed (an own-declared attack is never overridden); opting out is not.
- **Disengage refusal**: flee / parley / leave are rejected — the rage neither retreats nor negotiates.
- **Out of combat**: the reconcile-driven rampage window auto-engages the nearest sheeted NPC through `seed_or_feed_encounter_from_cast` (the same seam a deliberate attack uses — stakes/risk/evidence ride along); no NPC present → harmless rage emits. **Bystander PCs are never grabbed outside combat in v1** — a PC becomes a valid rampage target only by entering the fight.
- Basic-attack-only compulsion + round pacing keep the pre-kill grace window real: nothing dies to the first swing, and bystanders get rounds to talk the beast down.

## 3. Content: Wolf's Fury, battle form, Restore to Sense, Cani unease

- **"The Wolf's Fury"** (named by ApostateCD; TehomCD may rename): Moon-Bound drawback distinction + MINOR gift + Lycan `SpeciesGiftGrant`, seeded via `authored_or_sample`.
- **Battle form**: lazily provisioned per-character (ALTERNATE form + `FormCombatProfile` stat suite + `AlternateSelf`); Wolf's-Fury thread level feeds `tuning_value`. **Voluntary shifts drink the moonlight too** — `ShiftFormAction` passes the clarity multiplier for moon-bound shifters.
- **Restore to Sense** — wired since #567, content-free until now: the ActionTemplate rides the social-actions seeder (Persuasion) and the Berserk-removal effect config is seeded, closing the appeal-to-the-beast-within loop for every Berserk source.
- **Cani unease** (ruled: the umbrella carries it — khati subspecies stay umbrella families): Moonlit Unease flavor condition + one-time message under the open night moon.

## PLACEHOLDERs (inventory: #2844)

Difficulty/threshold/severity magnitudes in `moon_constants.py`; battle-form stat suite (sequence with TehomCD's species-gift pass); voluntary-shift capability grant for lycans (forced shift works regardless); rampage emits copy; Moonlit Unease copy; out-of-combat PC rampage targeting deferred (needs a hostile-consent read at the seeding seam — the in-combat path covers PC-vs-PC).

## Docs

ADR-0183, `docs/systems/species.md` moon section, INDEX addendum, species AGENT_GLOSSARY (Moon pull / Moon-Bound / Battle form / Moonlit Unease), `docs/roadmap/world-clock.md` consumer note. No model changes — no migrations, MODEL_MAP untouched.

## Test notes

34 new tests green on the SQLite tier (moon pull/reconcile/Berserk seed/provisioning/Cani unease/clarity scaling: 22; compulsion: 12). The actions-suite travel/condition failures seen locally are the pre-existing `areas_areaclosure` matview class (verified present with this branch's changes stashed); CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
