### PR TITLE
One player-visible em-dash missed in #2963 (CommandError message)

### DIFF
--- a/src/commands/story.py
+++ b/src/commands/story.py
@@ -1231,7 +1231,7 @@ class CmdStory(ArxNamespaceCommand):
             msg = "You do not own or lead this story."
             raise CommandError(msg)
         if story_is_cleared(story):
-            msg = "This story's impact tier is frozen — it has a cleared canon review."
+            msg = "This story's impact tier is frozen; it has a cleared canon review."
             raise CommandError(msg)
 
         story.impact_tier = new_tier


### PR DESCRIPTION
Found while verifying #2963 on merged main.

Evennia prints a `CommandError`'s text **straight to the player**, so those strings are
player-facing prose. My classifier in #2963 treated anything near a `raise` as a
staff/developer surface. That is right for logger calls and for `ValidationError` in a model
`clean()` (admin + API only, and the repo forbids `str(exc)` in responses) — but wrong for
`CommandError`.

An AST sweep of every `raise CommandError(...)` in `src/`, including the
`msg = "..."` / `raise CommandError(msg)` two-step this file uses, finds **exactly one**
such string carrying a dash:

```
src/commands/story.py:1234
- "This story's impact tier is frozen — it has a cleared canon review."
+ "This story's impact tier is frozen; it has a cleared canon review."
```

Two independent clauses, so a semicolon.

**Re-verified after the fix:** 0 em/en-dashes remain in Cmd* help docstrings, in
non-docstring string literals under `src/commands/` or `src/actions/`, or in any
player-visible `CommandError` message.

**Deliberately unchanged:** the `ValidationError` in
`src/actions/models/consequence_pools.py` keeps its dash — it surfaces in Django admin and
API validation, never to a player.