### PR TITLE
Interactive shell: zsh + oh-my-zsh by default, atuin, fzf, persistent history

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -110,3 +110,59 @@ RUN curl -fsS https://get.polytoken.dev | bash
 ARG ZELLIJ_VERSION=0.44.3
 RUN curl -fsSL "https://github.com/zellij-org/zellij/releases/download/v${ZELLIJ_VERSION}/zellij-x86_64-unknown-linux-musl.tar.gz" \
     | tar -xz -C /home/vscode/.local/bin zellij
+
+# Interactive-shell tooling. Pinned static binaries into ~/.local/bin, matching
+# the zellij pattern above: build-time network is unrestricted, so none of these
+# download hosts need an init-firewall.sh allowlist entry, and nothing here
+# contacts a network service at runtime (see the atuin config below).
+#   atuin  — SQLite-backed Ctrl-R history search, replacing bash's 1000-entry file
+#   fzf    — Ctrl-T / Alt-C fuzzy file and directory pickers
+#   zoxide — `z <fragment>` jumps to a previously visited directory
+# Wiring lives in shell-extras.sh; see that file for the keybinding decisions.
+ARG ATUIN_VERSION=18.18.1
+ARG FZF_VERSION=0.74.2
+ARG ZOXIDE_VERSION=0.10.0
+RUN curl -fsSL "https://github.com/atuinsh/atuin/releases/download/v${ATUIN_VERSION}/atuin-x86_64-unknown-linux-musl.tar.gz" \
+      | tar -xz -C /tmp \
+ && mv "/tmp/atuin-x86_64-unknown-linux-musl/atuin" /home/vscode/.local/bin/atuin \
+ && rm -rf /tmp/atuin-x86_64-unknown-linux-musl \
+ && curl -fsSL "https://github.com/junegunn/fzf/releases/download/v${FZF_VERSION}/fzf-${FZF_VERSION}-linux_amd64.tar.gz" \
+      | tar -xz -C /home/vscode/.local/bin fzf \
+ && curl -fsSL "https://github.com/ajeetdsouza/zoxide/releases/download/v${ZOXIDE_VERSION}/zoxide-${ZOXIDE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
+      | tar -xz -C /home/vscode/.local/bin zoxide
+
+# Pre-create the mountpoints for the shell-state volumes (docker-compose.yml) as
+# vscode, so they inherit vscode ownership instead of being created root-owned on
+# first mount. Same rationale as the ~/.claude pre-create above.
+#   ~/.local/state/arxii  — HISTFILE (arxii-shell-history)
+#   ~/.local/share/atuin  — atuin's SQLite database (arxii-atuin)
+RUN mkdir -p /home/vscode/.local/state/arxii /home/vscode/.local/share/atuin
+
+# Atuin runs strictly local: no account, no sync, no update ping. Both defaults
+# are "true" upstream and both would be blocked by the egress firewall, turning
+# a shell start or a Ctrl-R into a timeout rather than an error.
+RUN mkdir -p /home/vscode/.config/atuin \
+ && printf '%s\n' \
+      '# Managed by .devcontainer/Dockerfile — edits are lost on `just dc-build`.' \
+      'auto_sync = false' \
+      'update_check = false' \
+      > /home/vscode/.config/atuin/config.toml
+
+# Generate shell completions once at build time. Doing this in shell-extras.sh
+# instead would spawn four subprocesses on every shell start. gh comes from apt;
+# just/uv/mise need mise's PATH, hence `mise exec`.
+USER root
+RUN mkdir -p /usr/local/share/arxii/completions \
+ && chown -R vscode:vscode /usr/local/share/arxii
+USER vscode
+RUN gh completion -s bash > /usr/local/share/arxii/completions/gh.bash \
+ && ~/.local/bin/mise completion bash > /usr/local/share/arxii/completions/mise.bash \
+ && ~/.local/bin/mise exec -C /tmp/mise -- just --completions bash \
+      > /usr/local/share/arxii/completions/just.bash \
+ && ~/.local/bin/mise exec -C /tmp/mise -- uv generate-shell-completion bash \
+      > /usr/local/share/arxii/completions/uv.bash
+
+# Source the interactive-shell setup LAST, after the mise activate line above:
+# atuin must bind Ctrl-R after fzf, and both append to PROMPT_COMMAND.
+COPY --chown=vscode:vscode .devcontainer/shell-extras.sh /usr/local/share/arxii/shell-extras.sh
+RUN echo 'source /usr/local/share/arxii/shell-extras.sh' >> ~/.bashrc

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -115,21 +115,20 @@ RUN curl -fsSL "https://github.com/zellij-org/zellij/releases/download/v${ZELLIJ
 # the zellij pattern above: build-time network is unrestricted, so none of these
 # download hosts need an init-firewall.sh allowlist entry, and nothing here
 # contacts a network service at runtime (see the atuin config below).
-#   atuin  — SQLite-backed Ctrl-R history search, replacing bash's 1000-entry file
-#   fzf    — Ctrl-T / Alt-C fuzzy file and directory pickers
-#   zoxide — `z <fragment>` jumps to a previously visited directory
-# Wiring lives in shell-extras.sh; see that file for the keybinding decisions.
+#   atuin — SQLite-backed Ctrl-R history search, replacing bash's 1000-entry file
+#   fzf   — Ctrl-T / Alt-C fuzzy file and directory pickers, and the picker
+#           behind fzf-tab and `z <fragment><TAB>` on the zsh side
+# Directory jumping is deliberately NOT a binary here: oh-my-zsh's z plugin
+# (agkozak/zsh-z, native zsh) does the same job with nothing extra to pin.
+# Wiring lives in shell-extras.sh and zshrc; see those for keybinding decisions.
 ARG ATUIN_VERSION=18.18.1
 ARG FZF_VERSION=0.74.2
