### PR TITLE
Em-dash in a name is a lookup bug: rename 11 identifiers + repo-wide lint

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,26 @@ repos:
         language: system
         pass_filenames: true
         types: [python]
+      - id: identifier-dashes
+        name: Reject em-dashes in names, keys and slugs (lookup bug)
+        entry: uv run python tools/lint_identifier_dashes.py
+        language: system
+        pass_filenames: true
+        types_or: [python, json]
+        # Ruled 2026-08-03 (Tehom): "we should NOT have em dashes in natural
+        # keys/names ever ... a search by keyboard wouldn't match them because
+        # people are entering a hyphen and it's an em-dash."
+        #
+        # NOT the prose/AI-voice rule; that one lives in the deslop skill and is
+        # softer. This is correctness: a name IS a lookup key here (the dominant
+        # pattern is an exact `Model.objects.get(name=...)`), so a name carrying
+        # a character no keyboard produces is a row nobody can find, and
+        # `get_or_create` on the hyphenated spelling silently makes a DUPLICATE.
+        #
+        # Repo-wide from day one rather than rolled out app-by-app like
+        # objectdb-param: the whole codebase already passes, so there is no debt
+        # to phase in, and the failure mode is silent in both directions.
+        # Suppress a genuine external key with `# noqa: IDENT_DASH` plus a reason.
       - id: objectdb-param
         name: Reject ObjectDB-typed args and model FKs
         entry: uv run python tools/lint_objectdb_param.py

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,16 @@ Database design:
 Code quality (always-on; full list in `django_notes.md`):
 
 - **No relative imports** — absolute only (`from world.roster.models import Roster`).
+- **Never an em/en-dash in a name, key, slug or natural key.** Ruled 2026-08-03: a name
+  *is* a lookup key here (the dominant pattern is an exact
+  `Model.objects.get(name=...)`), and an em-dash is not on anyone's keyboard — so the row
+  becomes unfindable by player search, staff admin and hand-authored fixture references
+  alike, and `get_or_create` on the hyphenated spelling silently creates a **duplicate**.
+  Use a hyphen. Enforced repo-wide by `tools/lint_identifier_dashes.py`
+  (`identifier-dashes` hook) over both Python identifier strings and fixture identity
+  fields; `# noqa: IDENT_DASH` suppresses, and must say why. This is a *correctness* rule
+  and is distinct from the softer prose/AI-voice em-dash rule, which lives in the deslop
+  skill and covers `description`-style fields only.
 - **Never edit dependency code.** `site-packages` (Evennia included) is read-only; every
   linter, quality sweep, or fix pass must exclude Django apps we don't own — flag an
   upstream problem, never "fix" it in the vendored copy. Worktree venvs hardlink from

--- a/src/integration_tests/test_magic_story_pipeline.py
+++ b/src/integration_tests/test_magic_story_pipeline.py
@@ -40,13 +40,13 @@ Cascade math for the High celestial room (magnitude=80):
   backfire_difficulty = 30 + round(80 * 0.500) = 70
 
 ALIGNED room (Abyssal/Dissolution, magnitude=60):
-  60 >= HIGH band threshold (min_magnitude=40) → "Abyssal Resonance — Deep Attunement"
+  60 >= HIGH band threshold (min_magnitude=40) → "Abyssal Resonance - Deep Attunement"
 
 Test data dependencies (seeded by seed_starter_magic_story):
 - ConditionTemplate "Singed", "Burning", "Tempered Against Light",
   "Hallowed Burn", "Cast Disrupted"
-- ConditionTemplate "Abyssal Resonance — Minor Attunement" (min_magnitude=1)
-- ConditionTemplate "Abyssal Resonance — Deep Attunement" (min_magnitude=40)
+- ConditionTemplate "Abyssal Resonance - Minor Attunement" (min_magnitude=1)
+- ConditionTemplate "Abyssal Resonance - Deep Attunement" (min_magnitude=40)
 - ResonanceAlignmentBoonTier rows on pair #5 (Abyssal→Abyssal)
 - Room "The Hallowed Threshold (Low)"   — Celestial cascade magnitude 10
 - Room "The Hallowed Threshold (High)"  — Celestial cascade magnitude 80
