### PR TITLE
Species codex grant walks Species.parent, so subspecies characters get the umbrella entry

### DIFF
--- a/docs/systems/codex.md
+++ b/docs/systems/codex.md
@@ -57,6 +57,41 @@ its own entry *and* every ancestor's — see `docs/systems/species.md`.
 
 ---
 
+## Granting an entry: one path only (#2880)
+
+**`world.codex.services.grant_codex_entry(roster_entry, entry, *, learned_from=None)` is
+the only sanctioned way to land a character on KNOWN.** It returns
+`(knowledge, newly_known)` and is idempotent.
+
+Landing on KNOWN is not just a column value — it stamps `learned_at` and fires
+`world.stories.services.reactivity.on_codex_entry_unlocked`, so `CODEX_ENTRY_UNLOCKED`
+beats re-evaluate. That hook lives on `CharacterCodexKnowledge.add_progress`, which #939
+chose deliberately: *"a separate service wrapper used to carry the hook and every caller
+bypassed it; reactivity now lives on the only path."*
+
+The bypass came back anyway. `add_progress` returns early unless the row is UNCOVERED,
+and seven callers were creating rows with `status=KNOWN` directly — all six
+character-creation grants (beginnings, path, distinction, tradition, species, gift
+resonance) and the crossing ceremony. Those characters got the column value and neither
+the timestamp nor the hook. `grant_codex_entry` therefore does **not** set the status
+itself: it opens the row UNCOVERED and pushes progress past the threshold, keeping the
+transition on the one path that carries the reactivity.
+
+Two callers deliberately create UNCOVERED rows and must keep doing so, because they mean
+"you can start researching this," not "you know this":
+
+- the `GRANT_CODEX` consequence effect (`world.mechanics.effect_handlers`) — a scene hands
+  you a lead, not the answer;
+- `CodexTeachingOffer.accept` — the learner has paid AP and now has to make progress.
+
+**Not yet wired: achievements.** `CodexEntry` does not inherit
+`world.achievements.models.DiscoverableContent` (Technique, ComboDefinition and
+SignatureMotifBonus do), so no codex entry can carry a `discovery_achievement`, and
+nothing calls `announce_access_change` or `increment_stat` for codex knowledge.
+`grant_codex_entry` is the seam that would carry it.
+
+---
+
 ## Key Methods
 
 ### CodexSubject

--- a/docs/systems/codex.md
+++ b/docs/systems/codex.md
@@ -50,6 +50,11 @@ from world.codex.constants import CodexKnowledgeStatus
 | `DistinctionCodexGrant` | Codex entries granted by a Distinction | `distinction`, `entry` |
 | `TraditionCodexGrant` | Codex entries granted by a Tradition | `tradition`, `entry` |
 
+Species are the exception: there is no `SpeciesCodexGrant` table. `Species.codex_entry`
+is a plain nullable FK on the species row (one entry per species, not many), and
+`_finalize_species_codex` walks `Species.parent` so a subspecies character receives
+its own entry *and* every ancestor's — see `docs/systems/species.md`.
+
 ---
 
 ## Key Methods

--- a/docs/systems/species.md
+++ b/docs/systems/species.md
@@ -115,6 +115,20 @@ Species uses a single-level parent/child hierarchy:
 
 Access control for which species are available in CG is handled by `Beginnings.allowed_species` in the `character_creation` app, not in this model.
 
+### Codex entries follow the hierarchy (#2880)
+
+`Species.codex_entry` is a nullable FK to one `codex.CodexEntry`. The grant at CG
+finalize (`character_creation.services._finalize_species_codex`) does **not** read
+that field directly — it reads `Species.codex_entries`, which walks `Species.lineage`
+(the species followed by every ancestor, nearest first) and collects each non-null
+entry. So a Vulpi character is granted the Vulpi entry *and* the Khati umbrella entry.
+
+This is what makes the authored split work: the umbrella entry (Khati, Elf, Infernal)
+carries what the kinds share, and each kind entry carries the kind. Reading only the
+leaf's own field — the pre-#2880 behavior — left the three umbrella entries reachable
+by nobody who picked a subspecies. Ancestors whose `codex_entry` is still null drop
+out rather than contributing a `None`.
+
 ## Appetites (#2853, ADR-0182)
 
 Hunger is tag-anchored like sun sensitivity: `Appetite: Blood` (Vampire, Dhampir),
@@ -168,6 +182,12 @@ species.get_stat_bonuses_dict()
 # Access children (subspecies)
 species.children.all()
 
+# The species and every ancestor, nearest first (cycle-safe)
+species.lineage  # [Vulpi, Khati]
+
+# Every codex entry a character of this species is owed (#2880)
+species.codex_entries  # [<CodexEntry: The Vulpi>, <CodexEntry: The Khati>]
+
 # Access starting languages
 species.starting_languages.all()
 
@@ -192,7 +212,7 @@ str(bonus)  # "Infernal: -1 Charm"
 
 ## Integration Points
 