-ARG ZOXIDE_VERSION=0.10.0
 RUN curl -fsSL "https://github.com/atuinsh/atuin/releases/download/v${ATUIN_VERSION}/atuin-x86_64-unknown-linux-musl.tar.gz" \
       | tar -xz -C /tmp \
  && mv "/tmp/atuin-x86_64-unknown-linux-musl/atuin" /home/vscode/.local/bin/atuin \
  && rm -rf /tmp/atuin-x86_64-unknown-linux-musl \
  && curl -fsSL "https://github.com/junegunn/fzf/releases/download/v${FZF_VERSION}/fzf-${FZF_VERSION}-linux_amd64.tar.gz" \
-      | tar -xz -C /home/vscode/.local/bin fzf \
- && curl -fsSL "https://github.com/ajeetdsouza/zoxide/releases/download/v${ZOXIDE_VERSION}/zoxide-${ZOXIDE_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
-      | tar -xz -C /home/vscode/.local/bin zoxide
+      | tar -xz -C /home/vscode/.local/bin fzf
 
 # Pre-create the mountpoints for the shell-state volumes (docker-compose.yml) as
 # vscode, so they inherit vscode ownership instead of being created root-owned on

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -166,3 +166,47 @@ RUN gh completion -s bash > /usr/local/share/arxii/completions/gh.bash \
 # atuin must bind Ctrl-R after fzf, and both append to PROMPT_COMMAND.
 COPY --chown=vscode:vscode .devcontainer/shell-extras.sh /usr/local/share/arxii/shell-extras.sh
 RUN echo 'source /usr/local/share/arxii/shell-extras.sh' >> ~/.bashrc
+
+# zsh + oh-my-zsh is the DEFAULT interactive shell (SHELL=/bin/zsh in
+# docker-compose.yml; zellij takes its pane shell from $SHELL). bash keeps its
+# own setup above -- `devcontainer exec`, `bash -lc` and agent tooling still land
+# there, and it should not be a downgrade. zsh itself is already in the base
+# image; only the framework and plugins are added here.
+#
+# zsh and oh-my-zsh itself come from the base devcontainer image, which already
+# installs both (~/.oh-my-zsh plus a stock ~/.zshrc that the COPY below
+# replaces). Its version therefore moves with the base image tag, like gh and
+# zsh do -- do not re-clone it here. Only the three custom plugins are added,
+# pinned to tags/commits and cloned shallow.
+#
+# oh-my-zsh's own updater is disabled in zshrc for the same reason atuin's is:
+# it would reach github.com on a schedule and hang against the egress firewall.
+ARG ZSH_AUTOSUGGESTIONS_VERSION=v0.7.1
+ARG ZSH_SYNTAX_HIGHLIGHTING_VERSION=0.8.0
+ARG FZF_TAB_COMMIT=24105b15714bfec37989ed5c5b6e60f572253019
+RUN git clone -q --depth 1 --branch "${ZSH_AUTOSUGGESTIONS_VERSION}" \
+      https://github.com/zsh-users/zsh-autosuggestions.git \
+      /home/vscode/.oh-my-zsh/custom/plugins/zsh-autosuggestions \
+ && git clone -q --depth 1 --branch "${ZSH_SYNTAX_HIGHLIGHTING_VERSION}" \
+      https://github.com/zsh-users/zsh-syntax-highlighting.git \
+      /home/vscode/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting \
+ && git init -q /home/vscode/.oh-my-zsh/custom/plugins/fzf-tab \
+ && git -C /home/vscode/.oh-my-zsh/custom/plugins/fzf-tab remote add origin \
+      https://github.com/Aloxaf/fzf-tab.git \
+ && git -C /home/vscode/.oh-my-zsh/custom/plugins/fzf-tab fetch -q --depth 1 origin "${FZF_TAB_COMMIT}" \
+ && git -C /home/vscode/.oh-my-zsh/custom/plugins/fzf-tab checkout -q FETCH_HEAD
+
+# zsh completions are autoloaded by compinit from fpath, so unlike the bash side
+# these are plain `_<cmd>` files and cost nothing until first use.
+USER root
+RUN mkdir -p /usr/local/share/arxii/zsh-completions \
+ && chown -R vscode:vscode /usr/local/share/arxii
+USER vscode
+RUN gh completion -s zsh > /usr/local/share/arxii/zsh-completions/_gh \
+ && ~/.local/bin/mise completion zsh > /usr/local/share/arxii/zsh-completions/_mise \
+ && ~/.local/bin/mise exec -C /tmp/mise -- just --completions zsh \
+      > /usr/local/share/arxii/zsh-completions/_just \
+ && ~/.local/bin/mise exec -C /tmp/mise -- uv generate-shell-completion zsh \
+      > /usr/local/share/arxii/zsh-completions/_uv
+
+COPY --chown=vscode:vscode .devcontainer/zshrc /home/vscode/.zshrc

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -90,7 +90,13 @@ services:
       # libedit, so the same panes have no history and up-arrow just emits ^[[A.
       # Setting SHELL here fixes both at once (zellij reads $SHELL for pane
       # shells). Same rationale as TERM above: container-wide, survives rebuilds.
