### PR TITLE
Set SHELL=/bin/bash so dc-attach panes get bash, not dash

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -76,6 +76,15 @@ services:
       # just recipes), not just interactive login shells.
       TERM: xterm-256color
       COLORTERM: truecolor
+      # `devcontainer exec` (what `just dc-shell`/`dc-attach` run on) provides no
+      # SHELL, so zellij falls back to /bin/sh — dash on this image. Dash never
+      # sources ~/.bashrc, so `mise activate` never runs and the mise node bin dir
+      # stays off PATH: inside a `just dc-attach` pane, `claude`, `just`, `uv` and
+      # `python` are all "command not found". Ubuntu's dash is also built without
+      # libedit, so the same panes have no history and up-arrow just emits ^[[A.
+      # Setting SHELL here fixes both at once (zellij reads $SHELL for pane
+      # shells). Same rationale as TERM above: container-wide, survives rebuilds.
+      SHELL: /bin/bash
     # Forward the brainstorm-server port so http://localhost:49200/ in the
     # Windows browser reaches the in-container server. The skill's
     # start-server.sh defaults to binding 127.0.0.1; pass --host 0.0.0.0

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -455,6 +455,14 @@ or `NET_RAW` capabilities. Verify the `cap_add` block in
 This can happen if the container was started with raw `docker compose up` instead of
 `just dc-up`. Run `just dc-down` then `just dc-up` to re-provision.
 
+**`claude`/`just`/`uv` not found, or up-arrow prints `^[[A`, inside a `dc-attach`
+pane** — the pane is running `/bin/sh` (dash) instead of bash, so `~/.bashrc` never
+ran and `mise activate` never put the toolchain on `PATH`; dash also has no line
+editing, hence the dead arrow keys. `docker-compose.yml` sets `SHELL: /bin/bash` to
+prevent this (zellij reads `$SHELL`, and `devcontainer exec` supplies none). If you
+land in such a pane anyway, `exec bash -l` recovers it; confirm the fix stuck with
+`ps -eo pid,args --forest` — pane shells should be `/bin/bash`.
+
 **`devcontainer: command not found`** — the CLI is not installed. Run:
 ```powershell
 npm install -g @devcontainers/cli


### PR DESCRIPTION
## Problem

After a container rebuild, `claude` was "command not found" inside a `just dc-attach`
pane — and up-arrow printed a literal `^[[A` instead of recalling history.

Both are the same bug. `devcontainer exec` (what `dc-shell`/`dc-attach` run on)
supplies no `SHELL`, so zellij falls back to `/bin/sh`, which is dash on this image:

```
1367  zellij --server /tmp/zellij-1000/contract_version_1/main
1393   \_ /bin/sh          <-- the pane
```

- Dash never sources `~/.bashrc`, so the `mise activate bash` line the Dockerfile
  appends there never runs. The pane's `PATH` stays at the bare
  `/home/vscode/.local/bin:/usr/local/sbin:...` — no mise bin dirs, so `claude`,
  `just`, `uv` and `python` are all missing, even though `claude` is installed at
  image-build time at `~/.local/share/mise/installs/node/24.4.1/bin/claude`.
- Ubuntu's dash is built without libedit, so those panes also have no line editing
  and no history at all — hence the dead arrow keys.

## Fix

Set `SHELL: /bin/bash` container-wide in `.devcontainer/docker-compose.yml`, next to
the existing `TERM`/`COLORTERM` entries and for the same reason: it survives rebuilds
(`/home/vscode` is not a named volume) and applies to every entry point rather than
only interactive login shells. zellij reads `$SHELL` for pane shells, so this fixes
both symptoms at once, and helps any other tool that consults `$SHELL`.

A `default_shell "bash"` line in `~/.config/zellij/config.kdl` would also work, but
that file is autogenerated inside the container and is not in version control, so it
would not survive a rebuild.

## Verification

Started a probe zellij session in the running container with `SHELL` set; the pane
process is `/bin/bash` instead of `/bin/sh`:

```
2463  zellij --server /tmp/zellij-1000/contract_version_1/probe
2485   \_ /bin/bash
```

And `bash -ic 'which claude'` from `/workspaces/arxii` resolves correctly once mise
activates. Docs/compose only — no test suite applies.

## Docs

Adds the symptom, the cause and the `exec bash -l` in-pane recovery to the
troubleshooting list in `docs/devcontainer-setup.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
