### PR TITLE
Add ~wt and ~arxii named directories to the zsh config

### DIFF
--- a/.devcontainer/zshrc
+++ b/.devcontainer/zshrc
@@ -97,3 +97,16 @@ if command -v atuin >/dev/null 2>&1; then
 fi
 
 # Directory jumping is the `z` plugin above, not a separate binary.
+#
+# `z` only knows directories this shell has already visited, and worktrees are
+# usually created by an agent or another session -- so the one you most want to
+# reach is often the one `z` has never heard of. These named directories cover
+# that first visit: `cd ~wt/<TAB>` opens the fzf-tab picker over every worktree,
+# after which `z 2462` works for the rest of the day.
+#
+# hash -d, not an alias: a named directory works in argument position too
+# (`rg TODO ~wt/feature-2734-*/`), tab-completes as a path, and zsh substitutes
+# it back when PRINTING paths -- so the prompt shows ~wt/feature-2462-... rather
+# than the full string. An alias only ever expands as the first word.
+hash -d wt=/workspaces/arxii/.claude/worktrees
+hash -d arxii=/workspaces/arxii

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -213,6 +213,12 @@ plugin is deliberately **not** enabled: its `Ctrl-R` binding would shadow atuin'
 zsh and oh-my-zsh itself come from the base devcontainer image; only the three custom
 plugins are pinned here.
 
+**Reaching a worktree** is a two-move habit. `z 2462` matches the issue number
+anywhere in the path and is what you want most of the time — but `z` only knows
+directories the shell has already visited, and worktrees are usually created by an
+agent or another session. For that first visit use `cd ~wt/<TAB>`, which opens the
+fzf-tab picker over every worktree; `z` learns it from there.
+
 Directory jumping is the `z` plugin rather than a separate zoxide binary. omz ships
 [agkozak/zsh-z](https://github.com/agkozak/zsh-z), a native-zsh implementation with no
 `awk`/`sed` subprocesses — a wash with zoxide on speed, one less pinned dependency,
@@ -228,8 +234,9 @@ navigation, and atuin records cwd for finding your way back.
 | `Ctrl-R` | atuin: fuzzy search over full history, with exit code, duration and cwd |
 | `Ctrl-T` | fzf: pick a file, insert its path at the cursor |
 | `Alt-C` | fzf: pick a subdirectory and `cd` into it |
-| `z <fragment>` | jump to a previously visited directory, e.g. `z shell-tooling` (zsh only) |
+| `z <fragment>` | jump to a previously visited directory, e.g. `z 2462` (zsh only) |
 | `z <fragment>`+`Tab` | same, but pick from an fzf list when several match |
+| `~wt` / `~arxii` | named directories for the worktree root and the workspace (zsh only) |
 
 Up-arrow is deliberately left as the shell's own history — atuin's full-screen TUI is
 wanted on `Ctrl-R`, not on every "previous command". Change that by dropping


### PR DESCRIPTION
Small follow-up to #2960.

## Why

`z` only knows directories the shell has already visited — and worktrees are usually
created by an agent or another session, so the worktree you most want to reach is
often the one `z` has never heard of. That first visit currently means typing
`/workspaces/arxii/.claude/worktrees/` in full.

Two named directories close the gap:

```zsh
cd ~wt/<TAB>     # fzf-tab picker over every worktree; type 2462, pick
z 2462           # works for the rest of the day, once visited
```

## `hash -d` rather than an alias

`alias wt='cd …'` would only ever expand as the first word of a command. A named
directory does three things an alias can't:

- works in argument position — `rg TODO ~wt/feature-2734-*/`
- tab-completes as a path, which is what makes the fzf-tab picker work
- substitutes *back* when zsh prints paths, so the prompt reads
  `~wt/feature-2462-…` instead of the full string

## Verification

In the running container: `zsh -n` parses the edited file, `cd ~wt` and `cd ~arxii`
both resolve, and `${(D)PWD}` renders the short form.

Docs updated with the two-move habit (`z <number>` for revisits, `~wt/<TAB>` for the
first visit). **Takes effect on the next `just dc-build`** — no need to rebuild for it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
