### PR TITLE
Technique surfaces never show a caster which alternate forms of a technique they have

### DIFF
--- a/docs/roadmap/magic.md
+++ b/docs/roadmap/magic.md
@@ -28,6 +28,7 @@ the one specialization engine, fall/redemption, Covenant of the Court.
 | Distinctions grant/shape resonance (standing + potency) | ✅ built | `#1834` — `DistinctionResonanceGrant` + `reconcile_distinction_resonance_grants`; see `magic-build-history.md` |
 | **A real character actually being able to cast** | ✅ wired | `#1306` — shared template + per-character check; see below |
 | **A player being able to find out what a technique does** | ✅ built | `#2898` — one derived `effect_summary` block (plain-words line + structured effects) on all four surfaces + telnet; see below |
+| **A player being able to find out which forms of it they can work** | ✅ built | `#2901` — `available_technique_forms`: base + each unlocked variant + one step ahead, on the sheet and the cast list; see below |
 
 The backend cast→pose→log→outcome loop is fully wired and resolves end-to-end (verified
 by tracing + a throwaway smoke test). The remaining frontier is **assembly, content, and
@@ -113,16 +114,42 @@ magic." Each is a filed issue — work these, not micro-hardening tickets.
    **Still open (content, not engine):** the 86 techniques with no derivable relationship
    need conditions authored in the lore repo. Display now makes the gap visible — that was
    the point — but the authoring itself is out of scope per the issue.