@@ -126,10 +126,10 @@ class MagicStoryPipelineTests(ResonanceCacheIsolationMixin, EvenniaTestCase):
 
         # ALIGNED boon templates seeded by T13
         cls.minor_attunement_template = ConditionTemplate.objects.get(
-            name="Abyssal Resonance — Minor Attunement"
+            name="Abyssal Resonance - Minor Attunement"
         )
         cls.deep_attunement_template = ConditionTemplate.objects.get(
-            name="Abyssal Resonance — Deep Attunement"
+            name="Abyssal Resonance - Deep Attunement"
         )
 
         # Store PKs for Evennia ObjectDB rooms — re-fetched in setUp to avoid DbHolder deepcopy.
@@ -551,13 +551,13 @@ class MagicStoryPipelineTests(ResonanceCacheIsolationMixin, EvenniaTestCase):
         """Abyssal caster moves into Abyssal Sanctum (ALIGNED/AMPLIFY) → boon applied.
 
         Uses the REAL movement hook (at_post_move) rather than a direct service call.
-        magnitude=60 ≥ HIGH band threshold (min_magnitude=40) → "Abyssal Resonance —
+        magnitude=60 ≥ HIGH band threshold (min_magnitude=40) → "Abyssal Resonance -
         Deep Attunement" is selected. No perform_check is ever issued (ALIGNED path does
         not trigger backfire). StoryProgress remains at "Stepping Into Light" — ALIGNED
         does not satisfy any hallowed-threshold beat.
 
         Assertions:
-          - "Abyssal Resonance — Deep Attunement" ConditionInstance on caster.
+          - "Abyssal Resonance - Deep Attunement" ConditionInstance on caster.
           - Exactly one boon ConditionInstance (no stacking).
           - No OPPOSED reaction conditions applied.
           - StoryProgress still at "Stepping Into Light".
@@ -577,7 +577,7 @@ class MagicStoryPipelineTests(ResonanceCacheIsolationMixin, EvenniaTestCase):
             "ALIGNED path must not call perform_check; force_check_outcome should be unused",
         )
 
-        # "Abyssal Resonance — Deep Attunement" (band = HIGH, min_magnitude=40,
+        # "Abyssal Resonance - Deep Attunement" (band = HIGH, min_magnitude=40,
         # seeded Abyssal Sanctum magnitude=60 ≥ 40) must be applied.
         boon_instances = self._boon_instances_on_caster()
         self.assertEqual(
@@ -588,7 +588,7 @@ class MagicStoryPipelineTests(ResonanceCacheIsolationMixin, EvenniaTestCase):
         self.assertEqual(
             boon_instances[0].condition_id,
             self.deep_attunement_template.pk,
-            "Expected 'Abyssal Resonance — Deep Attunement' (HIGH band, magnitude 60 ≥ 40)",
+            "Expected 'Abyssal Resonance - Deep Attunement' (HIGH band, magnitude 60 ≥ 40)",
         )
 
         # No OPPOSED reaction conditions should have been applied.

--- a/src/web/admin/sphinx_views.py
+++ b/src/web/admin/sphinx_views.py
@@ -30,7 +30,7 @@ def sphinx_audit(request: HttpRequest) -> HttpResponse:
     from world.covenants.sphinx import audit_vow_coverage  # noqa: PLC0415
 
     context = {
-        "title": "Sphinx of Black Quartz — Coverage Audit",
+        "title": "Sphinx of Black Quartz - Coverage Audit",
         "rows": audit_vow_coverage(),
     }
     return render(request, "admin/sphinx_audit.html", context)

--- a/src/world/combat/factories.py
+++ b/src/world/combat/factories.py
@@ -925,7 +925,7 @@ class BossFightScenarioFactory:
             vulnerability_intensity_bonus=2,
         )
 
-        pool_p2 = ThreatPoolFactory(name="Boss Threat Pool — Phase 2+")
+        pool_p2 = ThreatPoolFactory(name="Boss Threat Pool - Phase 2+")
         add_template = CreatureTemplate.objects.create(
             name="Boss Fight Add",
             tier=OpponentTier.MOOK,

--- a/src/world/covenants/court_grant.py
+++ b/src/world/covenants/court_grant.py
@@ -202,7 +202,7 @@ def ensure_court_grant_role(covenant: Covenant) -> NPCRole:
     config = get_court_grant_config()
 
     role = NPCRole.objects.create(
-        name=f"{covenant.name} — Court Master's Grant",
+        name=f"{covenant.name} - Court Master's Grant",
         faction_affiliation=covenant.organization,
     )
     offer = NPCServiceOffer.objects.create(

--- a/src/world/covenants/tests/test_court_grant_role.py
+++ b/src/world/covenants/tests/test_court_grant_role.py
@@ -43,7 +43,7 @@ class EnsureCourtGrantRoleTests(TestCase):
         cleanly instead of permanently failing.
         """
         covenant = CovenantFactory(covenant_type=CovenantType.COURT)