-      SHELL: /bin/bash
+      #
+      # The value is zsh rather than bash because zsh + oh-my-zsh is the default
+      # interactive shell (see .devcontainer/zshrc). This is not a revert of the
+      # fix above — the bug was the *absence* of SHELL, not its value, and bash
+      # keeps its own equivalent setup (shell-extras.sh) for `devcontainer exec`,
+      # `bash -lc` and agent tooling.
+      SHELL: /bin/zsh
     # Forward the brainstorm-server port so http://localhost:49200/ in the
     # Windows browser reaches the in-container server. The skill's
     # start-server.sh defaults to binding 127.0.0.1; pass --host 0.0.0.0

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -32,6 +32,12 @@ services:
       # ~/.local/share/polytoken (XDG). Verify the session dir at first dc-build.
       - arxii-polytoken-config:/home/vscode/.config/polytoken
       - arxii-polytoken-data:/home/vscode/.local/share/polytoken
+      # Shell history, same rationale as the volumes above: /home/vscode is
+      # image state, so without these every rebuild starts from an empty
+      # history. HISTFILE is pointed at the first path by shell-extras.sh; the
+      # second is atuin's SQLite database.
+      - arxii-shell-history:/home/vscode/.local/state/arxii
+      - arxii-atuin:/home/vscode/.local/share/atuin
       # Shadow the host's src/.env (which points DATABASE_URL at a bare-metal
       # localhost Postgres) with a container-specific file. sync-env.sh
       # generates dev.env from src/.env with DATABASE_URL rewritten before
@@ -139,3 +145,5 @@ volumes:
   arxii-claude-home:
   arxii-polytoken-config:
   arxii-polytoken-data:
+  arxii-shell-history:
+  arxii-atuin:

--- a/.devcontainer/shell-extras.sh
+++ b/.devcontainer/shell-extras.sh
@@ -92,12 +92,8 @@ if command -v atuin >/dev/null 2>&1; then
     eval "$(atuin init bash --disable-up-arrow --disable-ai)"
 fi
 
-# --------------------------------------------------------------------------
-# zoxide -- `z <fragment>` jumps to a previously visited directory
-# --------------------------------------------------------------------------
-# Mainly for worktrees: `z shell-tooling` beats typing
-# .claude/worktrees/devcontainer-shell-tooling. `zi` opens an fzf picker when
-# several directories match. Plain `cd` is untouched.
-if command -v zoxide >/dev/null 2>&1; then
-    eval "$(zoxide init bash)"
-fi
+# No directory-jumping (`z`) here: that is oh-my-zsh's z plugin, which is
+# zsh-only. bash is the fallback shell for `devcontainer exec`, `bash -lc` and
+# agent tooling rather than a place anyone navigates by hand, so it is not worth
+# a second implementation. Atuin's Ctrl-R is shared between the two shells and
+# records cwd, which covers finding your way back to a path from here.

--- a/.devcontainer/shell-extras.sh
+++ b/.devcontainer/shell-extras.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Interactive-shell setup for the arxii devcontainer.
+#
+# Installed to /usr/local/share/arxii/shell-extras.sh and sourced from the LAST
+# line of ~/.bashrc (see Dockerfile). It must come last because both mise and
+# atuin append to PROMPT_COMMAND, and atuin must bind Ctrl-R after fzf does --
+# see the keybinding note below.
+#
+# This file is baked into the image rather than hand-edited in the container:
+# /home/vscode is not a named volume (only ~/.claude, ~/.config/polytoken and
+# ~/.local/share/polytoken are), so a runtime ~/.bashrc edit is lost on the next
+# `just dc-build`. Same rationale as the SHELL/TERM entries in docker-compose.yml.
+
+# Interactive shells only. Guards against `bash -c` / scp / rsync sessions, which
+# break if a startup file writes to stdout.
+[[ $- == *i* ]] || return 0
+
+# --------------------------------------------------------------------------
+# History
+# --------------------------------------------------------------------------
+# Debian's defaults (HISTSIZE=1000, HISTFILESIZE=2000) truncate away most of a
+# working session. Unlimited is fine here: the file lives on its own named
+# volume and is plain text.
+HISTSIZE=-1
+HISTFILESIZE=-1
+# ignoreboth = ignoredups + ignorespace; erasedups also drops older duplicates,
+# so repeated `just test-fast ...` invocations collapse to one entry.
+HISTCONTROL=ignoreboth:erasedups
+HISTTIMEFORMAT='%F %T '
+# histappend: never truncate the file on exit. cmdhist: keep a multi-line
+# command as one entry rather than one entry per line.
+shopt -s histappend cmdhist
+
+# HISTFILE points into the arxii-shell-history volume (docker-compose.yml) so
+# history survives `just dc-build`. Without this it lives at ~/.bash_history,
+# which is image state and is destroyed on every rebuild.
+HISTFILE=/home/vscode/.local/state/arxii/bash_history
+
+# Flush after every command instead of only at exit. Several zellij tabs are
+# normally open at once; without this the last shell to exit wins and the other
+# tabs' history is silently discarded.
+PROMPT_COMMAND="${PROMPT_COMMAND:+$PROMPT_COMMAND; }history -a"
+
+# --------------------------------------------------------------------------
+# Completions
+# --------------------------------------------------------------------------
+# Generated at image-build time (Dockerfile) rather than by running
+# `gh completion`/`just --completions`/... on every shell start, which would add
+# four subprocess spawns to the prompt.
+#
+# Each file is named after its command and is sourced only when that command is
+# actually on PATH. mise puts just/uv on PATH per-directory, so in a shell
+# started outside the workspace they are absent -- and `just`'s generated
+# completion is a runtime shim (`eval "$(JUST_COMPLETE=bash just)"`) that would
+# print "just: command not found" on every such prompt.
+if [[ -d /usr/local/share/arxii/completions ]]; then
+    for _arxii_completion in /usr/local/share/arxii/completions/*.bash; do
+        [[ -r $_arxii_completion ]] || continue
+        _arxii_cmd=${_arxii_completion##*/}
+        _arxii_cmd=${_arxii_cmd%.bash}
+        command -v "$_arxii_cmd" >/dev/null 2>&1 || continue
+        source "$_arxii_completion"
+    done
+    unset _arxii_completion _arxii_cmd
+fi
+
+# --------------------------------------------------------------------------
+# fzf -- Ctrl-T (insert file path), Alt-C (cd into subdirectory)
+# --------------------------------------------------------------------------
+# ORDER MATTERS: fzf must load BEFORE atuin. Both bind Ctrl-R to their own
+# history search and the last binding wins; with fzf second, fzf's Ctrl-R
+# silently shadows atuin's and atuin becomes recall-only. Verified by inspecting
+# `bind -X` with each ordering.
+if command -v fzf >/dev/null 2>&1; then
+    eval "$(fzf --bash)"
+fi
+
+# --------------------------------------------------------------------------
+# atuin -- Ctrl-R history search, backed by SQLite
+# --------------------------------------------------------------------------
+# --disable-up-arrow: up-arrow stays vanilla bash history. Atuin's full-screen
+#   TUI is deliberate on Ctrl-R but too heavy for a plain "previous command".
+# --disable-ai: atuin otherwise binds the bare `?` key to `atuin ai`, an LLM
+#   round-trip that would also hit the egress firewall. Nothing here should
+#   reach a network service on a keypress.
+# Atuin bundles its own copy of bash-preexec (__atuin_load_builtin_preexec), so
+# no separate bash-preexec install is needed. Note that bash-preexec calls any
+# user-defined preexec/precmd functions: the base image defines a pair for
+# terminal titles, but only when TERM is exactly "xterm", and compose pins
+# TERM=xterm-256color, so they never load and cannot collide.
+if command -v atuin >/dev/null 2>&1; then
+    eval "$(atuin init bash --disable-up-arrow --disable-ai)"
+fi
+
+# --------------------------------------------------------------------------
+# zoxide -- `z <fragment>` jumps to a previously visited directory
+# --------------------------------------------------------------------------
+# Mainly for worktrees: `z shell-tooling` beats typing
+# .claude/worktrees/devcontainer-shell-tooling. `zi` opens an fzf picker when
+# several directories match. Plain `cd` is untouched.
+if command -v zoxide >/dev/null 2>&1; then
+    eval "$(zoxide init bash)"
+fi