-4. **🟠 #1307 — seed produces no playable character or scene** (`priority:next`). The
+4. **✅ #2901 — RESOLVED: surfaces now show which forms a caster can work** (spawned by
+   #2898). #2898's block describes the *authored* technique, which is right for CG and the
+   magic API but not for the two per-character surfaces: a `TechniqueVariant` does not
+   replace a technique, it makes an alternate version available. Nothing anywhere enumerated
+   a caster's forms — `Technique.cached_variants` had no display caller — so a player could
+   pass `base` or `variant=<resonance>` to `cast` without any surface having told them those
+   forms existed.
+   - **A list, not one resolved answer:** `available_technique_forms`
+     (`world/magic/services/technique_forms.py`) returns the base form, each unlocked
+     variant (at most one per GIFT-thread resonance, since `matching_variant` shadows lower
+     tiers), and the next locked form per resonance as a visible goal. The signature rides
+     beside it as a delta, never as a sibling row (ADR-0072).
+   - **One resolver, reused not reinvented:** every entry comes from calling
+     `resolve_specialized_variant`; the `is_default` marker comes from the
+     `preferred_resonance=None` call specifically, because that is the path carrying the
+     alt-self resonance override.
+   - **The caching concern in the issue dissolved:** a resolved form takes no caster input,
+     so each form's summary caches on its `TechniqueVariant` row exactly as the base one
+     caches on the `Technique` row. Sheet 37 → 39 queries, telnet cast listing 5 → 7, all
+     fixed rather than per-technique.
+   - **A silent correctness bug closed on the way:** `_ResolvedTechnique` exposed
+     `damage_profiles` while every payload reader reads `cached_damage_profiles`, so
+     `__getattr__` forwarded those to the parent and a variant with its own payload
+     summarised as the base form under the variant's name.
+   - **Web parity:** `preferred_resonance_id` on the cast request — telnet has had
+     `variant=<resonance>` since #1619, and the web had no counterpart at all.
+5. **🟠 #1307 — seed produces no playable character or scene** (`priority:next`). The
    "Big Button" (`world/seeds/database.py:seed_dev_database`, #651) seeds rules content
    only — 0 CharacterSheets / Personas / Scenes. Needs a playable-slice path (demo
    character via `create_character_with_sheet` + CG finalize, placed in a scene). Child
    of epic #1220.
-5. **🟡 #1308 — the web cast loop is never tested live** (`priority:next`). Frontend cast
+6. **🟡 #1308 — the web cast loop is never tested live** (`priority:next`). Frontend cast
    tests mock `castTechnique`; backend tested only at service level. No test drives
    `POST /api/action-requests/cast/` against a seeded + CG'd character. Add one as the
    regression guard. Cross-refs #617.
-6. **🟢 #1309 — frictionless scene start** (`priority:later`). Casting needs an active
+7. **🟢 #1309 — frictionless scene start** (`priority:later`). Casting needs an active
    scene; a player should be able to start/auto-join one without staff setup (the
    "implicit scene start" intent).
 

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -161,6 +161,33 @@ Powers, affinities, auras, resonances, threads-as-currency, rituals, and Mage Sc
     `technique_is_underspecified` (nothing authored at all), collected by
     `technique_effect_authoring_gaps()` and surfaced on `TechniqueAdmin` as
     columns + a filter. See magic.md "Technique effect summary".
+  - **Per-caster technique forms (#2901):** the effect summary above describes
+    the *authored* technique, which is the whole story for the two catalog
+    surfaces (CG, the magic API) but not for the two per-character ones. A
+    variant does not replace a technique — it makes an alternate version
+    available — so the character sheet and the in-scene cast list carry a
+    **list** of forms, not one resolved answer.
+    `available_technique_forms(character, technique, *, character_technique=None,
+    sheet=None) -> list[TechniqueFormPayload]` (`services/technique_forms.py`)
+    returns the base form, each unlocked `TechniqueVariant` (at most one per GIFT
+    thread resonance — `matching_variant` shadows lower tiers), and the next
+    locked form per resonance as a visible goal.
+    `technique_signature_payload` returns the signature flourish beside it, never
+    inside it (ADR-0072). Every entry is derived by **calling
+    `resolve_specialized_variant`**, never by re-implementing its selection rule;
+    the `is_default` marker comes from the `preferred_resonance=None` call, the
+    path that folds in the active alt-self resonance override.
+    No per-caster cache exists or is needed: a resolved form is fully determined
+    by `(parent_technique, variant)`, so its summary caches on
+    `TechniqueVariant.cached_effect_summary` (drop it with
+    `invalidate_variant_payload_caches`). Serialized by
+    `TechniqueFormSerializer`; embedded as `forms` on `CastableTechniqueSerializer`
+    (unlocked only — the scene shows what you can work now) and on `TechniqueEntry`
+    via `_build_magic_gifts` (the full catalogue plus `signature`).
+    `preferred_resonance_id` on the cast request is the web counterpart to
+    telnet's `cast <tech> variant=<resonance>` (#1619); before #2901 the web had
+    `use_base_form` alone and could not reach a specialized form at all.
+    See magic.md "Per-caster technique forms".
   - **Ritual Liturgy (#1352):** `RitualLiturgy` (OneToOne → `Ritual`; `opening_call`
     TextField — the officiant's authored ceremonial words; public, non-spoiler).
     Seeded alongside the Ritual of the Durance via `RitualLiturgyFactory`.

--- a/docs/systems/magic.md
+++ b/docs/systems/magic.md
@@ -1259,6 +1259,85 @@ with variant deltas applied), or the raw parent `Technique` when no variant matc
 `resolve_effective_role` cache coherence). `resolve_effective_role` is now a one-line shim
 over this resolver — no parallel specialization systems (ADR-0016).
 
+### Per-caster technique forms (#2901)
+
+The specialization engine above answers *which* variant applies to a cast. It does
+not answer the question the two per-character display surfaces need: **which forms
+of this technique can this caster work at all.** A variant does not replace a
+technique — it makes an alternate version available, and `cast <tech> base` /
+`cast <tech> variant=<resonance>` both stay reachable — so a display that collapsed
+to one resolved form would misreport what the character can do. Until #2901 nothing
+anywhere enumerated a caster's forms: `Technique.cached_variants` had no display
+caller, and a player could pass `base` or `variant=` without any surface having told
+them those forms existed.
+
+`available_technique_forms(character, technique, *, character_technique=None,
+sheet=None) -> list[TechniqueFormPayload]` (`world/magic/services/technique_forms.py`)
+returns, in order:
+
+1. **The base form** — always present, `variant_id=None`.
+2. **Each unlocked specialized form** — at most one per GIFT-thread resonance,
+   because `matching_variant` picks the *highest* qualifying `unlock_thread_level`
+   per resonance and shadows the rest. A multi-resonance caster (#1619) gets one
+   entry per thread; a role-granted technique (#2022) resolves through its
+   COVENANT_ROLE thread instead.
+3. **The next locked form per resonance** — the lowest `unlock_thread_level`
+   strictly above the thread's current level, carried with `is_locked=True` so the
+   deepening reads as a goal. One step ahead, not the whole ladder.
+
+`technique_signature_payload(character, technique) -> TechniqueSignaturePayload | None`
+returns the signature flourish *beside* the list. A signature is an additive
+modifier on whichever form is chosen, never a sibling form (ADR-0072).
+
+**Three invariants hold this together.**
+
+*One resolver, never a second selection rule.* Each entry is produced by calling
+`resolve_specialized_variant` once per candidate resonance. Re-deriving
+`matching_variant`'s predicate in a display service would drift from the cast the
+first time either side changed (ADR-0055/ADR-0016).
+
+*The `is_default` marker comes from the resolver too.* A bare `cast <tech>` resolves
+with `preferred_resonance=None`, a path that folds in the active alt-self resonance
+override (`_active_alt_self_resonance`). A display assuming "default = the thread's
+own resonance" would mislabel a shifted character.
+
+*No per-caster cache exists or is needed.* A resolved form is fully determined by
+`(parent_technique, variant)` — no caster input reaches it — so each form's effect
+summary caches on `TechniqueVariant.cached_effect_summary` exactly as the base one
+caches on the `Technique` row. Invalidate with `invalidate_variant_payload_caches`
+(shorter than the technique's list: a variant has no `removed_conditions` relation).
+The only per-caster work is deciding which forms are reachable, and that reads two
+already-cached lists (`character.threads`, `technique.cached_variants`).
+
+**The `cached_*` alias fix.** Every payload *reader* —
+`summarize_technique_effects`, `is_technique_hostile`, `derive_target_relationship` —
+reads the `cached_<payload>` names, but `_ResolvedTechnique` originally exposed only
+the bare `damage_profiles` / `capability_grants` / `condition_applications`. Its
+`__getattr__` forwarded the `cached_` reads straight to the parent `Technique`, so a
+variant that swapped its damage rows summarised as the **base** form under the
+variant's name and nothing failed. `_ResolvedTechnique` now declares all four
+`cached_*` names; `cached_removed_conditions` is declared explicitly to make the
+asymmetry visible — there is no `TechniqueVariantRemovedCondition` model, so a
+variant can never override which conditions a technique strips.
+
+**Surfaces.** The sheet describes, the scene does:
+
+| Surface | Carries |
+|---|---|
+| `sheet/magic` (telnet) + web Magic tab (`SpellbookTab`) | The full catalogue: every unlocked form with its own effect summary and intensity/control, the next locked form, and the signature line. Silent when only the base form is reachable. |
+| bare `cast` (telnet) + web castable list (`ActionPanel`) | A compact `Forms: base \| Cinder (Ashfall Lash) (default)` affordance plus the structured `forms` payload driving the web picker. Locked forms omitted. |
+
+**The web could not choose a form at all before this.** `CastRequestSerializer`
+carried `use_base_form` (#1581) but no `preferred_resonance_id`, so telnet's
+`variant=<resonance>` (#1619) had no web counterpart; the Action kwarg
+(`actions/definitions/cast.py`) already existed, only the wire field was missing.
+#2901 adds it and forwards it from `SceneActionRequestViewSet.cast`.
+
+**Query cost.** Both read paths prefetch `technique__variants`
+(`select_related("resonance")`) and make one read of the cached threads handler.
+Both are fixed regardless of how many techniques or variants are involved: the
+character sheet went 37 → 39 queries, the telnet cast listing 5 → 7.
+
 **Cast-time variant wiring [BUILT & WIRED, #1581]:** `resolve_specialized_variant` is called
 at two cast seams so unlocked variants shape every cast automatically: (1)
 `get_runtime_technique_stats` (`world/magic/services/techniques.py`) — combat runtime stats;

--- a/frontend/src/character_sheets/api.ts
+++ b/frontend/src/character_sheets/api.ts
@@ -11,7 +11,7 @@
  */
 
 import { apiFetch } from '@/evennia_replacements/api';
-import type { TechniqueEffectSummary } from '@/magic/types';
+import type { TechniqueEffectSummary, TechniqueForm, TechniqueSignature } from '@/magic/types';
 
 /** Mirrors `world.character_sheets.types.TechniqueEntry`. */
 export interface CharacterSheetTechnique {
@@ -21,6 +21,15 @@ export interface CharacterSheetTechnique {
   description: string;
   /** The shared effect block (#2898) — cost, reach, targeting, hostility, plain-words summary. */
   effect_summary: TechniqueEffectSummary;
+  /**
+   * Which forms of it this caster can work (#2901): base, each unlocked
+   * variant, and one step ahead. Always at least one entry. The sheet
+   * describes, so it carries the full catalogue; the cast list carries only a
+   * compact affordance.
+   */
+  forms: TechniqueForm[];
+  /** The signature flourish riding whichever form is chosen, if any. */
+  signature: TechniqueSignature | null;
 }
 
 /** Mirrors `world.character_sheets.types.GiftEntry`. */

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -22099,7 +22099,7 @@ export interface components {
     /**
      * @description Serializes a Technique for the castable-techniques list endpoint.
      *
-     *     Takes ``Technique`` rows — which is what ``castable_techniques_for_sheet``,
+     *     Takes ``Technique`` rows — which is what ``castable_technique_links_for_sheet``,
      *     its only source, returns. ``get_hostile`` and ``get_target_spec`` used to
      *     carry a ``CharacterTechnique`` branch as well, but neither could ever run:
      *     the declared ``name`` / ``anima_cost`` / ``tier`` fields raise on a link long
@@ -22127,6 +22127,7 @@ export interface components {
         [key: string]: unknown;
       } | null;
       readonly effect_summary: components['schemas']['TechniqueEffectSummary'];
+      readonly forms: components['schemas']['TechniqueForm'][];
     };
     /**
      * @description For staff triaging GM scenario-catalog suggestions (#2127).
@@ -38211,6 +38212,7 @@ export interface components {
       pull?: components['schemas']['CastPullRequestRequest'] | null;
       /** @default false */
       use_base_form: boolean;
+      preferred_resonance_id?: number | null;
       /** @default false */
       cast_openly: boolean;
     };
@@ -38236,6 +38238,32 @@ export interface components {
       readonly grants: components['schemas']['CapabilityEffect'][];
       readonly summary: string;
       readonly is_underspecified: boolean;
+    };
+    /**
+     * @description One form of a technique a given caster can work (#2901).
+     *
+     *     Serializes a ``TechniqueFormPayload`` from
+     *     ``world.magic.services.technique_forms.available_technique_forms``. Shared by
+     *     the character sheet (full catalogue, locked forms included) and the in-scene
+     *     cast list (unlocked only), so the two cannot describe the same character's
+     *     options differently.
+     *
+     *     ``resonance_name`` doubles as the token a player passes to
+     *     ``cast <technique> variant=<resonance>``; the base form (``variant_id`` null)
+     *     is reached with ``cast <technique> base``.
+     */
+    TechniqueForm: {
+      readonly variant_id: number | null;
+      readonly name: string;
+      readonly resonance_id: number | null;
+      readonly resonance_name: string;
+      readonly intensity: number;
+      readonly control: number;
+      readonly is_default: boolean;
+      readonly is_locked: boolean;
+      readonly unlock_thread_level: number;
+      readonly thread_level: number;
+      readonly effect_summary: components['schemas']['TechniqueEffectSummary'];
     };
     /**
      * @description * `same` - Same position

--- a/frontend/src/magic/components/SpellbookTab.test.tsx
+++ b/frontend/src/magic/components/SpellbookTab.test.tsx
@@ -23,7 +23,7 @@ import type {
   CharacterSheetDistinction,
 } from '@/character_sheets/api';
 import type { GlimpseTagOption } from './glimpse/glimpseTypes';
-import type { TechniqueEffectSummary } from '../types';
+import type { TechniqueEffectSummary, TechniqueForm, TechniqueSignature } from '../types';
 
 /** Minimal mock effect_summary (#2898). */
 const mockEffectSummary: TechniqueEffectSummary = {
@@ -40,6 +40,21 @@ const mockEffectSummary: TechniqueEffectSummary = {
   grants: [],
   summary: 'Cast on an enemy, in melee range, in the physical arena. Costs 5 anima.',
   is_underspecified: false,
+};
+
+/** The base form every caster always has (#2901). */
+const mockBaseForm: TechniqueForm = {
+  variant_id: null,
+  name: 'Flare',
+  resonance_id: null,
+  resonance_name: '',
+  intensity: 6,
+  control: 4,
+  is_default: true,
+  is_locked: false,
+  unlock_thread_level: 0,
+  thread_level: 0,
+  effect_summary: mockEffectSummary,
 };
 
 vi.mock('@/character_sheets/queries', () => ({
@@ -191,6 +206,8 @@ function makeMagic(overrides: Partial<CharacterSheetMagic> = {}): CharacterSheet
             style: 'Manifestation',
             description: 'A burst of fire.',
             effect_summary: mockEffectSummary,
+            forms: [mockBaseForm],
+            signature: null,
           },
         ],
       },
@@ -421,5 +438,78 @@ describe('SpellbookTab', () => {
       // it calls the link (not unlink) side.
       expect(toggleDistinction).toHaveBeenCalledWith(7, false);
     });
+  });
+});
+
+describe('SpellbookTab technique forms (#2901)', () => {
+  const variantForm: TechniqueForm = {
+    variant_id: 7,
+    name: 'Ashfall Flare',
+    resonance_id: 2,
+    resonance_name: 'Cinder',
+    intensity: 8,
+    control: 3,
+    is_default: true,
+    is_locked: false,
+    unlock_thread_level: 3,
+    thread_level: 3,
+    effect_summary: mockEffectSummary,
+  };
+
+  const lockedForm: TechniqueForm = {
+    ...variantForm,
+    variant_id: 9,
+    name: 'Cinderfall Rite',
+    is_default: false,
+    is_locked: true,
+    unlock_thread_level: 6,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMotifStyleQueries();
+    mockGlimpseQueries();
+  });
+
+  function renderWithForms(forms: TechniqueForm[], signature: TechniqueSignature | null = null) {
+    const magic = makeMagic();
+    magic.gifts[0].techniques[0].forms = forms;
+    magic.gifts[0].techniques[0].signature = signature;
+    mockPayload(magic);
+    renderWithProviders(<SpellbookTab characterId={1} isMyCharacter={false} />);
+  }
+
+  it('says nothing when the base form is all there is', () => {
+    renderWithForms([{ ...mockBaseForm, is_default: true }]);
+    expect(screen.queryByTestId('technique-forms')).not.toBeInTheDocument();
+  });
+
+  it('lists the base form alongside an unlocked variant, marking the default', () => {
+    renderWithForms([{ ...mockBaseForm, is_default: false }, variantForm]);
+
+    expect(screen.getByTestId('technique-forms')).toBeInTheDocument();
+    expect(screen.getByText('base form')).toBeInTheDocument();
+    expect(screen.getByText('Ashfall Flare (Cinder)')).toBeInTheDocument();
+    expect(screen.getByText('default')).toBeInTheDocument();
+    expect(screen.getByText(/intensity 8, control 3/)).toBeInTheDocument();
+  });
+
+  it('shows the next form as a goal rather than hiding it', () => {
+    renderWithForms([mockBaseForm, lockedForm]);
+
+    expect(screen.getByText('Not yet yours')).toBeInTheDocument();
+    expect(screen.getByText('Cinderfall Rite (Cinder), at thread level 6')).toBeInTheDocument();
+  });
+
+  it('renders the signature as a delta, not another form row', () => {
+    renderWithForms([mockBaseForm], {
+      name: 'Sparks Answer Her Name',
+      narrative_snippet: 'the sparks answer her name',
+      intensity_delta: 1,
+    });
+
+    expect(screen.getByTestId('technique-signature')).toBeInTheDocument();
+    expect(screen.getByText(/\+1 intensity/)).toBeInTheDocument();
+    expect(screen.queryAllByTestId('technique-form')).toHaveLength(0);
   });
 });

--- a/frontend/src/magic/components/SpellbookTab.tsx
+++ b/frontend/src/magic/components/SpellbookTab.tsx
@@ -23,7 +23,8 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { useCharacterSheetQuery } from '@/character_sheets/queries';
-import type { CharacterSheetAura } from '@/character_sheets/api';
+import type { CharacterSheetAura, CharacterSheetTechnique } from '@/character_sheets/api';
+import type { TechniqueForm } from '@/magic/types';
 import { MotifStylePanel } from './MotifStylePanel';
 import { TechniqueEffectSummaryDisplay } from './TechniqueEffectSummary';
 import { GlimpseEditorDialog } from './glimpse/GlimpseEditorDialog';
@@ -33,6 +34,92 @@ interface Props {
   characterId: number;
   /** True when the viewer owns this character — gates the workbench link-outs. */
   isMyCharacter: boolean;
+}
+
+/**
+ * Which forms of one technique this caster can work (#2901).
+ *
+ * A variant does not replace the technique, so this is a list: the base form,
+ * each unlocked resonance-specialized form, and one step ahead as a goal. The
+ * sheet describes, so it carries the whole catalogue; the in-scene cast list
+ * carries only a compact affordance.
+ *
+ * Silent when the caster has only the base form and nothing ahead of them —
+ * a one-item list would say nothing the technique's own name did not.
+ */
+function TechniqueForms({ technique }: { technique: CharacterSheetTechnique }) {
+  const unlocked = technique.forms.filter((form) => !form.is_locked);
+  const locked = technique.forms.filter((form) => form.is_locked);
+  const { signature } = technique;
+
+  if (unlocked.length <= 1 && locked.length === 0 && !signature) return null;
+
+  const label = (form: TechniqueForm) =>
+    form.variant_id === null ? 'base form' : `${form.name} (${form.resonance_name})`;
+
+  return (
+    <div className="mt-2 space-y-2 border-t pt-2" data-testid="technique-forms">
+      {(unlocked.length > 1 || locked.length > 0) && (
+        <div className="space-y-1">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Forms you can work
+          </p>
+          {unlocked.map((form) => (
+            <div key={form.variant_id ?? 'base'} data-testid="technique-form">
+              <div className="flex flex-wrap items-center gap-2">
+                <span className="text-sm">{label(form)}</span>
+                {form.is_default && (
+                  <Badge variant="secondary" className="text-xs">
+                    default
+                  </Badge>
+                )}
+                <span className="text-xs text-muted-foreground">
+                  intensity {form.intensity}, control {form.control}
+                </span>
+              </div>
+              {form.variant_id !== null && (
+                <TechniqueEffectSummaryDisplay
+                  summary={form.effect_summary}
+                  variant="compact"
+                  className="mt-0.5"
+                />
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {locked.length > 0 && (
+        <div className="space-y-1">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Not yet yours
+          </p>
+          {locked.map((form) => (
+            <p
+              key={form.variant_id ?? 'base'}
+              className="text-sm text-muted-foreground"
+              data-testid="technique-form-locked"
+            >
+              {label(form)}, at thread level {form.unlock_thread_level}
+            </p>
+          ))}
+        </div>
+      )}
+
+      {signature && (
+        <p className="text-sm" data-testid="technique-signature">
+          <span className="font-medium">Signature:</span> {signature.name} (
+          {signature.intensity_delta >= 0 ? '+' : ''}
+          {signature.intensity_delta} intensity)
+          {signature.narrative_snippet && (
+            <span className="block text-xs italic text-muted-foreground">
+              {signature.narrative_snippet}
+            </span>
+          )}
+        </p>
+      )}
+    </div>
+  );
 }
 
 /** The affinity with the highest share, as a qualitative label — never the raw percentage. */
@@ -112,6 +199,7 @@ export function SpellbookTab({ characterId, isMyCharacter }: Props) {
                       variant="full"
                       className="mt-1"
                     />
+                    <TechniqueForms technique={technique} />
                   </div>
                 ))}
               </CardContent>

--- a/frontend/src/magic/types.ts
+++ b/frontend/src/magic/types.ts
@@ -528,3 +528,49 @@ export interface TechniqueEffectSummary {
   summary: string;
   is_underspecified: boolean;
 }
+
+// ---------------------------------------------------------------------------
+// Per-caster technique forms (#2901). A variant does NOT replace a technique;
+// it makes an alternate version available, so this is a list rather than one
+// resolved answer. Declared beside `TechniqueEffectSummary` for the same
+// reason it was: the character sheet and the in-scene cast list both embed it,
+// and two hand-rolled copies would drift.
+// ---------------------------------------------------------------------------
+
+/**
+ * One form of a technique a caster can work. `resonance_name` doubles as the
+ * token a player passes to `cast <tech> variant=<resonance>`; the base form
+ * (`variant_id === null`) is reached with `cast <tech> base`.
+ *
+ * Exactly one entry in a list carries `is_default` — the form a bare
+ * `cast <tech>` works right now. `is_locked` entries are shown as a goal on
+ * the character sheet and omitted from the in-scene cast list.
+ */
+export interface TechniqueForm {
+  /** null = the base form. */
+  variant_id: number | null;
+  name: string;
+  /** null = the base form, which is resonance-agnostic. */
+  resonance_id: number | null;
+  /** "" for the base form. */
+  resonance_name: string;
+  intensity: number;
+  control: number;
+  is_default: boolean;
+  is_locked: boolean;
+  /** 0 for the base form. */
+  unlock_thread_level: number;
+  thread_level: number;
+  effect_summary: TechniqueEffectSummary;
+}
+
+/**
+ * The signature flourish riding whichever form is chosen. Additive, never a
+ * sibling form (ADR-0072), so render it as a delta beside the list rather than
+ * as another row in it.
+ */
+export interface TechniqueSignature {
+  name: string;
+  narrative_snippet: string;
+  intensity_delta: number;
+}

--- a/frontend/src/scenes/actionQueries.ts
+++ b/frontend/src/scenes/actionQueries.ts
@@ -358,6 +358,9 @@ export async function castTechnique(
     target_persona_ids?: number[];
     strain_commitment?: number;
     pull?: CastPullRequestBody;
+    /** #2901: which form to work — omit for the default. */
+    use_base_form?: boolean;
+    preferred_resonance_id?: number | null;
   }
 ): Promise<CastResponse> {
   const body: CastRequestBody = {
@@ -376,6 +379,12 @@ export async function castTechnique(
   }
   if (params.pull !== undefined) {
     body.pull = params.pull;
+  }
+  if (params.use_base_form) {
+    body.use_base_form = true;
+  }
+  if (params.preferred_resonance_id != null) {
+    body.preferred_resonance_id = params.preferred_resonance_id;
   }
   const res = await apiFetch('/api/action-requests/cast/', {
     method: 'POST',

--- a/frontend/src/scenes/actionTypes.ts
+++ b/frontend/src/scenes/actionTypes.ts
@@ -2,7 +2,7 @@
 // Legacy scene action types (now slimmed — fetchSceneActions has been removed)
 // ---------------------------------------------------------------------------
 
-import type { PowerLedger, TechniqueEffectSummary } from '@/magic/types';
+import type { PowerLedger, TechniqueEffectSummary, TechniqueForm } from '@/magic/types';
 
 export interface TechniqueOption {
   id: number;
@@ -384,6 +384,14 @@ export interface CastableTechnique {
   target_spec: TargetSpec | null;
   /** The shared effect block (#2898) — cost, reach, targeting, hostility, plain-words summary. */
   effect_summary: TechniqueEffectSummary;
+  /**
+   * The forms of this technique the caster can work right now (#2901): the base
+   * form plus each unlocked resonance-specialized one. Always at least one
+   * entry, exactly one of which is `is_default`. Locked forms are omitted here
+   * (the character sheet shows those); pick one by sending its `resonance_id`
+   * as `preferred_resonance_id`, or the base form via `use_base_form`.
+   */
+  forms: TechniqueForm[];
 }
 
 export interface CastPullRequestBody {
@@ -401,6 +409,13 @@ export interface CastRequestBody {
   target_persona_ids?: number[];
   strain_commitment?: number;
   pull?: CastPullRequestBody;
+  /** Cast the unspecialized base form (#1581) — telnet's `cast <tech> base`. */
+  use_base_form?: boolean;
+  /**
+   * Work the form specialized to this resonance (#2901) — telnet's
+   * `cast <tech> variant=<resonance>`. Omit for the default form.
+   */
+  preferred_resonance_id?: number | null;
 }
 
 /** Immediate-path cast result (EnhancedSceneActionResultSerializer). */

--- a/frontend/src/scenes/components/ActionPanel.test.tsx
+++ b/frontend/src/scenes/components/ActionPanel.test.tsx
@@ -4,7 +4,7 @@ import { vi } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 import type { PlayerActionsResponse } from '../actionTypes';
-import type { TechniqueEffectSummary } from '@/magic/types';
+import type { TechniqueEffectSummary, TechniqueForm } from '@/magic/types';
 
 vi.mock('../actionQueries', async (importOriginal) => {
   // Keep the real toastDispositionMessage (it only depends on 'sonner', mocked
@@ -186,6 +186,21 @@ const CASTABLE_EFFECT_SUMMARY: TechniqueEffectSummary = {
   is_underspecified: false,
 };
 
+/** The base form every caster always has (#2901). */
+const CASTABLE_BASE_FORM: TechniqueForm = {
+  variant_id: null,
+  name: 'Ember Touch',
+  resonance_id: null,
+  resonance_name: '',
+  intensity: 2,
+  control: 1,
+  is_default: true,
+  is_locked: false,
+  unlock_thread_level: 0,
+  thread_level: 0,
+  effect_summary: CASTABLE_EFFECT_SUMMARY,
+};
+
 const MOCK_ACTIONS: PlayerActionsResponse = {
   count: 3,
   next: null,
@@ -253,6 +268,7 @@ describe('ActionPanel', () => {
           hostile: false,
           description: 'A test technique.',
           effect_summary: CASTABLE_EFFECT_SUMMARY,
+          forms: [CASTABLE_BASE_FORM],
         },
       ],
       isLoading: false,
@@ -299,6 +315,105 @@ describe('ActionPanel', () => {
     // Select the technique
     await user.click(screen.getByText('Ember Touch'));
   }
+
+  /** Ember Touch with a second, unlocked form (#2901). */
+  function mockEmberTouchWithVariant() {
+    vi.mocked(useCastableTechniques).mockReturnValue({
+      data: [
+        {
+          id: 10,
+          name: 'Ember Touch',
+          anima_cost: 3,
+          tier: 1,
+          intensity: 2,
+          control: 1,
+          hostile: false,
+          description: 'A test technique.',
+          effect_summary: CASTABLE_EFFECT_SUMMARY,
+          forms: [
+            { ...CASTABLE_BASE_FORM, is_default: false },
+            {
+              ...CASTABLE_BASE_FORM,
+              variant_id: 55,
+              name: 'Ashfall Touch',
+              resonance_id: 4,
+              resonance_name: 'Cinder',
+              is_default: true,
+              unlock_thread_level: 3,
+              thread_level: 3,
+            },
+          ],
+        },
+      ],
+      isLoading: false,
+    } as unknown as ReturnType<typeof useCastableTechniques>);
+  }
+
+  async function openCastDialogWithVariant(user: ReturnType<typeof userEvent.setup>) {
+    vi.mocked(fetchAvailableActions).mockResolvedValue(MOCK_ACTIONS);
+    mockEmberTouchWithVariant();
+    await mockRosterWithPersona();
+
+    render(<ActionPanel sceneId="42" />, { wrapper: createWrapper() });
+    await user.click(screen.getByRole('button'));
+    await waitFor(() => {
+      expect(screen.getByText('Cast')).toBeInTheDocument();
+    });
+    await user.click(screen.getByText('Cast'));
+    await waitFor(() => {
+      expect(screen.getAllByText('Ember Touch').length).toBeGreaterThan(0);
+    });
+    await user.click(screen.getAllByText('Ember Touch')[0]);
+  }
+
+  it('shows no form picker when only the base form is reachable (#2901)', async () => {
+    const user = userEvent.setup();
+    await openCastDialogWithEmberTouch(user);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /cast ember touch/i })).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('technique-form-picker')).not.toBeInTheDocument();
+  });
+
+  it('offers the caster their alternate forms and sends the pick (#2901)', async () => {
+    vi.mocked(castTechnique).mockResolvedValue({ id: 99, status: 'pending' });
+    const user = userEvent.setup();
+    await openCastDialogWithVariant(user);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('technique-form-picker')).toBeInTheDocument();
+    });
+    // Opting back to the base form is the whole point of `use_base_form`.
+    await user.click(screen.getByRole('button', { name: /base form/i }));
+    await user.click(screen.getByRole('button', { name: /^cast ember touch$/i }));
+
+    await waitFor(() => {
+      expect(castTechnique).toHaveBeenCalledWith(
+        '42',
+        expect.objectContaining({ technique_id: 10, use_base_form: true })
+      );
+    });
+  });
+
+  it('sends the resonance when a specialized form is picked (#2901)', async () => {
+    vi.mocked(castTechnique).mockResolvedValue({ id: 99, status: 'pending' });
+    const user = userEvent.setup();
+    await openCastDialogWithVariant(user);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('technique-form-picker')).toBeInTheDocument();
+    });
+    await user.click(screen.getByRole('button', { name: /ashfall touch/i }));
+    await user.click(screen.getByRole('button', { name: /^cast ember touch$/i }));
+
+    await waitFor(() => {
+      expect(castTechnique).toHaveBeenCalledWith(
+        '42',
+        expect.objectContaining({ technique_id: 10, preferred_resonance_id: 4 })
+      );
+    });
+  });
 
   it('renders actions after opening the panel', async () => {
     vi.mocked(fetchAvailableActions).mockResolvedValue(MOCK_ACTIONS);
@@ -622,6 +737,7 @@ describe('ActionPanel', () => {
           hostile: false,
           description: 'A test technique.',
           effect_summary: CASTABLE_EFFECT_SUMMARY,
+          forms: [CASTABLE_BASE_FORM],
         },
         {
           id: 11,
@@ -633,6 +749,7 @@ describe('ActionPanel', () => {
           hostile: true,
           description: 'A test technique.',
           effect_summary: CASTABLE_EFFECT_SUMMARY,
+          forms: [CASTABLE_BASE_FORM],
         },
       ],
       isLoading: false,
@@ -1145,6 +1262,7 @@ describe('ActionPanel', () => {
           hostile: false,
           description: 'A test technique.',
           effect_summary: CASTABLE_EFFECT_SUMMARY,
+          forms: [CASTABLE_BASE_FORM],
           target_type: 'area',
           reach: 'any',
           target_spec: {
@@ -1212,6 +1330,7 @@ describe('ActionPanel', () => {
           hostile: false,
           description: 'A test technique.',
           effect_summary: CASTABLE_EFFECT_SUMMARY,
+          forms: [CASTABLE_BASE_FORM],
           target_type: 'filtered_group',
           reach: 'any',
           target_spec: {
@@ -1280,6 +1399,7 @@ describe('ActionPanel', () => {
           hostile: false,
           description: 'A test technique.',
           effect_summary: CASTABLE_EFFECT_SUMMARY,
+          forms: [CASTABLE_BASE_FORM],
           target_type: 'filtered_group',
           reach: 'any',
           target_spec: {
@@ -1361,6 +1481,7 @@ describe('ActionPanel', () => {
           hostile: false,
           description: 'A test technique.',
           effect_summary: CASTABLE_EFFECT_SUMMARY,
+          forms: [CASTABLE_BASE_FORM],
           target_type: 'single',
           reach: 'any',
           target_spec: {
@@ -1420,6 +1541,7 @@ describe('ActionPanel', () => {
           hostile: false,
           description: 'A test technique.',
           effect_summary: CASTABLE_EFFECT_SUMMARY,
+          forms: [CASTABLE_BASE_FORM],
           target_type: 'self',
           reach: 'any',
           target_spec: {

--- a/frontend/src/scenes/components/ActionPanel.tsx
+++ b/frontend/src/scenes/components/ActionPanel.tsx
@@ -68,6 +68,84 @@ const DEFAULT_EFFORT = 'medium';
  * and renders each PlayerAction with optional enhancement list, strain slider,
  * and target picker — all sourced from inline fields on the action.
  */
+/**
+ * Which form the player picked, if any (#2901).
+ *
+ * `null` is "left the default alone", which is NOT the same as picking the base
+ * form: when a variant is the default, choosing the base form is a real
+ * instruction (`use_base_form`) and must not collapse back to "no pick". The
+ * base form has no variant id of its own, hence the sentinel rather than null.
+ */
+type FormChoice = number | 'base' | null;
+
+/**
+ * The cast-request fields naming which form to work (#2901).
+ *
+ * Sends nothing when the player left the default alone — the server resolves
+ * the same form a bare `cast` would. The base form maps to `use_base_form`; a
+ * specialized form is named by its resonance, the same token telnet takes as
+ * `variant=<resonance>`.
+ */
+function formSelection(
+  technique: CastableTechnique,
+  choice: FormChoice
+): { use_base_form?: boolean; preferred_resonance_id?: number | null } {
+  if (choice === null) return {};
+  if (choice === 'base') return { use_base_form: true };
+  const form = technique.forms.find((f) => f.variant_id === choice);
+  if (!form) return {};
+  return { preferred_resonance_id: form.resonance_id };
+}
+
+/**
+ * Lets the caster pick among the forms of the selected technique (#2901).
+ *
+ * Renders nothing when only one form is reachable — a picker with a single
+ * option is noise. Before this the `base` and `variant=<resonance>` options
+ * existed only as undocumented telnet syntax, and the web could not reach the
+ * second one at all.
+ */
+function TechniqueFormPicker({
+  technique,
+  choice,
+  onSelect,
+}: {
+  technique: CastableTechnique;
+  choice: FormChoice;
+  onSelect: (choice: FormChoice) => void;
+}) {
+  if (technique.forms.length < 2) return null;
+
+  const defaultForm = technique.forms.find((f) => f.is_default);
+  const active: FormChoice = choice ?? (defaultForm ? (defaultForm.variant_id ?? 'base') : null);
+
+  return (
+    <div className="space-y-1" data-testid="technique-form-picker">
+      <p className="text-xs font-medium">Form</p>
+      <div className="flex flex-wrap gap-1">
+        {technique.forms.map((form) => {
+          const key: FormChoice = form.variant_id ?? 'base';
+          const isActive = key === active;
+          return (
+            <button
+              key={key}
+              type="button"
+              onClick={() => onSelect(key)}
+              aria-pressed={isActive}
+              className={`rounded border px-2 py-1 text-xs ${
+                isActive ? 'border-primary bg-primary/10' : 'border-muted text-muted-foreground'
+              }`}
+            >
+              {form.variant_id === null ? 'base form' : `${form.name} (${form.resonance_name})`}
+              {form.is_default && ' \u2022 default'}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
 export function ActionPanel({ sceneId }: Props) {
   const navigate = useNavigate();
   const [open, setOpen] = useState(false);
@@ -91,6 +169,9 @@ export function ActionPanel({ sceneId }: Props) {
   /** Selected persona ids for FILTERED_GROUP multi-cast. */
   const [castTargetPersonaIds, setCastTargetPersonaIds] = useState<number[]>([]);
   const [castPickingTarget, setCastPickingTarget] = useState(false);
+  // #2901: which form of the selected technique to work. null = the default
+  // form, which is what a bare cast does; the base form is variant_id null.
+  const [selectedForm, setSelectedForm] = useState<FormChoice>(null);
   const [castLedgerResult, setCastLedgerResult] = useState<CastResponse | null>(null);
 
   const queryClient = useQueryClient();
@@ -158,6 +239,7 @@ export function ActionPanel({ sceneId }: Props) {
     onSuccess: (data) => {
       invalidateActionOutcomeQueries();
       setSelectedTechnique(null);
+      setSelectedForm(null);
       setCastTargetPersonaId(null);
       setCastTargetPersonaIds([]);
       setCastPickingTarget(false);
@@ -350,6 +432,7 @@ export function ActionPanel({ sceneId }: Props) {
       performCast.mutate({
         technique_id: selectedTechnique.id,
         target_persona_ids: castTargetPersonaIds,
+        ...formSelection(selectedTechnique, selectedForm),
         ...payload,
       });
     } else {
@@ -357,6 +440,7 @@ export function ActionPanel({ sceneId }: Props) {
       performCast.mutate({
         technique_id: selectedTechnique.id,
         target_persona: castTargetPersonaId ?? null,
+        ...formSelection(selectedTechnique, selectedForm),
         ...payload,
       });
     }
@@ -639,6 +723,12 @@ export function ActionPanel({ sceneId }: Props) {
                       <TechniqueEffectSummaryDisplay
                         summary={selectedTechnique.effect_summary}
                         variant="full"
+                      />
+
+                      <TechniqueFormPicker
+                        technique={selectedTechnique}
+                        choice={selectedForm}
+                        onSelect={setSelectedForm}
                       />
 
                       {selectedTechnique.hostile && (

--- a/frontend/src/scenes/components/__tests__/EntranceTechniqueAttachment.test.tsx
+++ b/frontend/src/scenes/components/__tests__/EntranceTechniqueAttachment.test.tsx
@@ -50,6 +50,21 @@ function makeTechnique(overrides: Partial<CastableTechnique> = {}): CastableTech
     reach: 'any',
     target_spec: null,
     effect_summary: mockEffectSummary,
+    forms: [
+      {
+        variant_id: null,
+        name: 'Ember Touch',
+        resonance_id: null,
+        resonance_name: '',
+        intensity: 2,
+        control: 1,
+        is_default: true,
+        is_locked: false,
+        unlock_thread_level: 0,
+        thread_level: 0,
+        effect_summary: mockEffectSummary,
+      },
+    ],
     ...overrides,
   };
 }

--- a/src/commands/account/sheet_sections.py
+++ b/src/commands/account/sheet_sections.py
@@ -21,6 +21,8 @@ if TYPE_CHECKING:
     from evennia import Command
 
     from world.character_sheets.models import CharacterSheet
+    from world.character_sheets.types import TechniqueEntry
+    from world.magic.types.technique_effects import TechniqueFormPayload
     from world.roster.models import ParentageEdge as ParentageEdgeType
     from world.secrets.models import Secret, SecretKnowledge
 
@@ -360,6 +362,54 @@ def _render_distinction_section(command: Command) -> list[str]:
     return lines
 
 
+def _form_label(form: TechniqueFormPayload) -> str:
+    """One form's headline: what it is called and how to reach it.
+
+    The base form is always castable as ``cast <tech> base``; a specialized form
+    is reached with ``cast <tech> variant=<resonance>``, so the resonance name
+    doubles as the token a player types.
+    """
+    if form["variant_id"] is None:
+        return "base form"
+    return f"{form['name']} ({form['resonance_name']})"
+
+
+def _render_technique_forms(technique: TechniqueEntry) -> list[str]:
+    """The caster's forms of one technique, plus any signature flourish (#2901).
+
+    Silent when the caster has only the base form and nothing ahead of them:
+    a character with no thread on the gift would otherwise read a one-item
+    "forms" list saying nothing the technique's own name did not already say.
+    """
+    forms = technique["forms"]
+    unlocked = [f for f in forms if not f["is_locked"]]
+    locked = [f for f in forms if f["is_locked"]]
+    signature = technique["signature"]
+
+    lines: list[str] = []
+    if len(unlocked) > 1 or locked:
+        lines.append("      Forms you can work:")
+        for form in unlocked:
+            marker = " |w(default)|n" if form["is_default"] else ""
+            lines.append(f"        {_form_label(form)}{marker}")
+            lines.append(f"          intensity {form['intensity']}, control {form['control']}")
+            if form["variant_id"] is not None:
+                lines.append(f"          {form['effect_summary']['summary']}")
+    if locked:
+        lines.append("      Not yet yours:")
+        lines.extend(
+            f"        {_form_label(form)}, at thread level {form['unlock_thread_level']}"
+            for form in locked
+        )
+    if signature:
+        delta = signature["intensity_delta"]
+        sign = "+" if delta >= 0 else ""
+        lines.append(f"      Signature: {signature['name']} ({sign}{delta} intensity)")
+        if signature["narrative_snippet"]:
+            lines.append(f"        {signature['narrative_snippet']}")
+    return lines
+
+
 def _render_magic_section(command: Command) -> list[str]:
     """The magic section (#1446): the active character's spellbook/status view.
 
@@ -385,6 +435,7 @@ def _render_magic_section(command: Command) -> list[str]:
             # their own spellbook without learning what a single technique did.
             lines.append(f"    {technique['name']} (level {technique['level']})")
             lines.append(f"      {technique['effect_summary']['summary']}")
+            lines.extend(_render_technique_forms(technique))
         if gift["resonances"]:
             lines.append(f"    resonances: {', '.join(gift['resonances'])}")
     motif = magic["motif"]

--- a/src/commands/combat.py
+++ b/src/commands/combat.py
@@ -69,6 +69,9 @@ _STRAIN_PREFIX = "strain="
 _POSITION_PREFIX = "position="
 # Keyword prefix used to parse variant=<resonance> from cast command args (#1619).
 _VARIANT_PREFIX = "variant="
+# Below this many reachable forms, the bare-`cast` listing says nothing about them
+# (#2901) — naming a single option is no help, and the list is already dense.
+_MIN_FORMS_WORTH_LISTING = 2
 # Keyword prefix used to parse position_a=<name>,position_b=<name> pair tokens from
 # cast command args (#2206) — arrives as a single whitespace token, kept whole (not
 # stripped) so _resolve_position_params's `val.startswith("position_a=")` branch fires.
@@ -718,20 +721,59 @@ class CmdDeclareTechnique(_CombatCommandMixin, DispatchCommand):
 
     def _castable_listing(self) -> list[str]:
         """Lines for the bare-``cast`` listing: every castable technique and what it does."""
-        from world.scenes.cast_services import castable_techniques_for_sheet  # noqa: PLC0415
+        from world.magic.services.technique_forms import (  # noqa: PLC0415
+            available_technique_forms,
+        )
+        from world.scenes.cast_services import (  # noqa: PLC0415
+            castable_technique_links_for_sheet,
+        )
 
-        techniques = castable_techniques_for_sheet(self.caller.sheet_data.pk)
-        if not techniques:
+        sheet = self.caller.sheet_data
+        # The links rather than the bare techniques: the form list needs them to
+        # spot a role-granted technique (#2901), and this way it is one fetch.
+        links = {ct.technique_id: ct for ct in castable_technique_links_for_sheet(sheet.pk)}
+        if not links:
             return ["You know no techniques you can cast."]
         lines = ["|wYou can cast:|n"]
-        for technique in techniques:
+        for link in links.values():
+            technique = link.technique
             lines.append(f"  |w{technique.name}|n")
             lines.append(f"    {technique.cached_effect_summary['summary']}")
             if technique.description:
                 lines.append(f"    {technique.description}")
+            forms_line = self._forms_line(
+                available_technique_forms(
+                    self.caller, technique, character_technique=link, sheet=sheet
+                )
+            )
+            if forms_line:
+                lines.append(f"    {forms_line}")
         lines.append("")
         lines.append("Use |wcast <technique> [at <target>]|n to work one.")
         return lines
+
+    @staticmethod
+    def _forms_line(forms: list) -> str:
+        """One compact line naming the caster's alternate forms, or ``""`` (#2901).
+
+        The cast list is already dense, so this is an affordance rather than a
+        catalogue: enough to reveal that ``base`` and ``variant=<resonance>``
+        exist and what they are called. The sheet carries the full block,
+        including forms not yet unlocked.
+
+        Silent when only the base form is reachable, since naming one option is
+        no help.
+        """
+        unlocked = [form for form in forms if not form["is_locked"]]
+        if len(unlocked) < _MIN_FORMS_WORTH_LISTING:
+            return ""
+        parts = []
+        for form in unlocked:
+            label = "base" if form["variant_id"] is None else f"{form['resonance_name']}"
+            if form["variant_id"] is not None:
+                label = f"{label} ({form['name']})"
+            parts.append(f"{label} (default)" if form["is_default"] else label)
+        return "Forms: " + " | ".join(parts)
 
     def resolve_action_ref(self) -> ActionRef:
         """Build a SCENE_ADAPTIVE ``ActionRef`` for the named technique.

--- a/src/commands/combat.py
+++ b/src/commands/combat.py
@@ -712,7 +712,7 @@ class CmdDeclareTechnique(_CombatCommandMixin, DispatchCommand):
         error, and the sheet's magic section printed name and level only, so a
         player could not find out what any technique did from any telnet surface.
         This is the telnet face of the web castable-techniques list; both read
-        ``castable_techniques_for_sheet``.
+        ``castable_technique_links_for_sheet``.
         """
         if (self.args or "").strip():
             super().func()

--- a/src/commands/tests/test_cast_listing.py
+++ b/src/commands/tests/test_cast_listing.py
@@ -1,8 +1,12 @@
-"""Bare ``cast`` is the telnet cast list (#2898).
+"""Bare ``cast`` is the telnet cast list (#2898, #2901).
 
 Telnet had no way to find out what a technique does. ``sheet/magic`` printed name
 and level; bare ``cast`` raised a usage error. This is the telnet face of the web
-castable-techniques list — both read ``castable_techniques_for_sheet``.
+castable-techniques list — both read ``castable_technique_links_for_sheet``.
+
+#2901 adds the compact forms line: enough to reveal that ``base`` and
+``variant=<resonance>`` exist and what they are called, without turning an
+already-dense list into a catalogue.
 """
 
 from __future__ import annotations
@@ -13,13 +17,19 @@ from actions.factories import ActionTemplateFactory
 from commands.combat import CmdDeclareTechnique
 from world.character_sheets.factories import CharacterFactory, CharacterSheetFactory
 from world.conditions.factories import ConditionTemplateFactory
+from world.magic.constants import TargetKind
 from world.magic.factories import (
     BinaryEffectTypeFactory,
     CharacterTechniqueFactory,
+    GiftFactory,
+    ResonanceFactory,
     TechniqueAppliedConditionFactory,
     TechniqueFactory,
 )
+from world.magic.models import Thread
 from world.magic.models.techniques import ConditionTargetKind
+from world.magic.specialization.models import TechniqueVariant
+from world.magic.specialization.services import provision_latent_gift_thread
 
 
 class _RecordingCmd(CmdDeclareTechnique):
@@ -78,12 +88,81 @@ class CastListingTests(TestCase):
 
     def test_listing_does_not_scale_queries_with_technique_count(self) -> None:
         """The payload tables prefetch onto the cached_property names the summary
-        reads, so N techniques cost a fixed handful of queries, not 4N."""
+        reads, so N techniques cost a fixed handful of queries, not 4N.
+
+        7 queries: the CharacterTechnique rows, the four #2898 payload prefetches,
+        the #2901 variants prefetch (the caster's alternate forms), and one read
+        of the cached threads handler (which of those variants they have
+        unlocked). Every one is fixed; none is per technique.
+        """
         for name in ("Ward of Ash", "Ember Lash", "Cinder Step", "Ash Veil"):
             self._technique(name)
 
         cmd = _RecordingCmd(self.character)
-        with self.assertNumQueries(5):
+        with self.assertNumQueries(7):
             lines = cmd._castable_listing()
 
         self.assertIn("Ash Veil", "\n".join(lines))
+
+
+class CastListingFormsTests(TestCase):
+    """The forms affordance on the bare-``cast`` listing (#2901)."""
+
+    def setUp(self) -> None:
+        self.character = CharacterFactory()
+        self.sheet = CharacterSheetFactory(character=self.character)
+        self.gift = GiftFactory()
+        self.resonance = ResonanceFactory(name="Cinder")
+        self.gift.resonances.add(self.resonance)
+        self.technique = TechniqueFactory(
+            name="Ember Lash",
+            gift=self.gift,
+            effect_type=BinaryEffectTypeFactory(),
+            damage_profile=False,
+            action_template=ActionTemplateFactory(),
+        )
+        CharacterTechniqueFactory(character=self.sheet, technique=self.technique)
+
+    def _unlock_variant(self, level: int) -> TechniqueVariant:
+        variant = TechniqueVariant.objects.create(
+            parent_technique=self.technique,
+            resonance=self.resonance,
+            unlock_thread_level=3,
+            name_override="Ashfall Lash",
+        )
+        provision_latent_gift_thread(self.sheet, self.gift, resonance=self.resonance)
+        thread = Thread.objects.get(
+            owner=self.sheet, target_kind=TargetKind.GIFT, target_gift=self.gift
+        )
+        thread.level = level
+        thread.save(update_fields=["level"])
+        self.character.threads.invalidate()
+        return variant
+
+    def test_no_forms_line_when_only_the_base_form_is_reachable(self) -> None:
+        """Naming a single option is no help, so the dense list stays quiet."""
+        cmd = _RecordingCmd(self.character)
+        cmd.func()
+
+        self.assertNotIn("Forms:", "\n".join(cmd.sent))
+
+    def test_forms_line_names_the_variant_and_marks_the_default(self) -> None:
+        """This is what makes `base` and `variant=<resonance>` discoverable."""
+        self._unlock_variant(level=3)
+
+        cmd = _RecordingCmd(self.character)
+        cmd.func()
+        text = "\n".join(cmd.sent)
+
+        self.assertIn("Forms: base | Cinder (Ashfall Lash) (default)", text)
+
+    def test_locked_forms_stay_off_the_cast_list(self) -> None:
+        """The scene shows what you can do; the sheet shows what you are becoming."""
+        self._unlock_variant(level=1)
+
+        cmd = _RecordingCmd(self.character)
+        cmd.func()
+        text = "\n".join(cmd.sent)
+
+        self.assertNotIn("Forms:", text)
+        self.assertNotIn("Ashfall Lash", text)

--- a/src/schema.json
+++ b/src/schema.json
@@ -36985,7 +36985,7 @@ components:
       description: |-
         Serializes a Technique for the castable-techniques list endpoint.
 
-        Takes ``Technique`` rows — which is what ``castable_techniques_for_sheet``,
+        Takes ``Technique`` rows — which is what ``castable_technique_links_for_sheet``,
         its only source, returns. ``get_hostile`` and ``get_target_spec`` used to
         carry a ``CharacterTechnique`` branch as well, but neither could ever run:
         the declared ``name`` / ``anima_cost`` / ``tier`` fields raise on a link long
@@ -37027,11 +37027,17 @@ components:
           allOf:
           - $ref: '#/components/schemas/TechniqueEffectSummary'
           readOnly: true
+        forms:
+          type: array
+          items:
+            $ref: '#/components/schemas/TechniqueForm'
+          readOnly: true
       required:
       - anima_cost
       - control
       - description
       - effect_summary
+      - forms
       - hostile
       - id
       - intensity
@@ -68466,6 +68472,9 @@ components:
         use_base_form:
           type: boolean
           default: false
+        preferred_resonance_id:
+          type: integer
+          nullable: true
         cast_openly:
           type: boolean
           default: false
@@ -68544,6 +68553,69 @@ components:
       - removes
       - summary
       - target_type
+    TechniqueForm:
+      type: object
+      description: |-
+        One form of a technique a given caster can work (#2901).
+
+        Serializes a ``TechniqueFormPayload`` from
+        ``world.magic.services.technique_forms.available_technique_forms``. Shared by
+        the character sheet (full catalogue, locked forms included) and the in-scene
+        cast list (unlocked only), so the two cannot describe the same character's
+        options differently.
+
+        ``resonance_name`` doubles as the token a player passes to
+        ``cast <technique> variant=<resonance>``; the base form (``variant_id`` null)
+        is reached with ``cast <technique> base``.
+      properties:
+        variant_id:
+          type: integer
+          readOnly: true
+          nullable: true
+        name:
+          type: string
+          readOnly: true
+        resonance_id:
+          type: integer
+          readOnly: true
+          nullable: true
+        resonance_name:
+          type: string
+          readOnly: true
+        intensity:
+          type: integer
+          readOnly: true
+        control:
+          type: integer
+          readOnly: true
+        is_default:
+          type: boolean
+          readOnly: true
+        is_locked:
+          type: boolean
+          readOnly: true
+        unlock_thread_level:
+          type: integer
+          readOnly: true
+        thread_level:
+          type: integer
+          readOnly: true
+        effect_summary:
+          allOf:
+          - $ref: '#/components/schemas/TechniqueEffectSummary'
+          readOnly: true
+      required:
+      - control
+      - effect_summary
+      - intensity
+      - is_default
+      - is_locked
+      - name
+      - resonance_id
+      - resonance_name
+      - thread_level
+      - unlock_thread_level
+      - variant_id
     TechniqueReachEnum:
       enum:
       - same

--- a/src/world/character_sheets/serializers.py
+++ b/src/world/character_sheets/serializers.py
@@ -77,6 +77,11 @@ from world.magic.models import (
     TechniqueCapabilityGrant,
     TechniqueDamageProfile,
     TechniqueRemovedCondition,
+    TechniqueVariant,
+)
+from world.magic.services.technique_forms import (
+    available_technique_forms,
+    technique_signature_payload,
 )
 from world.progression.models import CharacterPathHistory
 from world.roster.models import RosterTenure
@@ -713,6 +718,17 @@ _MAGIC_PREFETCH_RELATED: tuple[str | Prefetch, ...] = (
                 queryset=TechniqueCapabilityGrant.objects.select_related("capability"),
                 to_attr="cached_capability_grants",
             ),
+            # #2901: the per-caster form list walks the technique's variants.
+            # select_related("resonance") because each form is labelled by the
+            # resonance a player passes to `cast ... variant=<resonance>`; the
+            # variants' own payload rows are NOT prefetched here because each
+            # form's summary is cached on its TechniqueVariant row and so is
+            # built once per variant for the whole process, not per sheet read.
+            Prefetch(
+                "technique__variants",
+                queryset=TechniqueVariant.objects.select_related("resonance"),
+                to_attr="cached_variants",
+            ),
         ),
         to_attr="cached_character_techniques",
     ),
@@ -758,6 +774,7 @@ def _build_magic_gifts(sheet: CharacterSheet) -> list[GiftEntry]:
     )
 
     # Build a lookup of techniques by gift_id from prefetched character_techniques
+    character = sheet.character
     techniques_by_gift: dict[int, list[TechniqueEntry]] = {}
     for ct in sheet.cached_character_techniques:
         tech = ct.technique
@@ -770,6 +787,14 @@ def _build_magic_gifts(sheet: CharacterSheet) -> list[GiftEntry]:
                 # Cached on the Technique row, so the whole spellbook costs one
                 # build per distinct technique however many characters read it (#2898).
                 effect_summary=tech.cached_effect_summary,
+                # Which forms of it this caster can work (#2901). Reads the
+                # prefetched variants + the cached threads handler, and each
+                # form's own summary is cached on its TechniqueVariant row, so
+                # this adds no query per technique.
+                forms=available_technique_forms(
+                    character, tech, character_technique=ct, sheet=sheet
+                ),
+                signature=technique_signature_payload(character, tech),
             )
         )
 

--- a/src/world/character_sheets/tests/test_viewset.py
+++ b/src/world/character_sheets/tests/test_viewset.py
@@ -2125,9 +2125,18 @@ class TestCharacterSheetQueryCount(TestCase):
                 for the whole spellbook, not four per technique: the alternative
                 was showing the player a technique list that says nothing about
                 what any of the techniques do.
+        38.    technique variants prefetch (#2901 — the resonance-specialized forms
+                each known technique offers, select_related onto the resonance that
+                labels them). One fixed query, and it carries no payload prefetch of
+                its own: each form's effect summary is cached on its TechniqueVariant
+                row, so it is built once per variant for the process rather than once
+                per sheet read.
+        39.    character.threads (CharacterThreadHandler._all, #2901) — which of
+                those variants this caster has actually unlocked. A per-Character
+                cached handler, so one query however many techniques are known.
         """
         url = f"/api/character-sheets/{self.character.pk}/"
-        with self.assertNumQueries(37):
+        with self.assertNumQueries(39):
             response = self.client.get(url)
         assert response.status_code == 200
         # Verify all sections are populated
@@ -2346,7 +2355,15 @@ class TestPrefetchCompleteness(TestCase):
         #      rows via the handler; not part of _MAGIC_PREFETCH_RELATED (a per-Character
         #      handler, not a CharacterSheet-rooted prefetch), so it costs its one cached
         #      query here — not an N+1, since the handler is called once.
-        with self.assertNumQueries(2):
+        #   3. character.threads (CharacterThreadHandler._all, #2901) —
+        #      available_technique_forms reads the caster's threads to decide which
+        #      forms of each known technique are reachable. Same shape as (2): a
+        #      per-Character cached handler rather than a CharacterSheet-rooted
+        #      prefetch, so it costs exactly one query however many techniques the
+        #      spellbook holds. The per-form effect summaries are cached on their
+        #      own TechniqueVariant rows and the variants themselves are prefetched,
+        #      so nothing else here scales with technique or variant count.
+        with self.assertNumQueries(3):
             _build_magic(sheet)
 
     def test_story_zero_queries(self) -> None:

--- a/src/world/character_sheets/types.py
+++ b/src/world/character_sheets/types.py
@@ -9,7 +9,11 @@ from typing import TypedDict
 
 from django.db import models
 
-from world.magic.types.technique_effects import TechniqueEffectPayload
+from world.magic.types.technique_effects import (
+    TechniqueEffectPayload,
+    TechniqueFormPayload,
+    TechniqueSignaturePayload,
+)
 
 # --- API response shape TypedDicts ---
 
@@ -151,6 +155,14 @@ class TechniqueEntry(TypedDict):
     #: What the technique actually does (#2898) — the same block CG, the magic
     #: API, and the in-scene cast list carry, so the sheet can't drift from them.
     effect_summary: TechniqueEffectPayload
+    #: Which forms of it this caster can work (#2901): the base form, each
+    #: unlocked resonance-specialized variant, and one step ahead. Always at
+    #: least one entry. The sheet describes, so it carries the full catalogue;
+    #: the in-scene cast list carries only a compact affordance.
+    forms: list[TechniqueFormPayload]
+    #: The signature flourish riding whichever form is chosen, or ``None``.
+    #: Additive, never a sibling form (ADR-0072), so it sits beside the list.
+    signature: TechniqueSignaturePayload | None
 
 
 class GiftEntry(TypedDict):

--- a/src/world/magic/CLAUDE.md
+++ b/src/world/magic/CLAUDE.md
@@ -770,6 +770,26 @@ regeneration step.
   `(parent_technique, resonance, unlock_thread_level)`.
 - `CovenantRole` — refactored to inherit `AbstractSpecializedVariant` (schema no-op;
   `parent_role` with `related_name="sub_roles"` is the variant parent).
+- `TechniqueVariant.cached_effect_summary` (#2901) — the per-form sibling of
+  `Technique.cached_effect_summary`. A resolved form is fully determined by
+  `(parent_technique, variant)` with no caster input, so it caches on the variant row;
+  invalidate with `invalidate_variant_payload_caches`.
+
+**Per-caster forms — `available_technique_forms` (#2901)**
+(`services/technique_forms.py`): the display counterpart to the resolver. A variant does
+NOT replace a technique — it makes an alternate version available — so the character sheet
+and the in-scene cast list carry a **list** (base form + each unlocked variant + the next
+locked one per resonance), never one collapsed answer. `technique_signature_payload`
+returns the signature beside it, never inside it (ADR-0072).
+**Invariant: every entry is produced by calling `resolve_specialized_variant`** once per
+candidate resonance — never by re-implementing `matching_variant`'s predicate. The
+`is_default` marker must come from the `preferred_resonance=None` call, since that is the
+path carrying the alt-self resonance override.
+**Trap this closed:** `_ResolvedTechnique` exposed `damage_profiles` etc. while every
+payload reader reads `cached_damage_profiles`, so `__getattr__` forwarded those to the
+parent and a variant summarised as the base form under the variant's name. All four
+`cached_*` names are now declared on it; `cached_removed_conditions` is parent-only
+because no `TechniqueVariantRemovedCondition` model exists.
 
 **Resolver — `resolve_specialized_variant(*, entity, character)`**
 (`world/magic/specialization/services.py`): the single specialization resolver.

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -222,6 +222,45 @@ class TechniqueEffectSummarySerializer(serializers.Serializer):
     is_underspecified = serializers.BooleanField(read_only=True)
 
 
+class TechniqueFormSerializer(serializers.Serializer):
+    """One form of a technique a given caster can work (#2901).
+
+    Serializes a ``TechniqueFormPayload`` from
+    ``world.magic.services.technique_forms.available_technique_forms``. Shared by
+    the character sheet (full catalogue, locked forms included) and the in-scene
+    cast list (unlocked only), so the two cannot describe the same character's
+    options differently.
+
+    ``resonance_name`` doubles as the token a player passes to
+    ``cast <technique> variant=<resonance>``; the base form (``variant_id`` null)
+    is reached with ``cast <technique> base``.
+    """
+
+    variant_id = serializers.IntegerField(read_only=True, allow_null=True)
+    name = serializers.CharField(read_only=True)
+    resonance_id = serializers.IntegerField(read_only=True, allow_null=True)
+    resonance_name = serializers.CharField(read_only=True)
+    intensity = serializers.IntegerField(read_only=True)
+    control = serializers.IntegerField(read_only=True)
+    is_default = serializers.BooleanField(read_only=True)
+    is_locked = serializers.BooleanField(read_only=True)
+    unlock_thread_level = serializers.IntegerField(read_only=True)
+    thread_level = serializers.IntegerField(read_only=True)
+    effect_summary = TechniqueEffectSummarySerializer(read_only=True)
+
+
+class TechniqueSignatureSerializer(serializers.Serializer):
+    """The signature flourish riding whichever form is worked (#2901).
+
+    Additive, never a sibling form (ADR-0072), so it serializes beside a form
+    list rather than as an entry inside one.
+    """
+
+    name = serializers.CharField(read_only=True)
+    narrative_snippet = serializers.CharField(read_only=True)
+    intensity_delta = serializers.IntegerField(read_only=True)
+
+
 class TechniqueSerializer(serializers.ModelSerializer):
     """Serializer for Technique records with intensity and control stats."""
 

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -249,18 +249,6 @@ class TechniqueFormSerializer(serializers.Serializer):
     effect_summary = TechniqueEffectSummarySerializer(read_only=True)
 
 
-class TechniqueSignatureSerializer(serializers.Serializer):
-    """The signature flourish riding whichever form is worked (#2901).
-
-    Additive, never a sibling form (ADR-0072), so it serializes beside a form
-    list rather than as an entry inside one.
-    """
-
-    name = serializers.CharField(read_only=True)
-    narrative_snippet = serializers.CharField(read_only=True)
-    intensity_delta = serializers.IntegerField(read_only=True)
-
-
 class TechniqueSerializer(serializers.ModelSerializer):
     """Serializer for Technique records with intensity and control stats."""
 

--- a/src/world/magic/services/technique_effects.py
+++ b/src/world/magic/services/technique_effects.py
@@ -50,6 +50,12 @@ if TYPE_CHECKING:
         AbstractCapabilityGrant,
         AbstractDamageProfile,
     )
+    from world.magic.specialization.services import _ResolvedTechnique
+
+    #: What the summariser accepts: an authored ``Technique`` row, or a resolved
+    #: *form* of one. Both answer the same ``cached_<payload>`` reads (#2901) —
+    #: ``_ResolvedTechnique`` aliases them onto the variant's payload.
+    SummarizableTechnique = Technique | _ResolvedTechnique
 
 
 # --------------------------------------------------------------------------- #
@@ -198,7 +204,7 @@ def _capability_payload(row: AbstractCapabilityGrant) -> CapabilityEffectPayload
     )
 
 
-def technique_is_underspecified(technique: Technique) -> bool:
+def technique_is_underspecified(technique: SummarizableTechnique) -> bool:
     """True when nothing about the technique's effect is derivable from authored data.
 
     No applied condition, no removal, and no damage profile means
@@ -214,7 +220,7 @@ def technique_is_underspecified(technique: Technique) -> bool:
     )
 
 
-def technique_relationship_is_ambiguous(technique: Technique) -> bool:
+def technique_relationship_is_ambiguous(technique: SummarizableTechnique) -> bool:
     """True when the technique's payload rows disagree about who it targets.
 
     ``derive_target_relationship`` must return exactly one relationship, so a
@@ -234,7 +240,7 @@ def technique_relationship_is_ambiguous(technique: Technique) -> bool:
     return len(kinds) > 1
 
 
-def summarize_technique_effects(technique: Technique) -> TechniqueEffectPayload:
+def summarize_technique_effects(technique: SummarizableTechnique) -> TechniqueEffectPayload:
     """Build the shared effect summary for *technique*.
 
     Reads the technique's ``cached_*`` payload lists and the two existing
@@ -300,6 +306,35 @@ def invalidate_technique_payload_caches(technique: Technique) -> None:
     """
     for attr in _PAYLOAD_CACHE_ATTRS:
         technique.__dict__.pop(attr, None)
+
+
+#: The cached_property names that go stale when a variant's payload rows change.
+#: A variant has no ``removed_conditions`` relation (no
+#: ``TechniqueVariantRemovedCondition`` model) and no ``is_lock_applying``, so
+#: this is deliberately shorter than ``_PAYLOAD_CACHE_ATTRS``.
+_VARIANT_PAYLOAD_CACHE_ATTRS = (
+    "cached_condition_applications",
+    "cached_damage_profiles",
+    "cached_capability_grants",
+    "cached_effect_summary",
+)
+
+
+def invalidate_variant_payload_caches(variant) -> None:
+    """Drop the per-instance payload caches on a ``TechniqueVariant`` (#2901).
+
+    The variant sibling of :func:`invalidate_technique_payload_caches`. Variants
+    are SharedMemoryModels too, so a variant that has already answered the form
+    list keeps that answer for the life of the process. Safe to call when
+    nothing was cached.
+
+    A variant's summary is built from its parent's scalar fields as well as its
+    own payload, so editing the *parent* invalidates the variant too: call this
+    for each of ``technique.cached_variants`` after
+    :func:`invalidate_technique_payload_caches`.
+    """
+    for attr in _VARIANT_PAYLOAD_CACHE_ATTRS:
+        variant.__dict__.pop(attr, None)
 
 
 def technique_effect_authoring_gaps() -> list[TechniqueAuthoringGap]:

--- a/src/world/magic/services/technique_forms.py
+++ b/src/world/magic/services/technique_forms.py
@@ -39,6 +39,7 @@ from world.magic.types.technique_effects import (
 )
 
 if TYPE_CHECKING:
+    from world.character_sheets.models import CharacterSheet
     from world.magic.models.techniques import CharacterTechnique, Technique
     from world.magic.models.threads import Thread
 
@@ -144,6 +145,7 @@ def available_technique_forms(
     technique: Technique,
     *,
     character_technique: CharacterTechnique | None = None,
+    sheet: CharacterSheet | None = None,
 ) -> list[TechniqueFormPayload]:
     """Every form of ``technique`` that ``character`` can work, plus the next locked one.
 
@@ -155,6 +157,10 @@ def available_technique_forms(
     A caster with no thread on the technique's gift gets the base form alone,
     marked default. So does a sheetless character (an NPC), which has no threads
     at all.
+
+    ``sheet`` lets a caller that already holds the ``CharacterSheet`` — the two
+    display surfaces both do, and both call this once per known technique — hand
+    it in rather than have every call re-``SELECT`` the row it is standing on.
     """
     from world.magic.services.techniques import _get_character_sheet  # noqa: PLC0415
     from world.magic.specialization.services import (  # noqa: PLC0415
@@ -162,7 +168,8 @@ def available_technique_forms(
         resolve_specialized_variant,
     )
 
-    sheet = _get_character_sheet(character)
+    if sheet is None:
+        sheet = _get_character_sheet(character)
     if sheet is None:
         return [_base_form(technique, is_default=True)]
 

--- a/src/world/magic/services/technique_forms.py
+++ b/src/world/magic/services/technique_forms.py
@@ -1,0 +1,244 @@
+"""Which forms of a technique a specific caster can work (#2901).
+
+#2898 gave every technique surface a shared ``effect_summary``, derived per
+``Technique`` and cached on the row. That is right for the two catalog surfaces
+(character creation, the magic API), which describe the authored technique with
+no caster in scope. The two per-character surfaces need something else: **a
+variant does not replace the technique, it makes an alternate version
+available**, so a per-caster view that collapsed to one form would misreport
+what the character can actually do.
+
+Three rules hold this module together:
+
+**One resolver, never a second selection rule.** Which variant applies is
+answered by ``resolve_specialized_variant`` (ADR-0055/ADR-0016), called once per
+candidate resonance. Re-deriving ``matching_variant``'s predicate here would
+drift from the cast the first time either side changed.
+
+**The default marker comes from the resolver too.** A bare ``cast <tech>``
+resolves with ``preferred_resonance=None``, a path that folds in the active
+alt-self resonance override. Assuming "default = the thread's own resonance"
+mislabels a shifted character, so the marker is read off that call and no other.
+
+**No per-caster cache is needed.** A resolved form is fully determined by
+``(parent_technique, variant)``, so its summary caches on the ``TechniqueVariant``
+row (``cached_effect_summary``) exactly as the base one caches on the
+``Technique`` row. The only per-caster work is deciding *which* forms are
+reachable, and that reads two already-cached lists: ``character.threads`` (a
+cached handler) and ``technique.cached_variants``.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from world.magic.constants import TargetKind
+from world.magic.types.technique_effects import (
+    TechniqueFormPayload,
+    TechniqueSignaturePayload,
+)
+
+if TYPE_CHECKING:
+    from world.magic.models.techniques import CharacterTechnique, Technique
+    from world.magic.models.threads import Thread
+
+
+def _candidate_threads(character, technique: Technique, character_technique) -> list[Thread]:
+    """The threads whose resonance and level decide this technique's forms.
+
+    Mirrors the branch in ``_resolve_technique_variant`` so enumeration and
+    resolution agree about which thread is in play:
+
+    - A role-granted technique (``CharacterTechnique.role_source`` set, #2022)
+      specializes by the vow's depth, so the COVENANT_ROLE thread is the only
+      candidate.
+    - Otherwise every active GIFT thread on the technique's gift is a candidate
+      (a multi-resonance character holds more than one, #1619).
+
+    Read through the cached ``character.threads`` handler with a list-comp, never
+    a fresh ``Thread.objects.filter()`` (project cached-property rule).
+    """
+    if character_technique is not None and character_technique.role_source_id is not None:
+        role_source = character_technique.role_source
+        return [
+            t
+            for t in character.threads.all()
+            if t.target_kind == TargetKind.COVENANT_ROLE
+            and t.target_covenant_role_id == role_source.covenant_role_id
+            and t.retired_at is None
+        ]
+    return [
+        t
+        for t in character.threads.all()
+        if t.target_kind == TargetKind.GIFT
+        and t.target_gift_id == technique.gift_id
+        and t.retired_at is None
+    ]
+
+
+def _base_form(technique: Technique, *, is_default: bool) -> TechniqueFormPayload:
+    """The always-available unspecialized form (``cast <tech> base``)."""
+    return TechniqueFormPayload(
+        variant_id=None,
+        name=technique.name,
+        resonance_id=None,
+        resonance_name="",
+        intensity=technique.intensity,
+        control=technique.control,
+        is_default=is_default,
+        is_locked=False,
+        unlock_thread_level=0,
+        thread_level=0,
+        effect_summary=technique.cached_effect_summary,
+    )
+
+
+def _variant_form(
+    technique: Technique,
+    variant,
+    *,
+    thread_level: int,
+    is_default: bool,
+    is_locked: bool,
+) -> TechniqueFormPayload:
+    """One specialized form, unlocked or not.
+
+    ``effect_summary`` is read off ``variant.cached_effect_summary`` rather than
+    re-summarised here: the resolved form takes no caster input, so the build is
+    shared by every character who reaches this variant.
+    """
+    return TechniqueFormPayload(
+        variant_id=variant.pk,
+        name=variant.name_override or technique.name,
+        resonance_id=variant.resonance_id,
+        resonance_name=variant.resonance.name if variant.resonance_id else "",
+        intensity=technique.intensity + variant.intensity_delta,
+        control=technique.control + variant.control_delta,
+        is_default=is_default,
+        is_locked=is_locked,
+        unlock_thread_level=variant.unlock_thread_level,
+        thread_level=thread_level,
+        effect_summary=variant.cached_effect_summary,
+    )
+
+
+def _next_locked_variant(technique: Technique, *, resonance_id: int, thread_level: int):
+    """The nearest form this thread has not reached yet, or ``None``.
+
+    One step ahead per resonance, not the whole ladder: the lowest
+    ``unlock_thread_level`` strictly above the thread's current level. Filters
+    the already-cached ``technique.cached_variants`` list rather than querying.
+    """
+    ahead = [
+        v
+        for v in technique.cached_variants
+        if v.resonance_id == resonance_id and v.unlock_thread_level > thread_level
+    ]
+    if not ahead:
+        return None
+    return min(ahead, key=lambda v: v.unlock_thread_level)
+
+
+def available_technique_forms(
+    character,
+    technique: Technique,
+    *,
+    character_technique: CharacterTechnique | None = None,
+) -> list[TechniqueFormPayload]:
+    """Every form of ``technique`` that ``character`` can work, plus the next locked one.
+
+    The base form always leads. Each specialized form the caster has unlocked
+    follows, at most one per thread resonance (``matching_variant`` picks the
+    highest qualifying variant per resonance, so lower tiers are shadowed rather
+    than listed alongside). Locked entries come last and carry ``is_locked=True``.
+
+    A caster with no thread on the technique's gift gets the base form alone,
+    marked default. So does a sheetless character (an NPC), which has no threads
+    at all.
+    """
+    from world.magic.services.techniques import _get_character_sheet  # noqa: PLC0415
+    from world.magic.specialization.services import (  # noqa: PLC0415
+        _ResolvedTechnique,
+        resolve_specialized_variant,
+    )
+
+    sheet = _get_character_sheet(character)
+    if sheet is None:
+        return [_base_form(technique, is_default=True)]
+
+    # What a bare ``cast <tech>`` works right now — the alt-self override lives
+    # on this path, so the default marker must come from here.
+    default = resolve_specialized_variant(
+        entity=technique,
+        character=character,
+        character_technique=character_technique,
+        _sheet=sheet,
+    )
+    default_variant_id = (
+        default.variant.pk if isinstance(default, _ResolvedTechnique) else None  # type: ignore[union-attr]
+    )
+
+    threads = _candidate_threads(character, technique, character_technique)
+    forms: list[TechniqueFormPayload] = [
+        _base_form(technique, is_default=default_variant_id is None)
+    ]
+
+    seen_variant_ids: set[int] = set()
+    locked: list[TechniqueFormPayload] = []
+    for thread in threads:
+        resolved = resolve_specialized_variant(
+            entity=technique,
+            character=character,
+            character_technique=character_technique,
+            preferred_resonance=thread.resonance,
+            _sheet=sheet,
+        )
+        if isinstance(resolved, _ResolvedTechnique) and resolved.variant.pk not in seen_variant_ids:
+            seen_variant_ids.add(resolved.variant.pk)
+            forms.append(
+                _variant_form(
+                    technique,
+                    resolved.variant,
+                    thread_level=thread.level,
+                    is_default=resolved.variant.pk == default_variant_id,
+                    is_locked=False,
+                )
+            )
+
+        ahead = _next_locked_variant(
+            technique, resonance_id=thread.resonance_id, thread_level=thread.level
+        )
+        if ahead is not None and ahead.pk not in seen_variant_ids:
+            seen_variant_ids.add(ahead.pk)
+            locked.append(
+                _variant_form(
+                    technique,
+                    ahead,
+                    thread_level=thread.level,
+                    is_default=False,
+                    is_locked=True,
+                )
+            )
+
+    return forms + locked
+
+
+def technique_signature_payload(
+    character, technique: Technique
+) -> TechniqueSignaturePayload | None:
+    """The signature flourish riding whichever form is chosen, or ``None``.
+
+    Additive, never a sibling form (ADR-0072), so this is returned beside the
+    form list rather than as an entry inside it. Delegates the lookup to the
+    existing ``signature_bonus_for`` — the same read the cast wiring makes.
+    """
+    from world.magic.services.signature import signature_bonus_for  # noqa: PLC0415
+
+    bonus = signature_bonus_for(character, technique)
+    if bonus is None:
+        return None
+    return TechniqueSignaturePayload(
+        name=bonus.name,
+        narrative_snippet=bonus.narrative_snippet,
+        intensity_delta=bonus.flat_intensity_delta,
+    )

--- a/src/world/magic/services/technique_forms.py
+++ b/src/world/magic/services/technique_forms.py
@@ -94,6 +94,16 @@ def _base_form(technique: Technique, *, is_default: bool) -> TechniqueFormPayloa
     )
 
 
+def base_technique_form(technique: Technique) -> list[TechniqueFormPayload]:
+    """The form list for a reader with no caster in scope.
+
+    A one-entry list holding the base form, marked default. Used by the schema
+    -generation path and any surface that describes a technique rather than a
+    character's reach into it, so ``forms`` is never an absent field.
+    """
+    return [_base_form(technique, is_default=True)]
+
+
 def _variant_form(
     technique: Technique,
     variant,

--- a/src/world/magic/specialization/models.py
+++ b/src/world/magic/specialization/models.py
@@ -33,6 +33,7 @@ if TYPE_CHECKING:
 
     from world.character_sheets.models import CharacterSheet
     from world.magic.models.affinity import Resonance
+    from world.magic.types.technique_effects import TechniqueEffectPayload
 
 
 class AbstractSpecializedVariant(SharedMemoryModel):
@@ -250,6 +251,26 @@ class TechniqueVariant(AbstractSpecializedVariant):
         To invalidate: ``del instance.cached_condition_applications``.
         """
         return list(self.condition_applications.all())
+
+    @cached_property
+    def cached_effect_summary(self) -> TechniqueEffectPayload:
+        """What this *form* of the parent technique does (#2901).
+
+        The variant sibling of ``Technique.cached_effect_summary``. A resolved
+        form is fully determined by ``(parent_technique, variant)`` — no caster
+        input reaches it — so the summary caches on this row exactly the way the
+        base one caches on the ``Technique`` row, and a form shown to a hundred
+        casters costs one build.
+
+        To invalidate after editing payload rows:
+        ``invalidate_variant_payload_caches(variant)``.
+        """
+        from world.magic.services.technique_effects import (  # noqa: PLC0415
+            summarize_technique_effects,
+        )
+        from world.magic.specialization.services import _ResolvedTechnique  # noqa: PLC0415
+
+        return summarize_technique_effects(_ResolvedTechnique(self.parent_technique, variant=self))
 
     def discovery_narrative(
         self,

--- a/src/world/magic/specialization/services.py
+++ b/src/world/magic/specialization/services.py
@@ -466,6 +466,37 @@ class _ResolvedTechnique:
                 return payload
         return self.technique.cached_condition_applications
 
+    # ``cached_<payload>`` aliases (#2901). Every payload *reader* in the codebase
+    # — ``summarize_technique_effects``, ``is_technique_hostile``,
+    # ``derive_target_relationship`` — reads the ``cached_`` names, not the bare
+    # ones above. Without these aliases ``__getattr__`` forwards those reads
+    # straight to the parent ``Technique``, so a variant that swaps its damage
+    # rows summarises as the *base* form under the variant's name and nothing
+    # fails. The aliases make a payload read resolve the same way whether the
+    # caller asks for ``damage_profiles`` or ``cached_damage_profiles``.
+    @property
+    def cached_damage_profiles(self) -> list:
+        return self.damage_profiles
+
+    @property
+    def cached_capability_grants(self) -> list:
+        return self.capability_grants
+
+    @property
+    def cached_condition_applications(self) -> list:
+        return self.condition_applications
+
+    @property
+    def cached_removed_conditions(self) -> list:
+        """Dispel rows, always the parent's.
+
+        There is no ``TechniqueVariantRemovedCondition`` model, so a variant
+        cannot override which conditions the technique strips. Declared
+        explicitly rather than left to ``__getattr__`` so the asymmetry is
+        visible next to the three payloads a variant *can* override.
+        """
+        return self.technique.cached_removed_conditions
+
     # Pass-through for the cast pipeline's other technique reads.
     def __getattr__(self, item):
         return getattr(self.technique, item)

--- a/src/world/magic/tests/test_technique_effect_surfaces.py
+++ b/src/world/magic/tests/test_technique_effect_surfaces.py
@@ -89,20 +89,25 @@ class TechniqueEffectSummaryOnEverySurfaceTests(TestCase):
         self.assertEqual(data["hostile"], data["effect_summary"]["hostile"])
 
     def test_castable_list_is_fed_technique_rows(self):
-        """castable_techniques_for_sheet — the list's only source — yields Techniques.
+        """The cast list serializer receives ``Technique`` rows, never links.
 
         The serializer previously carried a CharacterTechnique branch in two
         method fields that could never run; its declared ``name`` field raises on
         a link first. This pins the shape the serializer actually receives.
+
+        Reads ``castable_technique_links_for_sheet`` (#2901 made it the one seam —
+        the form list needs the link to spot a role-granted technique) and asserts
+        what the serializer is handed: ``ct.technique``.
         """
         from world.character_sheets.factories import CharacterSheetFactory
         from world.magic.factories import CharacterTechniqueFactory
-        from world.magic.models.techniques import Technique
-        from world.scenes.cast_services import castable_techniques_for_sheet
+        from world.magic.models.techniques import CharacterTechnique, Technique
+        from world.scenes.cast_services import castable_technique_links_for_sheet
 
         sheet = CharacterSheetFactory()
         CharacterTechniqueFactory(character=sheet, technique=self.technique)
 
-        rows = castable_techniques_for_sheet(sheet.pk)
+        links = castable_technique_links_for_sheet(sheet.pk)
 
-        self.assertTrue(all(isinstance(row, Technique) for row in rows))
+        self.assertTrue(all(isinstance(link, CharacterTechnique) for link in links))
+        self.assertTrue(all(isinstance(link.technique, Technique) for link in links))

--- a/src/world/magic/tests/test_technique_forms.py
+++ b/src/world/magic/tests/test_technique_forms.py
@@ -1,0 +1,235 @@
+"""The per-caster form list (#2901).
+
+#2898 proved every surface shows *what a technique does*. This proves the two
+per-character surfaces also show *which forms of it this caster can work* —
+base, each unlocked variant, and one step ahead.
+
+The regression this file exists to prevent is the silent one: a variant with its
+own payload summarising as the base form under the variant's name, because
+``_ResolvedTechnique`` exposed ``damage_profiles`` while the summariser reads
+``cached_damage_profiles`` and ``__getattr__`` forwarded that to the parent.
+"""
+
+from typing import ClassVar
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.character_sheets.models import CharacterSheet
+from world.conditions.factories import ConditionTemplateFactory, DamageTypeFactory
+from world.magic.constants import TargetKind
+from world.magic.factories import (
+    BinaryEffectTypeFactory,
+    GiftFactory,
+    ResonanceFactory,
+    TechniqueFactory,
+)
+from world.magic.models import Gift, Resonance, Technique, Thread
+from world.magic.services.technique_effects import invalidate_variant_payload_caches
+from world.magic.services.technique_forms import available_technique_forms
+from world.magic.specialization.models import (
+    TechniqueVariant,
+    TechniqueVariantDamageProfile,
+)
+from world.magic.specialization.services import (
+    _ResolvedTechnique,
+    provision_latent_gift_thread,
+)
+
+
+class ResolvedTechniquePayloadAliasTest(TestCase):
+    """``summarize_technique_effects`` must read the *variant's* payload."""
+
+    technique: ClassVar[Technique]
+    variant: ClassVar[TechniqueVariant]
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        gift = GiftFactory()
+        cls.technique = TechniqueFactory(
+            gift=gift, effect_type=BinaryEffectTypeFactory(), damage_profile=False
+        )
+        cls.variant = TechniqueVariant.objects.create(
+            parent_technique=cls.technique,
+            resonance=ResonanceFactory(),
+            unlock_thread_level=3,
+            name_override="Ashfall Form",
+        )
+        TechniqueVariantDamageProfile.objects.create(
+            variant=cls.variant,
+            damage_type=DamageTypeFactory(name="cinder"),
+            base_damage=11,
+            minimum_success_level=1,
+        )
+
+    def test_variant_summary_reads_variant_damage_not_parent(self) -> None:
+        """The variant's own damage rows reach the summary.
+
+        Before the ``cached_*`` aliases this returned the parent's damage
+        silently, so a variant that swapped its payload was displayed as the
+        base form under the variant's name and nothing failed.
+        """
+        summary = self.variant.cached_effect_summary
+        self.assertEqual(
+            [row["damage_type"] for row in summary["damage"]],
+            ["cinder"],
+        )
+        self.assertNotEqual(summary["damage"], self.technique.cached_effect_summary["damage"])
+        self.assertIn("cinder damage", summary["summary"])
+
+    def test_resolved_technique_aliases_agree_with_bare_accessors(self) -> None:
+        """``cached_x`` and ``x`` must never disagree on a resolved form."""
+        resolved = _ResolvedTechnique(self.technique, variant=self.variant)
+        self.assertEqual(resolved.cached_damage_profiles, resolved.damage_profiles)
+        self.assertEqual(resolved.cached_capability_grants, resolved.capability_grants)
+        self.assertEqual(resolved.cached_condition_applications, resolved.condition_applications)
+
+    def test_removed_conditions_always_come_from_the_parent(self) -> None:
+        """No ``TechniqueVariantRemovedCondition`` model exists, so dispel is parent-only."""
+        resolved = _ResolvedTechnique(self.technique, variant=self.variant)
+        self.assertEqual(
+            resolved.cached_removed_conditions,
+            self.technique.cached_removed_conditions,
+        )
+
+
+class AvailableTechniqueFormsTest(TestCase):
+    """What the sheet and the cast list read."""
+
+    sheet: ClassVar[CharacterSheet]
+    gift: ClassVar[Gift]
+    resonance: ClassVar[Resonance]
+    other_resonance: ClassVar[Resonance]
+    technique: ClassVar[Technique]
+    variant: ClassVar[TechniqueVariant]
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.sheet = CharacterSheetFactory()
+        cls.gift = GiftFactory()
+        cls.resonance = ResonanceFactory(name="Cinder")
+        cls.other_resonance = ResonanceFactory(name="Tide")
+        cls.gift.resonances.add(cls.resonance, cls.other_resonance)
+        cls.technique = TechniqueFactory(
+            gift=cls.gift, effect_type=BinaryEffectTypeFactory(), damage_profile=False
+        )
+        cls.variant = TechniqueVariant.objects.create(
+            parent_technique=cls.technique,
+            resonance=cls.resonance,
+            unlock_thread_level=3,
+            name_override="Ashfall Lash",
+            intensity_delta=2,
+            control_delta=-1,
+        )
+
+    def _thread_at(self, level: int, resonance: Resonance | None = None) -> Thread:
+        provision_latent_gift_thread(self.sheet, self.gift, resonance=resonance or self.resonance)
+        thread = Thread.objects.get(
+            owner=self.sheet,
+            target_kind=TargetKind.GIFT,
+            target_gift=self.gift,
+            resonance=resonance or self.resonance,
+        )
+        thread.level = level
+        thread.save(update_fields=["level"])
+        self.sheet.character.threads.invalidate()
+        return thread
+
+    def test_no_thread_yields_base_form_only(self) -> None:
+        forms = available_technique_forms(self.sheet.character, self.technique)
+        self.assertEqual(len(forms), 1)
+        self.assertIsNone(forms[0]["variant_id"])
+        self.assertTrue(forms[0]["is_default"])
+        self.assertFalse(forms[0]["is_locked"])
+
+    def test_below_unlock_shows_base_default_and_the_next_form_locked(self) -> None:
+        """The deepening reads as a goal, one step ahead."""
+        self._thread_at(1)
+        forms = available_technique_forms(self.sheet.character, self.technique)
+
+        base, locked = forms
+        self.assertIsNone(base["variant_id"])
+        self.assertTrue(base["is_default"])
+
+        self.assertEqual(locked["variant_id"], self.variant.pk)
+        self.assertTrue(locked["is_locked"])
+        self.assertFalse(locked["is_default"])
+        self.assertEqual(locked["unlock_thread_level"], 3)
+        self.assertEqual(locked["thread_level"], 1)
+        self.assertEqual(locked["resonance_name"], "Cinder")
+
+    def test_at_unlock_the_variant_becomes_default_and_base_stays_available(self) -> None:
+        """A variant does not replace the technique; it adds a form."""
+        self._thread_at(3)
+        forms = available_technique_forms(self.sheet.character, self.technique)
+
+        self.assertEqual(len(forms), 2)
+        base, unlocked = forms
+        self.assertIsNone(base["variant_id"])
+        self.assertFalse(base["is_default"])
+        self.assertFalse(base["is_locked"])
+
+        self.assertEqual(unlocked["variant_id"], self.variant.pk)
+        self.assertTrue(unlocked["is_default"])
+        self.assertFalse(unlocked["is_locked"])
+        self.assertEqual(unlocked["name"], "Ashfall Lash")
+        self.assertEqual(unlocked["intensity"], self.technique.intensity + 2)
+        self.assertEqual(unlocked["control"], self.technique.control - 1)
+
+    def test_exactly_one_form_is_default(self) -> None:
+        self._thread_at(3)
+        forms = available_technique_forms(self.sheet.character, self.technique)
+        self.assertEqual(sum(1 for f in forms if f["is_default"]), 1)
+
+    def test_higher_tier_shadows_the_lower_rather_than_listing_both(self) -> None:
+        """``matching_variant`` picks the highest qualifying tier per resonance."""
+        deeper = TechniqueVariant.objects.create(
+            parent_technique=self.technique,
+            resonance=self.resonance,
+            unlock_thread_level=6,
+            name_override="Cinderfall Rite",
+        )
+        self.technique.__dict__.pop("cached_variants", None)
+        self._thread_at(6)
+
+        forms = available_technique_forms(self.sheet.character, self.technique)
+        variant_ids = [f["variant_id"] for f in forms if f["variant_id"] is not None]
+        self.assertEqual(variant_ids, [deeper.pk])
+
+    def test_multi_resonance_caster_gets_one_form_per_thread(self) -> None:
+        """#1619: a second thread at another resonance adds its own form."""
+        tide_variant = TechniqueVariant.objects.create(
+            parent_technique=self.technique,
+            resonance=self.other_resonance,
+            unlock_thread_level=3,
+            name_override="Tidewrack Lash",
+        )
+        self.technique.__dict__.pop("cached_variants", None)
+        self._thread_at(3)
+        self._thread_at(3, resonance=self.other_resonance)
+
+        forms = available_technique_forms(self.sheet.character, self.technique)
+        names = {f["name"] for f in forms}
+        self.assertIn("Ashfall Lash", names)
+        self.assertIn("Tidewrack Lash", names)
+        self.assertIn(tide_variant.pk, {f["variant_id"] for f in forms})
+        self.assertEqual(sum(1 for f in forms if f["is_default"]), 1)
+
+    def test_each_form_carries_its_own_effect_summary(self) -> None:
+        """The block #2898 built, per form rather than per technique."""
+        self._thread_at(3)
+        forms = available_technique_forms(self.sheet.character, self.technique)
+        for form in forms:
+            self.assertIn("summary", form["effect_summary"])
+            self.assertIn("applies", form["effect_summary"])
+
+    def test_variant_payload_reaches_the_form_summary(self) -> None:
+        """End-to-end guard on the alias fix, through the display service."""
+        condition = ConditionTemplateFactory(name="Scorched")
+        self.variant.condition_applications.create(condition=condition, target_kind="enemy")
+        invalidate_variant_payload_caches(self.variant)
+        self._thread_at(3)
+
+        forms = available_technique_forms(self.sheet.character, self.technique)
+        unlocked = next(f for f in forms if f["variant_id"] == self.variant.pk)
+        self.assertIn("Scorched", [row["name"] for row in unlocked["effect_summary"]["applies"]])

--- a/src/world/magic/types/technique_effects.py
+++ b/src/world/magic/types/technique_effects.py
@@ -81,6 +81,57 @@ class TechniqueEffectPayload(TypedDict):
     is_underspecified: bool
 
 
+class TechniqueFormPayload(TypedDict):
+    """One form of a technique that a specific caster can work (#2901).
+
+    #2898's ``TechniqueEffectPayload`` describes the *authored* technique, which
+    is the whole story for the two catalog surfaces. A caster who has woven a
+    GIFT thread also reaches resonance-specialized forms of the same technique,
+    and the base form remains available alongside them (``cast <tech> base``).
+    This is one entry in that list.
+
+    Built by ``world.magic.services.technique_forms.available_technique_forms``.
+    """
+
+    #: ``TechniqueVariant`` pk, or ``None`` for the base form.
+    variant_id: int | None
+    #: What the form is called: the variant's ``name_override``, else the
+    #: technique's own name.
+    name: str
+    #: ``Resonance`` pk this form manifests through, or ``None`` for the base
+    #: form (which is resonance-agnostic).
+    resonance_id: int | None
+    #: Display name of that resonance, or ``""`` for the base form. Doubles as
+    #: the token a player passes to ``cast <tech> variant=<resonance>``.
+    resonance_name: str
+    intensity: int
+    control: int
+    #: True for the form a bare ``cast <tech>`` works right now. Exactly one
+    #: entry in a list carries this.
+    is_default: bool
+    #: True when the caster cannot work this form yet. Locked entries carry the
+    #: authored numbers so the deepening reads as a goal, and are omitted from
+    #: the in-scene cast list.
+    is_locked: bool
+    #: Thread level that unlocks this form; 0 for the base form.
+    unlock_thread_level: int
+    #: The caster's current level on the thread this form resolves through.
+    thread_level: int
+    effect_summary: TechniqueEffectPayload
+
+
+class TechniqueSignaturePayload(TypedDict):
+    """The signature flourish riding whichever form the caster works (#2901).
+
+    A signature is an ADDITIVE modifier, never a sibling form (ADR-0072), so it
+    is a single field beside the form list rather than an entry inside it.
+    """
+
+    name: str
+    narrative_snippet: str
+    intensity_delta: int
+
+
 @dataclass(frozen=True)
 class TechniqueAuthoringGap:
     """One technique whose authored payload cannot be read back with confidence.

--- a/src/world/scenes/action_serializers.py
+++ b/src/world/scenes/action_serializers.py
@@ -273,7 +273,7 @@ class TechniqueCastCreateSerializer(serializers.Serializer):
 class CastableTechniqueSerializer(serializers.Serializer):
     """Serializes a Technique for the castable-techniques list endpoint.
 
-    Takes ``Technique`` rows — which is what ``castable_techniques_for_sheet``,
+    Takes ``Technique`` rows — which is what ``castable_technique_links_for_sheet``,
     its only source, returns. ``get_hostile`` and ``get_target_spec`` used to
     carry a ``CharacterTechnique`` branch as well, but neither could ever run:
     the declared ``name`` / ``anima_cost`` / ``tier`` fields raise on a link long

--- a/src/world/scenes/action_serializers.py
+++ b/src/world/scenes/action_serializers.py
@@ -10,8 +10,15 @@ from rest_framework import serializers
 from world.combat.cast_seed import encounter_requiring_risk_acknowledgement
 from world.fatigue.constants import EffortLevel
 from world.magic.models.techniques import Technique
-from world.magic.serializers import TechniqueEffectSummarySerializer
+from world.magic.serializers import (
+    TechniqueEffectSummarySerializer,
+    TechniqueFormSerializer,
+)
 from world.magic.services.hostility import is_technique_hostile
+from world.magic.services.technique_forms import (
+    available_technique_forms,
+    base_technique_form,
+)
 from world.scenes.action_constants import (
     ActionDelivery,
     ActionRequestStatus,
@@ -245,6 +252,13 @@ class TechniqueCastCreateSerializer(serializers.Serializer):
     fury_anchor_id = serializers.IntegerField(required=False, allow_null=True, default=None)
     pull = CastPullRequestSerializer(required=False, allow_null=True)
     use_base_form = serializers.BooleanField(required=False, default=False)
+    # #2901: telnet has offered `variant=<resonance>` since #1619, but the web
+    # request carried only `use_base_form` — so a multi-resonance caster could
+    # reach the base form or the default form from a browser and nothing else.
+    # The Action kwarg already existed (actions/definitions/cast.py); this is the
+    # wire field that was missing, and the cast list's `forms` payload is
+    # unusable without it.
+    preferred_resonance_id = serializers.IntegerField(required=False, allow_null=True, default=None)
     cast_openly = serializers.BooleanField(required=False, default=False)
 
     def validate(self, attrs: dict) -> dict:
@@ -281,11 +295,36 @@ class CastableTechniqueSerializer(serializers.Serializer):
     reach = serializers.CharField()
     target_spec = serializers.SerializerMethodField()
     effect_summary = serializers.SerializerMethodField()
+    forms = serializers.SerializerMethodField()
 
     @extend_schema_field(TechniqueEffectSummarySerializer)
     def get_effect_summary(self, obj: Technique) -> dict:
         """The shared effect block (#2898) — same shape as CG, magic API, and sheet."""
         return TechniqueEffectSummarySerializer(obj.cached_effect_summary).data
+
+    @extend_schema_field(TechniqueFormSerializer(many=True))
+    def get_forms(self, obj: Technique) -> list[dict]:
+        """The forms this caster can work right now (#2901).
+
+        Locked forms are filtered out here: the scene shows what you can do, the
+        sheet shows what you are becoming. Returns just the base form when the
+        serializer has no character in context (the schema-generation path), so
+        the field is never absent.
+        """
+        character = self.context.get("character")
+        if character is None:
+            return list(TechniqueFormSerializer(base_technique_form(obj), many=True).data)
+        forms = available_technique_forms(
+            character,
+            obj,
+            character_technique=self.context.get("character_techniques", {}).get(obj.pk),
+            sheet=self.context.get("character_sheet"),
+        )
+        return list(
+            TechniqueFormSerializer(
+                [form for form in forms if not form["is_locked"]], many=True
+            ).data
+        )
 
     def get_hostile(self, obj: Technique) -> bool:
         # Read off the same summary the block ships, so the two can never disagree.

--- a/src/world/scenes/action_views.py
+++ b/src/world/scenes/action_views.py
@@ -624,7 +624,7 @@ class SceneActionRequestViewSet(PuppetActorMixin, viewsets.ModelViewSet):
         - benign at another PC → PENDING consent request (201, no result yet)
         - hostile at another PC → seeds/feeds a combat encounter (201 with encounter summary)
         """
-        from world.magic.models import Technique  # noqa: PLC0415
+        from world.magic.models import Resonance, Technique  # noqa: PLC0415
 
         serializer = TechniqueCastCreateSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
@@ -689,6 +689,14 @@ class SceneActionRequestViewSet(PuppetActorMixin, viewsets.ModelViewSet):
         use_base_form: bool = vd.get("use_base_form", False)
         cast_openly: bool = vd.get("cast_openly", False)
 
+        # #2901: which form to work. Telnet has had `variant=<resonance>` since
+        # #1619; this is its web counterpart, so the `forms` list the cast API
+        # now ships is something a browser client can actually act on.
+        preferred_resonance = None
+        preferred_resonance_id = vd.get("preferred_resonance_id")
+        if preferred_resonance_id is not None:
+            preferred_resonance = get_object_or_404(Resonance, pk=preferred_resonance_id)
+
         try:
             cast_result = request_technique_cast(
                 scene=scene,
@@ -699,6 +707,7 @@ class SceneActionRequestViewSet(PuppetActorMixin, viewsets.ModelViewSet):
                 cast_pull=cast_pull,
                 supplied_personas=supplied_personas,
                 use_base_form=use_base_form,
+                preferred_resonance=preferred_resonance,
                 cast_openly=cast_openly,
             )
         except DjangoValidationError as exc:
@@ -764,7 +773,9 @@ class SceneActionRequestViewSet(PuppetActorMixin, viewsets.ModelViewSet):
         Requires ?initiator_persona=<id> query param. Returns only techniques
         with an action_template (castable standalone) known by that character.
         """
-        from world.scenes.cast_services import castable_techniques_for_sheet  # noqa: PLC0415
+        from world.scenes.cast_services import (  # noqa: PLC0415
+            castable_technique_links_for_sheet,
+        )
 
         initiator_persona_id_str = request.query_params.get("initiator_persona")  # noqa: USE_FILTERSET
         if not initiator_persona_id_str:
@@ -789,8 +800,22 @@ class SceneActionRequestViewSet(PuppetActorMixin, viewsets.ModelViewSet):
             )
 
         initiator_persona = get_object_or_404(Persona, pk=initiator_persona_id)
-        techniques = castable_techniques_for_sheet(initiator_persona.character_sheet_id)
-        return Response(CastableTechniqueSerializer(techniques, many=True).data)
+        sheet = initiator_persona.character_sheet
+        # One fetch, two uses: the techniques serialized, and the links the form
+        # list needs to spot a role-granted technique (#2901). The context keys
+        # let the per-row form build reuse the sheet and threads handler rather
+        # than re-resolving them per serialized row.
+        links = castable_technique_links_for_sheet(sheet.pk)
+        context = {
+            "character": sheet.character,
+            "character_sheet": sheet,
+            "character_techniques": {ct.technique_id: ct for ct in links},
+        }
+        return Response(
+            CastableTechniqueSerializer(
+                [ct.technique for ct in links], many=True, context=context
+            ).data
+        )
 
     @extend_schema(
         parameters=[

--- a/src/world/scenes/cast_services.py
+++ b/src/world/scenes/cast_services.py
@@ -75,18 +75,25 @@ if TYPE_CHECKING:
 _PULL_FIZZLE_NOTE = "The declared thread pull fizzles — its committed resonance is spent."
 
 
-def castable_techniques_for_sheet(character_sheet_id: int) -> list[Technique]:
-    """Techniques *character_sheet_id* knows that can be cast standalone.
+def castable_technique_links_for_sheet(character_sheet_id: int) -> list[CharacterTechnique]:
+    """``CharacterTechnique`` links for what *character_sheet_id* can cast standalone.
 
     Known (a ``CharacterTechnique`` link) and castable (an ``action_template``),
-    by name. Shared by the web castable-techniques endpoint and the telnet cast
-    list so the two faces of "what can I cast" cannot drift (#2898) — the drift
-    between four independently-built technique payloads is what that issue exists
-    to close.
+    by technique name. Shared by the web castable-techniques endpoint and the
+    telnet cast list so the two faces of "what can I cast" cannot drift (#2898) —
+    the drift between four independently-built technique payloads is what that
+    issue exists to close.
 
     The payload tables are prefetched onto the cached_property names the effect
     summary reads, so rendering the whole list costs a fixed handful of queries
     rather than one per technique per table.
+
+    The *link* rather than the bare technique, because the caster's form list
+    needs it (#2901): a role-granted technique (``CharacterTechnique
+    .role_source``) specializes by the covenant vow's depth rather than the
+    personal gift's (#2022). Callers wanting only the techniques use
+    ``castable_techniques_for_sheet``; callers wanting both read this once and
+    derive, rather than paying for the same rows twice.
     """
     from world.magic.models.techniques import (  # noqa: PLC0415
         TechniqueAppliedCondition,
@@ -94,6 +101,7 @@ def castable_techniques_for_sheet(character_sheet_id: int) -> list[Technique]:
         TechniqueDamageProfile,
         TechniqueRemovedCondition,
     )
+    from world.magic.specialization.models import TechniqueVariant  # noqa: PLC0415
 
     char_techniques = (
         CharacterTechnique.objects.filter(
@@ -122,10 +130,27 @@ def castable_techniques_for_sheet(character_sheet_id: int) -> list[Technique]:
                 queryset=TechniqueCapabilityGrant.objects.select_related("capability"),
                 to_attr="cached_capability_grants",
             ),
+            # #2901: the caster's form list walks each technique's variants.
+            # select_related("resonance") because the resonance name is the token
+            # a player passes to `cast ... variant=<resonance>`.
+            Prefetch(
+                "technique__variants",
+                queryset=TechniqueVariant.objects.select_related("resonance"),
+                to_attr="cached_variants",
+            ),
         )
+        .select_related("role_source")
         .order_by("technique__name")
     )
-    return [ct.technique for ct in char_techniques]
+    return list(char_techniques)
+
+
+def castable_techniques_for_sheet(character_sheet_id: int) -> list[Technique]:
+    """The techniques behind ``castable_technique_links_for_sheet``, same order.
+
+    The narrow face for callers that never need the link.
+    """
+    return [ct.technique for ct in castable_technique_links_for_sheet(character_sheet_id)]
 
 
 def derive_cast_difficulty(technique: Technique) -> int:

--- a/src/world/scenes/cast_services.py
+++ b/src/world/scenes/cast_services.py
@@ -145,14 +145,6 @@ def castable_technique_links_for_sheet(character_sheet_id: int) -> list[Characte
     return list(char_techniques)
 
 
-def castable_techniques_for_sheet(character_sheet_id: int) -> list[Technique]:
-    """The techniques behind ``castable_technique_links_for_sheet``, same order.
-
-    The narrow face for callers that never need the link.
-    """
-    return [ct.technique for ct in castable_technique_links_for_sheet(character_sheet_id)]
-
-
 def derive_cast_difficulty(technique: Technique) -> int:
     """Difficulty for a standalone cast, sourced from the technique's authored intensity."""
     intensity = technique.intensity or 1

--- a/src/world/scenes/tests/test_cast_form_selection.py
+++ b/src/world/scenes/tests/test_cast_form_selection.py
@@ -1,0 +1,149 @@
+"""The web's half of choosing a technique's form (#2901).
+
+Telnet has offered ``variant=<resonance>`` since #1619 and ``base`` since #1581,
+but the web cast request carried only ``use_base_form`` — so a multi-resonance
+caster could reach the base form or the default form from a browser and nothing
+else, and no surface told them the other forms existed at all.
+
+Two contracts here: the cast list ships the caster's reachable forms, and the
+cast request accepts the one they picked.
+"""
+
+from __future__ import annotations
+
+from typing import ClassVar
+
+from django.test import TestCase
+
+from actions.factories import ActionTemplateFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.character_sheets.models import CharacterSheet
+from world.magic.constants import TargetKind
+from world.magic.factories import (
+    BinaryEffectTypeFactory,
+    CharacterTechniqueFactory,
+    GiftFactory,
+    ResonanceFactory,
+    TechniqueFactory,
+)
+from world.magic.models import Gift, Resonance, Technique, Thread
+from world.magic.specialization.models import TechniqueVariant
+from world.magic.specialization.services import provision_latent_gift_thread
+from world.scenes.action_serializers import (
+    CastableTechniqueSerializer,
+    TechniqueCastCreateSerializer,
+)
+
+
+class CastableTechniqueFormsTest(TestCase):
+    """``forms`` on the in-scene cast list."""
+
+    sheet: ClassVar[CharacterSheet]
+    gift: ClassVar[Gift]
+    resonance: ClassVar[Resonance]
+    technique: ClassVar[Technique]
+    variant: ClassVar[TechniqueVariant]
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.sheet = CharacterSheetFactory()
+        cls.gift = GiftFactory()
+        cls.resonance = ResonanceFactory(name="Cinder")
+        cls.gift.resonances.add(cls.resonance)
+        cls.technique = TechniqueFactory(
+            gift=cls.gift,
+            effect_type=BinaryEffectTypeFactory(),
+            damage_profile=False,
+            action_template=ActionTemplateFactory(),
+        )
+        cls.link = CharacterTechniqueFactory(character=cls.sheet, technique=cls.technique)
+        cls.variant = TechniqueVariant.objects.create(
+            parent_technique=cls.technique,
+            resonance=cls.resonance,
+            unlock_thread_level=3,
+            name_override="Ashfall Lash",
+        )
+
+    def _thread_at(self, level: int) -> Thread:
+        provision_latent_gift_thread(self.sheet, self.gift, resonance=self.resonance)
+        thread = Thread.objects.get(
+            owner=self.sheet, target_kind=TargetKind.GIFT, target_gift=self.gift
+        )
+        thread.level = level
+        thread.save(update_fields=["level"])
+        self.sheet.character.threads.invalidate()
+        return thread
+
+    def _serialize(self) -> dict:
+        return CastableTechniqueSerializer(
+            self.technique,
+            context={
+                "character": self.sheet.character,
+                "character_sheet": self.sheet,
+                "character_techniques": {self.technique.pk: self.link},
+            },
+        ).data
+
+    def test_ships_the_base_form_when_nothing_is_unlocked(self) -> None:
+        data = self._serialize()
+        self.assertEqual(len(data["forms"]), 1)
+        self.assertIsNone(data["forms"][0]["variant_id"])
+        self.assertTrue(data["forms"][0]["is_default"])
+
+    def test_ships_base_and_variant_once_the_thread_reaches_the_unlock(self) -> None:
+        """A variant adds a form; it does not replace the technique."""
+        self._thread_at(3)
+        data = self._serialize()
+
+        self.assertEqual(len(data["forms"]), 2)
+        base, variant = data["forms"]
+        self.assertIsNone(base["variant_id"])
+        self.assertFalse(base["is_default"])
+        self.assertEqual(variant["variant_id"], self.variant.pk)
+        self.assertTrue(variant["is_default"])
+        # The resonance name IS the token a player passes to `variant=`.
+        self.assertEqual(variant["resonance_name"], "Cinder")
+
+    def test_locked_forms_are_omitted_from_the_scene(self) -> None:
+        """The scene shows what you can work now; the sheet shows the goal."""
+        self._thread_at(1)
+        data = self._serialize()
+
+        self.assertEqual([f["variant_id"] for f in data["forms"]], [None])
+
+    def test_forms_is_never_absent_without_a_caster_in_context(self) -> None:
+        """Schema generation and caster-less reads still get a well-formed field."""
+        data = CastableTechniqueSerializer(self.technique).data
+        self.assertEqual(len(data["forms"]), 1)
+        self.assertIsNone(data["forms"][0]["variant_id"])
+
+    def test_each_form_carries_the_shared_effect_block(self) -> None:
+        self._thread_at(3)
+        data = self._serialize()
+        for form in data["forms"]:
+            self.assertIn("summary", form["effect_summary"])
+
+
+class CastRequestFormSelectionTest(TestCase):
+    """``preferred_resonance_id`` on the cast request — telnet's ``variant=`` for the web."""
+
+    def _validated(self, **extra) -> dict:
+        serializer = TechniqueCastCreateSerializer(
+            data={"scene": 1, "initiator_persona": 1, "technique_id": 1, **extra}
+        )
+        serializer.is_valid(raise_exception=True)
+        return serializer.validated_data
+
+    def test_preferred_resonance_id_is_accepted_and_carried(self) -> None:
+        self.assertEqual(self._validated(preferred_resonance_id=7)["preferred_resonance_id"], 7)
+
+    def test_omitting_it_means_the_default_form(self) -> None:
+        """No pick is not the same as picking the base form."""
+        validated = self._validated()
+        self.assertIsNone(validated["preferred_resonance_id"])
+        self.assertFalse(validated["use_base_form"])
+
+    def test_base_form_opt_out_still_works_alongside_it(self) -> None:
+        validated = self._validated(use_base_form=True)
+        self.assertTrue(validated["use_base_form"])
+        self.assertIsNone(validated["preferred_resonance_id"])


### PR DESCRIPTION
Closes #2901

## Summary

A variant does not replace a technique — it makes an alternate version available — so the two per-character surfaces now show a **list** of forms rather than one collapsed answer: the base form, each unlocked resonance-specialized form, and the next locked one as a visible goal. The sheet carries the full catalogue; the cast list carries a compact affordance plus the picker payload.

Three things the code-verification pass changed about the shape of the work:

- **The issue's caching concern dissolved.** A resolved form is fully determined by `(parent_technique, variant)` with no caster input, so each form's summary caches on its `TechniqueVariant` row exactly as the base one caches on the `Technique` row. The only per-caster work is deciding which forms are reachable, off two already-cached lists. Sheet 37 → 39 queries, telnet cast listing 5 → 7; all fixed, none per-technique.
- **A silent correctness bug, fixed underneath.** `summarize_technique_effects` reads the `cached_*` payload names, but `_ResolvedTechnique` exposed only the bare ones, so `__getattr__` forwarded those reads to the parent `Technique`. A variant that swapped its damage rows summarised as the *base* form under the variant's name and nothing failed. All four `cached_*` names are now declared on the value object, with a test that locks it.
- **The web could not choose a form at all.** `CastRequestSerializer` carried `use_base_form` but no `preferred_resonance_id`, so telnet's `variant=<resonance>` (#1619) had no web counterpart and a `forms` payload would have been a picker the client could not act on. The Action kwarg already existed; only the wire field was missing.

Every form is derived by **calling `resolve_specialized_variant`**, never by re-implementing `matching_variant` (ADR-0055/ADR-0016). The `is_default` marker comes specifically from the `preferred_resonance=None` call, because that is the path folding in the alt-self resonance override — assuming "default = the thread's own resonance" would mislabel a shifted character.

No new models and no migrations. Two surfaces I had added were removed again for having no caller (`TechniqueSignatureSerializer`, and `castable_techniques_for_sheet` once both cast-list callers moved to the links seam).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2901 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main cleanly (6 commits, no conflicts).

<!-- last-addressed-comment: 0 -->