### PR TITLE
CG→checks scale bridge: skills never reach checks, stats stored unscaled, Brewing unlinked (Apostate's ×10 ruling)

### DIFF
--- a/docs/adr/0193-stats-store-x10-skills-display-true-value.md
+++ b/docs/adr/0193-stats-store-x10-skills-display-true-value.md
@@ -1,0 +1,25 @@
+# 0193 — Stats store ×10 under the hood; skills store and display true value
+
+**Status:** Accepted (2026-08-03, Apostate's ruling on #2894)
+
+`CharacterTraitValue` holds one storage scale — the fine-grained 1-100 range —
+but the two trait families *display* differently. **Skills show their true
+stored value** (a skill of 35 reads 35): development moves them by single
+points (11…19) and an XP unlock crosses the rung boundary to 20, so the
+fine grain is player-visible by design. **Stats display single-digit and are
+×10 under the hood** (strength 2 = stored 20): players allocate 1-5 dots, and
+the ×10 conversion happens once at CG finalization so stats land on the same
+storage scale as everything else. Strength 2 + weapon skill 35 = 20 + 35 = 55
+check points. Character creation previously wrote stats at display scale — the
+sole display-scale writer in the repo — which silently zeroed CG characters in
+every storage-scale consumer (checks, encumbrance, health, stat modifiers,
+thread anchor caps, trait predicates) and spawned per-consumer compatibility
+guards. The alternative — declaring 1-5 the canonical stat storage — was
+rejected: modifiers, DP level-ups, and `PointConversionRange` all already
+operate on the ×10 scale. Stat display conversion happens at the edge via
+`world.traits.models.display_trait_value` / `STAT_DISPLAY_DIVISOR`; authored
+display-dot numbers (e.g. `MaturationStatCap`) convert at the comparison,
+never at rest; skill display paths never divide. CG skills also bridge into
+matching `CharacterTraitValue` rows at finalization — `perform_check` reads
+only trait rows, and `DevelopmentPoints.award_points` increments those same
+rows from the CG level onward.

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -611,12 +611,18 @@ Powers, affinities, auras, resonances, threads-as-currency, rituals, and Mage Sc
 ### Traits
 Character statistics and dice rolling mechanics.
 
+- **Scale (ADR-0193, #2894):** storage is the fine-grained 1-100 range for all
+  trait values. Skills display their TRUE stored value (35 reads 35 — never
+  divided); stats display single-digit and store ×10 (strength 2 = stored 20),
+  converted at the edge via `display_trait_value` / `STAT_DISPLAY_DIVISOR`.
+  CG finalization converts stat dots ×10 and bridges CG skills into
+  `CharacterTraitValue` rows.
 - **Models:** `Trait`, `CharacterTraitValue`, `PointConversionRange`, `CheckRank`, `ResultChart`, `ResultChartOutcome`
 - **Handlers:** `TraitHandler` (via `character.traits`), `StatHandler` (via `character.stats`)
 - **Key Functions:**
   - `character.traits.get_trait_value(name)` — with modifiers applied
   - `character.traits.get_base_trait_value(name)` — raw, no modifiers
-  - `character.traits.get_trait_display_value(name)` — 1.0-10.0 scale
+  - `character.traits.get_trait_display_value(name)` — stats ÷10, skills true value
   - `character.traits.get_traits_by_type(type)` — dict[name → value]
   - `character.traits.calculate_check_points(trait_names)` — weighted points
   - `character.stats.get_stat(name)` — internal value
@@ -1567,7 +1573,7 @@ XP, kudos, development points, and unlock system. Contains the most explicit pre
 - **Models:** `ExperiencePointsData`, `XPTransaction`, `CharacterXP`, `DevelopmentPoints`, `DevelopmentTransaction`, `KudosPointsData`, `KudosTransaction`, `CharacterUnlock`, `XPCostChart`, `XPCostEntry`, `CharacterPathHistory`, `PathIntent` (player's declared next-path preference — one per character sheet; FK to `CharacterSheet` + `Path`), `KudosDifficultyWeight` (staff-tunable band→multiplier for good-sport kudos; one row per `DifficultyChoice`), `WeeklySocialEngagement` (per-account weekly pending-kudos accumulator; `pending_points`, `granted`, `game_week` FK; `distinct_initiators` is a derived property counting child rows), `WeeklyEngagementInitiator` (child row recording each unique initiator toward a ledger; `UniqueConstraint(ledger, initiator_account)`),
   **Class-Level Advancement (#1352):** `AbstractClassLevelAdvancement` (abstract base shared by `ClassLevelAdvancement` and `AudereMajoraCrossing`; carries `scene`, `declaration_interaction`, `level_before`, `level_after`, `created_at`), `ClassLevelAdvancement` (within-tier Durance receipt — `character_sheet`, `character_class`, `officiant`, `ritual`, `witnesses` M2M → `scenes.Persona`),
   **Training Site (#1700):** `DuranceTrainingSite` (room + trainer-of-record pair; enables site-convened sessions — `room_profile` FK → `RoomProfile`, `officiant` FK → `CharacterSheet`, `training_path` FK → `Path` (nullable), `is_active`; unique `(room_profile, officiant)`),
-  **Maturation Points (#2756, ADR-0172):** `MaturationStatCap` (authored per-`PathStage` stat cap, seeded 5/6/11/16/21/26 PLACEHOLDER) + `MaturationSpend` (sheet FK, trait FK, `milestone_year`, `is_active` — active iff `milestone_year <= sheet.matured_years`; unique per (sheet, milestone_year)). Services in `progression/services/maturation.py`: `milestone_count` / `available_points` / `spend_maturation_point` (+1 raw stat value, stage-capped) / `sync_maturation_spends` (reversal deactivates, re-aging reactivates — every `matured_years` writer outside the birthday tick must call it)
+  **Maturation Points (#2756, ADR-0172):** `MaturationStatCap` (authored per-`PathStage` stat cap, seeded 5/6/11/16/21/26 PLACEHOLDER) + `MaturationSpend` (sheet FK, trait FK, `milestone_year`, `is_active` — active iff `milestone_year <= sheet.matured_years`; unique per (sheet, milestone_year)). Services in `progression/services/maturation.py`: `milestone_count` / `available_points` / `spend_maturation_point` (+1 display dot = +10 internal, stage-capped; caps are authored in display dots and convert at the comparison — ADR-0193) / `sync_maturation_spends` (reversal deactivates, re-aging reactivates — every `matured_years` writer outside the birthday tick must call it)
 - **Unlock Requirements** (all have `is_met_by_character(character) -> tuple[bool, str]`):
   - `TraitRequirement` — checks CharacterTraitValue
   - `LevelRequirement` — checks character_class_levels
@@ -4096,7 +4102,8 @@ Items, equipment, inventory, and currency. Spec D PR1 shipped facets, equip/uneq
   a consumable ItemTemplate + deterministic on-use pool (`seed_consumable_catalog` — bread,
   stew, wine, ale, firebrandy, Cardian Ambrosia, all PLACEHOLDER). Cooking tradeskill
   activation (`world/seeds/provisioning_checks.py`, cluster `provisioning`): Cooking
-  skill/CheckType (wits+Cooking, Brewing spec), first LIVE QualityTier ladder
+  skill/CheckType (wits+agility avg + Cooking, Brewing spec linked as a
+  `CheckTypeSpecialization` row at weight 1.0 — #2894), first LIVE QualityTier ladder
   (Common/Fine/Masterwork), stationless ITEM_CREATE recipes (Hearty Stew, Honeyed Wine) +
   ingredients + skill caps. Event catering: `EventCatering` snapshot rows
   (#2869 reshaped: `designate_catering_container` flags a vessel — banquet table,

--- a/docs/systems/character_creation.md
+++ b/docs/systems/character_creation.md
@@ -83,7 +83,7 @@ expands seed data in this public repo (TehomCD ruling, 2026-07-17).
 | 4 | Distinctions | `traits_complete` flag set; CG points >= 0 |
 | 5 | Path | Path selected (`get_path_errors`) |
 | 6 | Gift | Tradition, gift, >=1 technique(s), gift resonance, and Anima Check stat/skill all selected and valid (`compute_magic_errors`, 5-branch return-first gate); renders the `GiftStage` funnel component (#2426 Task 10) |
-| 7 | Attributes & Skills | All 12 primary stats present, valid range (1-5), points remaining = 0; skill point allocation validated against budget (moved in from Path, #2426 Task 9) |
+| 7 | Attributes & Skills | All 12 primary stats present, valid range (1-5), points remaining = 0; skill point allocation validated against budget (moved in from Path, #2426 Task 9). Draft allocations are display-scale; finalization stores stats ×10 and bridges each CG skill into a matching `CharacterTraitValue` row so checks and DP progression read them (ADR-0193, #2894) |
 | 8 | Appearance | Age, height band, height inches, build all set |
 | 9 | Identity | `first_name` in draft_data |
 | 10 | Final Touches | Always complete (goals are optional) |

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -39742,7 +39742,6 @@ export interface components {
       trait_id: number;
       name: string;
       trait_type: string;
-      /** Format: double */
       display_value: number;
     };
   };

--- a/src/commands/progression.py
+++ b/src/commands/progression.py
@@ -434,14 +434,14 @@ class CmdProgressionUnlock(DispatchCommand):
             return ["No skill breakthroughs available."]
         lines = ["", "Skill breakthroughs:"]
         for prospect in prospects:
-            rating = prospect.next_rating / 10
+            # Skills display their true stored value (ADR-0193): rung 20 reads 20.
+            rating = prospect.next_rating
             if prospect.authored:
                 lines.append(
-                    f"[skill] {prospect.skill.name} breakthrough to {rating:.1f}: "
-                    f"{prospect.xp_cost} XP"
+                    f"[skill] {prospect.skill.name} breakthrough to {rating}: {prospect.xp_cost} XP"
                 )
             else:
                 lines.append(
-                    f"[skill] {prospect.skill.name} at threshold {rating:.1f}: not yet authored"
+                    f"[skill] {prospect.skill.name} at threshold {rating}: not yet authored"
                 )
         return lines

--- a/src/schema.json
+++ b/src/schema.json
@@ -71395,8 +71395,7 @@ components:
         trait_type:
           type: string
         display_value:
-          type: number
-          format: double
+          type: integer
       required:
       - display_value
       - name

--- a/src/world/character_creation/constants.py
+++ b/src/world/character_creation/constants.py
@@ -6,15 +6,15 @@ and keep models.py focused on model definitions.
 
 from django.db import models
 
-from world.traits.constants import PrimaryStat
+# STAT_DISPLAY_DIVISOR's canonical definition lives in world.traits.constants (#2894);
+# re-exported here for the CG modules that convert display allocations to internal scale.
+from world.traits.constants import STAT_DISPLAY_DIVISOR, PrimaryStat  # noqa: F401
 
-# Primary stat constants (1-5 scale)
+# Primary stat constants (1-5 DISPLAY scale — draft_data holds display values;
+# finalization multiplies by STAT_DISPLAY_DIVISOR when writing CharacterTraitValue)
 STAT_MIN_VALUE = 1  # Minimum stat value
 STAT_MAX_VALUE = 5  # Maximum stat value during character creation
 STAT_DEFAULT_VALUE = 2  # Default starting value
-
-# Internal divisor for converting distinction effect values (stored as 10/20/etc.) to display scale
-STAT_DISPLAY_DIVISOR = 10
 
 # Age constraints for character creation
 AGE_MIN = 18

--- a/src/world/character_creation/services.py
+++ b/src/world/character_creation/services.py
@@ -21,6 +21,7 @@ from evennia.objects.models import ObjectDB
 from evennia_extensions.models import PlayerData
 from world.character_creation.constants import (
     PATH_OF_THE_CHOSEN_NAME,
+    STAT_DISPLAY_DIVISOR,
     ApplicationStatus,
     CommentType,
     OriginStoryState,
@@ -745,9 +746,13 @@ def _create_stat_values(
         trait.name: trait
         for trait in _trait_cls.objects.filter(name__in=stat_names, trait_type=_trait_type_cls.STAT)
     }
+    # Draft allocations are display-scale (1-5); storage is internal ×10 (#2894)
+    # so checks, modifiers, and DP level-ups all read one scale.
     trait_values = [
         _character_trait_value_cls(
-            character=character.sheet_data, trait=traits_by_name[name], value=value
+            character=character.sheet_data,
+            trait=traits_by_name[name],
+            value=value * STAT_DISPLAY_DIVISOR,
         )
         for name, value in stats.items()
         if name in traits_by_name
@@ -803,7 +808,9 @@ def _apply_post_cg_bonuses(
     """Apply post-CG stat bonuses from the draft (reserved for future use).
 
     NOTE: This is reserved for future functionality where other CG stages might
-    modify stats beyond the normal 1-5 range. Not currently used.
+    modify stats beyond the normal 1-5 display range. Not currently used.
+    Bonuses are display-scale (+1 = one stat dot) and convert to internal
+    scale here, like ``_create_stat_values`` (#2894).
 
     Args:
         character: The newly created ``ObjectDB`` character.
@@ -818,7 +825,7 @@ def _apply_post_cg_bonuses(
             character_id=character.pk, trait__name=stat_name
         ).first()
         if trait_value:
-            trait_value.value += int(bonus)
+            trait_value.value += int(bonus) * STAT_DISPLAY_DIVISOR
             trait_value.save()
 
 
@@ -1155,22 +1162,34 @@ def _apply_form_trait_descriptors(
 
 
 def _create_skill_values(character: ObjectDB, draft: CharacterDraft) -> None:
-    """Create CharacterSkillValue and CharacterSpecializationValue records from draft."""
+    """Create CharacterSkillValue and CharacterSpecializationValue records from draft.
+
+    Also writes the matching ``CharacterTraitValue`` row for each skill (#2894):
+    ``perform_check`` reads only trait values, so without this bridge a freshly
+    finalized character contributed zero skill points to every check until the
+    DP path happened to seed a trait row (at 10, ignoring the CG allocation).
+    Skill values are already stored (and displayed) at their true 1-100 value,
+    so the number carries over verbatim — no conversion, unlike stats — and
+    ``DevelopmentPoints.award_points`` increments the same row from the CG
+    level onward.
+    """
     from world.skills.models import (  # noqa: PLC0415
         CharacterSkillValue,
         CharacterSpecializationValue,
         Skill,
         Specialization,
     )
+    from world.traits.models import CharacterTraitValue  # noqa: PLC0415
 
     skills_data = draft.draft_data.get("skills", {})
     specializations_data = draft.draft_data.get("specializations", {})
 
-    # Create skill values
+    # Create skill values + the trait-row bridge the check engine reads
+    skill_trait_values = []
     for skill_id, value in skills_data.items():
         if value > 0:
             try:
-                skill = Skill.objects.get(pk=int(skill_id))
+                skill = Skill.objects.select_related("trait").get(pk=int(skill_id))
                 CharacterSkillValue.objects.create(
                     character=character.sheet_data,
                     skill=skill,
@@ -1178,12 +1197,18 @@ def _create_skill_values(character: ObjectDB, draft: CharacterDraft) -> None:
                     development_points=0,
                     rust_points=0,
                 )
+                skill_trait_values.append(
+                    CharacterTraitValue(
+                        character=character.sheet_data, trait=skill.trait, value=value
+                    )
+                )
             except Skill.DoesNotExist:
                 logger.warning(
                     "Invalid skill ID %s in draft for character %s",
                     skill_id,
                     character.key,
                 )
+    CharacterTraitValue.objects.bulk_create(skill_trait_values)
 
     # Create specialization values
     for spec_id, value in specializations_data.items():

--- a/src/world/character_creation/tests/test_check_scale_bridge.py
+++ b/src/world/character_creation/tests/test_check_scale_bridge.py
@@ -1,0 +1,104 @@
+"""#2894 acceptance: CG output and hand-seeded rows roll identical check points.
+
+The scale ruling (Apostate, ADR-0193): stats display single-digit but store
+×10 under the hood; skills store and display their true 1-100 value. CG
+finalization converts stat dots ×10 and bridges each CG skill verbatim into a
+matching ``CharacterTraitValue`` — so a freshly finalized character
+contributes real points to checks, identical to a test character whose rows
+were seeded by hand on the storage scale.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.test import TestCase
+from evennia.accounts.models import AccountDB
+
+from world.character_creation.services import finalize_character
+from world.character_creation.tests.test_services import DEFAULT_STATS, FinalizationTestMixin
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.factories import (
+    CheckCategoryFactory,
+    CheckTypeFactory,
+    CheckTypeTraitFactory,
+)
+from world.checks.services import perform_check
+from world.skills.factories import SkillFactory
+from world.traits.factories import CheckSystemSetupFactory
+from world.traits.models import (
+    CharacterTraitValue,
+    CheckRank,
+    PointConversionRange,
+    Trait,
+    TraitType,
+)
+
+
+class CgCheckScaleBridgeTests(FinalizationTestMixin, TestCase):
+    """A CG-finalized character and a hand-seeded twin score the same points."""
+
+    def setUp(self):
+        self._flush_common_caches()
+        Trait.flush_instance_cache()
+        CharacterTraitValue.flush_instance_cache()
+        self.account = AccountDB.objects.create(username="bridgeuser")
+        self._setup_finalization_base(self, prefix="Bridge Test", height_min=700, height_max=800)
+
+        CheckSystemSetupFactory.create()
+        for trait_type in (TraitType.STAT, TraitType.SKILL):
+            PointConversionRange.objects.get_or_create(
+                trait_type=trait_type,
+                min_value=1,
+                defaults={"max_value": 100, "points_per_level": 1},
+            )
+        for rank_val, min_pts, name in [
+            (0, 0, "BridgeNone"),
+            (1, 10, "BridgeNovice"),
+            (2, 25, "BridgeCompetent"),
+            (3, 50, "BridgeExpert"),
+        ]:
+            CheckRank.objects.get_or_create(
+                rank=rank_val, defaults={"min_points": min_pts, "name": name}
+            )
+
+    def test_cg_character_matches_hand_seeded_check_points(self):
+        skill = SkillFactory()
+        # Skills store AND display true value: 30 is 30 (ADR-0193).
+        draft = self._create_base_draft(skills={str(skill.pk): 30})
+        character = finalize_character(draft, add_to_roster=True)
+
+        strength = Trait.objects.get(name="strength", trait_type=TraitType.STAT)
+        category = CheckCategoryFactory(name="bridge_test_category")
+        check_type = CheckTypeFactory(name="bridge_test_check", category=category)
+        CheckTypeTraitFactory(check_type=check_type, trait=strength, weight=Decimal("0.5"))
+        CheckTypeTraitFactory(check_type=check_type, trait=skill.trait, weight=Decimal("1.0"))
+
+        twin = CharacterSheetFactory().character
+        CharacterTraitValue.objects.create(
+            character=twin.sheet_data, trait=strength, value=20
+        )  # display 2, like DEFAULT_STATS
+        CharacterTraitValue.objects.create(character=twin.sheet_data, trait=skill.trait, value=30)
+
+        cg_result = perform_check(character, check_type, target_difficulty=0)
+        twin_result = perform_check(twin, check_type, target_difficulty=0)
+
+        # strength 20 × 0.5 → 10 pts; skill 30 × 1.0 → 30 pts (1 pt/level)
+        assert cg_result.trait_points == 40
+        assert twin_result.trait_points == 40
+
+    def test_finalize_bridges_cg_skills_into_trait_rows(self):
+        skill = SkillFactory()
+        draft = self._create_base_draft(skills={str(skill.pk): 30})
+        character = finalize_character(draft, add_to_roster=True)
+
+        row = CharacterTraitValue.objects.get(character_id=character.pk, trait=skill.trait)
+        assert row.value == 30
+
+    def test_finalize_stores_stats_internal_scale(self):
+        draft = self._create_base_draft()
+        character = finalize_character(draft, add_to_roster=True)
+
+        strength = Trait.objects.get(name="strength", trait_type=TraitType.STAT)
+        row = CharacterTraitValue.objects.get(character_id=character.pk, trait=strength)
+        assert row.value == DEFAULT_STATS["strength"] * 10

--- a/src/world/character_creation/tests/test_services.py
+++ b/src/world/character_creation/tests/test_services.py
@@ -229,21 +229,21 @@ class CharacterFinalizationTests(FinalizationTestMixin, TestCase):
         trait_values = CharacterTraitValue.objects.filter(character_id=character.pk)
         assert trait_values.count() == 12
 
-        # Verify specific values directly from database (1-5 scale)
+        # Verify specific values directly from database — stored internal ×10 (#2894)
         strength_value = CharacterTraitValue.objects.get(
             character_id=character.pk, trait=self.stats["strength"]
         )
-        assert strength_value.value == 2
+        assert strength_value.value == 20
 
         agility_value = CharacterTraitValue.objects.get(
             character_id=character.pk, trait=self.stats["agility"]
         )
-        assert agility_value.value == 2
+        assert agility_value.value == 20
 
         willpower_value = CharacterTraitValue.objects.get(
             character_id=character.pk, trait=self.stats["willpower"]
         )
-        assert willpower_value.value == 2
+        assert willpower_value.value == 20
 
     def test_staff_add_to_roster_stamps_staff_provenance(self):
         """add_to_roster (staff direct-add) records STAFF provenance + the actor (#1506)."""
@@ -335,16 +335,16 @@ class CharacterFinalizationTests(FinalizationTestMixin, TestCase):
         sheet = CharacterSheet.objects.get(character=character)
         assert sheet is not None
 
-        # Verify stats were created with correct values (1-5 scale)
+        # Verify stats were created with correct values — internal ×10 (#2894)
         strength_value = CharacterTraitValue.objects.get(
             character_id=character.pk, trait=self.stats["strength"]
         )
-        assert strength_value.value == 2
+        assert strength_value.value == 20
 
         willpower_value = CharacterTraitValue.objects.get(
             character_id=character.pk, trait=self.stats["willpower"]
         )
-        assert willpower_value.value == 2
+        assert willpower_value.value == 20
 
     def test_finalize_origin_story_from_slots(self) -> None:
         """Finalize assembles Profile.background from origin slots (#2478)."""

--- a/src/world/character_sheets/views.py
+++ b/src/world/character_sheets/views.py
@@ -119,6 +119,7 @@ class CharacterSheetViewSet(RetrieveModelMixin, GenericViewSet):
             milestone_count,
             stat_cap_for,
         )
+        from world.traits.constants import STAT_DISPLAY_DIVISOR  # noqa: PLC0415
         from world.traits.models import CharacterTraitValue, Trait, TraitType  # noqa: PLC0415
 
         sheet = self.get_object()
@@ -126,8 +127,10 @@ class CharacterSheetViewSet(RetrieveModelMixin, GenericViewSet):
         earned = milestone_count(sheet.matured_years)
         next_milestone = MATURATION_START_YEAR + earned * MATURATION_INTERVAL_YEARS
         cap = stat_cap_for(sheet)
+        # Stats store internal ×10 (#2894); the panel speaks display dots, the
+        # same scale the caps are authored in.
         values = {
-            tv.trait_id: tv.value
+            tv.trait_id: tv.value // STAT_DISPLAY_DIVISOR
             for tv in CharacterTraitValue.objects.filter(
                 character=sheet, trait__trait_type=TraitType.STAT
             )

--- a/src/world/checks/services.py
+++ b/src/world/checks/services.py
@@ -881,6 +881,12 @@ def _calculate_specialization_points(
     art) adds its owner's value. A character who doesn't own the spec contributes 0 (so a
     non-specialist simply rolls stat + skill). Specialization values scale like skills, so they
     convert through the same ``PointConversionRange`` as a SKILL trait.
+
+    The runtime branch applies no weight **by design** (#2894): a spec is fully
+    additive with its skill (Apostate: 50 skill + 50 spec ≡ 100 skill), i.e.
+    weight 1.0 — which is also ``CheckTypeSpecialization.weight``'s default, so
+    authored and runtime paths agree unless a check author deliberately tunes a
+    row's weight.
     """
     from world.skills.services import get_specialization_value  # noqa: PLC0415 — avoid app cycle
 

--- a/src/world/fatigue/services.py
+++ b/src/world/fatigue/services.py
@@ -13,7 +13,6 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.db import transaction
 
 from world.action_points.models import ActionPointPool
-from world.character_creation.constants import STAT_MAX_VALUE
 from world.character_sheets.models import CharacterSheet
 from world.checks.models import CheckCategory, CheckType, CheckTypeTrait
 from world.checks.services import perform_check_with_modifiers
@@ -34,7 +33,7 @@ from world.fatigue.constants import (
 )
 from world.fatigue.models import FatiguePool
 from world.fatigue.types import FatigueCollapseResult, RestResult
-from world.traits.constants import PrimaryStat
+from world.traits.constants import STAT_DISPLAY_DIVISOR, PrimaryStat
 from world.traits.services import ensure_stat_trait
 
 if TYPE_CHECKING:
@@ -54,16 +53,12 @@ def get_or_create_fatigue_pool(character_sheet: CharacterSheet) -> FatiguePool:
 def _get_display_stat_value(character_sheet: CharacterSheet, stat_name: str) -> int:
     """Get a stat's display value (1-5 scale) from the trait handler.
 
-    Handles both storage conventions:
-    - Legacy characters: values stored as 10-50 (internal scale), divided by 10
-    - CG-simplified characters: values stored as 1-5 (display scale), used directly
-
-    Values > 5 are assumed to be internal scale. Values 1-5 are display scale.
+    Storage is internal ×10 (#2894 — CG writes 10-50 like every other writer),
+    so display is a plain ÷10. Capacity constants are tuned for display-scale
+    input.
     """
     raw_value = character_sheet.character.traits.get_trait_value(stat_name)
-    if raw_value > STAT_MAX_VALUE:
-        return raw_value // 10
-    return raw_value
+    return raw_value // STAT_DISPLAY_DIVISOR
 
 
 def get_fatigue_capacity(

--- a/src/world/fatigue/tests/test_services.py
+++ b/src/world/fatigue/tests/test_services.py
@@ -328,8 +328,7 @@ class ShouldCheckCollapseTests(TestCase):
         _setup_stat(char, "stamina", 30, TraitCategory.PHYSICAL)
         _setup_stat(char, "willpower", 20, TraitCategory.META)
         pool = get_or_create_fatigue_pool(self.sheet)
-        # capacity = 30*10 + 20*3 = 360... wait, that's display scale
-        # stamina display=3, so capacity = 3*10 + 2*3 = 36
+        # stamina display 3, willpower display 2: capacity = 3*10 + 2*3 = 36
         pool.set_current("physical", 40)  # 111% of 36 → exhausted
         pool.save()
         result = should_check_collapse(self.sheet, ActionCategory.PHYSICAL, EffortLevel.MEDIUM)

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -2764,7 +2764,8 @@ class _WeavableTraitSerializer(serializers.Serializer):
     trait_id = serializers.IntegerField()
     name = serializers.CharField()
     trait_type = serializers.CharField()
-    display_value = serializers.FloatField()
+    # Stats ÷10, skills true value (#2894) — always whole numbers now.
+    display_value = serializers.IntegerField()
 
 
 class _WeavableTechniqueSerializer(serializers.Serializer):

--- a/src/world/magic/tests/test_thread_hub_summary_view.py
+++ b/src/world/magic/tests/test_thread_hub_summary_view.py
@@ -270,7 +270,7 @@ class ThreadHubSummaryPickerDataTests(APITestCase):
         CharacterTraitValueFactory(
             character=cls.character.sheet_data,
             trait=cls.trait,
-            value=30,  # display_value = 3.0
+            value=30,  # SKILL trait: displays true value 30 (ADR-0193)
         )
 
         # TECHNIQUE unlock + matching CharacterTechnique
@@ -308,7 +308,7 @@ class ThreadHubSummaryPickerDataTests(APITestCase):
         self.assertEqual(len(traits), 1)
         self.assertEqual(traits[0]["trait_id"], self.trait.pk)
         self.assertEqual(traits[0]["name"], "Persuasion")
-        self.assertAlmostEqual(float(traits[0]["display_value"]), 3.0, places=1)
+        self.assertEqual(traits[0]["display_value"], 30)
 
     def test_trait_with_zero_value_excluded(self) -> None:
         """Trait unlock exists but character's value is 0 → not in weavable_traits."""

--- a/src/world/progression/admin/unlocks_admin.py
+++ b/src/world/progression/admin/unlocks_admin.py
@@ -164,7 +164,9 @@ class TraitRequirementAdmin(admin.ModelAdmin):
     ]
 
     def minimum_value_display(self, obj):
-        return f"{obj.minimum_value / 10:.1f}"
+        from world.traits.models import display_trait_value  # noqa: PLC0415
+
+        return str(display_trait_value(obj.trait.trait_type, obj.minimum_value))
 
     minimum_value_display.short_description = "Min Value"
 

--- a/src/world/progression/models/maturation.py
+++ b/src/world/progression/models/maturation.py
@@ -17,9 +17,10 @@ from world.classes.models import PathStage
 class MaturationStatCap(SharedMemoryModel):
     """Authored per-stage cap on any single stat's value (PLACEHOLDER tuning).
 
-    Seeded 5/6/11/16/21/26 for PROSPECT..TRANSCENDENT. The cap binds the
-    maturation spend path; CG's ``STAT_MAX_VALUE`` (5) is the PROSPECT row
-    enforced at creation time.
+    Seeded 5/6/11/16/21/26 for PROSPECT..TRANSCENDENT. Caps are display dots
+    (stat storage is internal ×10 — #2894; the spend service multiplies at the
+    comparison). The cap binds the maturation spend path; CG's
+    ``STAT_MAX_VALUE`` (5) is the PROSPECT row enforced at creation time.
     """
 
     path_stage = models.PositiveSmallIntegerField(

--- a/src/world/progression/models/unlocks.py
+++ b/src/world/progression/models/unlocks.py
@@ -15,7 +15,7 @@ from django.db import models
 from evennia.objects.models import ObjectDB
 from evennia.utils.idmapper.models import SharedMemoryModel
 
-from world.traits.models import CharacterTraitValue
+from world.traits.models import CharacterTraitValue, display_trait_value
 
 # XP Cost System
 
@@ -231,7 +231,7 @@ class TraitRatingUnlock(SharedMemoryModel):
 
     def __str__(self) -> str:
         rating = cast(int, self.target_rating)
-        return f"{self.trait.name} Rating {rating / RATING_DIVISOR:.1f}"
+        return f"{self.trait.name} Rating {display_trait_value(self.trait.trait_type, rating)}"
 
 
 # Abstract Requirements System
@@ -348,23 +348,24 @@ class TraitRequirement(AbstractClassLevelRequirement):
                     True,
                     f"Has {self.trait.name} {trait_value.display_value}",
                 )
+            needed = display_trait_value(self.trait.trait_type, cast(int, self.minimum_value))
             return (
                 False,
-                f"Need {self.trait.name} {cast(int, self.minimum_value) / RATING_DIVISOR:.1f}, "
-                f"have {trait_value.display_value}",
+                f"Need {self.trait.name} {needed}, have {trait_value.display_value}",
             )
         except ObjectDoesNotExist:
+            needed = display_trait_value(self.trait.trait_type, cast(int, self.minimum_value))
             return (
                 False,
-                (
-                    f"Need {self.trait.name} "
-                    f"{cast(int, self.minimum_value) / RATING_DIVISOR:.1f}, trait not set"
-                ),
+                f"Need {self.trait.name} {needed}, trait not set",
             )
 
     def __str__(self) -> str:
         minimum_value = cast(int, self.minimum_value)
-        return f"Trait: {self.trait.name} >= {minimum_value / RATING_DIVISOR:.1f}"
+        return (
+            f"Trait: {self.trait.name} >= "
+            f"{display_trait_value(self.trait.trait_type, minimum_value)}"
+        )
 
 
 class LevelRequirement(AbstractClassLevelRequirement):

--- a/src/world/progression/services/maturation.py
+++ b/src/world/progression/services/maturation.py
@@ -19,6 +19,7 @@ from world.progression.exceptions import (
 )
 from world.progression.models import MaturationSpend, MaturationStatCap
 from world.progression.services.skill_development import get_character_path_level
+from world.traits.constants import STAT_DISPLAY_DIVISOR
 from world.traits.models import CharacterTraitValue, Trait, TraitType
 
 if TYPE_CHECKING:
@@ -88,11 +89,12 @@ def spend_maturation_point(sheet: "CharacterSheet", trait: Trait) -> MaturationS
     trait_value, _ = CharacterTraitValue.objects.get_or_create(
         character=sheet, trait=trait, defaults={"value": 0}
     )
+    # Caps are authored in display dots; stat storage is internal ×10 (#2894).
     cap = stat_cap_for(sheet)
-    if cap is not None and trait_value.value >= cap:
+    if cap is not None and trait_value.value >= cap * STAT_DISPLAY_DIVISOR:
         raise MaturationCapReachedError(MaturationCapReachedError.user_message)
 
-    trait_value.value += 1
+    trait_value.value += STAT_DISPLAY_DIVISOR
     trait_value.save()
     return MaturationSpend.objects.create(
         character_sheet=sheet,
@@ -116,7 +118,7 @@ def sync_maturation_spends(sheet: "CharacterSheet") -> int:
         should_be_active = spend.milestone_year <= sheet.matured_years
         if spend.is_active == should_be_active:
             continue
-        delta = 1 if should_be_active else -1
+        delta = STAT_DISPLAY_DIVISOR if should_be_active else -STAT_DISPLAY_DIVISOR
         trait_value, _ = CharacterTraitValue.objects.get_or_create(
             character=sheet, trait=spend.trait, defaults={"value": 0}
         )

--- a/src/world/progression/tests/test_maturation.py
+++ b/src/world/progression/tests/test_maturation.py
@@ -66,14 +66,15 @@ class MaturationServiceTests(TestCase):
 
     def test_spend_raises_stat_value_and_consumes_lowest_milestone(self):
         sheet = self._sheet(matured=21)
-        CharacterTraitValue.objects.create(character=sheet, trait=self.stat, value=3)
+        # Stat storage is internal ×10 (#2894): display 3 = 30.
+        CharacterTraitValue.objects.create(character=sheet, trait=self.stat, value=30)
 
         spend = spend_maturation_point(sheet, self.stat)
 
         self.assertEqual(spend.milestone_year, 21)
         self.assertTrue(spend.is_active)
         value = CharacterTraitValue.objects.get(character=sheet, trait=self.stat).value
-        self.assertEqual(value, 4)
+        self.assertEqual(value, 40)
         self.assertEqual(available_points(sheet), 0)
 
     def test_spend_without_points_raises(self):
@@ -82,8 +83,8 @@ class MaturationServiceTests(TestCase):
             spend_maturation_point(sheet, self.stat)
 
     def test_spend_past_stage_cap_raises(self):
-        sheet = self._sheet(matured=21)  # level 1 -> PROSPECT cap 5
-        CharacterTraitValue.objects.create(character=sheet, trait=self.stat, value=5)
+        sheet = self._sheet(matured=21)  # level 1 -> PROSPECT cap 5 display dots
+        CharacterTraitValue.objects.create(character=sheet, trait=self.stat, value=50)
         with self.assertRaises(MaturationCapReachedError):
             spend_maturation_point(sheet, self.stat)
 
@@ -94,17 +95,21 @@ class MaturationServiceTests(TestCase):
 
     def test_reversal_deactivates_spends_and_reaging_reactivates(self):
         sheet = self._sheet(matured=24)  # milestones 21, 24
-        CharacterTraitValue.objects.create(character=sheet, trait=self.stat, value=1)
+        CharacterTraitValue.objects.create(character=sheet, trait=self.stat, value=10)
         spend_maturation_point(sheet, self.stat)
         spend_maturation_point(sheet, self.stat)
-        self.assertEqual(CharacterTraitValue.objects.get(character=sheet, trait=self.stat).value, 3)
+        self.assertEqual(
+            CharacterTraitValue.objects.get(character=sheet, trait=self.stat).value, 30
+        )
 
         # True age-reversal magic winds back to 22: year 24's point lifts off.
         sheet.matured_years = 22
         sheet.save()
         sync_maturation_spends(sheet)
 
-        self.assertEqual(CharacterTraitValue.objects.get(character=sheet, trait=self.stat).value, 2)
+        self.assertEqual(
+            CharacterTraitValue.objects.get(character=sheet, trait=self.stat).value, 20
+        )
         self.assertEqual(
             MaturationSpend.objects.filter(character_sheet=sheet, is_active=True).count(), 1
         )
@@ -115,5 +120,7 @@ class MaturationServiceTests(TestCase):
         sheet.save()
         sync_maturation_spends(sheet)
 
-        self.assertEqual(CharacterTraitValue.objects.get(character=sheet, trait=self.stat).value, 3)
+        self.assertEqual(
+            CharacterTraitValue.objects.get(character=sheet, trait=self.stat).value, 30
+        )
         self.assertEqual(available_points(sheet), 0)

--- a/src/world/seeds/provisioning_checks.py
+++ b/src/world/seeds/provisioning_checks.py
@@ -118,7 +118,12 @@ def seed_provisioning_content() -> None:
 
 def _ensure_cooking_check():
     """The Cooking CheckType (wits + Cooking skill), content-owned rows."""
-    from world.checks.models import CheckCategory, CheckType, CheckTypeTrait  # noqa: PLC0415
+    from world.checks.models import (  # noqa: PLC0415
+        CheckCategory,
+        CheckType,
+        CheckTypeSpecialization,
+        CheckTypeTrait,
+    )
     from world.seeds.sample_content import authored_or_sample  # noqa: PLC0415
     from world.skills.models import Skill, Specialization  # noqa: PLC0415
     from world.traits.models import Trait, TraitCategory, TraitType  # noqa: PLC0415
@@ -139,8 +144,9 @@ def _ensure_cooking_check():
         },
         trait=skill_trait,
     )
+    brewing = None
     if skill is not None:
-        Specialization.objects.get_or_create(
+        brewing, _created = Specialization.objects.get_or_create(
             parent_skill=skill,
             name=BREWING_SPECIALIZATION_NAME,
             defaults={"display_order": 0, "is_active": True},
@@ -172,6 +178,15 @@ def _ensure_cooking_check():
     CheckTypeTrait.objects.get_or_create(
         check_type=check_type, trait=skill_trait, defaults={"weight": Decimal("1.00")}
     )
+    # Brewing rides the check as an authored specialization row (#2894 — the
+    # Specialization existed but was never linked, so it contributed nothing).
+    # Weight 1.0: spec is fully additive with the skill (Apostate: 50+50 ≡ 100).
+    if brewing is not None:
+        CheckTypeSpecialization.objects.get_or_create(
+            check_type=check_type,
+            specialization=brewing,
+            defaults={"weight": Decimal("1.00")},
+        )
     # Stat side = the AVERAGE of wits and agility (#2886, Apostate — echoing
     # Arx 1's higher-of-wits-and-dex; the average is what weighted rows can
     # express). update_or_create so the pre-ruling wits-0.50 rows retune.

--- a/src/world/skills/models.py
+++ b/src/world/skills/models.py
@@ -171,9 +171,10 @@ class CharacterSkillValue(SharedMemoryModel):
         return f"{character.key}: {self.skill.name} = {self.display_value}"
 
     @property
-    def display_value(self) -> float:
-        """Display value as shown to players (e.g., 2.5 for value 25)."""
-        return round(self.value / 10, 1)
+    def display_value(self) -> int:
+        """Skills display their true stored value (#2894) — development moves
+        them by single points, so 25 shows as 25, never 2.5."""
+        return cast(int, self.value)
 
 
 class CharacterSpecializationValue(SharedMemoryModel):
@@ -216,9 +217,9 @@ class CharacterSpecializationValue(SharedMemoryModel):
         return f"{character.key}: {self.specialization} = {self.display_value}"
 
     @property
-    def display_value(self) -> float:
-        """Display value as shown to players (e.g., 1.5 for value 15)."""
-        return round(self.value / 10, 1)
+    def display_value(self) -> int:
+        """Specializations display their true stored value, like skills (#2894)."""
+        return cast(int, self.value)
 
 
 class SkillPointBudget(SharedMemoryModel):

--- a/src/world/skills/services.py
+++ b/src/world/skills/services.py
@@ -125,8 +125,9 @@ def has_specialization(
 ) -> bool:
     """Whether a character owns a specialization at ``minimum_rank`` or better (#1688).
 
-    Ranks are display values (1.0, 2.0, …) stored ×10, so rank 1 is a stored value of 10. Gates
-    surfacing of spec-only options (e.g. the gossip option only appears at Gossip ≥ 1).
+    A rank is ten points of stored value (rank 1 = value 10 — the same rung
+    boundaries XP unlocks cross). Gates surfacing of spec-only options
+    (e.g. the gossip option only appears at Gossip rank ≥ 1).
     """
     return _get_spec_value(character, specialization) >= minimum_rank * 10
 

--- a/src/world/skills/tests/test_models.py
+++ b/src/world/skills/tests/test_models.py
@@ -120,7 +120,7 @@ class CharacterSkillValueModelTests(TestCase):
         assert csv.rust_points == 0
 
     def test_character_skill_display_value(self):
-        """Display value should be value / 10."""
+        """Skills display their true stored value (ADR-0193)."""
         from world.skills.models import CharacterSkillValue
 
         csv = CharacterSkillValue.objects.create(
@@ -128,7 +128,7 @@ class CharacterSkillValueModelTests(TestCase):
             skill=self.skill,
             value=25,
         )
-        assert csv.display_value == 2.5
+        assert csv.display_value == 25
 
     def test_character_skill_unique_constraint(self):
         """Character can only have one value per skill."""
@@ -192,7 +192,7 @@ class CharacterSpecializationValueModelTests(TestCase):
         # No rust_points - specializations are immune
 
     def test_character_specialization_display_value(self):
-        """Display value should be value / 10."""
+        """Specializations display their true stored value, like skills (ADR-0193)."""
         from world.skills.models import CharacterSpecializationValue
 
         csw = CharacterSpecializationValue.objects.create(
@@ -200,7 +200,7 @@ class CharacterSpecializationValueModelTests(TestCase):
             specialization=self.spec,
             value=15,
         )
-        assert csw.display_value == 1.5
+        assert csw.display_value == 15
 
 
 class SkillPointBudgetModelTests(TestCase):

--- a/src/world/traits/AGENT_GLOSSARY.md
+++ b/src/world/traits/AGENT_GLOSSARY.md
@@ -1,5 +1,9 @@
 # Traits glossary
 
+**Storage scale**:
+Every `CharacterTraitValue` stores the fine-grained 1-100 range (ADR-0193, #2894), but display differs by family: **skills show their true stored value** (35 reads 35 — development moves them by single points, XP unlocks cross the ×10 rung boundaries), while **stats display single-digit and store ×10** (strength 2 = stored 20; players allocate 1-5 dots in CG, converted once at finalization). Convert stat display at the edge via `display_trait_value` / `STAT_DISPLAY_DIVISOR`; never divide a skill for display, and never write a display-scale stat to a trait row.
+_Avoid_: "1-5 scale" for storage (that's stat display, draft-side only), dividing skill values by 10
+
 **Trait**:
 The base definition template for any measurable character quality, typed as STAT, SKILL, MODIFIER, or OTHER and grouped by category. Every Stat and Skill is backed by a Trait record, giving them a unified check-resolution pipeline.
 _Avoid_: attribute, stat (for the generic case)

--- a/src/world/traits/constants.py
+++ b/src/world/traits/constants.py
@@ -8,7 +8,12 @@ from typing import NamedTuple
 
 from django.db import models
 
-from world.traits.models import TraitCategory, TraitType
+# STAT_DISPLAY_DIVISOR (#2894, ADR-0193): stats store internal ×10 and display
+# single-digit; skills store AND display their true 1-100 value (development
+# moves them by single points). Canonical definition lives in
+# world.traits.models (this module imports models, so it can't be defined here);
+# re-exported for the many display-edge consumers.
+from world.traits.models import STAT_DISPLAY_DIVISOR, TraitCategory, TraitType  # noqa: F401
 
 
 class PrimaryStat(models.TextChoices):

--- a/src/world/traits/handlers.py
+++ b/src/world/traits/handlers.py
@@ -20,6 +20,7 @@ from world.traits.models import (
     PointConversionRange,
     Trait,
     TraitType,
+    display_trait_value,
 )
 
 
@@ -37,8 +38,8 @@ class DefaultTraitValue:
         self.value = 0
 
     @property
-    def display_value(self) -> float:
-        return 0.0
+    def display_value(self) -> int:
+        return 0
 
     def __str__(self) -> str:
         return f"Default: {self.trait_name} = 0"
@@ -219,18 +220,19 @@ class TraitHandler:
             return 0
         return get_modifier_total(sheet, target) + get_condition_modifier_total(sheet, target)
 
-    def get_trait_display_value(self, trait_name: str) -> float:
+    def get_trait_display_value(self, trait_name: str) -> int:
         """
-        Get the display value (1.0-10.0 scale) for a trait.
+        Get the display value for a trait (#2894): stats ÷10, skills true value.
 
         Args:
             trait_name: Name of the trait
 
         Returns:
-            Display value rounded to 1 decimal place
+            The value as players see it (modifiers included).
         """
         value = self.get_trait_value(trait_name)
-        return round(value / 10, 1)
+        trait = Trait.get_by_name(trait_name)
+        return display_trait_value(trait.trait_type if trait else TraitType.OTHER, value)
 
     def set_trait_value(self, trait_name: str, value: int) -> bool:
         """

--- a/src/world/traits/models.py
+++ b/src/world/traits/models.py
@@ -31,6 +31,24 @@ class TraitType(models.TextChoices):
     OTHER = "other", "Other"
 
 
+# The stat display divisor (#2894, ADR-0193). STATS store internal ×10 (stat 2
+# → stored 20) and display single-digit (÷10). SKILLS store and display their
+# true 1-100 value — development moves them by single points (11…19) and XP
+# unlocks cross the ×10 rung boundaries — so skill display is the stored value,
+# never divided. Convert stat display at the edge with this divisor; never
+# write a display-scale stat to CharacterTraitValue.
+# (Defined here, not in constants.py, because constants.py imports this module;
+# constants.py re-exports it.)
+STAT_DISPLAY_DIVISOR = 10
+
+
+def display_trait_value(trait_type: str, value: int) -> int:
+    """A trait value as players see it: stats ÷10, everything else true value."""
+    if trait_type == TraitType.STAT:
+        return value // STAT_DISPLAY_DIVISOR
+    return value
+
+
 def _trait_type_label(trait_type: str) -> str:
     """Return the display label for a trait type."""
     try:
@@ -188,10 +206,9 @@ class TraitRankDescription(NaturalKeyMixin, SharedMemoryModel):
         return f"{self.trait.name}: {self.label} ({self.display_value})"
 
     @property
-    def display_value(self) -> float:
-        """Display value as shown to players (e.g., 2.0 for value 20)."""
-        value = cast(int, self.value)
-        return round(value / 10, 1)
+    def display_value(self) -> int:
+        """Display value as shown to players: stats ÷10, skills true value (#2894)."""
+        return display_trait_value(self.trait.trait_type, cast(int, self.value))
 
 
 class CharacterTraitValue(SharedMemoryModel):
@@ -229,10 +246,9 @@ class CharacterTraitValue(SharedMemoryModel):
         return f"{self.character}: {self.trait.name} = {self.display_value}"
 
     @property
-    def display_value(self) -> float:
-        """Display value as shown to players (e.g., 2.5 for value 25)."""
-        value = cast(int, self.value)
-        return round(value / 10, 1)
+    def display_value(self) -> int:
+        """Display value as shown to players: stats ÷10, skills true value (#2894)."""
+        return display_trait_value(self.trait.trait_type, cast(int, self.value))
 
     def save(self, *args: Any, **kwargs: Any) -> None:
         """Override save to update character's trait handler cache."""

--- a/src/world/traits/tests.py
+++ b/src/world/traits/tests.py
@@ -65,7 +65,8 @@ class TraitModelTests(TestCase):
         )
 
         assert trait_value.value == 25
-        assert trait_value.display_value == 2.5
+        # strength is a STAT: display ÷10, floored (ADR-0193)
+        assert trait_value.display_value == 2
 
     def test_trait_rank_description(self):
         """Test trait rank descriptions."""
@@ -76,7 +77,7 @@ class TraitModelTests(TestCase):
             description="Someone with exceptional physical strength",
         )
 
-        assert rank_desc.display_value == 3.0
+        assert rank_desc.display_value == 3
         assert "Powerful Warrior" in str(rank_desc)
 
     def test_trait_case_insensitive_lookup(self):
@@ -267,10 +268,10 @@ class TraitHandlerTests(TestCase):
         assert value == 35
 
     def test_get_display_value(self):
-        """Test getting display values."""
+        """Skills display their true stored value (ADR-0193) — never divided."""
         self.handler.set_trait_value("swords", 25)
         display = self.handler.get_trait_display_value("swords")
-        assert display == 2.5
+        assert display == 25
 
     def test_calculate_check_points(self):
         """Test calculating check points."""


### PR DESCRIPTION
Closes #2894

## Summary

Fixes the three CG→checks wiring holes from the #2886 crafting-math audit, per Apostate's scale ruling (now ADR-0193): stats display single-digit but store ×10 under the hood; skills store AND display their true 1-100 value. CG finalization now writes stats ×10 and bridges each CG skill into a matching CharacterTraitValue row, so a freshly finalized character contributes real points to every check (previously: zero skill points, ~1/10th stat points). Maturation spends/caps, the fatigue guard, and every display seam converted; skill display paths stop dividing by 10 (thread-hub picker, unlock messages, admin, telnet breakthrough lines) via one type-aware display_trait_value() helper. Brewing is now linked to the Cooking check as a CheckTypeSpecialization row (weight 1.0), and the runtime-spec no-weight branch is documented as by-design (spec is fully additive). Acceptance test proves a CG-finalized character rolls identical check points to a hand-seeded twin.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2894 (in the issue body)
- Brainstorm/plan: skipped (bug with a code-verified diagnosis in the issue body; Apostate ruled the design in-chat and green-lit implementation)
- Sync-with-main: Branch created from current main (921b553c4, the #2881 merge); sync-with-main reports up to date; no conflicts, no migrations in this PR.

<!-- last-addressed-comment: 0 -->