--- a/.devcontainer/zshrc
+++ b/.devcontainer/zshrc
@@ -21,6 +21,13 @@ zstyle ':omz:update' mode disabled
 
 # Deliberately short list. Ordering is load order and matters:
 #   git                    — the alias pack (gst/gco/gd/...)
+#   z                      — `z <fragment>` jumps to a previously visited
+#                            directory. This is agkozak/zsh-z, a native-zsh
+#                            implementation with no awk/sed/date subprocesses,
+#                            NOT the older rupa/z script. Chosen over zoxide to
+#                            avoid carrying another pinned binary: it is a wash
+#                            on speed, and `z frag<TAB>` gets an fzf picker via
+#                            fzf-tab, which is what `zi` would have provided.
 #   fzf-tab                — replaces the completion menu with an fzf picker.
 #                            Must come after compinit (oh-my-zsh runs it) and
 #                            before any plugin that wraps ZLE widgets, i.e.
@@ -29,9 +36,15 @@ zstyle ':omz:update' mode disabled
 #   zsh-syntax-highlighting— must be LAST; it wraps every widget defined so far
 #
 # NOT enabled, on purpose:
-#   z / autojump  — duplicate zoxide and fight over the name `z`
+#   autojump      — duplicates z and fights over the same job
 #   fzf           — its Ctrl-R binding would shadow atuin's (see below)
-plugins=(git fzf-tab zsh-autosuggestions zsh-syntax-highlighting)
+plugins=(git z fzf-tab zsh-autosuggestions zsh-syntax-highlighting)
+
+# The z plugin's datafile, on the arxii-shell-history volume rather than its
+# ~/.z default -- otherwise the jump database would reset on every
+# `just dc-build`, which is exactly the problem the volume exists to solve.
+# Read at plugin load time, so it must be set before oh-my-zsh.sh.
+export ZSHZ_DATA=/home/vscode/.local/state/arxii/z
 
 # Completions for gh/just/uv/mise, generated at image-build time (Dockerfile).
 # Must be on fpath BEFORE oh-my-zsh.sh, which is what runs compinit. Unlike the
@@ -83,12 +96,4 @@ if command -v atuin >/dev/null 2>&1; then
     eval "$(atuin init zsh --disable-up-arrow --disable-ai)"
 fi
 
-# --------------------------------------------------------------------------
-# zoxide -- `z <fragment>` jumps to a previously visited directory
-# --------------------------------------------------------------------------
-# Mainly for worktrees: `z shell-tooling` beats typing
-# .claude/worktrees/devcontainer-shell-tooling. `zi` opens an fzf picker when
-# several directories match. Plain `cd` is untouched.
-if command -v zoxide >/dev/null 2>&1; then
-    eval "$(zoxide init zsh)"
-fi
+# Directory jumping is the `z` plugin above, not a separate binary.