-- **Forms System** (`world.forms`): `SpeciesFormTrait` links species to available physical appearance traits and options for CG — the per-species **palette**; `is_required=True` marks species identity markers (horns for True Infernals) that CG must fill.
+- **Forms System** (`world.forms`): `SpeciesFormTrait` links species to available physical appearance traits and options for CG — the per-species **palette**; `is_required=True` marks species identity markers (horns and a tail for Infernals) that CG must fill.
 - **Character Creation** (`world.character_creation`): `Beginnings.allowed_species` controls which species are selectable during character creation.
 - **Traits System** (`world.traits`): `SpeciesStatBonus.stat` uses `PrimaryStat` choices from `world.traits.constants`.
 - **Heredity / Parent Dominance** (#2815): a child's species derives from its parents via `world.roster.services.heredity` — maternal by default, flipping to the father's line only when his power band strictly exceeds hers, with chimeric (unique authored `Species` rows) possible only when both parents are Grand+ (level 16+). Cross-species parents unlock *their actual colors* for the child in CG; palettes are broad with pointed per-species exclusions, and wearing an excluded color is the visible tell of cross-line blood. See `docs/systems/kinship.md` and ADR-0173. NB: "crossing" remains the magic-progression term — this system's vocabulary is "Parent Dominance" / "power band".

--- a/src/world/character_creation/services.py
+++ b/src/world/character_creation/services.py
@@ -7,6 +7,7 @@ draft management and character finalization.
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING, Any
@@ -1311,32 +1312,40 @@ def _finalize_gift_and_techniques(draft: CharacterDraft, sheet: CharacterSheet) 
     )
 
 
+def _grant_codex_entries(sheet: CharacterSheet, entry_ids: Iterable[int]) -> None:
+    """Grant every entry in ``entry_ids`` to the sheet's character, as KNOWN.
+
+    One shared body for the six CG grant sources (beginnings, path, distinction,
+    tradition, species, gift resonance), all of which previously carried their
+    own ``get_or_create`` with ``status=KNOWN``. That is what made them skip the
+    KNOWN-transition hook — see ``world.codex.services.grant_codex_entry``, which
+    is the only sanctioned way to land a character on KNOWN.
+    """
+    from world.codex.models import CodexEntry  # noqa: PLC0415
+    from world.codex.services import grant_codex_entry  # noqa: PLC0415
+
+    entry_ids = list(entry_ids)
+    if not entry_ids:
+        return
+
+    roster_entry = sheet.roster_entry
+    for entry in CodexEntry.objects.filter(pk__in=entry_ids):
+        grant_codex_entry(roster_entry, entry)
+
+
 def _finalize_tradition_codex_grants(draft: CharacterDraft, sheet: CharacterSheet) -> None:
     """Step 3: apply tradition codex grants. No-op without a selected tradition."""
     if not draft.selected_tradition:
         return
 
-    from world.codex.constants import CodexKnowledgeStatus  # noqa: PLC0415
-    from world.codex.models import (  # noqa: PLC0415
-        CharacterCodexKnowledge,
-        TraditionCodexGrant,
-    )
+    from world.codex.models import TraditionCodexGrant  # noqa: PLC0415
 
-    grant_entry_ids = list(
+    _grant_codex_entries(
+        sheet,
         TraditionCodexGrant.objects.filter(tradition=draft.selected_tradition).values_list(
             "entry_id", flat=True
-        )
+        ),
     )
-    if not grant_entry_ids:
-        return
-
-    roster_entry = sheet.roster_entry
-    for entry_id in grant_entry_ids:
-        CharacterCodexKnowledge.objects.get_or_create(
-            roster_entry=roster_entry,
-            entry_id=entry_id,
-            defaults={"status": CodexKnowledgeStatus.KNOWN},
-        )
 
 
 def _finalize_path_codex_grants(draft: CharacterDraft, sheet: CharacterSheet) -> None:
@@ -1349,22 +1358,12 @@ def _finalize_path_codex_grants(draft: CharacterDraft, sheet: CharacterSheet) ->
     if not draft.selected_path:
         return
 
-    from world.codex.constants import CodexKnowledgeStatus  # noqa: PLC0415
-    from world.codex.models import CharacterCodexKnowledge, PathCodexGrant  # noqa: PLC0415
+    from world.codex.models import PathCodexGrant  # noqa: PLC0415
 
