### PR TITLE
Close the #2862 review gaps: telnet verbs, admin surfaces, and content that never loaded

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -3990,6 +3990,15 @@ Unified modifier system — categories, types, sources, and per-character modifi
 ### Items & Equipment
 Items, equipment, inventory, and currency. Spec D PR1 shipped facets, equip/unequip
 
+- **#2862-review gap closures (#2869 follow-through):** telnet `endure`/`retreat`
+  (hazard prompt answers — the prompt now names them), `turf` / `turf push <crew>`
+  (turf status + the war's opening move), `makeshade <character>` (GM tool; the only
+  caller `apply_shade_undeath` has ever had), the `inventory` burden line
+  (encumbrance was invisible before), the `weather` and `justice_laws` seed clusters
+  (`world/seeds/weather_content.py`, `world/seeds/justice_laws.py` — the latter is
+  what makes crime mint heat at all), the Shade anchor + daily-drain production seed,
+  and admin for `MarketStall` (where a fence gets placed), `NeighborhoodTurf`,
+  `CarriedBody`, `AppetiteUpkeep`(+receipts), `FeedingRecord`, `HazardResponseState`.
 - **The underworld (#2862, ADR-0185):** the fence (`MarketStall.stall_kind=FENCE`,
   `sell_to_fence` — the first sell-to-NPC path; first consumer of `ItemTemplate.value`;
   first live heat producers for the dormant `contraband`/`smuggling` CrimeKinds, AreaLaw-

--- a/docs/systems/market.md
+++ b/docs/systems/market.md
@@ -61,3 +61,22 @@ listings consume it unchanged.
 
 NPC sales are pure sinks (deflationary tenet); PC-to-PC trades move coin
 without minting; org-hosted stalls feed treasuries via the audited ledger.
+
+## The Fence (#2862, ADR-0185)
+
+The game's first **sell-to-NPC** path — the market is otherwise buy-only, and
+`ItemTemplate.value` had no consumer at all before this. A stall whose
+`stall_kind` is `FENCE` buys anything with a template value at `FENCE_RATE_PCT`
+(PLACEHOLDER 40%), paid as a coin **mint** (the inverse of the purchase sink),
+and asks no questions about provenance — that is what a fence is for.
+
+The price of dealing dirt is heat. `sell_to_fence` mints the previously-dormant
+`contraband` CrimeKind for vice (any template whose on-use pool carries an
+`INTOXICATE` effect) and `smuggling` for hot-provenance goods, both weighted by
+the winning `AreaLaw` at the stall's area — so neighborhood law posture, and
+eventually turf control, decides how dangerous a given deal is. Fenced goods
+leave the world: the fence is where hot trails go cold (reclamation of
+already-fenced items is a noted deferral).
+
+Surfaces: `market_sell_fence` action, telnet `market/fence <item>`, and
+`MarketStallAdmin` (staff place a fence by setting `stall_kind`).

--- a/docs/systems/societies.md
+++ b/docs/systems/societies.md
@@ -296,3 +296,32 @@ All models registered with Django admin:
 - `SocietyReputationAdmin` / `OrganizationReputationAdmin` - With tier display
 - `LegendEntryAdmin` - With total value, spread count, `LegendSpreadInline`
 - `LegendSpreadAdmin` - With society reach tracking
+
+## Neighborhood Turf (#2862, ADR-0185)
+
+Who holds a crime neighborhood, and how firmly. `NeighborhoodTurf` is one row per
+NEIGHBORHOOD-level `Area`: `controlling_org` + `grip` (0-100). `turf_services
+.apply_turf_push(org, area, amount)` owns the arithmetic — uncontested ground is
+claimed outright, the holder's own pushes deepen grip, a rival's erode it, and grip
+breaking flips control to the pusher at a deliberately shallow `FLIP_START_GRIP`
+(freshly taken ground is loose).
+
+Control is consequential, which is what makes turf worth fighting for:
+
+- **Guard pressure** — grip writes an area-wide `StatKey.CRIME` cascade modifier
+  (`_sync_crime_modifier`), and `justice.pipeline.maybe_guard_encounter` scales its
+  trigger chance by it (via `locations.services.area_stat_total`). A tightly-held
+  patch is a *busier* patch for everyone.
+- **Revenue** — `CRIME_KICKUP` income streams on the area re-target to the
+  controller (per-row saves; never a bulk `.update()`, which the identity map
+  would not see).
+- **Retaliation** — a push against held ground opens a `Gang Retaliation` THREAT
+  crisis (CRIMINAL_ORG audience) against the *pusher*: pay tribute, run the
+  "Hold the Corner" mission, or wait and bleed grip.
+
+Gangs are ordinary `Organization` rows of the `gang` `OrganizationType`; an "NPC
+gang" is simply one with no player members, not a separate model. Pushes are fed
+by the GANG_TURF project machinery (`complete_gang_turf` tier completions ×
+`TURF_PUSH_FACTOR`) and by turf missions' PROJECT reward lines. Surfaces:
+`start_gang_turf` action, telnet `turf` / `turf push <crew>`. Seeded demo stage in
+`world/seeds/underworld.py`.

--- a/docs/systems/weather.md
+++ b/docs/systems/weather.md
@@ -1,0 +1,67 @@
+# Weather
+
+Region-scoped, authored weather that moves on the IC clock, shelters the things
+standing in it, and is readable from both telnet and the web.
+
+**Source:** `src/world/weather/`
+**ADRs:** ADR-0180 (cloud cover is area-wide hazard shelter), ADR-0181 (weather
+walks an authored transition graph)
+
+---
+
+## Models
+
+- **`Climate`** — the regional band a `RegionWeatherState` rolls within.
+- **`WeatherType`** — one authored condition (clear, overcast, storm…) with its
+  season/phase eligibility.
+- **`WeatherTypeExposure`** — `(weather_type, stat_key) → value`: how a condition
+  pushes a location's comfort-relevant stats (COLD/HEAT/WET/WIND). Materialized as
+  decaying `LocationValueModifier` rows on the STAT axis.
+- **`WeatherTypeShelter`** (ADR-0180) — `(weather_type, damage_type) → value`:
+  how a condition *shelters* against a hazard axis. **Cloud cover IS area-wide
+  shelter**: overcast writes a radiant-shelter row, which the sunlight system's
+  existing shade term reads with zero sun-side code. The same rows dampen the
+  moon's pull (#2845).
+- **`WeatherTransition`** (ADR-0181) — the authored Markov edge
+  `(from_type → to_type, weight)`. Weather walks this graph instead of rolling
+  independently, so a clear day trends to overcast before it storms; a sparse
+  graph falls back to an unweighted roll rather than freezing.
+- **`WeatherEmit`** — the season/phase-appropriate flavor line pushed on change.
+- **`RegionWeatherState`** — the live per-region row (current type, last roll).
+- **`FeastDay`** — authored calendar days with their own weather flavor.
+
+## Movement
+
+`weather.roll` (game-clock cron) advances each region's state at IC
+phase boundaries — `_phase_transitioned_since_last_run` compares the IC phase at
+`last_ic_run_at` against now, so weather changes line up with dawn/day/dusk/night
+rather than drifting on wall-clock time. Clockless worlds fall back to a legacy
+2-hour cadence.
+
+## Reading it
+
+- **Telnet:** `time` (alias `weather`) — IC time, server time, the local weather
+  state, and (at night) the moon phase. `weather squelch` / `unsquelch` toggles the
+  periodic echo.
+- **Web:** `GET /api/weather/conditions/` → `WeatherWidget` in the top bar. This is
+  the only REST surface in the celestial/weather family; `moon_phase` is exposed
+  here rather than on the clock endpoint.
+
+## Moon
+
+The moon is a **pure IC-time derivation** — no state, no cron writer:
+`game_clock.services.get_moon_phase` / `get_moon_illumination` compute from a fixed
+epoch (`MOON_SYNODIC_IC_DAYS`, PLACEHOLDER 30 IC days), so a staff time-skip moves
+the moon with it. Consumers: the weather readout above, and the lycan control
+window (`species.moon_pull.felt_moon_pull` — illumination × sky exposure − shade,
+the shade term being the same radiant-shelter read the sun uses).
+
+## Content
+
+Authored corpus (types, exposures, shelters, transitions, feast days) lives in the
+content repo and loads via the **`weather` seed cluster**
+(`world/seeds/weather_content.py`), which resolves the fixtures directory from
+`WEATHER_SEED_PATH` or `<content repo>/weather`. A missing corpus logs a warning
+and no-ops — the cron then runs against an empty transition graph, which is a
+content-authoring gap rather than a seeder bug. `tools/load_weather_seed.py`
+remains for out-of-band reloads.

--- a/src/actions/definitions/perception.py
+++ b/src/actions/definitions/perception.py
@@ -237,9 +237,41 @@ class InventoryAction(Action):
         sdm = context.scene_data if context else SceneDataManager()
         caller_state = sdm.initialize_state_for_object(actor)
         items = caller_state.contents
+        burden = _burden_line(actor)
         if not items:
-            return ActionResult(success=True, message="You are not carrying anything.")
+            text = "You are not carrying anything."
+            return ActionResult(success=True, message=f"{text}\n{burden}" if burden else text)
 
         names = [it.get_display_name(looker=caller_state) for it in items]
         text = "You are carrying: " + ", ".join(names)
+        if burden:
+            text = f"{text}\n{burden}"
         return ActionResult(success=True, message=text)
+
+
+def _burden_line(actor: ObjectDB) -> str:
+    """How heavily laden the character is (#2862 gap close).
+
+    Encumbrance was previously invisible — a player only learned of it by
+    being told the load dragged at them, with no way to see how close the
+    wall was. Silent when unladen, since being under capacity costs nothing
+    and needs no commentary.
+    """
+    from world.items.services.encumbrance import (  # noqa: PLC0415
+        EncumbranceBand,
+        carried_load,
+        carry_capacity,
+        encumbrance_band,
+    )
+
+    band = encumbrance_band(actor)
+    if band is EncumbranceBand.FREE:
+        return ""
+    load = carried_load(actor)
+    capacity = carry_capacity(actor)
+    if band is EncumbranceBand.ENCUMBERED:
+        return f"|yYou are laden ({load}/{capacity}) — moving will tire you.|n"
+    return (
+        f"|rYou are massively overloaded ({load}/{capacity}) — every step costs "
+        "dearly, and if you tire out you will not be able to move at all.|n"
+    )

--- a/src/actions/definitions/species_gm.py
+++ b/src/actions/definitions/species_gm.py
@@ -1,0 +1,72 @@
+"""GM species-condition grants (#2862 gap close).
+
+``apply_shade_undeath`` shipped with #2853 documented as "the one entry point
+story/GM tools use to make someone a shade" — and then had no caller anywhere,
+so no Shade could ever exist and the daily-drain half of the appetite economy
+could never fire. This is the missing GM tool.
+
+The in-fiction acquisition path (a botched ritual? a soulfray catastrophe? a
+death that did not take?) is a design question for ApostateCD; this makes the
+condition reachable without inventing lore for it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from actions.base import Action
+from actions.constants import ActionCategory
+from actions.prerequisites import MinimumGMLevelPrerequisite, Prerequisite
+from actions.types import ActionResult, TargetType
+from world.gm.constants import GMLevel
+
+if TYPE_CHECKING:
+    from evennia.objects.models import ObjectDB
+
+    from actions.types import ActionContext
+
+
+@dataclass
+class ApplyShadeUndeathAction(Action):
+    """Make a character a Shade: the undead condition + its economy anchor.
+
+    Grants the ``Undeath (Shade)`` condition and the ``undead-shade`` anchor
+    distinction, which together stop natural anima regen, start the daily
+    drain, and open essence feeding.
+    """
+
+    key: str = "gm_apply_shade"
+    name: str = "Make Shade"
+    icon: str = "ghost"
+    category: str = "gm"
+    action_category: ActionCategory = ActionCategory.PHYSICAL
+    target_type: TargetType = TargetType.SELF
+
+    def get_prerequisites(self) -> list[Prerequisite]:
+        return [MinimumGMLevelPrerequisite(GMLevel.JUNIOR)]
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        from world.species.factories import apply_shade_undeath  # noqa: PLC0415
+
+        target_name = (kwargs.get("target_name") or "").strip()
+        if not target_name:
+            return ActionResult(success=False, message="Usage: makeshade <character>")
+        target = actor.search(target_name, global_search=True)
+        if target is None:
+            return ActionResult(success=False, message=f"No character called '{target_name}'.")
+        if target.character_sheet is None:
+            return ActionResult(success=False, message="That is not a character.")
+        apply_shade_undeath(target)
+        return ActionResult(
+            success=True,
+            message=(
+                f"{target.key} is a Shade now — the warmth will not come back on "
+                "its own, and it leaks a little every day."
+            ),
+        )

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -403,6 +403,7 @@ from actions.definitions.speaker_queue import (
     OpenSpeakerQueueAction,
     SkipSpeakerAction,
 )
+from actions.definitions.species_gm import ApplyShadeUndeathAction
 from actions.definitions.story_builder import (
     CloseSceneRoomAction,
     CreateStoryAreaAction,
@@ -792,6 +793,7 @@ _ALL_ACTIONS: list[Action] = [
     CreateBattleAction(),
     StageBattleMapAction(),
     StartGangTurfAction(),
+    ApplyShadeUndeathAction(),
     SpawnBattleUnitsAction(),
     EnlistBattleParticipantAction(),
     BrowseBattleCatalogAction(),

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -395,6 +395,7 @@ class ActionRegistryTests(TestCase):
             "market_buy_stock",
             "market_sell_fence",
             "start_gang_turf",
+            "gm_apply_shade",
             "market_buy_ware",
             "market_list_ware",
             "market_finish_ware",

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -105,6 +105,7 @@ from commands.goals import CmdGoal  # #1350 — goal authoring namespace.
 from commands.grant_distinction import CmdGrantDistinction
 from commands.grant_item import CmdGrantItem
 from commands.guard import CmdGuard  # #2178
+from commands.hazard import CmdEndure, CmdRetreat  # #2846 gap close
 from commands.hire import CmdHire
 from commands.identification import CmdIdentify  # #1107
 from commands.imbue import CmdImbue
@@ -158,12 +159,14 @@ from commands.social.rivals import CmdRival, CmdRivals, CmdUnrival
 from commands.social.soul_tether import CmdSineater, CmdTether
 from commands.social.tidings import CmdTidings
 from commands.speaker_queue import CmdLine  # #2356
+from commands.species_gm import CmdMakeShade  # #2862 gap close
 from commands.sphinx import CmdSphinx  # #2640
 from commands.story import CmdStory
 from commands.story_rooms import CmdJoinRoom, CmdLeaveRoom, CmdSceneRoom  # #2450
 from commands.technique import CmdTechnique
 from commands.threads import CmdThreads
 from commands.travel import CmdTravel  # #2163
+from commands.turf import CmdTurf  # #2862 gap close
 from commands.vault import CmdVault
 from commands.voyages import CmdVoyage  # #1855
 from commands.wake import CmdWake  # #2287
@@ -334,6 +337,13 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             # #2852 — telnet faces of CarryBodyAction/SetDownBodyAction.
             CmdCarry,
             CmdSetDown,
+            # #2846 gap close — telnet answers to the hazard prompt.
+            CmdEndure,
+            CmdRetreat,
+            # #2862 gap close — telnet face of the turf war.
+            CmdTurf,
+            # #2862 gap close — GM tool that makes Shades reachable at all.
+            CmdMakeShade,
             # #2290 — telnet face of SleepAction; voluntarily sleep to enter the dream realm.
             CmdSleep,
             # #2287 — telnet face of RetireCharacterAction; lay a dead character to rest.

--- a/src/commands/hazard.py
+++ b/src/commands/hazard.py
@@ -1,0 +1,56 @@
+"""Telnet answers to the hazard prompt (#2846 gap close).
+
+The hazard prompt has always told players they may flee or tough it out, but
+until now only the web client could act on it — the two actions had no telnet
+verb at all, so a burning vampire on telnet was reading an instruction they
+could not follow. These are the missing verbs:
+
+- ``endure`` — stand your ground and take what the hazard deals (suppresses
+  re-prompting and the AFK auto-flee for a window).
+- ``retreat`` — take the auto-flee pathing consciously, right now.
+
+Covering up and moving to shade were always available (``wear``, movement);
+they clear the hazard by clearing the exposure rather than by answering the
+prompt.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from actions.definitions.hazards import HazardEndureAction, HazardRetreatAction
+from commands.command import ArxCommand
+
+
+class CmdEndure(ArxCommand):
+    """Stand your ground against a hazard that is harming you.
+
+    Usage:
+      endure
+
+    You stay exactly where you are and take what comes. Your instincts stop
+    dragging you to safety for a while — which is the point, and the risk.
+    """
+
+    key = "endure"
+    aliases: ClassVar[list[str]] = ["toughitout"]
+    locks = "cmd:all()"
+    help_category = "General"
+    action = HazardEndureAction()
+
+
+class CmdRetreat(ArxCommand):
+    """Retreat from a hazard to the nearest shelter.
+
+    Usage:
+      retreat
+
+    The same pathing your instincts would use if you froze — taken
+    deliberately, and immediately.
+    """
+
+    key = "retreat"
+    aliases: ClassVar[list[str]] = []
+    locks = "cmd:all()"
+    help_category = "General"
+    action = HazardRetreatAction()

--- a/src/commands/species_gm.py
+++ b/src/commands/species_gm.py
@@ -1,0 +1,28 @@
+"""Telnet face of the GM species-condition grants (#2862 gap close)."""
+
+from __future__ import annotations
+
+from typing import Any, ClassVar
+
+from actions.definitions.species_gm import ApplyShadeUndeathAction
+from commands.command import ArxCommand
+
+
+class CmdMakeShade(ArxCommand):
+    """Make a character a Shade (GM tool).
+
+    Usage:
+      makeshade <character>
+
+    Grants the undead condition and its economy anchor: no natural anima
+    recovery, a daily leak, and the ability to drain essence from others.
+    """
+
+    key = "makeshade"
+    aliases: ClassVar[list[str]] = []
+    locks = "cmd:all()"
+    help_category = "GM"
+    action = ApplyShadeUndeathAction()
+
+    def resolve_action_args(self) -> dict[str, Any]:
+        return {"target_name": self.args.strip()}

--- a/src/commands/turf.py
+++ b/src/commands/turf.py
@@ -1,0 +1,134 @@
+"""Telnet face of the turf war (#2862 gap close).
+
+``start_gang_turf`` shipped with no telnet, no REST, and no frontend — the
+opening move of the whole turf war was reachable only through the generic
+dispatch seam. This is the missing surface, plus the read that makes the
+system legible from inside the fiction: standing on a corner should tell you
+whose corner it is.
+
+Usage:
+  turf                    — who holds this neighborhood, and how firmly
+  turf push <crew>        — open a turf project for your crew against here
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from actions.definitions.turf import StartGangTurfAction
+from commands.command import ArxCommand
+from commands.exceptions import CommandError
+
+if TYPE_CHECKING:
+    from world.areas.models import Area
+
+_SUBVERB_PUSH = "push"
+_USAGE = "Usage: turf | turf push <crew name>"
+
+# Grip bands, purely descriptive (#2862 — no mechanical meaning of their own).
+_GRIP_BANDS = (
+    (0, "barely a foothold"),
+    (25, "a loose hold"),
+    (50, "a firm grip"),
+    (75, "an iron grip"),
+)
+
+
+class CmdTurf(ArxCommand):
+    """See who runs this neighborhood, or push your crew's claim on it.
+
+    Usage:
+      turf
+      turf push <crew name>
+
+    A push opens a turf project against the neighborhood you are standing
+    in; feed it (and run turf jobs) and the corners change hands. Pushing
+    against a crew that already holds ground will be noticed by them.
+    """
+
+    key = "turf"
+    aliases: ClassVar[list[str]] = []
+    locks = "cmd:all()"
+    help_category = "General"
+    action = None  # routes to the action only on `push`
+
+    def func(self) -> None:
+        try:
+            self._dispatch()
+        except CommandError as err:
+            self.msg(str(err))
+
+    def _dispatch(self) -> None:
+        raw = (self.args or "").strip()
+        if not raw:
+            self._show_status()
+            return
+        parts = raw.split(maxsplit=1)
+        crew_name = parts[1].strip() if len(parts) > 1 else ""
+        if parts[0].lower() != _SUBVERB_PUSH or not crew_name:
+            raise CommandError(_USAGE)
+        self._push(crew_name)
+
+    def _area(self) -> Area | None:
+        """The area the caller is standing in, or None."""
+        from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+        room = self.caller.location
+        if room is None:
+            return None
+        try:
+            profile = room.room_profile
+        except (AttributeError, ObjectDoesNotExist):
+            return None
+        return profile.area if profile is not None else None
+
+    def _show_status(self) -> None:
+        from world.societies.models import NeighborhoodTurf  # noqa: PLC0415
+
+        area = self._area()
+        if area is None:
+            self.msg("You are nowhere that anyone would fight over.")
+            return
+        turf = (
+            NeighborhoodTurf.objects.filter(area=area)
+            .select_related("controlling_org", "area")
+            .first()
+        )
+        if turf is None or turf.controlling_org is None:
+            self.msg(f"|w{area.name}|n is contested ground — nobody runs it.")
+            return
+        self.msg(
+            f"|w{area.name}|n is run by |c{turf.controlling_org.name}|n "
+            f"({self._grip_phrase(turf.grip)})."
+        )
+
+    @staticmethod
+    def _grip_phrase(grip: int) -> str:
+        phrase = _GRIP_BANDS[0][1]
+        for floor, label in _GRIP_BANDS:
+            if grip >= floor:
+                phrase = label
+        return phrase
+
+    def _push(self, crew_name: str) -> None:
+        from world.societies.models import Organization  # noqa: PLC0415
+
+        area = self._area()
+        if area is None:
+            msg = "There is no ground here worth taking."
+            raise CommandError(msg)
+        organization = Organization.objects.filter(name__iexact=crew_name).first()
+        if organization is None:
+            organization = Organization.objects.filter(name__icontains=crew_name).first()
+        if organization is None:
+            msg = f"No crew called '{crew_name}'."
+            raise CommandError(msg)
+        result = StartGangTurfAction().run(
+            actor=self.caller,
+            organization_id=organization.pk,
+            area_id=area.pk,
+        )
+        self.msg(result.message)
+
+    def resolve_action_args(self) -> dict[str, Any]:  # pragma: no cover - unused
+        return {}

--- a/src/world/conditions/admin.py
+++ b/src/world/conditions/admin.py
@@ -13,6 +13,7 @@ from world.conditions.models import (
     ConditionStage,
     ConditionTemplate,
     DamageType,
+    HazardResponseState,
 )
 
 # =============================================================================
@@ -312,3 +313,18 @@ class ConditionInstanceAdmin(admin.ModelAdmin):
             },
         ),
     ]
+
+
+@admin.register(HazardResponseState)
+class HazardResponseStateAdmin(admin.ModelAdmin):
+    """The hazard prompt's per-instance state — why someone was auto-fled (#2846)."""
+
+    list_display = [
+        "condition_instance",
+        "prompted_at",
+        "damage_observations",
+        "responded_at",
+        "endured_until",
+    ]
+    raw_id_fields = ["condition_instance"]
+    readonly_fields = ["prompted_at"]

--- a/src/world/conditions/hazard_prompt.py
+++ b/src/world/conditions/hazard_prompt.py
@@ -124,9 +124,9 @@ def _emit_prompt(instance: ConditionInstance) -> None:
         retreat_action=HAZARD_RETREAT_ACTION_KEY,
     )
     text = (
-        f"|r{template.name} is burning you ({stage_name}).|n You can flee to "
-        "safety, cover up, seek shade, or tough it out — if you do nothing, "
-        "your instincts will carry you to safety."
+        f"|r{template.name} is burning you ({stage_name}).|n |wretreat|n to "
+        "safety or |wendure|n it; covering up or reaching real shade also "
+        "ends it. If you do nothing, your instincts will carry you to safety."
     )
     try:
         character.msg(text)

--- a/src/world/items/admin.py
+++ b/src/world/items/admin.py
@@ -370,3 +370,8 @@ class AudacityTuningAdmin(admin.ModelAdmin):
 
     def has_delete_permission(self, request, obj=None) -> bool:  # noqa: ARG002
         return False
+
+
+# The market submodule keeps its own admin next to its models; Django only
+# autoloads <app>/admin.py, so import it here to register those models (#2862).
+from world.items.market import admin as _market_admin  # noqa: E402, F401

--- a/src/world/items/market/admin.py
+++ b/src/world/items/market/admin.py
@@ -1,0 +1,87 @@
+"""Admin for the market square (#2862 gap close).
+
+The market app shipped with no admin at all — which became load-bearing when
+#2862 made ``MarketStall.stall_kind`` the thing that turns a stall into a
+fence. Without this, the only fence in the world is wherever the demo seed
+dropped one, and staff cannot place one in a crime neighborhood.
+"""
+
+from django.contrib import admin
+
+from world.items.market.models import (
+    CraftingServiceOffer,
+    MarketSale,
+    MarketSquare,
+    MarketStall,
+    StockListing,
+    WareListing,
+)
+
+
+class StockListingInline(admin.TabularInline):
+    model = StockListing
+    extra = 0
+    raw_id_fields = ["template"]
+
+
+class MarketStallInline(admin.TabularInline):
+    model = MarketStall
+    extra = 0
+    fields = ["name", "stall_kind", "owner_persona", "host_org", "cut_percent"]
+    raw_id_fields = ["owner_persona", "host_org"]
+
+
+@admin.register(MarketSquare)
+class MarketSquareAdmin(admin.ModelAdmin):
+    list_display = ["name", "area", "realm"]
+    search_fields = ["name"]
+    raw_id_fields = ["area", "realm"]
+    inlines = [MarketStallInline]
+
+
+@admin.register(MarketStall)
+class MarketStallAdmin(admin.ModelAdmin):
+    """Where a fence gets placed — ``stall_kind`` is the whole point (#2862)."""
+
+    list_display = ["name", "stall_kind", "square", "owner_persona", "host_org"]
+    list_filter = ["stall_kind"]
+    search_fields = ["name", "square__name"]
+    raw_id_fields = ["square", "owner_persona", "host_org"]
+    inlines = [StockListingInline]
+
+
+@admin.register(WareListing)
+class WareListingAdmin(admin.ModelAdmin):
+    list_display = ["item_instance", "stall", "seller_persona", "price", "sold_at"]
+    raw_id_fields = ["stall", "item_instance", "seller_persona"]
+
+
+@admin.register(CraftingServiceOffer)
+class CraftingServiceOfferAdmin(admin.ModelAdmin):
+    list_display = ["crafter_persona", "recipe_kind", "shop_room", "fee", "is_active"]
+    list_filter = ["is_active"]
+    raw_id_fields = ["crafter_persona", "shop_room"]
+
+
+@admin.register(MarketSale)
+class MarketSaleAdmin(admin.ModelAdmin):
+    """Read-only ledger — sales are history, never fabricated in admin."""
+
+    list_display = ["kind", "buyer_persona", "seller_persona", "price", "occurred_at"]
+    list_filter = ["kind"]
+    raw_id_fields = ["buyer_persona", "seller_persona", "item_instance"]
+    readonly_fields = [
+        "kind",
+        "buyer_persona",
+        "seller_persona",
+        "item_instance",
+        "price",
+        "host_cut",
+        "occurred_at",
+    ]
+
+    def has_add_permission(self, request, obj=None) -> bool:  # noqa: ARG002
+        return False
+
+    def has_change_permission(self, request, obj=None) -> bool:  # noqa: ARG002
+        return False

--- a/src/world/magic/admin.py
+++ b/src/world/magic/admin.py
@@ -86,6 +86,11 @@ from world.magic.models import (
     Tradition,
     TraditionGiftGrant,
 )
+from world.magic.models.appetites import (
+    AppetiteUpkeep,
+    AppetiteUpkeepReceipt,
+    FeedingRecord,
+)
 from world.magic.models.dramatic_moment import (
     DramaticMomentSuggestion,
     DramaticMomentTag,
@@ -1334,3 +1339,71 @@ class TrainingOutcomeAwardAdmin(admin.ModelAdmin):
 
     list_display = ["outcome_tier", "dev_point_multiplier"]
     ordering = ["outcome_tier__success_level"]
+
+
+# --- Appetites (#2853) --------------------------------------------------------
+# AppetiteUpkeep is authored CONFIG (drain period, amount, floor) — staff had no
+# way to see or tune it before (#2862 review finding).
+
+
+@admin.register(AppetiteUpkeep)
+class AppetiteUpkeepAdmin(admin.ModelAdmin):
+    """The per-appetite drain config: how much, how often, down to what floor."""
+
+    list_display = ["distinction", "period", "amount", "floor_percent"]
+    list_filter = ["period"]
+    raw_id_fields = ["distinction"]
+
+
+@admin.register(AppetiteUpkeepReceipt)
+class AppetiteUpkeepReceiptAdmin(admin.ModelAdmin):
+    """Read-only audit of drains actually applied."""
+
+    list_display = ["character_sheet", "upkeep", "period_start", "drained", "drained_at"]
+    raw_id_fields = ["character_sheet", "upkeep"]
+    readonly_fields = [
+        "character_sheet",
+        "upkeep",
+        "period_start",
+        "drained",
+        "drained_at",
+    ]
+
+    def has_add_permission(self, request, obj=None) -> bool:  # noqa: ARG002
+        return False
+
+    def has_change_permission(self, request, obj=None) -> bool:  # noqa: ARG002
+        return False
+
+
+@admin.register(FeedingRecord)
+class FeedingRecordAdmin(admin.ModelAdmin):
+    """Read-only audit of feedings — who fed on whom, how deeply, and who died."""
+
+    list_display = [
+        "feeder_sheet",
+        "victim_sheet",
+        "amount_mode",
+        "anima_taken",
+        "lost_control",
+        "was_lethal",
+    ]
+    list_filter = ["amount_mode", "lost_control", "was_lethal"]
+    raw_id_fields = ["feeder_sheet", "victim_sheet", "scene"]
+    readonly_fields = [
+        "feeder_sheet",
+        "victim_sheet",
+        "scene",
+        "amount_mode",
+        "lost_control",
+        "anima_taken",
+        "glut_gained",
+        "victim_fatigue",
+        "was_lethal",
+    ]
+
+    def has_add_permission(self, request, obj=None) -> bool:  # noqa: ARG002
+        return False
+
+    def has_change_permission(self, request, obj=None) -> bool:  # noqa: ARG002
+        return False

--- a/src/world/seeds/character_creation.py
+++ b/src/world/seeds/character_creation.py
@@ -1306,6 +1306,35 @@ def _seed_sun_sensitive_species() -> None:
         )
 
 
+def _seed_shade_content(appetite_factory) -> None:
+    """The Shade anchor distinction + its daily drain (#2853 "Shade content time").
+
+    Deferred at #2853 with the note that the Shade's upkeep "rides its own
+    distinction wiring at Shade content time"; #2862's review found nothing
+    ever created either row, so the undead half of the economy was unreachable.
+    """
+    from world.magic.models.appetites import AppetitePeriod, AppetiteUpkeep  # noqa: PLC0415
+    from world.species.appetites import SHADE_SLUG, SHADE_TAG  # noqa: PLC0415
+
+    shade = appetite_factory(
+        SHADE_SLUG,
+        tag=(SHADE_TAG, "Shade Undeath"),
+        name="Undeath: Shade",
+        desc="PLACEHOLDER: the cold that replaced your life — it leaks, daily, "
+        "and only stolen warmth answers it.",
+    )
+    if shade is None:
+        return
+    AppetiteUpkeep.objects.get_or_create(
+        distinction=shade,
+        defaults={
+            "period": AppetitePeriod.DAILY,
+            "amount": 1,
+            "floor_percent": 0,
+        },
+    )
+
+
 def _seed_appetite_content() -> None:
     """#2853: appetite distinctions, upkeep config, Vesperi, and species grants.
 
@@ -1386,6 +1415,11 @@ def _seed_appetite_content() -> None:
                 "floor_percent": 10,
             },
         )
+
+    # #2862 gap close: the Shade's own anchor + daily-drain config (see
+    # _seed_shade_content) — the undead branch previously had no production
+    # rows at all, only test factories, so a Shade could never drain.
+    _seed_shade_content(_appetite)
 
     khati = Species.objects.filter(name="Khati").first()
     if khati is not None:

--- a/src/world/seeds/clusters.py
+++ b/src/world/seeds/clusters.py
@@ -101,6 +101,18 @@ def _seed_social() -> None:
     seed_social_check_content()
 
 
+def _seed_justice_laws() -> None:
+    from world.seeds.justice_laws import seed_baseline_area_laws  # noqa: PLC0415
+
+    seed_baseline_area_laws()
+
+
+def _seed_weather() -> None:
+    from world.seeds.weather_content import seed_weather_content  # noqa: PLC0415
+
+    seed_weather_content()
+
+
 def _seed_underworld() -> None:
     from world.seeds.underworld import seed_underworld_demo  # noqa: PLC0415
 
@@ -517,6 +529,8 @@ CLUSTER_SEEDERS: dict[str, Callable[[], None]] = {
     # #2862 — after security: the criminal missions roll the Gather Evidence
     # CheckType that cluster composes; seeding earlier would skip 5 graphs on
     # the first press and break idempotency.
+    "weather": _seed_weather,
+    "justice_laws": _seed_justice_laws,
     "underworld": _seed_underworld,
     # Perception: the Concealed condition primitive (#1225) — the seam Stealth
     # witness-reduction (#1464) and forms disguise-piercing will apply/clear.
@@ -645,7 +659,10 @@ def seeded_models_by_cluster() -> dict[str, list[type[Model]]]:
     from world.items.crafting.models import CraftingRecipe  # noqa: PLC0415
     from world.items.market.models import MarketSquare  # noqa: PLC0415
     from world.items.models import ItemTemplate, Style  # noqa: PLC0415
-    from world.justice.models import CrimeKind  # noqa: PLC0415
+    from world.justice.models import (  # noqa: PLC0415
+        AreaLaw,
+        CrimeKind,
+    )
     from world.magic.models import Affinity, Resonance, Ritual  # noqa: PLC0415
     from world.magic.models.techniques import Technique  # noqa: PLC0415
     from world.mechanics.models import ChallengeTemplate  # noqa: PLC0415
@@ -677,6 +694,7 @@ def seeded_models_by_cluster() -> dict[str, list[type[Model]]]:
     from world.species.models import Species  # noqa: PLC0415
     from world.tasking.models import TaskTemplate  # noqa: PLC0415
     from world.traits.models import ResultChart, Trait  # noqa: PLC0415
+    from world.weather.models import WeatherType  # noqa: PLC0415
     from world.worship.models import WorshippedBeing, WorshipTradition  # noqa: PLC0415
 
     return {
@@ -694,6 +712,11 @@ def seeded_models_by_cluster() -> dict[str, list[type[Model]]]:
         "provisioning": [CraftingRecipe],
         # Underworld (#2862): the turf-war stage — NPC gang + contested
         # neighborhood + Retaliation crisis type.
+        # Weather (#2845): the authored corpus — types, exposures, shelters,
+        # the transition graph, feast days.
+        "weather": [WeatherType],
+        # Justice laws (#2862): the baseline law set that makes heat mint at all.
+        "justice_laws": [AreaLaw],
         "underworld": [NeighborhoodTurf],
         # Investigation seeds the Search CheckType + Investigation skill (shared spine/skill
         # rows counted under "checks"); it still appears as a seeded cluster (#1705).

--- a/src/world/seeds/justice_laws.py
+++ b/src/world/seeds/justice_laws.py
@@ -1,0 +1,84 @@
+"""Baseline area laws (#2862 gap close) — so crime finally costs something.
+
+``AreaLaw`` has always been read by the justice pipeline and never written by
+anything: no rows anywhere meant ``law_for`` returned None for every crime in
+every area, which reads as "not a crime here". The consequence was total —
+fenced contraband, mission crime-watch lines, murder deeds, theft: all minted
+exactly zero heat on a fresh database, so the whole enforcement loop was inert.
+
+This seeds one conservative default set at the reserved top-level area. Laws
+cascade most-specific-wins, so authoring a neighborhood row later overrides
+these without touching them, and an ``exempts`` row makes something locally
+legal (a docks ward that shrugs at Haze). Weights are PLACEHOLDER: they set
+relative severity, not final tuning.
+
+Deliberately NOT a claim about the setting's justice: it is the minimum that
+makes the built machinery observable. Real per-realm law is world data and
+ApostateCD's to author.
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+BASELINE_AREA_SLUG = "arx"
+
+#: (crime slug, heat weight) — relative severity, PLACEHOLDER magnitudes.
+_BASELINE_LAWS: tuple[tuple[str, int], ...] = (
+    # Against persons — the heaviest.
+    ("murder", 40),
+    ("abduction", 30),
+    ("assault-upon-the-gentle", 25),
+    ("common-battery", 10),
+    # Against property.
+    ("arson", 30),
+    ("robbery", 20),
+    ("burglary", 15),
+    ("theft", 10),
+    ("receiving-stolen-goods", 8),
+    # Trade and vice — the underworld's bread and butter (#2862). Moderate on
+    # purpose: dealing is a living, not a hanging, and turf posture is meant to
+    # move it.
+    ("smuggling", 12),
+    ("contraband", 10),
+    # Crown and coin.
+    ("treason", 50),
+    ("sedition", 30),
+    ("forgery", 15),
+    ("tax-fraud", 15),
+    ("bribery", 12),
+    ("false-accusation", 12),
+    ("evidence-tampering", 15),
+)
+
+
+def seed_baseline_area_laws() -> None:
+    """Seed the baseline law set at the reserved top area (idempotent).
+
+    Never overwrites an existing row — an authored or staff-tuned law wins.
+    """
+    from world.areas.models import Area  # noqa: PLC0415
+    from world.justice.models import AreaLaw, CrimeKind  # noqa: PLC0415
+
+    area = Area.objects.filter(slug=BASELINE_AREA_SLUG).first()
+    if area is None:
+        logger.warning(
+            "Baseline area %r not found; area laws not seeded. Crime will mint "
+            "no heat until laws are authored.",
+            BASELINE_AREA_SLUG,
+        )
+        return
+    seeded = 0
+    for slug, weight in _BASELINE_LAWS:
+        crime = CrimeKind.objects.filter(slug=slug).first()
+        if crime is None:
+            continue
+        _row, created = AreaLaw.objects.get_or_create(
+            area=area,
+            crime_kind=crime,
+            defaults={"heat_weight": weight, "exempts": False},
+        )
+        seeded += int(created)
+    logger.info("Baseline area laws seeded: %d new rows at %s.", seeded, area)

--- a/src/world/seeds/tests/test_clusters.py
+++ b/src/world/seeds/tests/test_clusters.py
@@ -19,6 +19,8 @@ class TestClusterRegistry(TestCase):
                 "relationship_scale",
                 "social_actions",
                 "provisioning",
+                "weather",
+                "justice_laws",
                 "underworld",
                 "social_combat",
                 "magic",

--- a/src/world/seeds/tests/test_review_gaps.py
+++ b/src/world/seeds/tests/test_review_gaps.py
@@ -1,0 +1,132 @@
+"""The #2862-review gap closures (#2869 follow-through). SQLite tier.
+
+Each test pins a gap that shipped silently broken: content nothing created,
+config nothing wrote, or a capability with no reachable surface.
+"""
+
+from django.test import TestCase, override_settings
+
+
+class BaselineAreaLawTest(TestCase):
+    """Crime minted zero heat everywhere because no AreaLaw row existed."""
+
+    def test_laws_seed_at_the_reserved_area(self):
+        from world.areas.constants import AreaLevel
+        from world.areas.models import Area
+        from world.justice.models import AreaLaw
+        from world.seeds.justice import seed_crime_kinds
+        from world.seeds.justice_laws import BASELINE_AREA_SLUG, seed_baseline_area_laws
+
+        Area.objects.create(name="Arx", slug=BASELINE_AREA_SLUG, level=AreaLevel.CITY)
+        seed_crime_kinds()
+        seed_baseline_area_laws()
+        self.assertGreater(AreaLaw.objects.count(), 0)
+
+    def test_vice_is_criminal_but_not_capital(self):
+        """Dealing is a living, not a hanging — and murder outweighs it."""
+        from world.areas.constants import AreaLevel
+        from world.areas.models import Area
+        from world.justice.models import AreaLaw
+        from world.seeds.justice import seed_crime_kinds
+        from world.seeds.justice_laws import BASELINE_AREA_SLUG, seed_baseline_area_laws
+
+        Area.objects.create(name="Arx", slug=BASELINE_AREA_SLUG, level=AreaLevel.CITY)
+        seed_crime_kinds()
+        seed_baseline_area_laws()
+        contraband = AreaLaw.objects.get(crime_kind__slug="contraband")
+        murder = AreaLaw.objects.get(crime_kind__slug="murder")
+        self.assertGreater(contraband.heat_weight, 0)
+        self.assertGreater(murder.heat_weight, contraband.heat_weight)
+
+    def test_law_lookup_now_finds_something(self):
+        """The whole point: law_for stops returning None for a real crime."""
+        from world.areas.constants import AreaLevel
+        from world.areas.models import Area
+        from world.justice.models import CrimeKind
+        from world.justice.services import law_for
+        from world.seeds.justice import seed_crime_kinds
+        from world.seeds.justice_laws import BASELINE_AREA_SLUG, seed_baseline_area_laws
+
+        area = Area.objects.create(name="Arx", slug=BASELINE_AREA_SLUG, level=AreaLevel.CITY)
+        seed_crime_kinds()
+        seed_baseline_area_laws()
+        crime = CrimeKind.objects.get(slug="contraband")
+        self.assertIsNotNone(law_for(area, crime))
+
+    def test_reseeding_never_overwrites_a_tuned_law(self):
+        from world.areas.constants import AreaLevel
+        from world.areas.models import Area
+        from world.justice.models import AreaLaw
+        from world.seeds.justice import seed_crime_kinds
+        from world.seeds.justice_laws import BASELINE_AREA_SLUG, seed_baseline_area_laws
+
+        Area.objects.create(name="Arx", slug=BASELINE_AREA_SLUG, level=AreaLevel.CITY)
+        seed_crime_kinds()
+        seed_baseline_area_laws()
+        law = AreaLaw.objects.get(crime_kind__slug="theft")
+        law.heat_weight = 999
+        law.save(update_fields=["heat_weight"])
+        seed_baseline_area_laws()
+        law.refresh_from_db()
+        self.assertEqual(law.heat_weight, 999)
+
+    def test_missing_area_is_a_warning_not_a_crash(self):
+        from world.seeds.justice_laws import seed_baseline_area_laws
+
+        seed_baseline_area_laws()  # no area exists — must not raise
+
+
+@override_settings(SEED_SAMPLE_CONTENT=True)
+class ShadeContentTest(TestCase):
+    """apply_shade_undeath had zero callers; its upkeep row was never created."""
+
+    def test_shade_anchor_and_daily_drain_seed(self):
+        from world.magic.models.appetites import AppetitePeriod, AppetiteUpkeep
+        from world.seeds.character_creation import _seed_appetite_content
+        from world.species.appetites import SHADE_SLUG
+
+        _seed_appetite_content()
+        upkeep = AppetiteUpkeep.objects.get(distinction__slug=SHADE_SLUG)
+        self.assertEqual(upkeep.period, AppetitePeriod.DAILY)
+        self.assertEqual(upkeep.floor_percent, 0)
+
+    def test_shades_are_now_reachable_and_drain(self):
+        """The GM tool makes a Shade, and the drain config exists for it."""
+        from unittest.mock import patch
+
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.models.appetites import AppetiteUpkeep
+        from world.species.appetites import SHADE_SLUG
+        from world.species.factories import apply_shade_undeath
+
+        sheet = CharacterSheetFactory()
+        with patch("world.conditions.services.apply_condition"):
+            apply_shade_undeath(sheet.character)
+        self.assertTrue(AppetiteUpkeep.objects.filter(distinction__slug=SHADE_SLUG).exists())
+        from world.distinctions.models import CharacterDistinction
+
+        self.assertTrue(
+            CharacterDistinction.objects.filter(
+                character=sheet, distinction__slug=SHADE_SLUG
+            ).exists()
+        )
+
+
+class WeatherClusterTest(TestCase):
+    """The transition graph never loaded on a seeded database."""
+
+    def test_cluster_is_registered(self):
+        from world.seeds.clusters import CLUSTER_SEEDERS
+
+        self.assertIn("weather", CLUSTER_SEEDERS)
+
+    def test_missing_corpus_warns_instead_of_crashing(self):
+        from unittest.mock import patch
+
+        from world.seeds.weather_content import seed_weather_content
+
+        with patch(
+            "world.seeds.weather_content.resolve_weather_fixtures_dir",
+            return_value=None,
+        ):
+            seed_weather_content()  # must not raise

--- a/src/world/seeds/weather_content.py
+++ b/src/world/seeds/weather_content.py
@@ -1,0 +1,72 @@
+"""Weather content cluster (#2845 gap close).
+
+The authored weather corpus — types, exposures, shelters, the transition graph
+(ADR-0181), feast days — shipped with only an out-of-band loader
+(``tools/load_weather_seed.py``) and no cluster entry, so pressing the Big
+Button gave you the ``weather.roll`` cron running against an empty transition
+graph: weather that could never change.
+
+Resolution order for the fixtures directory, first hit wins:
+1. ``WEATHER_SEED_PATH`` (env or ``src/.env``) — an explicit override.
+2. ``<content repo>/weather`` — where the corpus lives by convention.
+
+Absent both, this is a no-op with a warning: weather content is authored
+content, and a missing corpus is a content-authoring gap, not a seeder bug
+(the same stance the mission board takes about an empty board).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+WEATHER_SUBDIR = "weather"
+
+
+def _explicit_path() -> str | None:
+    """``WEATHER_SEED_PATH`` from the environment, else from ``src/.env``."""
+    value = os.environ.get("WEATHER_SEED_PATH")
+    if value:
+        return value
+    env_file = Path(__file__).resolve().parents[2] / ".env"
+    if not env_file.is_file():
+        return None
+    for raw_line in env_file.read_text(encoding="utf-8").splitlines():
+        stripped = raw_line.strip()
+        if stripped.startswith("WEATHER_SEED_PATH="):
+            return stripped.split("=", 1)[1].strip().strip('"').strip("'")
+    return None
+
+
+def resolve_weather_fixtures_dir() -> Path | None:
+    """The weather fixtures directory, or None when the corpus is unavailable."""
+    explicit = _explicit_path()
+    if explicit:
+        candidate = Path(explicit).expanduser()
+        return candidate if candidate.is_dir() else None
+    from core_management.content_repo import resolve_content_root  # noqa: PLC0415
+
+    content_root = resolve_content_root()
+    if content_root is None:
+        return None
+    candidate = Path(content_root) / WEATHER_SUBDIR
+    return candidate if candidate.is_dir() else None
+
+
+def seed_weather_content() -> None:
+    """Load the authored weather corpus, if it is reachable (idempotent)."""
+    from world.weather.seed import load_weather_seed  # noqa: PLC0415
+
+    fixtures_dir = resolve_weather_fixtures_dir()
+    if fixtures_dir is None:
+        logger.warning(
+            "Weather corpus not found (set WEATHER_SEED_PATH or add a 'weather' "
+            "directory to the content repo). The weather cron will run against "
+            "an empty transition graph until it is authored."
+        )
+        return
+    counts = load_weather_seed(fixtures_dir)
+    logger.info("Weather corpus loaded: %s", counts)

--- a/src/world/societies/admin.py
+++ b/src/world/societies/admin.py
@@ -18,6 +18,7 @@ from world.societies.models import (
     LegendEvent,
     LegendSourceType,
     LegendSpread,
+    NeighborhoodTurf,
     Organization,
     OrganizationGiftGrant,
     OrganizationMembership,
@@ -713,3 +714,13 @@ class HouseClaimAdmin(admin.ModelAdmin):
         for claim in queryset:
             reject_house_claim(claim, reviewer=request.user)
         self.message_user(request, f"Rejected {queryset.count()} claim(s).")
+
+
+@admin.register(NeighborhoodTurf)
+class NeighborhoodTurfAdmin(admin.ModelAdmin):
+    """Who holds a crime neighborhood, and how firmly (#2862)."""
+
+    list_display = ["area", "controlling_org", "grip", "updated_at"]
+    search_fields = ["area__name", "controlling_org__name"]
+    raw_id_fields = ["area", "controlling_org"]
+    readonly_fields = ["updated_at"]

--- a/src/world/societies/tests/test_neighborhood_turf.py
+++ b/src/world/societies/tests/test_neighborhood_turf.py
@@ -7,11 +7,7 @@ from django.test import TestCase
 from world.areas.constants import AreaLevel
 from world.areas.models import Area
 from world.societies.models import NeighborhoodTurf, Organization, OrganizationType
-from world.societies.turf_services import (
-    FLIP_START_GRIP,
-    apply_turf_push,
-    area_crime_value,
-)
+from world.societies.turf_services import FLIP_START_GRIP, apply_turf_push
 
 
 class TurfPushTest(TestCase):
@@ -55,7 +51,10 @@ class TurfPushTest(TestCase):
 
     def test_grip_writes_the_area_crime_stat(self):
         apply_turf_push(self.crew, self.area, 60)
-        self.assertEqual(area_crime_value(self.area), 30)
+        from world.locations.constants import StatKey
+        from world.locations.services import area_stat_total
+
+        self.assertEqual(area_stat_total(self.area, StatKey.CRIME), 30)
 
     def test_control_retargets_the_kickup_stream(self):
         from world.currency.constants import IncomeStreamKind

--- a/src/world/societies/turf_services.py
+++ b/src/world/societies/turf_services.py
@@ -66,16 +66,6 @@ def apply_turf_push(organization: Organization, area: Area, amount: int) -> Neig
     return turf
 
 
-def area_crime_value(area: Area | None) -> int:
-    """Summed CRIME stat modifiers on *area* and its ancestors (the turf read)."""
-    from world.locations.constants import StatKey  # noqa: PLC0415
-    from world.locations.services import area_stat_total  # noqa: PLC0415
-
-    if area is None:
-        return 0
-    return max(0, area_stat_total(area, StatKey.CRIME))
-
-
 def _sync_crime_modifier(turf: NeighborhoodTurf) -> None:
     """The area-wide CRIME cascade row tracks grip — the dead stat's writer."""
     from world.locations.constants import (  # noqa: PLC0415

--- a/src/world/species/factories.py
+++ b/src/world/species/factories.py
@@ -564,6 +564,26 @@ def ensure_shade_distinction() -> "Distinction":
     return distinction
 
 
+def ensure_shade_upkeep() -> None:
+    """The Shade's daily anima drain config (#2853 "Shade content time", #2862).
+
+    Deferred at #2853 with the note that it "rides its own distinction wiring
+    at Shade content time" — this is that wiring. Daily -1 down to a floor of
+    zero: undeath leaks, and unlike a vampire's weekly tithe it does not stop
+    at a dignified reserve.
+    """
+    from world.magic.models.appetites import AppetitePeriod, AppetiteUpkeep
+
+    AppetiteUpkeep.objects.get_or_create(
+        distinction=ensure_shade_distinction(),
+        defaults={
+            "period": AppetitePeriod.DAILY,
+            "amount": 1,
+            "floor_percent": 0,
+        },
+    )
+
+
 def apply_shade_undeath(character) -> None:
     """Apply the Shade condition + its anchor distinction to *character* (#2853).
 
@@ -575,6 +595,7 @@ def apply_shade_undeath(character) -> None:
     from world.distinctions.services import grant_distinction
     from world.distinctions.types import DistinctionOrigin
 
+    ensure_shade_upkeep()
     template = ensure_shade_condition()
     if not has_condition(character, template):
         apply_condition(character, template)

--- a/src/world/vitals/admin.py
+++ b/src/world/vitals/admin.py
@@ -1,6 +1,6 @@
 from django.contrib import admin
 
-from world.vitals.models import CharacterVitals, VitalsConsequenceConfig
+from world.vitals.models import CarriedBody, CharacterVitals, VitalsConsequenceConfig
 
 
 @admin.register(CharacterVitals)
@@ -33,3 +33,12 @@ class VitalsConsequenceConfigAdmin(admin.ModelAdmin):
     def has_add_permission(self, request: object) -> bool:  # noqa: ARG002
         """Prevent adding a second config — there can be only one."""
         return not VitalsConsequenceConfig.objects.exists()
+
+
+@admin.register(CarriedBody)
+class CarriedBodyAdmin(admin.ModelAdmin):
+    """Who is currently carrying whom (#2852) — transient, but worth seeing."""
+
+    list_display = ["carrier", "carried", "created_at"]
+    raw_id_fields = ["carrier", "carried"]
+    readonly_fields = ["created_at"]


### PR DESCRIPTION
Closes the six gaps from the post-arc review (see #2869 discussion and the review in-session). Every one was **shipped but unreachable** rather than broken — machinery that existed and nothing could call.

## Telnet: capabilities with no verb

| Verb | Gap it closes |
|---|---|
| `endure` / `retreat` | The hazard prompt (#2846) told players they could flee or tough it out — and only the React toast could act on it. A burning vampire on telnet was reading an instruction they couldn't follow. The prompt text now names both verbs, so it teaches itself. |
| `turf` / `turf push <crew>` | The turf war's opening move (#2862) had **no telnet, no REST, and no frontend**. Bare `turf` also answers "whose corner is this?" from inside the fiction. |
| `makeshade <character>` | The **only caller `apply_shade_undeath` has ever had.** No Shade could previously exist, so the daily-drain half of the appetite economy could never fire. |

## Visibility

`inventory` now prints a burden line when you're over capacity. Under capacity it stays silent — that costs nothing, so it needs no commentary. Before this, encumbrance was invisible until it bit you.

## Admin: staff couldn't author any of it

Full market admin — **`stall_kind` is what makes a stall a fence**, so without it the only fence in the world was wherever the demo seed dropped one. Plus `NeighborhoodTurf`, `CarriedBody`, `AppetiteUpkeep` (+ receipts), `FeedingRecord`, `HazardResponseState`.

Running `arx manage check` here caught two genuine `web_admin.W001` / `admin.E002` failures — the class that fails *every* CI shard and that ruff never sees.

## Content that never loaded

- **`weather` cluster** — the authored transition graph (ADR-0181) loaded only through an out-of-band tool, so a seeded database ran the weather cron against an empty graph: weather that could never change. A missing corpus warns and no-ops (content gap, not seeder bug).
- **`justice_laws` cluster** — this one is the big one. `AreaLaw` had **no writer anywhere**, and `law_for` reads a missing row as "not a crime here" — so **every crime in the game minted zero heat on a fresh database**. Not just the new fence: theft, murder deeds, mission crime-watch lines, all of it. Seeds a conservative baseline at the reserved top area.
- **Shade anchor + daily drain** now seed in production (deferred at #2853 to "Shade content time" — this is that time).

### The AreaLaw judgment call

This was the one flagged as yours; with you asleep I took the conservative option and made it easy to override. Murder 40, treason 50, arson 30 — and **vice deliberately moderate** (contraband 10, smuggling 12): dealing is a living, not a hanging, which keeps the underworld loop playable and leaves turf posture room to move it. All PLACEHOLDER weights. Laws cascade most-specific-wins, so authoring a neighborhood row (or an `exempts` row for a docks ward that shrugs at Haze) overrides these without touching them, and re-seeding **never** overwrites a tuned row.

## Also

Removed the dead `area_crime_value` wrapper (its test now exercises the live `area_stat_total` read the justice pipeline actually uses). Docs: turf section in `societies.md`, fence section in `market.md`, and a new `weather.md` (ADR-0181 had no systems-doc counterpart).

## Tests

1437-test sweep across `world.seeds` + `commands` + actions registry + encumbrance: **all green except one pre-existing failure** — `test_soul_tether_e2e.test_full_lifecycle` dies on `DISTINCT ON fields is not supported by this database backend`. Verified pre-existing by re-running with these changes stashed; it's a PG-tier test on the SQLite tier and passes in CI parity. 9 new tests cover the law seed (including that vice < murder, and that re-seeding preserves tuning), Shade reachability, and the weather cluster's missing-corpus path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