--- a/.devcontainer/zshrc
+++ b/.devcontainer/zshrc
@@ -1,0 +1,94 @@
+# Interactive zsh setup for the arxii devcontainer -- the default shell you get
+# in a `just dc-shell` or `just dc-attach` pane (SHELL is pinned to /bin/zsh in
+# docker-compose.yml, and zellij takes its pane shell from $SHELL).
+#
+# Installed to /home/vscode/.zshrc by the Dockerfile. Edit this file and
+# `just dc-build`; a hand-edit inside the container is lost on the next rebuild,
+# because /home/vscode is image state rather than a named volume.
+#
+# bash keeps its own equivalent (shell-extras.sh) -- `devcontainer exec`, `bash -lc`
+# and agent tooling all still land in bash, and it should not be a downgrade.
+# Atuin's database is shared between the two, so history recorded in a zsh pane is
+# searchable from bash and vice versa.
+
+export ZSH="$HOME/.oh-my-zsh"
+ZSH_THEME="robbyrussell"
+
+# oh-my-zsh's self-updater would reach github.com on a schedule, which the egress
+# firewall drops -- turning a shell start into a hang rather than an error.
+# Versions are pinned in the Dockerfile and move on `just dc-build`.
+zstyle ':omz:update' mode disabled
+
+# Deliberately short list. Ordering is load order and matters:
+#   git                    — the alias pack (gst/gco/gd/...)
+#   fzf-tab                — replaces the completion menu with an fzf picker.
+#                            Must come after compinit (oh-my-zsh runs it) and
+#                            before any plugin that wraps ZLE widgets, i.e.
+#                            before autosuggestions and syntax-highlighting.
+#   zsh-autosuggestions    — inline ghost-text from history
+#   zsh-syntax-highlighting— must be LAST; it wraps every widget defined so far
+#
+# NOT enabled, on purpose:
+#   z / autojump  — duplicate zoxide and fight over the name `z`
+#   fzf           — its Ctrl-R binding would shadow atuin's (see below)
+plugins=(git fzf-tab zsh-autosuggestions zsh-syntax-highlighting)
+
+# Completions for gh/just/uv/mise, generated at image-build time (Dockerfile).
+# Must be on fpath BEFORE oh-my-zsh.sh, which is what runs compinit. Unlike the
+# bash side these cost nothing at startup: zsh autoloads a _<cmd> file only when
+# you actually complete that command.
+fpath=(/usr/local/share/arxii/zsh-completions $fpath)
+
+source "$ZSH/oh-my-zsh.sh"
+
+# --------------------------------------------------------------------------
+# History
+# --------------------------------------------------------------------------
+# After oh-my-zsh, which sets its own history options.
+# HISTFILE lives on the arxii-shell-history volume (docker-compose.yml) so it
+# survives `just dc-build`; bash's file sits beside it under the same volume.
+HISTFILE=/home/vscode/.local/state/arxii/zsh_history
+HISTSIZE=1000000
+SAVEHIST=1000000
+# INC_APPEND_HISTORY writes each command as it runs, so several zellij tabs
+# interleave instead of the last one to exit overwriting the rest. Deliberately
+# not SHARE_HISTORY: that also *imports* other sessions' commands into this
+# shell's up-arrow, which makes plain recall unpredictable.
+setopt EXTENDED_HISTORY INC_APPEND_HISTORY HIST_IGNORE_DUPS HIST_IGNORE_SPACE
+setopt HIST_REDUCE_BLANKS HIST_VERIFY
+
+# --------------------------------------------------------------------------
+# mise -- puts python/node/uv/just/claude on PATH per-directory
+# --------------------------------------------------------------------------
+eval "$(~/.local/bin/mise activate zsh)"
+
+# --------------------------------------------------------------------------
+# fzf -- Ctrl-T (insert file path), Alt-C (cd into subdirectory)
+# --------------------------------------------------------------------------
+# ORDER MATTERS: fzf must load BEFORE atuin. Both bind Ctrl-R and the last
+# binding wins; with fzf second, its Ctrl-R silently shadows atuin's, leaving
+# atuin recording history that can never be searched.
+if command -v fzf >/dev/null 2>&1; then
+    source <(fzf --zsh)
+fi
+
+# --------------------------------------------------------------------------
+# atuin -- Ctrl-R history search, backed by SQLite
+# --------------------------------------------------------------------------
+# --disable-up-arrow: up-arrow stays zsh's own history search. Atuin's
+#   full-screen TUI is deliberate on Ctrl-R but too heavy for "previous command".
+# --disable-ai: atuin otherwise binds the bare `?` key to an LLM round-trip,
+#   which would also hit the egress firewall.
+if command -v atuin >/dev/null 2>&1; then
+    eval "$(atuin init zsh --disable-up-arrow --disable-ai)"
+fi
+
+# --------------------------------------------------------------------------
+# zoxide -- `z <fragment>` jumps to a previously visited directory
+# --------------------------------------------------------------------------
+# Mainly for worktrees: `z shell-tooling` beats typing
+# .claude/worktrees/devcontainer-shell-tooling. `zi` opens an fzf picker when
+# several directories match. Plain `cd` is untouched.
+if command -v zoxide >/dev/null 2>&1; then
+    eval "$(zoxide init zsh)"
+fi

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -190,6 +190,38 @@ that baked copy, so workspace edits to `init-firewall.sh` only take effect after
 `just dc-build`. This passes `--build-no-cache --remove-existing-container` to the
 devcontainer CLI.
 