-    grant_entry_ids = list(
-        PathCodexGrant.objects.filter(path=draft.selected_path).values_list("entry_id", flat=True)
+    _grant_codex_entries(
+        sheet,
+        PathCodexGrant.objects.filter(path=draft.selected_path).values_list("entry_id", flat=True),
     )
-    if not grant_entry_ids:
-        return
-
-    roster_entry = sheet.roster_entry
-    for entry_id in grant_entry_ids:
-        CharacterCodexKnowledge.objects.get_or_create(
-            roster_entry=roster_entry,
-            entry_id=entry_id,
-            defaults={"status": CodexKnowledgeStatus.KNOWN},
-        )
 
 
 def _finalize_beginnings_codex_grants(draft: CharacterDraft, sheet: CharacterSheet) -> None:
@@ -1376,27 +1375,14 @@ def _finalize_beginnings_codex_grants(draft: CharacterDraft, sheet: CharacterShe
     if not draft.selected_beginnings:
         return
 
-    from world.codex.constants import CodexKnowledgeStatus  # noqa: PLC0415
-    from world.codex.models import (  # noqa: PLC0415
-        BeginningsCodexGrant,
-        CharacterCodexKnowledge,
-    )
+    from world.codex.models import BeginningsCodexGrant  # noqa: PLC0415
 
-    grant_entry_ids = list(
+    _grant_codex_entries(
+        sheet,
         BeginningsCodexGrant.objects.filter(beginnings=draft.selected_beginnings).values_list(
             "entry_id", flat=True
-        )
+        ),
     )
-    if not grant_entry_ids:
-        return
-
-    roster_entry = sheet.roster_entry
-    for entry_id in grant_entry_ids:
-        CharacterCodexKnowledge.objects.get_or_create(
-            roster_entry=roster_entry,
-            entry_id=entry_id,
-            defaults={"status": CodexKnowledgeStatus.KNOWN},
-        )
 
 
 def _finalize_distinction_codex_grants(draft: CharacterDraft, sheet: CharacterSheet) -> None:
@@ -1408,11 +1394,7 @@ def _finalize_distinction_codex_grants(draft: CharacterDraft, sheet: CharacterSh
     if not distinctions_data:
         return
 
-    from world.codex.constants import CodexKnowledgeStatus  # noqa: PLC0415
-    from world.codex.models import (  # noqa: PLC0415
-        CharacterCodexKnowledge,
-        DistinctionCodexGrant,
-    )
+    from world.codex.models import DistinctionCodexGrant  # noqa: PLC0415
 
     distinction_ids = {
         d["distinction_id"]  # noqa: STRING_LITERAL
@@ -1422,21 +1404,12 @@ def _finalize_distinction_codex_grants(draft: CharacterDraft, sheet: CharacterSh
     if not distinction_ids:
         return
 
-    grant_entry_ids = list(
+    _grant_codex_entries(
+        sheet,
         DistinctionCodexGrant.objects.filter(distinction_id__in=distinction_ids).values_list(
             "entry_id", flat=True
-        )
+        ),
     )
-    if not grant_entry_ids:
-        return
-
-    roster_entry = sheet.roster_entry
-    for entry_id in grant_entry_ids:
-        CharacterCodexKnowledge.objects.get_or_create(
-            roster_entry=roster_entry,
-            entry_id=entry_id,
-            defaults={"status": CodexKnowledgeStatus.KNOWN},
-        )
 
 
 def _finalize_species_codex(sheet: CharacterSheet) -> None:
@@ -1455,15 +1428,11 @@ def _finalize_species_codex(sheet: CharacterSheet) -> None:
     if species is None:
         return
 
-    from world.codex.constants import CodexKnowledgeStatus  # noqa: PLC0415
-    from world.codex.models import CharacterCodexKnowledge  # noqa: PLC0415
+    from world.codex.services import grant_codex_entry  # noqa: PLC0415
 
+    roster_entry = sheet.roster_entry
     for entry in species.codex_entries:
-        CharacterCodexKnowledge.objects.get_or_create(
-            roster_entry=sheet.roster_entry,
-            entry_id=entry.pk,
-            defaults={"status": CodexKnowledgeStatus.KNOWN},
-        )
+        grant_codex_entry(roster_entry, entry)
 
 
 def _finalize_resonance_codex(draft: CharacterDraft, sheet: CharacterSheet) -> None:
@@ -1476,8 +1445,6 @@ def _finalize_resonance_codex(draft: CharacterDraft, sheet: CharacterSheet) -> N
     if not resonance_id:
         return
 
-    from world.codex.constants import CodexKnowledgeStatus  # noqa: PLC0415
-    from world.codex.models import CharacterCodexKnowledge  # noqa: PLC0415
     from world.magic.models import Resonance  # noqa: PLC0415
 
     try:
@@ -1487,11 +1454,7 @@ def _finalize_resonance_codex(draft: CharacterDraft, sheet: CharacterSheet) -> N
     if resonance.codex_entry_id is None:
         return
 
-    CharacterCodexKnowledge.objects.get_or_create(
-        roster_entry=sheet.roster_entry,
-        entry_id=resonance.codex_entry_id,
-        defaults={"status": CodexKnowledgeStatus.KNOWN},
-    )
+    _grant_codex_entries(sheet, [resonance.codex_entry_id])
 
 
 def _finalize_anima_ritual(draft: CharacterDraft, sheet: CharacterSheet) -> None:

--- a/src/world/character_creation/services.py
+++ b/src/world/character_creation/services.py
@@ -1428,10 +1428,18 @@ def _finalize_species_codex(sheet: CharacterSheet) -> None:
     if species is None:
         return
 
+    entries = species.codex_entries
+    if not entries:
+        return
+
     from world.codex.services import grant_codex_entry  # noqa: PLC0415
 
+    # Resolved only once there is something to grant: a species whose whole
+    # lineage has a null codex_entry must stay a no-op on a sheet that has no
+    # RosterEntry yet, which is the shape isolated unit tests build. The
+    # pre-#2880 version got this for free by returning on codex_entry_id.
     roster_entry = sheet.roster_entry
-    for entry in species.codex_entries:
+    for entry in entries:
         grant_codex_entry(roster_entry, entry)
 
 

--- a/src/world/character_creation/services.py
+++ b/src/world/character_creation/services.py
@@ -1440,22 +1440,30 @@ def _finalize_distinction_codex_grants(draft: CharacterDraft, sheet: CharacterSh
 
 
 def _finalize_species_codex(sheet: CharacterSheet) -> None:
-    """Grant the species's codex entry, if any. Idempotent via get_or_create."""
+    """Grant the codex entries owed to the character's species (#2880).
+
+    ``Species.codex_entries`` walks ``Species.parent``, so a Vulpi character
+    receives the Khati umbrella entry alongside the Vulpi one. Reading only the
+    leaf's own entry — which is what this did before — left the three umbrella
+    entries (Khati, Elf, Infernal) reachable by nobody who picked a subspecies.
+    Idempotent via get_or_create.
+    """
     try:
         species = sheet.species
     except AttributeError:
         return
-    if species is None or species.codex_entry_id is None:
+    if species is None:
         return
 
     from world.codex.constants import CodexKnowledgeStatus  # noqa: PLC0415
     from world.codex.models import CharacterCodexKnowledge  # noqa: PLC0415
 
-    CharacterCodexKnowledge.objects.get_or_create(
-        roster_entry=sheet.roster_entry,
-        entry_id=species.codex_entry_id,
-        defaults={"status": CodexKnowledgeStatus.KNOWN},
-    )
+    for entry in species.codex_entries:
+        CharacterCodexKnowledge.objects.get_or_create(
+            roster_entry=sheet.roster_entry,
+            entry_id=entry.pk,
+            defaults={"status": CodexKnowledgeStatus.KNOWN},
+        )
 
 
 def _finalize_resonance_codex(draft: CharacterDraft, sheet: CharacterSheet) -> None:

--- a/src/world/character_creation/tests/test_species_codex_grant.py
+++ b/src/world/character_creation/tests/test_species_codex_grant.py
@@ -87,6 +87,20 @@ class FinalizeSpeciesCodexTests(TestCase):
 
         self.assertEqual(self._known_entry_ids(sheet), set())
 
+    def test_species_without_any_entry_is_a_noop_on_a_sheet_with_no_roster_entry(self):
+        """The regression CI caught: don't touch sheet.roster_entry with nothing to grant.
+
+        ``world.species.tests.test_provision_species_gifts`` finalizes a sheet that
+        has no RosterEntry, which was safe before #2880 only because the old code
+        returned on a null ``codex_entry_id`` before ever reading the relation.
+        """
+        unbound = SpeciesFactory(name="GrantNoRosterEntry", codex_entry=None)
+        sheet = CharacterSheetFactory(species=unbound)
+
+        _finalize_species_codex(sheet)  # must not raise RelatedObjectDoesNotExist
+
+        self.assertEqual(CharacterCodexKnowledge.objects.count(), 0)
+
     def test_double_call_creates_one_row_per_entry(self):
         sheet = self._sheet_for(self.kind)
 

--- a/src/world/character_creation/tests/test_species_codex_grant.py
+++ b/src/world/character_creation/tests/test_species_codex_grant.py
@@ -1,0 +1,99 @@
+"""Tests for _finalize_species_codex: the species codex grant walks Species.parent.
+
+Before #2880 the grant read ``sheet.species.codex_entry`` and nothing else, so a
+Vulpi character received the Vulpi entry and never the Khati umbrella entry the
+whole Khati set is written to sit under. Ruled 2026-08-02 (Tehom, ``umbrella-grant
+= walk``): grant the parent chain too.
+"""
+
+from django.test import TestCase
+
+from world.character_creation.services import _finalize_species_codex
+from world.character_sheets.factories import CharacterSheetFactory
+from world.codex.constants import CodexKnowledgeStatus
+from world.codex.factories import CodexEntryFactory
+from world.codex.models import CharacterCodexKnowledge
+from world.roster.factories import RosterEntryFactory
+from world.species.factories import SpeciesFactory
+
+
+class FinalizeSpeciesCodexTests(TestCase):
+    """The grant covers the character's species and every ancestor of it."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.umbrella_entry = CodexEntryFactory(name="The Grant Umbrella")
+        cls.kind_entry = CodexEntryFactory(name="The Grant Kind")
+        cls.umbrella = SpeciesFactory(name="GrantUmbrella", codex_entry=cls.umbrella_entry)
+        cls.kind = SpeciesFactory(name="GrantKind", parent=cls.umbrella, codex_entry=cls.kind_entry)
+
+    def _sheet_for(self, species):
+        sheet = CharacterSheetFactory(species=species)
+        RosterEntryFactory(character_sheet__character=sheet.character)
+        sheet.refresh_from_db()
+        return sheet
+
+    def _known_entry_ids(self, sheet):
+        return set(
+            CharacterCodexKnowledge.objects.filter(roster_entry=sheet.roster_entry).values_list(
+                "entry_id", flat=True
+            )
+        )
+
+    def test_subspecies_receives_the_umbrella_entry_as_well(self):
+        sheet = self._sheet_for(self.kind)
+
+        _finalize_species_codex(sheet)
+
+        self.assertEqual(
+            self._known_entry_ids(sheet),
+            {self.kind_entry.pk, self.umbrella_entry.pk},
+        )
+
+    def test_granted_entries_are_known(self):
+        sheet = self._sheet_for(self.kind)
+
+        _finalize_species_codex(sheet)
+
+        statuses = set(
+            CharacterCodexKnowledge.objects.filter(roster_entry=sheet.roster_entry).values_list(
+                "status", flat=True
+            )
+        )
+        self.assertEqual(statuses, {CodexKnowledgeStatus.KNOWN})
+
+    def test_root_species_receives_only_its_own_entry(self):
+        sheet = self._sheet_for(self.umbrella)
+
+        _finalize_species_codex(sheet)
+
+        self.assertEqual(self._known_entry_ids(sheet), {self.umbrella_entry.pk})
+
+    def test_unbound_parent_does_not_block_the_child_grant(self):
+        """Saurian-shaped case: an ancestor with codex_entry still null."""
+        unbound = SpeciesFactory(name="GrantUnbound", codex_entry=None)
+        child = SpeciesFactory(name="GrantChild", parent=unbound, codex_entry=self.kind_entry)
+        sheet = self._sheet_for(child)
+
+        _finalize_species_codex(sheet)
+
+        self.assertEqual(self._known_entry_ids(sheet), {self.kind_entry.pk})
+
+    def test_species_without_any_entry_is_a_noop(self):
+        unbound = SpeciesFactory(name="GrantUnboundRoot", codex_entry=None)
+        sheet = self._sheet_for(unbound)
+
+        _finalize_species_codex(sheet)
+
+        self.assertEqual(self._known_entry_ids(sheet), set())
+
+    def test_double_call_creates_one_row_per_entry(self):
+        sheet = self._sheet_for(self.kind)
+
+        _finalize_species_codex(sheet)
+        _finalize_species_codex(sheet)
+
+        self.assertEqual(
+            CharacterCodexKnowledge.objects.filter(roster_entry=sheet.roster_entry).count(),
+            2,
+        )

--- a/src/world/clues/research.py
+++ b/src/world/clues/research.py
@@ -140,17 +140,10 @@ def resolve_research(project: Project, outcome_tier: CheckOutcome | None) -> Non
     if entry is None:
         return
 
-    from world.codex.constants import CodexKnowledgeStatus  # noqa: PLC0415
-    from world.codex.models import CharacterCodexKnowledge  # noqa: PLC0415
+    from world.codex.services import grant_codex_entry  # noqa: PLC0415
 
     for roster_entry in _distinct_contributor_roster_entries(project):
-        knowledge, _ = CharacterCodexKnowledge.objects.get_or_create(
-            roster_entry=roster_entry,
-            entry=entry,
-            defaults={"status": CodexKnowledgeStatus.UNCOVERED},
-        )
-        # Push past the threshold so the entry lands KNOWN (and fires the stories hook).
-        knowledge.add_progress(entry.learn_threshold)
+        grant_codex_entry(roster_entry, entry)
 
 
 def _resolve_secret_research(project: Project, clue: Clue) -> None:

--- a/src/world/clues/services.py
+++ b/src/world/clues/services.py
@@ -142,15 +142,9 @@ def _grant_codex_target(clue: Clue, roster_entry: RosterEntry) -> None:
     if entry is None:
         return
 
-    from world.codex.constants import CodexKnowledgeStatus  # noqa: PLC0415
-    from world.codex.models import CharacterCodexKnowledge  # noqa: PLC0415
+    from world.codex.services import grant_codex_entry  # noqa: PLC0415
 
-    knowledge, _ = CharacterCodexKnowledge.objects.get_or_create(
-        roster_entry=roster_entry,
-        entry=entry,
-        defaults={"status": CodexKnowledgeStatus.UNCOVERED},
-    )
-    knowledge.add_progress(entry.learn_threshold)
+    grant_codex_entry(roster_entry, entry)
 
 
 def _grant_rescue_target(clue: Clue, roster_entry: RosterEntry) -> None:

--- a/src/world/codex/services.py
+++ b/src/world/codex/services.py
@@ -1,7 +1,7 @@
 """Codex service functions.
 
-Link resolution for inline ``[[wikilink]]`` cross-references in codex entry
-content fields.
+Granting entries to characters, and link resolution for inline ``[[wikilink]]``
+cross-references in codex entry content fields.
 """
 
 from __future__ import annotations
@@ -10,15 +10,62 @@ import re
 from typing import TYPE_CHECKING
 
 from world.codex.constants import CodexKnowledgeStatus
-from world.codex.models import CodexEntry
+from world.codex.models import CharacterCodexKnowledge, CodexEntry
 
 if TYPE_CHECKING:
     from world.codex.models import CodexSubject
-    from world.roster.models import RosterEntry
+    from world.roster.models import RosterEntry, RosterTenure
 
 #: Regex matching ``[[Entry Name]]`` wikilink syntax in content fields.
 #: Captures everything between the brackets (excluding closing brackets).
 WIKILINK_RE = re.compile(r"\[\[([^\]]+)\]\]")
+
+
+def grant_codex_entry(
+    roster_entry: RosterEntry,
+    entry: CodexEntry,
+    *,
+    learned_from: RosterTenure | None = None,
+) -> tuple[CharacterCodexKnowledge, bool]:
+    """Grant ``entry`` to ``roster_entry`` as fully KNOWN. Idempotent.
+
+    **Every caller that means "this character now knows this" must come through
+    here rather than creating a ``CharacterCodexKnowledge`` row itself.** The
+    KNOWN transition is not just a column value: it stamps ``learned_at`` and
+    fires the stories reactivity hook so ``CODEX_ENTRY_UNLOCKED`` beats
+    re-evaluate. That hook lives on ``CharacterCodexKnowledge.add_progress``,
+    which #939 chose deliberately — "a separate service wrapper used to carry
+    the hook and every caller bypassed it; reactivity now lives on the only
+    path".
+
+    The bypass came back anyway (#2880), because ``add_progress`` returns early
+    unless the row is UNCOVERED, and seven callers were creating rows with
+    ``status=KNOWN`` directly: all six character-creation grants (beginnings,
+    path, distinction, tradition, species, gift resonance) and the crossing
+    ceremony. Those characters got the column value and neither the timestamp
+    nor the hook. So this wrapper does not set the status itself — it opens the
+    row UNCOVERED and pushes progress past the threshold, which is the same
+    thing clue research already did, and which keeps the transition on the one
+    path that carries the reactivity.
+
+    Returns ``(knowledge, newly_known)``; ``newly_known`` is False when the
+    character already knew the entry, which is what makes repeat calls safe.
+
+    **Not for "the character can now start researching this."** Two callers
+    deliberately create UNCOVERED rows and must keep doing so: the
+    ``GRANT_CODEX`` consequence effect (a scene hands you a lead, not the
+    answer) and ``CodexTeachingOffer.accept`` (the learner has paid AP and now
+    has to make progress).
+    """
+    knowledge, _ = CharacterCodexKnowledge.objects.get_or_create(
+        roster_entry=roster_entry,
+        entry=entry,
+        defaults={
+            "status": CodexKnowledgeStatus.UNCOVERED,
+            "learned_from": learned_from,
+        },
+    )
+    return knowledge, knowledge.add_progress(entry.learn_threshold)
 
 
 def resolve_codex_links(

--- a/src/world/codex/tests/test_grant_service.py
+++ b/src/world/codex/tests/test_grant_service.py
@@ -1,0 +1,92 @@
+"""Tests for grant_codex_entry, the single sanctioned path to KNOWN (#2880).
+
+Seven callers used to create ``CharacterCodexKnowledge`` rows with
+``status=KNOWN`` directly. ``add_progress`` returns early unless the row is
+UNCOVERED, and it is where #939 deliberately put the KNOWN-transition hook, so
+every one of those callers skipped both the stories reactivity hook and the
+``learned_at`` stamp.
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from world.codex.constants import CodexKnowledgeStatus
+from world.codex.factories import CodexEntryFactory
+from world.codex.models import CharacterCodexKnowledge
+from world.codex.services import grant_codex_entry
+from world.roster.factories import RosterEntryFactory, RosterTenureFactory
+
+HOOK = "world.stories.services.reactivity.on_codex_entry_unlocked"
+
+
+class GrantCodexEntryTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.entry = CodexEntryFactory(name="Granted Entry")
+
+    def test_lands_known(self):
+        roster_entry = RosterEntryFactory()
+
+        knowledge, newly_known = grant_codex_entry(roster_entry, self.entry)
+
+        self.assertTrue(newly_known)
+        self.assertEqual(knowledge.status, CodexKnowledgeStatus.KNOWN)
+
+    def test_stamps_learned_at(self):
+        """The column a direct ``status=KNOWN`` create left null."""
+        roster_entry = RosterEntryFactory()
+
+        knowledge, _ = grant_codex_entry(roster_entry, self.entry)
+
+        self.assertIsNotNone(knowledge.learned_at)
+
+    def test_fires_the_stories_unlock_hook(self):
+        """The whole reason this wrapper exists rather than a KNOWN create."""
+        roster_entry = RosterEntryFactory()
+
+        with patch(HOOK) as hook:
+            grant_codex_entry(roster_entry, self.entry)
+
+        hook.assert_called_once()
+        self.assertEqual(hook.call_args.args[1], self.entry)
+
+    def test_repeat_grant_is_a_noop_and_does_not_refire_the_hook(self):
+        roster_entry = RosterEntryFactory()
+        grant_codex_entry(roster_entry, self.entry)
+
+        with patch(HOOK) as hook:
+            _, newly_known = grant_codex_entry(roster_entry, self.entry)
+
+        self.assertFalse(newly_known)
+        hook.assert_not_called()
+        self.assertEqual(
+            CharacterCodexKnowledge.objects.filter(
+                roster_entry=roster_entry, entry=self.entry
+            ).count(),
+            1,
+        )
+
+    def test_completes_an_entry_the_character_was_part_way_through(self):
+        """A researcher who then gets the entry granted lands KNOWN, once."""
+        roster_entry = RosterEntryFactory()
+        partial = CharacterCodexKnowledge.objects.create(
+            roster_entry=roster_entry,
+            entry=self.entry,
+            status=CodexKnowledgeStatus.UNCOVERED,
+        )
+        partial.add_progress(1)
+
+        knowledge, newly_known = grant_codex_entry(roster_entry, self.entry)
+
+        self.assertTrue(newly_known)
+        self.assertEqual(knowledge.pk, partial.pk)
+        self.assertEqual(knowledge.status, CodexKnowledgeStatus.KNOWN)
+
+    def test_records_the_teacher_when_given_one(self):
+        roster_entry = RosterEntryFactory()
+        tenure = RosterTenureFactory()
+
+        knowledge, _ = grant_codex_entry(roster_entry, self.entry, learned_from=tenure)
+
+        self.assertEqual(knowledge.learned_from, tenure)

--- a/src/world/magic/crossing/ceremony.py
+++ b/src/world/magic/crossing/ceremony.py
@@ -140,11 +140,6 @@ def _unlock_codex(sheet: CharacterSheet, codex_entry: CodexEntry) -> None:
     if roster_entry is None:
         return
 
-    from world.codex.constants import CodexKnowledgeStatus  # noqa: PLC0415
-    from world.codex.models import CharacterCodexKnowledge  # noqa: PLC0415
+    from world.codex.services import grant_codex_entry  # noqa: PLC0415
 
-    CharacterCodexKnowledge.objects.get_or_create(
-        roster_entry=roster_entry,
-        entry=codex_entry,
-        defaults={"status": CodexKnowledgeStatus.KNOWN},
-    )
+    grant_codex_entry(roster_entry, codex_entry)

--- a/src/world/species/AGENT_GLOSSARY.md
+++ b/src/world/species/AGENT_GLOSSARY.md
@@ -14,9 +14,15 @@ Domain-local vocabulary for `world.species`. Root terms live in
   light-blue eyes); wearing an excluded color is the visible tell of
   cross-line blood. _Avoid:_ "human-exclusive colors" (retired first-pass
   framing).
+- **Species lineage** — `Species.lineage`: the species followed by every
+  ancestor via `parent`, nearest first. What `codex_entries` walks so a
+  subspecies character is granted the umbrella entry too (#2880). Still
+  taxonomy, not a character's ancestry. _Avoid:_ "ancestry", "family tree"
+  (those are the roster kinship graph).
 - **Required trait** — `SpeciesFormTrait.is_required=True`: a species
-  identity marker (horns + tail for True Infernals, wings for Daeva, fangs
-  for vampires) that CG must fill. Species identity is protected by required
+  identity marker (horns + tail for Infernals, wings for Daeva, fangs
+  for vampires) that CG must fill. ("True Infernal" is a retired term and the
+  species row was deleted in #2880 — the mainline is plain `Infernal`.) Species identity is protected by required
   structural traits, never by rationing colors.
 - **Chimeric species** — a unique authored `Species` row (with its own codex
   entry) for a true halfbreed, possible only when both parents are Grand+

--- a/src/world/species/models.py
+++ b/src/world/species/models.py
@@ -7,6 +7,8 @@ This module contains:
 - Language: Languages available in the game
 """
 
+from typing import TYPE_CHECKING
+
 from django.core.exceptions import ValidationError
 from django.db import models
 from django.utils.functional import cached_property
@@ -14,6 +16,9 @@ from evennia.utils.idmapper.models import SharedMemoryModel
 
 from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.traits.constants import PrimaryStat
+
+if TYPE_CHECKING:
+    from world.codex.models import CodexEntry
 
 
 class Species(NaturalKeyMixin, SharedMemoryModel):
@@ -103,6 +108,40 @@ class Species(NaturalKeyMixin, SharedMemoryModel):
     def is_subspecies(self) -> bool:
         """Return True if this species has a parent."""
         return self.parent_id is not None
+
+    @property
+    def lineage(self) -> list["Species"]:
+        """This species followed by every ancestor, nearest first.
+
+        The chain is at most two deep in practice (a Khati kind under Khati, an
+        elf line under Elf) and every row is served by the idmapper cache after
+        the first read, so the walk is cheap enough to do inline.
+
+        A ``parent`` cycle would be a data defect rather than a modelled state;
+        the seen-set keeps it from hanging whatever produced it.
+        """
+        chain: list[Species] = []
+        seen: set[int] = set()
+        current: Species | None = self
+        while current is not None and current.pk not in seen:
+            seen.add(current.pk)
+            chain.append(current)
+            current = current.parent
+        return chain
+
+    @property
+    def codex_entries(self) -> list["CodexEntry"]:
+        """Every codex entry a character of this species is owed (#2880).
+
+        The species tier is authored so that the umbrella entry (Khati, Elf,
+        Infernal) carries what the kinds share and each kind entry carries the
+        kind, which only works if a subspecies character receives both. Species
+        with ``codex_entry`` still null — Saurian, pending design — drop out
+        rather than contributing a None.
+        """
+        return [
+            species.codex_entry for species in self.lineage if species.codex_entry_id is not None
+        ]
 
     @cached_property
     def cached_stat_bonuses(self) -> list["SpeciesStatBonus"]:

--- a/src/world/species/tests/test_codex_entries.py
+++ b/src/world/species/tests/test_codex_entries.py
@@ -1,0 +1,58 @@
+"""Species lineage and the codex entries it carries (#2880)."""
+
+from django.test import TestCase
+
+from world.codex.factories import CodexEntryFactory
+from world.species.factories import SpeciesFactory
+
+
+class SpeciesLineageTests(TestCase):
+    """``Species.lineage`` walks ``parent`` from the species outward."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.khati = SpeciesFactory(name="LineageKhati")
+        cls.vulpi = SpeciesFactory(name="LineageVulpi", parent=cls.khati)
+
+    def test_root_species_lineage_is_itself(self):
+        self.assertEqual(self.khati.lineage, [self.khati])
+
+    def test_subspecies_lineage_runs_nearest_first(self):
+        self.assertEqual(self.vulpi.lineage, [self.vulpi, self.khati])
+
+    def test_lineage_terminates_on_a_parent_cycle(self):
+        """A cycle is a data defect, not a hang: each species appears once."""
+        self.khati.parent = self.vulpi
+        self.khati.save()
+        self.addCleanup(self._break_cycle)
+
+        self.assertEqual(self.vulpi.lineage, [self.vulpi, self.khati])
+
+    def _break_cycle(self):
+        self.khati.parent = None
+        self.khati.save()
+
+
+class SpeciesCodexEntriesTests(TestCase):
+    """``Species.codex_entries`` collects the lineage's entries, skipping gaps."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.umbrella_entry = CodexEntryFactory(name="The Umbrella Kind")
+        cls.leaf_entry = CodexEntryFactory(name="The Leaf Kind")
+        cls.umbrella = SpeciesFactory(name="CodexUmbrella", codex_entry=cls.umbrella_entry)
+        cls.leaf = SpeciesFactory(name="CodexLeaf", parent=cls.umbrella, codex_entry=cls.leaf_entry)
+
+    def test_subspecies_carries_its_own_entry_and_the_parents(self):
+        self.assertEqual(self.leaf.codex_entries, [self.leaf_entry, self.umbrella_entry])
+
+    def test_parent_without_an_entry_is_skipped_rather_than_yielding_none(self):
+        unbound = SpeciesFactory(name="CodexUnbound", codex_entry=None)
+        child = SpeciesFactory(name="CodexChild", parent=unbound, codex_entry=self.leaf_entry)
+
+        self.assertEqual(child.codex_entries, [self.leaf_entry])
+
+    def test_species_with_no_entry_anywhere_in_the_lineage_carries_none(self):
+        unbound = SpeciesFactory(name="CodexUnboundRoot", codex_entry=None)
+
+        self.assertEqual(unbound.codex_entries, [])


### PR DESCRIPTION
Part of #2880. Ruled 2026-08-02 (Tehom, `umbrella-grant: walk`).

## The problem

`_finalize_species_codex` read `sheet.species.codex_entry` and nothing else. A Vulpi
character got the Vulpi entry and never the Khati one, so the three umbrella entries
(Khati, Elf, Infernal) were reachable only by a character whose species IS that row.

That matters because the species tier is authored on a split: the umbrella entry carries
what the kinds share and each kind entry carries the kind. Without the walk, half of what
a Khati player is meant to be told is content nobody receives.

## The change

- `Species.lineage` — the species followed by every ancestor via `parent`, nearest first.
  Cycle-safe via a seen-set: a `parent` cycle is a data defect rather than a modelled
  state, and this keeps it from hanging whatever produced it.
- `Species.codex_entries` — the lineage's non-null entries. Ancestors whose `codex_entry`
  is still null (Saurian, pending design) drop out rather than contributing a `None`.
- `_finalize_species_codex` iterates that instead of reading the leaf's own field.
  Still idempotent via `get_or_create`.

The walk lives on the model rather than in the finalize service so anything else that
needs "what does this species know about itself" gets the same answer.

Chain depth is at most two in practice and every row is served by the idmapper cache
after the first read, so no prefetch is warranted.

## Verification

Verified RED first: with the service and model reverted, the two coverage assertions
fail (`AssertionError: 1 != 2`); with the change, 12 tests pass on the fast SQLite tier.

- `world.species.tests.test_codex_entries` — 6 tests: root lineage, subspecies ordering,
  cycle termination, entry collection, a null-entry ancestor being skipped, and an
  entirely unbound lineage.
- `world.character_creation.tests.test_species_codex_grant` — 6 tests: the subspecies
  receiving both entries, status KNOWN, a root species receiving only its own, a
  Saurian-shaped null ancestor, a no-op species, and double-call idempotence.

## Docs

`docs/systems/species.md` gains the codex-hierarchy section and the two new methods;
`docs/systems/codex.md` records why species have no `SpeciesCodexGrant` table.

Fixed on sight: `docs/systems/species.md` and `world/species/AGENT_GLOSSARY.md` both
described required traits as belonging to "True Infernals", a term retired 2026-07-31
whose species row is deleted in the content branch for this issue.

No model fields changed (both additions are properties), so no migration and no
`MODEL_MAP.md` regeneration.