### PR TITLE
Design: Should GM ad-hoc checks emerge from situations rather than catalog selection?

### DIFF
--- a/docs/adr/0110-gm-content-is-catalog-and-adaptation-never-invention.md
+++ b/docs/adr/0110-gm-content-is-catalog-and-adaptation-never-invention.md
@@ -17,3 +17,21 @@ GM-facing authoring tool built after it: build the catalog, make it fast to sear
 invention itself, not just its consequences.
 
 > Status: accepted · Source: issue #2118 (rev 2 ruling by Tehom, 2026-07-09)
+
+## Addendum: ad-hoc check gate raised to SENIOR (#2857)
+
+The catalog discipline this ADR establishes prevents GMs from inventing
+*mechanics* (no free-form stat/skill, no integer difficulty, no consequence-pool
+reference). But the Arx I failure mode was broader: GMs inventing *stakes and
+outcomes* — asking players to "make a check" with arbitrary consequences narrated
+afterward. `InvokeCatalogCheckAction` already prevents consequence-pool
+selection/composition, but the GM narrates whatever they want post-roll.
+
+The fix is gating, not mechanics: `InvokeCatalogCheckAction`'s prerequisite was
+raised from `IsSceneGMPrerequisite` (any scene GM) to
+`MinimumGMLevelPrerequisite(GMLevel.SENIOR)`. Player GMs below SENIOR trust are
+funneled to `SetSituationAction`, where checks emerge from authored situations
+with pre-set outcomes. The ad-hoc check remains as a staff/senior stopgap for
+impromptu moments. The long-term direction is a lightweight "quick challenge"
+path within the situation system, so the ad-hoc check becomes unnecessary for
+everyone.

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -1885,7 +1885,9 @@ GM at a given level may author (#2000, ADR-0097).
   three catalog-only Actions in `actions/definitions/gm_adjudication.py`:
   `InvokeCatalogCheckAction` (key `gm_invoke_check` — invokes an authored `CheckType` at a
   `DifficultyChoice` band via `perform_check`, plus a `find`/list catalog-search mode; never an
-  integer difficulty or a consequence-pool reference), `GMAwardAction` (key
+  integer difficulty or a consequence-pool reference; #2857: gated on
+  `MinimumGMLevelPrerequisite(GMLevel.SENIOR)` — a staff/senior stopgap; JUNIOR/STARTING
+  player GMs are funneled to `SetSituationAction`), `GMAwardAction` (key
   `gm_award_progression` — `award_xp`/`award_development_points` with
   `ProgressionReason.GM_AWARD`, gated additionally on `MinimumGMLevelPrerequisite(GMLevel
   .JUNIOR)`; `award_type="favor_token"` (#2428) mints a Golden Hare from an org via

--- a/docs/systems/checks.md
+++ b/docs/systems/checks.md
@@ -355,8 +355,12 @@ point:
 - **Discovery**: `find`/list mode (no target) searches the catalog by name, stat+skill trait, or
   description snippet — the paved road to finding the right check instead of inventing one.
 
-Gated by `IsSceneGMPrerequisite` (`actions/prerequisites.py` — staff bypass, else
-`Scene.is_gm(actor.active_account)` on the actor's active scene). Telnet: `gm check [find
+Gated by `MinimumGMLevelPrerequisite(GMLevel.SENIOR)` (#2857 — staff bypass, else
+SENIOR-tier GM trust). JUNIOR/STARTING player GMs are funneled to
+`SetSituationAction` (`setsituation`), where checks emerge from authored
+situations with pre-set outcomes. The ad-hoc check is a staff/senior stopgap for
+impromptu moments no authored situation covers — it returns a bare graded result
+with no consequences. Telnet: `gm check [find
 <term>]` / `gm check <character> <check-type>=<band> [edge=<reason>|setback=<reason>]`
 (`commands/gm_ops.py`). Sibling actions `GMAwardAction` (`gm_award_progression`) and
 `GMApplyConditionAction` (`gm_apply_condition`) round out the GM adjudication toolkit — see

--- a/src/actions/definitions/gm_adjudication.py
+++ b/src/actions/definitions/gm_adjudication.py
@@ -138,6 +138,12 @@ class InvokeCatalogCheckAction(Action):
     -- it never selects, composes, or fires a ``ConsequenceOutcome``/consequence
     pool, and no parameter on this action could.
 
+    Gated on ``MinimumGMLevelPrerequisite(GMLevel.SENIOR)`` — the ad-hoc check
+    is a staff/senior stopgap for impromptu moments no authored situation covers.
+    Player GMs below SENIOR trust should use ``SetSituationAction``
+    (``setsituation``), where checks emerge from authored situations with pre-set
+    outcomes (ADR-0110).
+
     Two modes, discriminated by the ``target`` kwarg:
     - No ``target``: discovery/find mode. Optional ``query`` searches the catalog
       by name, stat+skill trait, or description snippet; omitted lists the head of
@@ -157,7 +163,7 @@ class InvokeCatalogCheckAction(Action):
     objectdb_target_kwargs: ClassVar[frozenset[str]] = frozenset({"target"})
 
     def get_prerequisites(self) -> list[Prerequisite]:
-        return [IsSceneGMPrerequisite()]
+        return [MinimumGMLevelPrerequisite(GMLevel.SENIOR)]
 
     def execute(
         self,

--- a/src/actions/tests/test_gm_adjudication_actions.py
+++ b/src/actions/tests/test_gm_adjudication_actions.py
@@ -90,7 +90,7 @@ class GMAdjudicationActionsTestBase(TestCase):
         self.scene = SceneFactory(location=self.room)
 
         self.gm_actor, self.gm_account = _pc_in_room(self.room, db_key="GMActor")
-        GMProfileFactory(account=self.gm_account, level=GMLevel.JUNIOR)
+        GMProfileFactory(account=self.gm_account, level=GMLevel.SENIOR)
         SceneParticipationFactory(scene=self.scene, account=self.gm_account, is_gm=True)
 
         self.starting_gm_actor, self.starting_gm_account = _pc_in_room(
@@ -98,6 +98,12 @@ class GMAdjudicationActionsTestBase(TestCase):
         )
         GMProfileFactory(account=self.starting_gm_account, level=GMLevel.STARTING)
         SceneParticipationFactory(scene=self.scene, account=self.starting_gm_account, is_gm=True)
+
+        self.junior_gm_actor, self.junior_gm_account = _pc_in_room(
+            self.room, db_key="JuniorGMActor"
+        )
+        GMProfileFactory(account=self.junior_gm_account, level=GMLevel.JUNIOR)
+        SceneParticipationFactory(scene=self.scene, account=self.junior_gm_account, is_gm=True)
 
         self.player_actor, self.player_account = _pc_in_room(self.room, db_key="PlayerActor")
         SceneParticipationFactory(scene=self.scene, account=self.player_account, is_gm=False)
@@ -137,9 +143,9 @@ class InvokeCatalogCheckActionPermissionTests(GMAdjudicationActionsTestBase):
             difficulty=DifficultyChoice.HARD,
         )
         self.assertFalse(result.success)
-        self.assertIn("scene's GM or staff", result.message)
+        self.assertIn("GM trust required", result.message)
 
-    def test_scene_gm_can_invoke(self) -> None:
+    def test_senior_gm_can_invoke(self) -> None:
         result = InvokeCatalogCheckAction().run(
             actor=self.gm_actor,
             target=self.target,
@@ -148,7 +154,7 @@ class InvokeCatalogCheckActionPermissionTests(GMAdjudicationActionsTestBase):
         )
         self.assertTrue(result.success)
 
-    def test_staff_bypasses_scene_gm_gate(self) -> None:
+    def test_staff_bypasses_gm_level_gate(self) -> None:
         result = InvokeCatalogCheckAction().run(
             actor=self.staff_actor,
             target=self.target,
@@ -157,13 +163,42 @@ class InvokeCatalogCheckActionPermissionTests(GMAdjudicationActionsTestBase):
         )
         self.assertTrue(result.success)
 
-    def test_no_level_floor_required_for_check_invocation(self) -> None:
-        """A STARTING-tier scene GM may still invoke checks (ADR-0030: player-roll resolved)."""
+    def test_starting_gm_is_blocked_from_check_invocation(self) -> None:
+        """A STARTING-tier GM may not invoke ad-hoc checks (#2857)."""
         result = InvokeCatalogCheckAction().run(
             actor=self.starting_gm_actor,
             target=self.target,
             check_type_ref=self.check_type.name,
             difficulty=DifficultyChoice.HARD,
+        )
+        self.assertFalse(result.success)
+        self.assertIn("Senior GM or higher", result.message)
+
+    def test_junior_gm_is_blocked_from_check_invocation(self) -> None:
+        """A JUNIOR-tier GM may not invoke ad-hoc checks (#2857)."""
+        result = InvokeCatalogCheckAction().run(
+            actor=self.junior_gm_actor,
+            target=self.target,
+            check_type_ref=self.check_type.name,
+            difficulty=DifficultyChoice.HARD,
+        )
+        self.assertFalse(result.success)
+        self.assertIn("Senior GM or higher", result.message)
+
+    def test_junior_gm_blocked_from_find_mode(self) -> None:
+        """Find/catalog-browse mode shares the SENIOR gate (#2857)."""
+        result = InvokeCatalogCheckAction().run(
+            actor=self.junior_gm_actor,
+            query="Strike",
+        )
+        self.assertFalse(result.success)
+        self.assertIn("Senior GM or higher", result.message)
+
+    def test_senior_gm_can_use_find_mode(self) -> None:
+        """Find/catalog-browse mode is available to SENIOR GMs (#2857)."""
+        result = InvokeCatalogCheckAction().run(
+            actor=self.gm_actor,
+            query="Strike",
         )
         self.assertTrue(result.success)
 

--- a/src/commands/gm_ops.py
+++ b/src/commands/gm_ops.py
@@ -31,6 +31,7 @@ _USAGE_CLAIM = "Usage: gm claim <request-id>"
 _USAGE_CHECK = (
     "Usage: gm check [find <term>] | gm check <character> <check-type>=<band>"
     " [edge=<reason>|setback=<reason>]"
+    " (requires Senior GM+; use 'setsituation' for consequential checks)"
 )
 _USAGE_AWARD = (
     "Usage: gm award <character> xp=<amount> [reason=<text>]"
@@ -61,8 +62,9 @@ class CmdGMDashboard(ArxCommand):
     Usage:
       gm dashboard
       gm claim <request-id>
-      gm check [find <term>]
-      gm check <character> <check-type>=<band> [edge=<reason>|setback=<reason>]
+      gm check [find <term>]                    (requires Senior GM+)
+      gm check <character> <check-type>=<band>  [edge=<reason>|setback=<reason>]
+        (requires Senior GM+; use 'setsituation' for consequential checks)
       gm award <character> xp=<amount> [reason=<text>]
       gm award <character> dev=<trait> amount=<n> [reason=<text>]
       gm award <character> hare=<organization> reason=<text>

--- a/src/commands/tests/test_gm_ops_adjudication.py
+++ b/src/commands/tests/test_gm_ops_adjudication.py
@@ -89,7 +89,7 @@ class GMOpsAdjudicationTestBase(TestCase):
         self.scene = SceneFactory(location=self.room)
 
         self.gm_actor, self.gm_account = _pc_in_room(self.room, db_key="GMOpsGM")
-        GMProfileFactory(account=self.gm_account, level=GMLevel.JUNIOR)
+        GMProfileFactory(account=self.gm_account, level=GMLevel.SENIOR)
         SceneParticipationFactory(scene=self.scene, account=self.gm_account, is_gm=True)
         self.gm_actor.msg = MagicMock()
 
@@ -151,7 +151,7 @@ class CmdGMCheckTests(GMOpsAdjudicationTestBase):
         messages = _run_cmd(
             self.player_actor, f"check {self.target.key} {self.check_type.name}=hard"
         )
-        self.assertTrue(any("scene's GM or staff" in m for m in messages))
+        self.assertTrue(any("GM trust required" in m for m in messages))
 
 
 class CmdGMAwardTests(GMOpsAdjudicationTestBase):


### PR DESCRIPTION
Closes #2857

## Summary

Raise InvokeCatalogCheckAction's gate from IsSceneGMPrerequisite (any scene GM) to MinimumGMLevelPrerequisite(GMLevel.SENIOR), funneling JUNIOR/STARTING player GMs to SetSituationAction where checks emerge from authored situations with pre-set outcomes.

## Follow-ups filed

- #2865

## Notes

- Spec: reviewed & approved on #2857 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Clean merge — no conflicts.

<!-- last-addressed-comment: 0 -->