+### Shell setup
+
+Interactive shells are configured by `.devcontainer/shell-extras.sh`, baked into the
+image and sourced from the last line of `~/.bashrc`. Edit that file and
+`just dc-build`; a hand-edit inside the container is lost on the next rebuild,
+because `/home/vscode` is image state rather than a named volume.
+
+| Key | Does |
+|---|---|
+| `Up` | Vanilla bash history — one command back, no TUI |
+| `Ctrl-R` | atuin: fuzzy search over full history, with exit code, duration and cwd |
+| `Ctrl-T` | fzf: pick a file, insert its path at the cursor |
+| `Alt-C` | fzf: pick a subdirectory and `cd` into it |
+| `z <fragment>` | zoxide: jump to a previously visited directory, e.g. `z shell-tooling` |
+| `zi` | zoxide: same, but pick from an fzf list when several match |
+
+Up-arrow is deliberately left as plain bash — atuin's full-screen TUI is wanted on
+`Ctrl-R`, not on every "previous command". Change that by dropping
+`--disable-up-arrow` from the `atuin init` line in `shell-extras.sh`.
+
+**atuin is local-only**: no account, no sync, and `update_check = false`. It never
+contacts a network service, so it needs no `init-firewall.sh` allowlist entry. Its
+`?`-key AI binding is disabled for the same reason.
+
+History persists across `just dc-build` via two named volumes —
+`arxii-shell-history` (bash's `HISTFILE`) and `arxii-atuin` (atuin's SQLite
+database). History is unlimited and flushed after every command, so several zellij
+tabs interleave instead of the last one to exit overwriting the rest.
+
+Tab completion is installed for `gh`, `just`, `uv` and `mise`, generated at image
+build time.
+
 ### Do not use raw docker commands for daily use
 
 `docker compose up` and `docker exec` skip the devcontainer hooks. That means:

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -207,11 +207,18 @@ Edit either file and `just dc-build`; a hand-edit inside the container is lost o
 next rebuild, because `/home/vscode` is image state rather than a named volume.
 
 oh-my-zsh runs a deliberately short plugin list: `git` (the `gst`/`gco`/`gd` alias
-pack), `fzf-tab`, `zsh-autosuggestions`, `zsh-syntax-highlighting`. That order is load
-order and matters — see the comments in `zshrc` before changing it. omz's `z` and
-`fzf` plugins are deliberately **not** enabled: they would duplicate zoxide and steal
-`Ctrl-R` from atuin respectively. zsh and oh-my-zsh itself come from the base
-devcontainer image; only the three custom plugins are pinned here.
+pack), `z`, `fzf-tab`, `zsh-autosuggestions`, `zsh-syntax-highlighting`. That order is
+load order and matters — see the comments in `zshrc` before changing it. omz's `fzf`
+plugin is deliberately **not** enabled: its `Ctrl-R` binding would shadow atuin's.
+zsh and oh-my-zsh itself come from the base devcontainer image; only the three custom
+plugins are pinned here.
+
+Directory jumping is the `z` plugin rather than a separate zoxide binary. omz ships
+[agkozak/zsh-z](https://github.com/agkozak/zsh-z), a native-zsh implementation with no
+`awk`/`sed` subprocesses — a wash with zoxide on speed, one less pinned dependency,
+and `z frag<TAB>` gets an fzf picker through fzf-tab. It is zsh-only, so bash has no
+`z`; that shell exists for `devcontainer exec` and scripts rather than hand
+navigation, and atuin records cwd for finding your way back.
 
 | Key | Does |
 |---|---|
@@ -221,8 +228,8 @@ devcontainer image; only the three custom plugins are pinned here.
 | `Ctrl-R` | atuin: fuzzy search over full history, with exit code, duration and cwd |
 | `Ctrl-T` | fzf: pick a file, insert its path at the cursor |
 | `Alt-C` | fzf: pick a subdirectory and `cd` into it |
-| `z <fragment>` | zoxide: jump to a previously visited directory, e.g. `z shell-tooling` |
-| `zi` | zoxide: same, but pick from an fzf list when several match |
+| `z <fragment>` | jump to a previously visited directory, e.g. `z shell-tooling` (zsh only) |
+| `z <fragment>`+`Tab` | same, but pick from an fzf list when several match |
 
 Up-arrow is deliberately left as the shell's own history — atuin's full-screen TUI is
 wanted on `Ctrl-R`, not on every "previous command". Change that by dropping
@@ -233,8 +240,9 @@ contacts a network service, so it needs no `init-firewall.sh` allowlist entry. I
 `?`-key AI binding is disabled for the same reason.
 
 History persists across `just dc-build` via two named volumes —
-`arxii-shell-history` (the bash and zsh `HISTFILE`s) and `arxii-atuin` (atuin's SQLite
-database). History is unlimited and flushed after every command, so several zellij
+`arxii-shell-history` (the bash and zsh `HISTFILE`s, plus the `z` plugin's jump
+database via `ZSHZ_DATA`) and `arxii-atuin` (atuin's SQLite database). History is
+unlimited and flushed after every command, so several zellij
 tabs interleave instead of the last one to exit overwriting the rest.
 
 Tab completion is installed for `gh`, `just`, `uv` and `mise`, generated at image

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -192,30 +192,48 @@ devcontainer CLI.
 
 ### Shell setup
 
-Interactive shells are configured by `.devcontainer/shell-extras.sh`, baked into the
-image and sourced from the last line of `~/.bashrc`. Edit that file and
-`just dc-build`; a hand-edit inside the container is lost on the next rebuild,
-because `/home/vscode` is image state rather than a named volume.
+**zsh + oh-my-zsh is the default interactive shell.** `just dc-shell` and every
+`just dc-attach` pane land in it (`SHELL` is pinned to `/bin/zsh` in
+`docker-compose.yml`, and zellij takes its pane shell from `$SHELL`). Config lives in
+`.devcontainer/zshrc`.
+
+bash keeps an equivalent setup in `.devcontainer/shell-extras.sh` — `devcontainer
+exec`, `bash -lc` and agent tooling still land in bash, and it should not be a
+downgrade. **Atuin's database is shared between the two**, so history recorded in a
+zsh pane is searchable from a bash shell and vice versa. The plain `HISTFILE`s are
+separate.
+
+Edit either file and `just dc-build`; a hand-edit inside the container is lost on the
+next rebuild, because `/home/vscode` is image state rather than a named volume.
+
+oh-my-zsh runs a deliberately short plugin list: `git` (the `gst`/`gco`/`gd` alias
+pack), `fzf-tab`, `zsh-autosuggestions`, `zsh-syntax-highlighting`. That order is load
+order and matters — see the comments in `zshrc` before changing it. omz's `z` and
+`fzf` plugins are deliberately **not** enabled: they would duplicate zoxide and steal
+`Ctrl-R` from atuin respectively. zsh and oh-my-zsh itself come from the base
+devcontainer image; only the three custom plugins are pinned here.
 
 | Key | Does |
 |---|---|
-| `Up` | Vanilla bash history — one command back, no TUI |
+| `Tab` | fzf-tab: completion menu as an fzf picker (zsh only) |
+| `→` | Accept the inline autosuggestion (zsh only) |
+| `Up` | The shell's own history — one command back, no TUI |
 | `Ctrl-R` | atuin: fuzzy search over full history, with exit code, duration and cwd |
 | `Ctrl-T` | fzf: pick a file, insert its path at the cursor |
 | `Alt-C` | fzf: pick a subdirectory and `cd` into it |
 | `z <fragment>` | zoxide: jump to a previously visited directory, e.g. `z shell-tooling` |
 | `zi` | zoxide: same, but pick from an fzf list when several match |
 
-Up-arrow is deliberately left as plain bash — atuin's full-screen TUI is wanted on
-`Ctrl-R`, not on every "previous command". Change that by dropping
-`--disable-up-arrow` from the `atuin init` line in `shell-extras.sh`.
+Up-arrow is deliberately left as the shell's own history — atuin's full-screen TUI is
+wanted on `Ctrl-R`, not on every "previous command". Change that by dropping
+`--disable-up-arrow` from the `atuin init` line in `zshrc` / `shell-extras.sh`.
 
 **atuin is local-only**: no account, no sync, and `update_check = false`. It never
 contacts a network service, so it needs no `init-firewall.sh` allowlist entry. Its
 `?`-key AI binding is disabled for the same reason.
 
 History persists across `just dc-build` via two named volumes —
-`arxii-shell-history` (bash's `HISTFILE`) and `arxii-atuin` (atuin's SQLite
+`arxii-shell-history` (the bash and zsh `HISTFILE`s) and `arxii-atuin` (atuin's SQLite
 database). History is unlimited and flushed after every command, so several zellij
 tabs interleave instead of the last one to exit overwriting the rest.
 
@@ -488,12 +506,12 @@ This can happen if the container was started with raw `docker compose up` instea
 `just dc-up`. Run `just dc-down` then `just dc-up` to re-provision.
 
 **`claude`/`just`/`uv` not found, or up-arrow prints `^[[A`, inside a `dc-attach`
-pane** — the pane is running `/bin/sh` (dash) instead of bash, so `~/.bashrc` never
-ran and `mise activate` never put the toolchain on `PATH`; dash also has no line
-editing, hence the dead arrow keys. `docker-compose.yml` sets `SHELL: /bin/bash` to
-prevent this (zellij reads `$SHELL`, and `devcontainer exec` supplies none). If you
-land in such a pane anyway, `exec bash -l` recovers it; confirm the fix stuck with
-`ps -eo pid,args --forest` — pane shells should be `/bin/bash`.
+pane** — the pane is running `/bin/sh` (dash) instead of the configured shell, so no
+rc file ran and `mise activate` never put the toolchain on `PATH`; dash also has no
+line editing, hence the dead arrow keys. `docker-compose.yml` sets `SHELL: /bin/zsh`
+to prevent this (zellij reads `$SHELL`, and `devcontainer exec` supplies none). If you
+land in such a pane anyway, `exec zsh -l` recovers it; confirm the fix stuck with
+`ps -eo pid,args --forest` — pane shells should be `/bin/zsh`.
 
 **`devcontainer: command not found`** — the CLI is not installed. Run:
 ```powershell

--- a/justfile
+++ b/justfile
@@ -422,9 +422,11 @@ dc-build:
     bash .devcontainer/sync-env.sh
     devcontainer up --workspace-folder . --build-no-cache --remove-existing-container
 
-# Open a shell INSIDE the app container (this is where you run `claude`)
+# Open a shell INSIDE the app container (this is where you run `claude`).
+# zsh explicitly: `devcontainer exec` ignores $SHELL, so without naming it here
+# dc-shell would drop you in bash while dc-attach panes get zsh.
 dc-shell:
-    devcontainer exec --workspace-folder . bash
+    devcontainer exec --workspace-folder . zsh
 
 # Reattaches to <name> if it exists, creates it otherwise. Detach on purpose
 # with Ctrl-o d; agents inside keep running. See docs/devcontainer-setup.md


### PR DESCRIPTION
Follow-up to #2958, which made `dc-attach` panes run a real shell instead of dash.
This makes that shell worth using.

**Still draft** — the interactive feel is a matter of taste, so this is worth a
`just dc-build` and a day of actually using before merging.

## Problem

The devcontainer shipped Debian's stock interactive bash:

- `HISTSIZE=1000` / `HISTFILESIZE=2000`, the defaults, which truncate away most of a
  working session.
- `~/.bash_history` lives in image state. `/home/vscode` is not a named volume (only
  `~/.claude` and the polytoken dirs are), so **every `just dc-build` destroyed the
  history outright** — there was no `~/.bash_history` in the running container at all.
- No completions for `gh`, `just`, `uv` or `mise`.
- No autosuggestions or usable completion menu, because that's bash.

## Changes

**zsh + oh-my-zsh becomes the default interactive shell.** `just dc-shell` and every
`dc-attach` pane land in it. bash keeps an equivalent setup — `devcontainer exec`,
`bash -lc` and agent tooling still land there, and it shouldn't be a downgrade.
Atuin's database is shared between the two, so history recorded in a zsh pane is
searchable from bash and vice versa.

oh-my-zsh runs a deliberately short plugin list:

| Plugin | For |
|---|---|
| `git` | the `gst`/`gco`/`gd` alias pack |
| `z` | `z <fragment>` jumps to a previously visited directory |
| `fzf-tab` | completion menu as an fzf picker |
| `zsh-autosuggestions` | inline ghost-text from history |
| `zsh-syntax-highlighting` | invalid commands go red as you type |

Shared by both shells:

- **Persistent history** on two named volumes: `arxii-shell-history` (the bash and zsh
  `HISTFILE`s, plus the `z` jump database via `ZSHZ_DATA`) and `arxii-atuin` (atuin's
  SQLite database). Unlimited, deduped, and written per-command so concurrent zellij
  tabs interleave instead of the last one to exit overwriting the rest.
- **atuin on `Ctrl-R`** — fuzzy history search with exit code, duration and cwd.
  Up-arrow deliberately stays the shell's own history: the full-screen TUI is wanted
  for search, not for "previous command".
- **fzf** — `Ctrl-T` inserts a file path, `Alt-C` cds into a subdirectory, and it's the
  picker behind fzf-tab.
- **Completions** for `gh`, `just`, `uv`, `mise`, generated at build time.

New files: `.devcontainer/zshrc` and `.devcontainer/shell-extras.sh`. The Dockerfile
installs pinned static binaries (atuin 18.18.1, fzf 0.74.2) alongside zellij, plus the
three pinned zsh plugins.

## Nothing here touches the network

`init-firewall.sh` is unchanged and needs no new allowlist entry. Three separate
things wanted to phone home on a schedule and are all disabled: atuin's `auto_sync`
and `update_check`, oh-my-zsh's self-updater (`zstyle ':omz:update' mode disabled`),
and atuin's `--disable-ai`, which otherwise binds the bare `?` key to an LLM
round-trip. Behind the egress firewall each of these turns a shell start or a keypress
into a hang rather than an error.

## Findings worth preserving

All came out of testing rather than documentation, and each is commented at the
relevant line:

1. **fzf must load before atuin.** Both bind `Ctrl-R`; last writer wins. With fzf
   second its `Ctrl-R` silently shadowed atuin's — atuin still recorded history, but
   it could never be searched. Caught by diffing `bind -X` between orderings. Same
   reason omz's `fzf` plugin stays disabled.
2. **zsh and oh-my-zsh already ship in the base devcontainer image**, with a stock
   `~/.zshrc`. An earlier attempt to clone a pinned oh-my-zsh failed with `remote
   origin already exists`. Only the three custom plugins are pinned here; omz moves
   with the base image tag, like `gh` and `zsh` do.
3. **omz's `z` plugin is agkozak/zsh-z, not the old rupa/z script.** It's native zsh
   with no `awk`/`sed`/`date` subprocesses, which is why this dropped zoxide rather
   than the other way round: the speed argument is a wash, `z frag<TAB>` reaches
   `_zshz` through the alias and fzf-tab renders it (covering `zi`), and that leaves
   one less pinned binary. `ZSHZ_DATA` moves its database onto the history volume,
   since the `~/.z` default would reset on every rebuild.
4. **Completion files are sourced only when their command is on PATH** (bash side).
   `just --completions bash` emits a runtime shim that re-invokes `just`, printing
   `just: command not found` on every prompt outside the workspace, where mise hasn't
   put `just`/`uv` on PATH.
5. **atuin 18.x bundles its own bash-preexec**, so no separate install is needed — and
   the base image's `preexec`/`precmd` functions, which would otherwise collide, only
   load when `TERM` is exactly `xterm` while compose pins `xterm-256color`.

## `SHELL` moves from `/bin/bash` to `/bin/zsh`

Not a revert of #2958 — the bug there was the *absence* of `SHELL`, not its value.
`just dc-shell` names `zsh` explicitly, because `devcontainer exec` ignores `$SHELL`
and would otherwise hand out bash while `dc-attach` panes got zsh.

## Verification

Built under a throwaway tag (the running container untouched) and inspected real
interactive shells of both kinds.

zsh — `bindkey` shows `^R` on `atuin-search`, `^[[A` on zsh's own
`up-line-or-beginning-search`, `?` still `self-insert`, `^T`/`^[c` on the fzf widgets;
`_zsh_autosuggest_start`, `_zsh_highlight` and `fzf-tab-complete` all defined;
`_comps` has `gh`/`just`/`uv`/`mise`/`git`/`zshz` registered; `HISTFILE` and
`ZSHZ_DATA` resolve to the volume; a seeded jump database jumps correctly for two
different fragments; `claude` and `just` resolve once `mise.toml` is trusted.

bash — `bind -X` shows `Ctrl-R` on atuin and `?` unbound, up-arrow untouched,
`PROMPT_COMMAND` composing correctly with mise as `_mise_hook_prompt_command; history
-a`, all four completions loading, and a clean silent startup outside the workspace.

Docs/compose/Dockerfile/justfile only — no test suite applies.

**Takes effect on `just dc-build`**, not on the currently running container. Note that
the first rebuild starts history from empty, since the volumes don't exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