-        expected_name = f"{covenant.name} — Court Master's Grant"
+        expected_name = f"{covenant.name} - Court Master's Grant"
 
         with (
             mock.patch(

--- a/src/world/items/constants.py
+++ b/src/world/items/constants.py
@@ -284,7 +284,7 @@ FASHION_VOGUE_DECAY_RATE = 0.05  # proportional momentum lost per decay tick (fl
 
 # Seasonal trendsetter ceremony (#514)
 FASHION_TREND_FACET_COUNT = 3  # how many top facets define the new vogue
-FASHION_LIVING_STYLE_NAME_TEMPLATE = "{society} — Current Vogue"
+FASHION_LIVING_STYLE_NAME_TEMPLATE = "{society} - Current Vogue"
 FASHION_SEASON_INTERVAL = timedelta(days=30)  # seasonal ceremony cadence (real time)
 FASHION_VOGUE_DECAY_INTERVAL = timedelta(hours=8)  # momentum decay cadence (matches renown decay)
 

--- a/src/world/seeds/game_content/clash.py
+++ b/src/world/seeds/game_content/clash.py
@@ -187,7 +187,7 @@ class ClashContent:
 
         # Boss-held window condition — applied by LOCK resolution's PC_DECISIVE consequence.
         boss_held_condition, _ = ConditionTemplate.objects.get_or_create(
-            name="Boss Held — Suppress Window (Clash Test)",
+            name="Boss Held - Suppress Window (Clash Test)",
             defaults={
                 "category": cond_category,
                 "description": (
@@ -245,7 +245,7 @@ class ClashContent:
         # Consequence with a stable (outcome_tier, label) natural key.
         lock_decisive_consequence, _ = Consequence.objects.get_or_create(
             outcome_tier=decisive_outcome,
-            label="Lock Resolution: PC Decisive — Apply Boss Held (Clash Test)",
+            label="Lock Resolution: PC Decisive - Apply Boss Held (Clash Test)",
             defaults={
                 "mechanical_description": (
                     "Decisive lock win: boss is held, opening a combo window."
@@ -280,7 +280,7 @@ class ClashContent:
         marginal_outcome = check_outcomes[2]  # success_level=2 → PC_MARGINAL
         lock_marginal_consequence, _ = Consequence.objects.get_or_create(
             outcome_tier=marginal_outcome,
-            label="Lock Resolution: PC Marginal — Apply Boss Held (Clash Test)",
+            label="Lock Resolution: PC Marginal - Apply Boss Held (Clash Test)",
             defaults={
                 "mechanical_description": (
                     "Marginal lock win: boss is partially held, opening a combo window."

--- a/src/world/seeds/game_content/magic.py
+++ b/src/world/seeds/game_content/magic.py
@@ -1009,7 +1009,7 @@ def _seed_resonance_environment_consequence_pools() -> None:
 #: Descriptions narrate WHY an abyssal place empowers an abyssal caster.
 _ABYSSAL_BOON_SPECS: list[dict[str, str]] = [
     {
-        "name": "Abyssal Resonance — Minor Attunement",
+        "name": "Abyssal Resonance - Minor Attunement",
         "band": "low",
         "description": (
             "The dissolution that permeates this place recognises the caster's touch. "
@@ -1026,7 +1026,7 @@ _ABYSSAL_BOON_SPECS: list[dict[str, str]] = [
         ),
     },
     {
-        "name": "Abyssal Resonance — Deep Attunement",
+        "name": "Abyssal Resonance - Deep Attunement",
         "band": "high",
         "description": (
             "The concentrated dissolution saturating this place and the caster's own "

--- a/tools/lint_identifier_dashes.py
+++ b/tools/lint_identifier_dashes.py
@@ -1,0 +1,250 @@
+"""Reject em/en-dashes in identifier strings: names, keys, slugs, labels.
+
+Ruled 2026-08-03 (Tehom):
+
+    "we should NOT have em dashes in natural keys/names ever. Do you have any
+    idea how bad it is that a search by keyboard wouldn't match them because
+    people are entering a hyphen and it's an em-dash? That's incredibly bad,
+    not just from a slop perspective."
+
+This is NOT the prose/AI-voice rule. It is a correctness rule, and it is
+stricter, because in this codebase **a name IS a lookup key**. The dominant
+pattern is an exact match:
+
+    ConditionTemplate.objects.get(name=CHARM_CONDITION_NAME)
+    ConditionTemplate.objects.filter(name=SHIELDED_CONDITION_NAME).first()
+
+An em-dash is not on anyone's keyboard. A row whose name contains one is a row
+that cannot be found: player search misses it, staff admin autocomplete misses
+it, and a hand-authored fixture cross-reference resolves to nothing instead of
+raising. The failure is silent in every direction, which is what makes it worse
+than a typo.
+
+Caught in the wild by lore #42: two ConditionTemplate rows, "Abyssal Resonance
+<em-dash> Minor/Deep Attunement", were unreachable by keyboard while every
+prose sweep reported the corpus clean — because prose checks never look at a
+`name` field.
+
+What is flagged:
+
+* Python keyword arguments and dict-literal entries whose key is identifier-ish
+  (`name=`, `"key":`, `slug=`, `title=`, `label=`, `code=`) and whose value is a
+  string literal containing an em- or en-dash.
+* Identity fields and serialised natural keys in JSON fixtures.
+
+What is NOT flagged: comments, docstrings, and prose fields (`description`,
+`summary`, `player_description`, ...). Prose em-dashes are a separate, softer
+rule that lives in the deslop skill; this linter only cares about strings that
+have to be typed or matched.
+
+Use `# noqa: IDENT_DASH` on the same line when a dash in an identifier is
+genuinely correct — e.g. an external system's key that we do not control.
+Say why, in the comment; a bare suppression is indistinguishable from an
+oversight.
+"""
+
+from __future__ import annotations
+
+import ast
+from collections.abc import Iterator
+import json
+from pathlib import Path
+import re
+import sys
+
+SUPPRESSION_TOKEN = "noqa: ident_dash"  # noqa: S105
+
+DASHES = re.compile(r"[—–]")
+
+#: Substring hints. Catches `display_name`, `template_key`, `natural_key`, ...
+IDENTIFIER_HINTS = ("name", "key", "slug", "title", "label", "code", "ident")
+
+#: Prose wins over the hints. `display_text` is prose; `display_name` is not.
+#: Kept in step with FIXTURE_PROSE_KEYS in the deslop skill's check.py.
+PROSE_KEYS = frozenset(
+    {
+        "description",
+        "player_description",
+        "observer_description",
+        "summary",
+        "text",
+        "prose",
+        "body",
+        "content",
+        "flavor_text",
+        "narrative_snippet",
+        "lore_content",
+        "mechanics_content",
+        "frame_narrative",
+        "prompt",
+        "epigraph",
+        "display_text",
+        "pitch",
+        "success_text",
+        "failure_text",
+        "narrative_prose",
+        "announce_template",
+        "description_template",
+        "epilogue",
+        "tooltip",
+        # `verbose_name` is an admin display string, not a lookup key.
+        "verbose_name",
+        "verbose_name_plural",
+        "help_text",
+    }
+)
+
+
+def is_identifier_key(key: str) -> bool:
+    """True when `key` names an identity rather than prose."""
+    lowered = key.lower()
+    if lowered in PROSE_KEYS:
+        return False
+    return any(hint in lowered for hint in IDENTIFIER_HINTS)
+
+
+def _suppressed(lines: list[str], lineno: int) -> bool:
+    if 1 <= lineno <= len(lines):
+        return SUPPRESSION_TOKEN in lines[lineno - 1].lower()
+    return False
+
+
+def _call_pairs(node: ast.Call) -> Iterator[tuple[str, ast.expr]]:
+    """``Model.objects.get(name="...")``."""
+    for kw in node.keywords:
+        if kw.arg:
+            yield kw.arg, kw.value
+
+
+def _dict_pairs(node: ast.Dict) -> Iterator[tuple[str, ast.expr]]:
+    """``{"name": "..."}`` — the seed specs in ``world/seeds/game_content/``."""
+    for key_node, value_node in zip(node.keys, node.values, strict=True):
+        if isinstance(key_node, ast.Constant) and isinstance(key_node.value, str):
+            yield key_node.value, value_node
+
+
+def _assign_pairs(node: ast.Assign) -> Iterator[tuple[str, ast.expr]]:
+    """``SOME_NAME = "..."`` — the constants those lookups are keyed on."""
+    for target in node.targets:
+        if isinstance(target, ast.Name):
+            yield target.id, node.value
+
+
+def _identifier_pairs(tree: ast.AST) -> Iterator[tuple[str, ast.expr]]:
+    """Yield every ``(key, value-node)`` pair where `key` might name an identity."""
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            yield from _call_pairs(node)
+        elif isinstance(node, ast.Dict):
+            yield from _dict_pairs(node)
+        elif isinstance(node, ast.Assign):
+            yield from _assign_pairs(node)
+
+
+def _string_literals(node: ast.expr) -> Iterator[str]:
+    """Yield the literal text of `node`, if any.
+
+    Covers the plain constant and the f-string. The f-string case matters
+    because name TEMPLATES are how a single bad literal becomes many bad rows:
+    ``FASHION_LIVING_STYLE_NAME_TEMPLATE`` fed straight into
+    ``FashionStyle.objects.get_or_create(name=...)``.
+    """
+    if isinstance(node, ast.Constant):
+        if isinstance(node.value, str):
+            yield node.value
+    elif isinstance(node, ast.JoinedStr):
+        for part in node.values:
+            if isinstance(part, ast.Constant) and isinstance(part.value, str):
+                yield part.value
+
+
+def check_python(path: Path) -> list[tuple[int, str, str]]:
+    """Return (line, identifier-key, offending value) for each violation."""
+    try:
+        source = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    if not DASHES.search(source):
+        return []
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+
+    lines = source.splitlines()
+    found: list[tuple[int, str, str]] = []
+    for key, node in _identifier_pairs(tree):
+        if not is_identifier_key(key) or _suppressed(lines, node.lineno):
+            continue
+        found.extend(
+            (node.lineno, key, value) for value in _string_literals(node) if DASHES.search(value)
+        )
+    return found
+
+
+def _row_violations(index: int, row: dict) -> Iterator[tuple[int, str, str]]:
+    """Yield violations for one fixture row: serialised natural key, then fields."""
+    pk = row.get("pk")
+    if isinstance(pk, list):
+        for part in pk:
+            if isinstance(part, str) and DASHES.search(part):
+                yield index, "pk", part
+    fields = row.get("fields")
+    if not isinstance(fields, dict):
+        return
+    for key, value in fields.items():
+        if isinstance(value, str) and is_identifier_key(key) and DASHES.search(value):
+            yield index, key, value
+
+
+def check_fixture(path: Path) -> list[tuple[int, str, str]]:
+    """Identity fields and natural keys inside a Django fixture."""
+    try:
+        raw = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return []
+    if not DASHES.search(raw):
+        return []
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return []
+    if not isinstance(data, list):
+        return []
+
+    found: list[tuple[int, str, str]] = []
+    for index, row in enumerate(data):
+        if isinstance(row, dict):
+            found.extend(_row_violations(index, row))
+    return found
+
+
+def main(argv: list[str]) -> int:
+    errors_found = False
+    for name in argv:
+        path = Path(name)
+        if not path.is_file():
+            continue
+        if path.suffix == ".json":
+            for index, key, value in check_fixture(path):
+                errors_found = True
+                print(
+                    f"{path}:row {index}: IDENT_DASH "
+                    f"fixture {key!r} = {value!r} contains an em/en-dash. A name is "
+                    "matched exactly by name= lookups and cannot be typed with one. "
+                    "Use a hyphen."
+                )
+        elif path.suffix == ".py":
+            for lineno, key, value in check_python(path):
+                errors_found = True
+                print(
+                    f"{path}:{lineno}: IDENT_DASH "
+                    f"{key}={value!r} contains an em/en-dash. Identifier strings are "
+                    "matched exactly and typed by hand; use a hyphen, or add "
+                    "`# noqa: IDENT_DASH` stating why a dash is genuinely required."
+                )
+    return 1 if errors_found else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tools/sonarcloud_sync.py
+++ b/tools/sonarcloud_sync.py
@@ -28,7 +28,7 @@ def make_title(raw: dict) -> str:
     basename = fp.rsplit("/", 1)[-1] if "/" in fp else fp
     line = raw.get("line")
     location = f"{basename}:{line}" if line else basename
-    title = f"[sonarcloud:{tier}] {rule}: {msg} — {location}"
+    title = f"[sonarcloud:{tier}] {rule}: {msg} - {location}"
     return title[:120]
 
 


### PR DESCRIPTION
An em-dash in a **name** is a lookup bug, not a style problem. This renames every
identifier that had one and adds a repo-wide lint so it cannot come back.

Companion to Arx-Game/ArxII-lore#51 (merged), which fixed the content-repo half.

## Why this is a correctness issue

Ruled 2026-08-03 (Tehom):

> "we should NOT have em dashes in natural keys/names ever. Do you have any idea how bad it
> is that a search by keyboard wouldn't match them because people are entering a hyphen and
> it's an em-dash? That's incredibly bad, not just from a slop perspective."

In this codebase **a name IS a lookup key**. The dominant pattern is an exact match:

```python
ConditionTemplate.objects.get(name=CHARM_CONDITION_NAME)
ConditionTemplate.objects.filter(name=SHIELDED_CONDITION_NAME).first()
```

An em-dash is on nobody's keyboard, so a row whose name contains one cannot be found by
player search, staff admin, or a hand-authored fixture reference — and the miss is silent in
every direction, which is what makes it worse than a typo. Worse still with
`get_or_create(name=...)`: someone typing the hyphenated spelling gets a **new duplicate row**
rather than a match.

## The three that were actively generating bad rows

These are the reason this is worth a PR rather than a two-line rename. Each takes a single
bad literal and mints unfindable rows indefinitely:

| Generator | What it created | Rows so far |
|---|---|---|
| `FASHION_LIVING_STYLE_NAME_TEMPLATE` → `trendsetter.py` `FashionStyle.objects.get_or_create(name=...)` | a Style per society, every seasonal ceremony | **0** |
| `court_grant.py` `NPCRole.objects.create(name=f"{covenant.name} — Court Master's Grant")` | an NPCRole per court covenant (`name` is `unique=True`) | **0** |
| `sonarcloud_sync.py` issue title | GitHub issues humans search by title | n/a |

Both DB-backed ones shipped recently — the fashion template in `f31dee705`, yesterday — and
**zero rows exist with the bad names**, verified by query. So this is caught before any data
was created, which is the only reason it is a cheap fix.

## Everything renamed (em-dash → hyphen), 11 strings

- `ConditionTemplate` "Abyssal Resonance - Minor/Deep Attunement" — in
  `world/seeds/game_content/magic.py` (the seed that creates them) and
  `integration_tests/test_magic_story_pipeline.py` (which looks them up **by name**; 2 live
  lookups plus 7 doc references)
- the three generators above
- three clash test-seed names/labels, one combat factory name, one admin page title, one test
  mirror

The two dev-DB rows were renamed in place rather than reloaded, since the natural key changed
and a reload would have created new rows alongside the old ones. No data migration — per
ADR-0013 this is pre-production and schema-only.

## The guard

`tools/lint_identifier_dashes.py` + the `identifier-dashes` pre-commit hook, over Python and
JSON. It reads four shapes:

- keyword arguments — `Model.objects.get(name="...")`
- dict-literal entries — the seed specs in `world/seeds/game_content/`
- module-level constant assignments — how `FASHION_LIVING_STYLE_NAME_TEMPLATE` was caught
- **f-strings** — how `court_grant` and `sonarcloud_sync` were caught

The f-string case is not incidental. My first version only read plain constants, passed
clean, and missed both of those; adding f-strings found them immediately. Name *templates*
are exactly where this bug scales, so they are the case the linter most needs to see.

Prose fields are explicitly exempt (`description`, `summary`, `player_description`,
`display_text`, …), so `display_text` stays prose while `display_name` is an identity. That
list is kept in step with `FIXTURE_PROSE_KEYS` in the deslop skill. `# noqa: IDENT_DASH`
suppresses, and must state why.

**Scoped repo-wide from day one** rather than phased in app-by-app like `objectdb-param`:
the whole repo already passes after this PR, so there is no debt to roll out, and the failure
mode is silent enough that partial coverage would be misleading.

## Verification

- `ruff` clean; every pre-commit hook passes (`ruff-format` and the repo's own
  `getattr-literal` hook both caught real problems in my linter during development and are
  fixed).
- The lint exits **0** across every tracked `.py` and `.json`.
- On a probe file it exits **1** and catches all four identifier shapes, while correctly
  ignoring an em-dash in `description=` and a plain hyphen.
- A DB-wide scan of every unique/indexed `Char`/`TextField` on every model now reports **0**
  identity values containing an em/en-dash (it reported 2 before).
- `just test-fast world.items` — **909 tests, OK**.
- `just test-fast world.covenants` — **891 tests, OK**.
- CLAUDE.md records the rule alongside the other always-on invariants, and states plainly
  that it is distinct from the softer prose/AI-voice em-dash rule.

## What this does NOT do

It does not touch em-dashes in **prose** — docstrings, comments, `description=` strings.
There are ~1,384 of those in non-docstring string literals across `src/`, which is the
player-facing-prose sweep the lore repo just did for content, and is a separate, much larger
piece of work. This PR is only about strings that have to be typed or matched.
