### PR TITLE
SonarCloud sweep: clear all 50 open sonarcloud issues (S1192 x31, S3776 x18, S8495)

### DIFF
--- a/frontend/src/scenes/components/EndorsementControl.tsx
+++ b/frontend/src/scenes/components/EndorsementControl.tsx
@@ -51,10 +51,119 @@ import type { Interaction, EndorserBadge } from '../types';
 // Props
 // ---------------------------------------------------------------------------
 
+export type EndorsementKind = 'pose' | 'entry' | 'style';
+
 export interface EndorsementControlProps {
   interaction: Interaction;
   sceneId: string;
-  kind: 'pose' | 'entry' | 'style';
+  kind: EndorsementKind;
+}
+
+const ENDORSE_LABELS: Record<EndorsementKind, string> = {
+  pose: 'Endorse',
+  entry: 'Endorse entry',
+  style: 'Endorse style',
+};
+
+/**
+ * Whether the control renders nothing at all: nothing to endorse with, the
+ * viewer's own pose, a private/whispered pose, or (for entry/style) a payload
+ * missing the endorsee sheet the mutation needs.
+ */
+function isControlHidden(
+  interaction: Interaction,
+  kind: EndorsementKind,
+  viewerPersonaId: number | null | undefined
+): boolean {
+  const isSelfPose = viewerPersonaId != null && interaction.persona.id === viewerPersonaId;
+  if (
+    interaction.endorsable_resonances.length === 0 ||
+    isSelfPose ||
+    interaction.mode === 'whisper' ||
+    interaction.visibility === 'very_private'
+  ) {
+    return true;
+  }
+  // endorsee_sheet_id is typed number | null; for kind='entry'|'style' it must
+  // be present. If it's somehow null (impossible in practice but typed), hide
+  // rather than coerce.
+  return kind !== 'pose' && interaction.endorsee_sheet_id == null;
+}
+
+interface AffordanceProps {
+  kind: EndorsementKind;
+  resonances: { id: number; name: string }[];
+  myEndorsement: { id: number; resonance_id: number; settled: boolean } | null;
+  isImmutableEndorsedByMe: boolean;
+  isPending: boolean;
+  isRetracting: boolean;
+  onRetract: (endorsementId: number) => void;
+  onPick: (resonanceId: number) => void;
+}
+
+/**
+ * The one interactive affordance: retract (pose, unsettled), a permanent
+ * "Endorsed ✓" indicator (entry/style), or the resonance picker.
+ */
+function EndorsementAffordance({
+  kind,
+  resonances,
+  myEndorsement,
+  isImmutableEndorsedByMe,
+  isPending,
+  isRetracting,
+  onRetract,
+  onPick,
+}: AffordanceProps) {
+  if (myEndorsement != null) {
+    return (
+      <button
+        type="button"
+        disabled={myEndorsement.settled || isRetracting}
+        onClick={() => onRetract(myEndorsement.id)}
+        className={`rounded-full border px-2 py-0.5 text-xs transition-colors ${
+          myEndorsement.settled
+            ? 'cursor-not-allowed border-muted-foreground/20 opacity-50'
+            : 'border-amber-500 bg-amber-500/10 font-medium hover:bg-amber-500/20'
+        }`}
+      >
+        Retract
+      </button>
+    );
+  }
+
+  if (isImmutableEndorsedByMe) {
+    /* Entry/style endorsements are permanent — no retract affordance, just a display indicator. */
+    return (
+      <span
+        data-testid={`${kind}-endorsed-indicator`}
+        className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-xs text-amber-700 dark:text-amber-300"
+      >
+        Endorsed ✓
+      </span>
+    );
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          disabled={isPending}
+          className="rounded-full border border-muted-foreground/30 px-2 py-0.5 text-xs transition-colors hover:border-amber-500/60 disabled:opacity-50"
+        >
+          {ENDORSE_LABELS[kind]}
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start">
+        {resonances.map((r) => (
+          <DropdownMenuItem key={r.id} onClick={() => onPick(r.id)}>
+            {r.name}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -102,119 +211,57 @@ export function EndorsementControl({ interaction, sceneId, kind }: EndorsementCo
     [interaction.endorsable_resonances]
   );
 
-  // ----- Guard conditions — render nothing --------------------------------
-  const isSelfPose = viewerPersonaId != null && interaction.persona.id === viewerPersonaId;
-
-  if (
-    interaction.endorsable_resonances.length === 0 ||
-    isSelfPose ||
-    interaction.mode === 'whisper' ||
-    interaction.visibility === 'very_private'
-  ) {
-    return null;
-  }
-
-  // endorsee_sheet_id is typed number | null; for kind='entry'|'style' it must
-  // be present. If it's somehow null (impossible in practice but typed), hide
-  // rather than coerce.
-  if ((kind === 'entry' || kind === 'style') && interaction.endorsee_sheet_id == null) {
+  if (isControlHidden(interaction, kind, viewerPersonaId)) {
     return null;
   }
 
   // ----- Data for this kind -----------------------------------------------
-  const isPose = kind === 'pose';
-  const isEntry = kind === 'entry';
-  const isStyle = kind === 'style';
-  const endorsers: EndorserBadge[] = isPose
-    ? interaction.pose_endorsers
-    : isEntry
-      ? interaction.entry_endorsers
-      : [];
-
-  // ----- Handlers ---------------------------------------------------------
-  function handlePickResonance(resonanceId: number) {
-    if (isPose) {
-      createPose.mutate({ interaction: interaction.id, resonance: resonanceId });
-    } else if (isStyle) {
-      // endorsee_sheet_id is guaranteed non-null here by the guard above.
-      createStyle.mutate({
-        endorsee_sheet: interaction.endorsee_sheet_id!,
-        scene: Number(sceneId),
-        resonance: resonanceId,
-      });
-    } else {
-      createEntry.mutate({
-        endorsee_sheet: interaction.endorsee_sheet_id!,
-        scene: Number(sceneId),
-        resonance: resonanceId,
-      });
-    }
-  }
-
-  // ----- Render -----------------------------------------------------------
-  const isPending = isPose
-    ? createPose.isPending
-    : isStyle
-      ? createStyle.isPending
-      : createEntry.isPending;
-  const myEndorsement = isPose ? interaction.my_pose_endorsement : null;
-  const isEndorsed = myEndorsement != null;
+  const activeMutation = { pose: createPose, entry: createEntry, style: createStyle }[kind];
+  const endorsers: EndorserBadge[] = {
+    pose: interaction.pose_endorsers,
+    entry: interaction.entry_endorsers,
+    style: [] as EndorserBadge[],
+  }[kind];
+  const myEndorsement = kind === 'pose' ? interaction.my_pose_endorsement : null;
   // Entry's endorsed state is a persisted server flag; style has none (see
   // module docstring), so it's derived from the create-mutation's own
   // isSuccess — the mutation hook instance persists across re-renders of this
   // component, so the indicator sticks once the immediate grant succeeds.
   const isImmutableEndorsedByMe =
-    (isEntry && interaction.entry_endorsed_by_me) || (isStyle && createStyle.isSuccess);
-  const label = isPose ? 'Endorse' : isStyle ? 'Endorse style' : 'Endorse entry';
-  const activeError = isPose ? createPose.error : isStyle ? createStyle.error : createEntry.error;
+    (kind === 'entry' && interaction.entry_endorsed_by_me) ||
+    (kind === 'style' && createStyle.isSuccess);
 
+  // ----- Handlers ---------------------------------------------------------
+  function handlePickResonance(resonanceId: number) {
+    if (kind === 'pose') {
+      createPose.mutate({ interaction: interaction.id, resonance: resonanceId });
+      return;
+    }
+    // endorsee_sheet_id is guaranteed non-null here by the guard above.
+    const payload = {
+      endorsee_sheet: interaction.endorsee_sheet_id!,
+      scene: Number(sceneId),
+      resonance: resonanceId,
+    };
+    (kind === 'style' ? createStyle : createEntry).mutate(payload);
+  }
+
+  // ----- Render -----------------------------------------------------------
   return (
     <div
       data-testid={`endorsement-control-${kind}`}
       className="mt-1 flex flex-wrap items-center gap-1.5"
     >
-      {/* Resonance picker or retract affordance */}
-      {isEndorsed ? (
-        <button
-          type="button"
-          disabled={myEndorsement.settled || deletePose.isPending}
-          onClick={() => deletePose.mutate(myEndorsement.id)}
-          className={`rounded-full border px-2 py-0.5 text-xs transition-colors ${
-            myEndorsement.settled
-              ? 'cursor-not-allowed border-muted-foreground/20 opacity-50'
-              : 'border-amber-500 bg-amber-500/10 font-medium hover:bg-amber-500/20'
-          }`}
-        >
-          Retract
-        </button>
-      ) : isImmutableEndorsedByMe ? (
-        /* Entry/style endorsements are permanent — no retract affordance, just a display indicator. */
-        <span
-          data-testid={`${kind}-endorsed-indicator`}
-          className="rounded-full border border-amber-500/40 bg-amber-500/10 px-2 py-0.5 text-xs text-amber-700 dark:text-amber-300"
-        >
-          Endorsed ✓
-        </span>
-      ) : (
-        <DropdownMenu>
-          <DropdownMenuTrigger asChild>
-            <button
-              type="button"
-              disabled={isPending}
-              className="rounded-full border border-muted-foreground/30 px-2 py-0.5 text-xs transition-colors hover:border-amber-500/60 disabled:opacity-50"
-            >
-              {label}
-            </button>
-          </DropdownMenuTrigger>
-          <DropdownMenuContent align="start">
-            {interaction.endorsable_resonances.map((r) => (
-              <DropdownMenuItem key={r.id} onClick={() => handlePickResonance(r.id)}>
-                {r.name}
-              </DropdownMenuItem>
-            ))}
-          </DropdownMenuContent>
-        </DropdownMenu>
-      )}
+      <EndorsementAffordance
+        kind={kind}
+        resonances={interaction.endorsable_resonances}
+        myEndorsement={myEndorsement}
+        isImmutableEndorsedByMe={isImmutableEndorsedByMe}
+        isPending={activeMutation.isPending}
+        isRetracting={deletePose.isPending}
+        onRetract={(endorsementId) => deletePose.mutate(endorsementId)}
+        onPick={handlePickResonance}
+      />
 
       {/* Endorser badges */}
       {endorsers.map((badge) => (
@@ -226,9 +273,9 @@ export function EndorsementControl({ interaction, sceneId, kind }: EndorsementCo
       ))}
 
       {/* Backend error — meaningful text (e.g. "not wearing a bound style"), surfaced verbatim. */}
-      {activeError && (
+      {activeMutation.error && (
         <span data-testid="endorsement-error" className="text-xs text-destructive">
-          {activeError.message}
+          {activeMutation.error.message}
         </span>
       )}
     </div>

--- a/src/actions/definitions/distinctions.py
+++ b/src/actions/definitions/distinctions.py
@@ -17,6 +17,38 @@ if TYPE_CHECKING:
     from world.distinctions.models import SheetUpdateRequest
 
 
+#: The one non-default sub-verb; anything else (including the empty string) means add.
+_REMOVE_ACTION = "remove"
+
+
+def _usage_message(action_str: str) -> str:
+    """The usage line for whichever sub-verb the GM was reaching for."""
+    if action_str == _REMOVE_ACTION:
+        return "Usage: grant_distinction/remove <character>=<distinction slug>"
+    return "Usage: grant_distinction <character>=<distinction slug>[,rank]"
+
+
+def _validate_rank(rank_raw: Any, distinction: Any) -> ActionResult | None:
+    """A refusal for a bad explicit rank, or None when the request may proceed.
+
+    An absent rank is fine — the add path treats it as "first rank / rank up by
+    one". A garbage or over-max rank is rejected outright rather than clamped.
+    Validation only: ``_execute_add`` routes through the sheet-update request
+    framework, which takes no rank, so an accepted value is not applied here.
+    """
+    if rank_raw is None:
+        return None
+    rank = _coerce_positive_int(rank_raw)
+    if rank is None:
+        return ActionResult(success=False, message="rank must be a positive whole number.")
+    if rank > distinction.max_rank:
+        return ActionResult(
+            success=False,
+            message=f"{distinction.name} has a maximum rank of {distinction.max_rank}.",
+        )
+    return None
+
+
 def _coerce_positive_int(value: Any) -> int | None:
     """Return ``value`` as a positive int, or ``None`` if it isn't one.
 
@@ -107,15 +139,7 @@ class GMAwardDistinctionAction(Action):
         action_str = (kwargs.get("action") or "add").strip().lower()
 
         if not target_name or not distinction_slug:
-            if action_str == "remove":  # noqa: STRING_LITERAL
-                return ActionResult(
-                    success=False,
-                    message="Usage: grant_distinction/remove <character>=<distinction slug>",
-                )
-            return ActionResult(
-                success=False,
-                message="Usage: grant_distinction <character>=<distinction slug>[,rank]",
-            )
+            return ActionResult(success=False, message=_usage_message(action_str))
 
         target = actor.search(target_name, global_search=True)
         if target is None:
@@ -136,7 +160,7 @@ class GMAwardDistinctionAction(Action):
 
         gm_account = actor.account
 
-        if action_str == "remove":  # noqa: STRING_LITERAL
+        if action_str == _REMOVE_ACTION:
             return self._execute_remove(
                 sheet=sheet,
                 target=target,
@@ -153,18 +177,9 @@ class GMAwardDistinctionAction(Action):
             )
 
         # ADD (default)
-        rank: int | None = None
-        rank_raw = kwargs.get("rank")
-        if rank_raw is not None:
-            rank = _coerce_positive_int(rank_raw)
-            if rank is None:
-                return ActionResult(success=False, message="rank must be a positive whole number.")
-
-        if rank is not None and rank > distinction.max_rank:
-            return ActionResult(
-                success=False,
-                message=f"{distinction.name} has a maximum rank of {distinction.max_rank}.",
-            )
+        rank_refusal = _validate_rank(kwargs.get("rank"), distinction)
+        if rank_refusal is not None:
+            return rank_refusal
 
         return self._execute_add(
             sheet=sheet,

--- a/src/actions/definitions/locations.py
+++ b/src/actions/definitions/locations.py
@@ -33,6 +33,7 @@ from actions.prerequisites import (
 from actions.types import ActionResult, TargetType
 
 _NOT_PART_OF_BUILDING_MESSAGE = "This room isn't part of a building."
+_NOT_IN_ROOM_MESSAGE = "You're not in a room."
 
 if TYPE_CHECKING:
     from actions.types import ActionContext
@@ -105,7 +106,7 @@ def _resolve_room(actor: ObjectDB, kwargs: dict[str, Any]) -> ObjectDB | None:
 
 
 def _no_room_message(kwargs: dict[str, Any]) -> str:
-    return "No such room." if kwargs.get("room_id") else "You're not in a room."
+    return "No such room." if kwargs.get("room_id") else _NOT_IN_ROOM_MESSAGE
 
 
 def _no_exit_message(kwargs: dict[str, Any]) -> str:
@@ -580,7 +581,7 @@ class SetPrimaryHomeAction(Action):
 
         room = actor.location
         if room is None:
-            return ActionResult(success=False, message="You're not in a room.")
+            return ActionResult(success=False, message=_NOT_IN_ROOM_MESSAGE)
         try:
             set_primary_home(persona=_persona_for(actor), room=room)
         except RoomEditError as exc:
@@ -623,7 +624,7 @@ class TagRoomResonanceAction(Action):
 
         room = actor.location
         if room is None:
-            return ActionResult(success=False, message="You're not in a room.")
+            return ActionResult(success=False, message=_NOT_IN_ROOM_MESSAGE)
         resonance = Resonance.objects.filter(pk=kwargs.get("resonance_id")).first()
         if resonance is None:
             return ActionResult(success=False, message="No such resonance.")
@@ -669,7 +670,7 @@ class UntagRoomResonanceAction(Action):
 
         room = actor.location
         if room is None:
-            return ActionResult(success=False, message="You're not in a room.")
+            return ActionResult(success=False, message=_NOT_IN_ROOM_MESSAGE)
         resonance = Resonance.objects.filter(pk=kwargs.get("resonance_id")).first()
         if resonance is None:
             return ActionResult(success=False, message="No such resonance.")

--- a/src/actions/definitions/progression_rewards.py
+++ b/src/actions/definitions/progression_rewards.py
@@ -21,6 +21,7 @@ if TYPE_CHECKING:
     from actions.types import ActionContext
 
 _NO_ACCOUNT = "You have no active character on the roster."
+_NO_ACTIVE_CHARACTER = "No active character."
 
 
 def _resolve_account(actor: ObjectDB) -> AccountDB | None:
@@ -228,7 +229,7 @@ class SetPathIntentAction(Action):
         try:
             sheet = actor.sheet_data
         except (AttributeError, ObjectDoesNotExist):
-            return ActionResult(success=False, message="No active character.")
+            return ActionResult(success=False, message=_NO_ACTIVE_CHARACTER)
         path = Path.objects.filter(pk=kwargs.get("path_id"), is_active=True).first()
         if path is None:
             return ActionResult(success=False, message="That is not a valid path.")
@@ -256,7 +257,7 @@ class ClearPathIntentAction(Action):
         try:
             sheet = actor.sheet_data
         except (AttributeError, ObjectDoesNotExist):
-            return ActionResult(success=False, message="No active character.")
+            return ActionResult(success=False, message=_NO_ACTIVE_CHARACTER)
         clear_path_intent(sheet)
         return ActionResult(success=True, message="Path intent cleared.")
 
@@ -288,7 +289,7 @@ class SelectPathAction(Action):
         from world.progression.services.advancement import select_initial_path  # noqa: PLC0415
 
         if actor.character_sheet is None:
-            return ActionResult(success=False, message="No active character.")
+            return ActionResult(success=False, message=_NO_ACTIVE_CHARACTER)
         path = Path.objects.filter(
             pk=kwargs.get("path_id"), is_active=True, stage=PathStage.PROSPECT
         ).first()

--- a/src/actions/definitions/projects.py
+++ b/src/actions/definitions/projects.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 
 _MSG_NO_CHARACTER_SHEET = "You have no character sheet."
 _MSG_NO_SUCH_PROJECT = "No such project."
+_MSG_NO_ACTIVE_PERSONA = "You have no active persona."
 
 
 @dataclass
@@ -137,7 +138,7 @@ class CheckContributeAction(Action):
         try:
             persona = active_persona_for_sheet(sheet)
         except Persona.DoesNotExist:
-            return _ActionResult(success=False, message="You have no active persona.")
+            return _ActionResult(success=False, message=_MSG_NO_ACTIVE_PERSONA)
 
         project = Project.objects.filter(pk=project_id).first()
         if project is None:
@@ -203,7 +204,7 @@ class StoryContributeAction(Action):
         try:
             persona = active_persona_for_sheet(sheet)
         except Persona.DoesNotExist:
-            return _ActionResult(success=False, message="You have no active persona.")
+            return _ActionResult(success=False, message=_MSG_NO_ACTIVE_PERSONA)
 
         project = Project.objects.filter(pk=project_id).first()
         if project is None:
@@ -262,7 +263,7 @@ class LaunchPropagandaCampaignAction(Action):
         try:
             persona = active_persona_for_sheet(sheet)
         except Persona.DoesNotExist:
-            return _ActionResult(success=False, message="You have no active persona.")
+            return _ActionResult(success=False, message=_MSG_NO_ACTIVE_PERSONA)
 
         tier = PropagandaCampaignTier.objects.filter(pk=tier_id).first()
         if tier is None:

--- a/src/actions/definitions/tasking.py
+++ b/src/actions/definitions/tasking.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
     from world.scenes.models import Persona
 
 _CATEGORY = "tasking"
+_NOT_IN_ROOM_MESSAGE = "You're not in a room."
 
 
 def _active_persona(actor: ObjectDB) -> Persona | None:
@@ -323,7 +324,7 @@ class PostListenerAction(Action):
         else:
             room = _room_profile(actor)
         if room is None:
-            return ActionResult(success=False, message="You're not in a room.")
+            return ActionResult(success=False, message=_NOT_IN_ROOM_MESSAGE)
         npc_asset = NPCAsset.objects.filter(pk=kwargs.get("npc_asset_id")).first()
         if npc_asset is None:
             return ActionResult(success=False, message="No such agent.")
@@ -534,7 +535,7 @@ class DetectListenersAction(Action):
             return _NO_PERSONA
         room = _room_profile(actor)
         if room is None:
-            return ActionResult(success=False, message="You're not in a room.")
+            return ActionResult(success=False, message=_NOT_IN_ROOM_MESSAGE)
         try:
             revealed = detect_listeners(persona, room)
         except TaskingError as exc:
@@ -574,7 +575,7 @@ class ClearRoomListenersAction(Action):
             return _NO_PERSONA
         room = _room_profile(actor)
         if room is None:
-            return ActionResult(success=False, message="You're not in a room.")
+            return ActionResult(success=False, message=_NOT_IN_ROOM_MESSAGE)
         try:
             count = clear_room_listeners(persona, room)
         except TaskingError as exc:

--- a/src/actions/definitions/voyages.py
+++ b/src/actions/definitions/voyages.py
@@ -25,6 +25,9 @@ from world.travel.services import (
     start_voyage,
 )
 
+_NO_ACTIVE_PERSONA = "You need an active persona to travel."
+_NOT_ON_VOYAGE = "You aren't on a voyage."
+
 
 def _resolve_active_persona(actor: Any):
     """Resolve the actor's active Persona via sheet_data + active_persona_for_sheet."""
@@ -114,7 +117,7 @@ class StartVoyageAction(Action):
 
         persona = _resolve_active_persona(actor)
         if persona is None:
-            return ActionResult(success=False, message="You need an active persona to travel.")
+            return ActionResult(success=False, message=_NO_ACTIVE_PERSONA)
 
         try:
             voyage = start_voyage(
@@ -152,11 +155,11 @@ class AdvanceLegAction(Action):
     ) -> ActionResult:
         persona = _resolve_active_persona(actor)
         if persona is None:
-            return ActionResult(success=False, message="You need an active persona to travel.")
+            return ActionResult(success=False, message=_NO_ACTIVE_PERSONA)
 
         voyage = _get_active_voyage(persona)
         if voyage is None:
-            return ActionResult(success=False, message="You aren't on a voyage.")
+            return ActionResult(success=False, message=_NOT_ON_VOYAGE)
 
         try:
             advance_leg(voyage, caller=persona)
@@ -189,11 +192,11 @@ class CompleteVoyageAction(Action):
     ) -> ActionResult:
         persona = _resolve_active_persona(actor)
         if persona is None:
-            return ActionResult(success=False, message="You need an active persona to travel.")
+            return ActionResult(success=False, message=_NO_ACTIVE_PERSONA)
 
         voyage = _get_active_voyage(persona)
         if voyage is None:
-            return ActionResult(success=False, message="You aren't on a voyage.")
+            return ActionResult(success=False, message=_NOT_ON_VOYAGE)
 
         try:
             complete_voyage(voyage, caller=persona)
@@ -222,11 +225,11 @@ class AbandonVoyageAction(Action):
     ) -> ActionResult:
         persona = _resolve_active_persona(actor)
         if persona is None:
-            return ActionResult(success=False, message="You need an active persona to travel.")
+            return ActionResult(success=False, message=_NO_ACTIVE_PERSONA)
 
         voyage = _get_active_voyage(persona)
         if voyage is None:
-            return ActionResult(success=False, message="You aren't on a voyage.")
+            return ActionResult(success=False, message=_NOT_ON_VOYAGE)
 
         try:
             abandon_voyage(voyage, caller=persona)
@@ -262,11 +265,11 @@ class InviteToVoyageAction(Action):
 
         persona = _resolve_active_persona(actor)
         if persona is None:
-            return ActionResult(success=False, message="You need an active persona to travel.")
+            return ActionResult(success=False, message=_NO_ACTIVE_PERSONA)
 
         voyage = _get_active_voyage(persona)
         if voyage is None:
-            return ActionResult(success=False, message="You aren't on a voyage.")
+            return ActionResult(success=False, message=_NOT_ON_VOYAGE)
 
         invitee = Persona.objects.filter(pk=target_persona_id).first()
         if invitee is None:
@@ -346,11 +349,11 @@ class DepartVoyageAction(Action):
 
         persona = _resolve_active_persona(actor)
         if persona is None:
-            return ActionResult(success=False, message="You need an active persona to travel.")
+            return ActionResult(success=False, message=_NO_ACTIVE_PERSONA)
 
         voyage = _get_active_voyage(persona)
         if voyage is None:
-            return ActionResult(success=False, message="You aren't on a voyage.")
+            return ActionResult(success=False, message=_NOT_ON_VOYAGE)
 
         try:
             depart_voyage(voyage, caller=persona)

--- a/src/commands/account/sheet_sections.py
+++ b/src/commands/account/sheet_sections.py
@@ -22,7 +22,10 @@ if TYPE_CHECKING:
 
     from world.character_sheets.models import CharacterSheet
     from world.character_sheets.types import TechniqueEntry
-    from world.magic.types.technique_effects import TechniqueFormPayload
+    from world.magic.types.technique_effects import (
+        TechniqueFormPayload,
+        TechniqueSignaturePayload,
+    )
     from world.roster.models import ParentageEdge as ParentageEdgeType
     from world.secrets.models import Secret, SecretKnowledge
 
@@ -390,11 +393,7 @@ def _render_technique_forms(technique: TechniqueEntry) -> list[str]:
     if len(unlocked) > 1 or locked:
         lines.append("      Forms you can work:")
         for form in unlocked:
-            marker = " |w(default)|n" if form["is_default"] else ""
-            lines.append(f"        {_form_label(form)}{marker}")
-            lines.append(f"          intensity {form['intensity']}, control {form['control']}")
-            if form["variant_id"] is not None:
-                lines.append(f"          {form['effect_summary']['summary']}")
+            lines.extend(_render_unlocked_form(form))
     if locked:
         lines.append("      Not yet yours:")
         lines.extend(
@@ -402,11 +401,29 @@ def _render_technique_forms(technique: TechniqueEntry) -> list[str]:
             for form in locked
         )
     if signature:
-        delta = signature["intensity_delta"]
-        sign = "+" if delta >= 0 else ""
-        lines.append(f"      Signature: {signature['name']} ({sign}{delta} intensity)")
-        if signature["narrative_snippet"]:
-            lines.append(f"        {signature['narrative_snippet']}")
+        lines.extend(_render_signature(signature))
+    return lines
+
+
+def _render_unlocked_form(form: TechniqueFormPayload) -> list[str]:
+    """One workable form: label, its numbers, and (for variants) what it does."""
+    marker = " |w(default)|n" if form["is_default"] else ""
+    lines = [
+        f"        {_form_label(form)}{marker}",
+        f"          intensity {form['intensity']}, control {form['control']}",
+    ]
+    if form["variant_id"] is not None:
+        lines.append(f"          {form['effect_summary']['summary']}")
+    return lines
+
+
+def _render_signature(signature: TechniqueSignaturePayload) -> list[str]:
+    """The caster's signature flourish on a technique, with its narrative snippet."""
+    delta = signature["intensity_delta"]
+    sign = "+" if delta >= 0 else ""
+    lines = [f"      Signature: {signature['name']} ({sign}{delta} intensity)"]
+    if signature["narrative_snippet"]:
+        lines.append(f"        {signature['narrative_snippet']}")
     return lines
 
 

--- a/src/commands/combat_maneuvers.py
+++ b/src/commands/combat_maneuvers.py
@@ -61,6 +61,8 @@ _INTO_SEPARATOR = " into "
 # omitting the "into" clause entirely.
 _REDIRECT_AWAY_KEYWORD = "away"
 
+_NOT_IN_ACTIVE_ROUND = "You are not in an active combat round."
+
 
 class CmdCombat(_CombatCommandMixin, DispatchCommand):
     """Take a combat action other than casting or clashing.
@@ -219,7 +221,7 @@ class CmdCombat(_CombatCommandMixin, DispatchCommand):
 
         participant = self._combat_participant_or_none()
         if participant is None:
-            msg = "You are not in an active combat round."
+            msg = _NOT_IN_ACTIVE_ROUND
             raise CommandError(msg)
 
         opponent = CombatOpponent.objects.filter(
@@ -266,7 +268,7 @@ class CmdCombat(_CombatCommandMixin, DispatchCommand):
 
         participant = self._combat_participant_or_none()
         if participant is None:
-            msg = "You are not in an active combat round."
+            msg = _NOT_IN_ACTIVE_ROUND
             raise CommandError(msg)
         matches = list(
             CombatParticipant.objects.filter(
@@ -290,7 +292,7 @@ class CmdCombat(_CombatCommandMixin, DispatchCommand):
 
         participant = self._combat_participant_or_none()
         if participant is None:
-            msg = "You are not in an active combat round."
+            msg = _NOT_IN_ACTIVE_ROUND
             raise CommandError(msg)
         matches = list(
             CombatOpponent.objects.filter(
@@ -338,7 +340,7 @@ class CmdCombat(_CombatCommandMixin, DispatchCommand):
 
         participant = self._combat_participant_or_none()
         if participant is None:
-            msg = "You are not in an active combat round."
+            msg = _NOT_IN_ACTIVE_ROUND
             raise CommandError(msg)
         ally_matches = list(
             CombatParticipant.objects.filter(

--- a/src/commands/voyages.py
+++ b/src/commands/voyages.py
@@ -15,8 +15,14 @@ Usage:
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from commands.command import ArxCommand
 from world.travel.models import TravelHub, TravelMethod
+
+if TYPE_CHECKING:
+    from world.scenes.models import Persona
+    from world.travel.models import Voyage, VoyageParticipant
 
 _ACCEPT = "accept"
 _ADVANCE = "advance"
@@ -27,6 +33,13 @@ _INVITE = "invite"
 _METHOD = "method"
 _STATUS = "status"
 _STOP = "stop"
+
+#: Subverbs that take no argument and map 1:1 onto a voyage action.
+_BARE_SUBCOMMANDS = frozenset({_ADVANCE, _ARRIVE, _STOP, _DEPART})
+
+
+def _hub_name(voyage: Voyage) -> str:
+    return voyage.destination_hub.name if voyage.destination_hub else "unknown"
 
 
 class CmdVoyage(ArxCommand):
@@ -49,17 +62,7 @@ class CmdVoyage(ArxCommand):
     aliases = ["voyages"]
     help_category = "Travel"
 
-    def func(self) -> None:  # noqa: C901, PLR0911, PLR0912, PLR0915
-        from actions.definitions.voyages import (  # noqa: PLC0415
-            AbandonVoyageAction,
-            AdvanceLegAction,
-            CompleteVoyageAction,
-            DepartVoyageAction,
-            InviteToVoyageAction,
-            RespondVoyageInviteAction,
-            StartVoyageAction,
-        )
-
+    def func(self) -> None:
         args = self.args.strip().split()
         if not args:
             self.msg(
@@ -69,76 +72,78 @@ class CmdVoyage(ArxCommand):
             return
 
         subcommand = args[0].lower()
+        rest = args[1:]
 
-        if subcommand == _ADVANCE:
-            result = AdvanceLegAction().run(self.caller)
-            self.msg(result.message)
-            return
-
-        if subcommand == _ARRIVE:
-            result = CompleteVoyageAction().run(self.caller)
-            self.msg(result.message)
-            return
-
-        if subcommand == _STOP:
-            result = AbandonVoyageAction().run(self.caller)
-            self.msg(result.message)
-            return
-
-        if subcommand == _STATUS:
+        if subcommand in _BARE_SUBCOMMANDS:
+            self._run_bare_action(subcommand)
+        elif subcommand == _STATUS:
             self._show_status()
-            return
+        elif subcommand == _METHOD and rest:
+            self._set_travel_method(rest)
+        elif subcommand == _INVITE and rest:
+            self._invite(rest)
+        elif subcommand in (_ACCEPT, _DECLINE) and rest:
+            self._respond_to_invite(subcommand, rest)
+        else:
+            # Default: treat the whole argument as a destination hub name.
+            self._start_voyage(args)
 
-        if subcommand == _METHOD and len(args) > 1:
-            method_name = " ".join(args[1:])
-            method = TravelMethod.objects.filter(name__iexact=method_name).first()
-            if method is None:
-                self.msg(f"No travel method named '{method_name}'.")
-                return
-            self.caller.ndb.voyage_method = method
-            self.msg(f"Travel method set to {method.name}.")
-            return
+    def _run_bare_action(self, subcommand: str) -> None:
+        """Dispatch the argument-free subverbs (advance/arrive/stop/depart)."""
+        from actions.definitions.voyages import (  # noqa: PLC0415
+            AbandonVoyageAction,
+            AdvanceLegAction,
+            CompleteVoyageAction,
+            DepartVoyageAction,
+        )
 
-        if subcommand == _INVITE and len(args) > 1:
-            target_name = " ".join(args[1:])
-            target = self.caller.search(target_name)
-            if target is None:
-                return  # search already sent a "not found" message
-            try:
-                target_persona_id = target.sheet_data.primary_persona_id
-            except AttributeError:
-                self.msg("That character has no persona.")
-                return
-            result = InviteToVoyageAction().run(self.caller, target_persona_id=target_persona_id)
-            self.msg(result.message)
-            return
+        action_class = {
+            _ADVANCE: AdvanceLegAction,
+            _ARRIVE: CompleteVoyageAction,
+            _STOP: AbandonVoyageAction,
+            _DEPART: DepartVoyageAction,
+        }[subcommand]
+        self.msg(action_class().run(self.caller).message)
 
-        if subcommand == _ACCEPT and len(args) > 1:
-            try:
-                invite_id = int(args[1])
-            except ValueError:
-                self.msg("Usage: voyage accept <invite-id>")
-                return
-            result = RespondVoyageInviteAction().run(self.caller, invite_id=invite_id, accept=True)
-            self.msg(result.message)
+    def _set_travel_method(self, rest: list[str]) -> None:
+        method_name = " ".join(rest)
+        method = TravelMethod.objects.filter(name__iexact=method_name).first()
+        if method is None:
+            self.msg(f"No travel method named '{method_name}'.")
             return
+        self.caller.ndb.voyage_method = method
+        self.msg(f"Travel method set to {method.name}.")
 
-        if subcommand == _DECLINE and len(args) > 1:
-            try:
-                invite_id = int(args[1])
-            except ValueError:
-                self.msg("Usage: voyage decline <invite-id>")
-                return
-            result = RespondVoyageInviteAction().run(self.caller, invite_id=invite_id, accept=False)
-            self.msg(result.message)
+    def _invite(self, rest: list[str]) -> None:
+        from actions.definitions.voyages import InviteToVoyageAction  # noqa: PLC0415
+
+        target = self.caller.search(" ".join(rest))
+        if target is None:
+            return  # search already sent a "not found" message
+        try:
+            target_persona_id = target.sheet_data.primary_persona_id
+        except AttributeError:
+            self.msg("That character has no persona.")
             return
+        result = InviteToVoyageAction().run(self.caller, target_persona_id=target_persona_id)
+        self.msg(result.message)
 
-        if subcommand == _DEPART:
-            result = DepartVoyageAction().run(self.caller)
-            self.msg(result.message)
+    def _respond_to_invite(self, subcommand: str, rest: list[str]) -> None:
+        from actions.definitions.voyages import RespondVoyageInviteAction  # noqa: PLC0415
+
+        try:
+            invite_id = int(rest[0])
+        except ValueError:
+            self.msg(f"Usage: voyage {subcommand} <invite-id>")
             return
+        result = RespondVoyageInviteAction().run(
+            self.caller, invite_id=invite_id, accept=subcommand == _ACCEPT
+        )
+        self.msg(result.message)
 
-        # Default: treat as destination name
+    def _start_voyage(self, args: list[str]) -> None:
+        from actions.definitions.voyages import StartVoyageAction  # noqa: PLC0415
+
         dest_name = " ".join(args)
         hub = TravelHub.objects.filter(name__iexact=dest_name, is_active=True).first()
         if hub is None:
@@ -159,10 +164,9 @@ class CmdVoyage(ArxCommand):
         )
         self.msg(result.message)
 
-    def _show_status(self) -> None:  # noqa: C901
+    def _active_persona(self) -> Persona | None:
+        """The caller's active persona, or None after messaging why not."""
         from world.scenes.services import active_persona_for_sheet  # noqa: PLC0415
-        from world.travel.constants import VoyageStatus  # noqa: PLC0415
-        from world.travel.models import VoyageInvite, VoyageParticipant  # noqa: PLC0415
 
         try:
             sheet = self.caller.sheet_data
@@ -170,11 +174,19 @@ class CmdVoyage(ArxCommand):
             sheet = None
         if sheet is None:
             self.msg("You have no active character.")
-            return
+            return None
 
         persona = active_persona_for_sheet(sheet)
         if persona is None:
             self.msg("You have no active persona.")
+        return persona
+
+    def _show_status(self) -> None:
+        from world.travel.constants import VoyageStatus  # noqa: PLC0415
+        from world.travel.models import VoyageParticipant  # noqa: PLC0415
+
+        persona = self._active_persona()
+        if persona is None:
             return
 
         participant = (
@@ -187,45 +199,50 @@ class CmdVoyage(ArxCommand):
             .first()
         )
         if participant is None:
-            # Check for pending invites
-            invites = VoyageInvite.objects.filter(
-                target_persona=persona,
-                response=VoyageInvite.Response.PENDING,
-            ).select_related("voyage", "voyage__destination_hub")
-            if invites:
-                self.msg("You have pending voyage invitations:")
-                for inv in invites:
-                    dest = (
-                        inv.voyage.destination_hub.name if inv.voyage.destination_hub else "unknown"
-                    )
-                    self.msg(f"  #{inv.pk}: Voyage to {dest} (invited by {inv.invited_by})")
-                self.msg("Use 'voyage accept <id>' or 'voyage decline <id>'.")
-            else:
-                self.msg("You are not currently on a voyage.")
-            return
-
-        voyage = participant.voyage
-        dest_name = voyage.destination_hub.name if voyage.destination_hub else "unknown"
-
-        if voyage.status == VoyageStatus.DRAFT:
-            self.msg(f"DRAFT voyage to {dest_name} via {voyage.travel_method.name}.")
-            # Show party roster
-            accepted = voyage.invites.filter(response=VoyageInvite.Response.ACCEPTED)
-            pending = voyage.invites.filter(response=VoyageInvite.Response.PENDING)
-            declined = voyage.invites.filter(response=VoyageInvite.Response.DECLINED)
-            self.msg(f"  Participants: {voyage.participants.filter(left_at__isnull=True).count()}")
-            if accepted:
-                self.msg("  Accepted: " + ", ".join(str(i.target_persona) for i in accepted))
-            if pending:
-                self.msg("  Pending: " + ", ".join(str(i.target_persona) for i in pending))
-            if declined:
-                self.msg("  Declined: " + ", ".join(str(i.target_persona) for i in declined))
-            self.msg("Use 'voyage depart' to set out, or 'voyage stop' to cancel.")
+            self._show_pending_invites(persona)
+        elif participant.voyage.status == VoyageStatus.DRAFT:
+            self._show_draft_voyage(participant.voyage)
         else:
-            total_hubs = len(voyage.route_hubs)
+            self._show_voyage_in_transit(participant)
+
+    def _show_pending_invites(self, persona: Persona) -> None:
+        from world.travel.models import VoyageInvite  # noqa: PLC0415
+
+        invites = VoyageInvite.objects.filter(
+            target_persona=persona,
+            response=VoyageInvite.Response.PENDING,
+        ).select_related("voyage", "voyage__destination_hub")
+        if not invites:
+            self.msg("You are not currently on a voyage.")
+            return
+        self.msg("You have pending voyage invitations:")
+        for inv in invites:
             self.msg(
-                f"Voyage to {dest_name} "
-                f"(hub {voyage.current_leg_index + 1}/{total_hubs}) "
-                f"via {voyage.travel_method.name}. "
-                f"Legs traveled: {participant.legs_traveled}."
+                f"  #{inv.pk}: Voyage to {_hub_name(inv.voyage)} (invited by {inv.invited_by})"
             )
+        self.msg("Use 'voyage accept <id>' or 'voyage decline <id>'.")
+
+    def _show_draft_voyage(self, voyage: Voyage) -> None:
+        from world.travel.models import VoyageInvite  # noqa: PLC0415
+
+        self.msg(f"DRAFT voyage to {_hub_name(voyage)} via {voyage.travel_method.name}.")
+        self.msg(f"  Participants: {voyage.participants.filter(left_at__isnull=True).count()}")
+        for label, response in (
+            ("Accepted", VoyageInvite.Response.ACCEPTED),
+            ("Pending", VoyageInvite.Response.PENDING),
+            ("Declined", VoyageInvite.Response.DECLINED),
+        ):
+            invites = voyage.invites.filter(response=response)
+            if invites:
+                self.msg(f"  {label}: " + ", ".join(str(i.target_persona) for i in invites))
+        self.msg("Use 'voyage depart' to set out, or 'voyage stop' to cancel.")
+
+    def _show_voyage_in_transit(self, participant: VoyageParticipant) -> None:
+        voyage = participant.voyage
+        total_hubs = len(voyage.route_hubs)
+        self.msg(
+            f"Voyage to {_hub_name(voyage)} "
+            f"(hub {voyage.current_leg_index + 1}/{total_hubs}) "
+            f"via {voyage.travel_method.name}. "
+            f"Legs traveled: {participant.legs_traveled}."
+        )

--- a/src/world/battles/models.py
+++ b/src/world/battles/models.py
@@ -46,6 +46,7 @@ SCENE_MODEL = "scenes.Scene"
 STORY_MODEL = "stories.Story"
 COMBAT_ENCOUNTER_MODEL = "combat.CombatEncounter"
 CHARACTER_SHEET_MODEL = "character_sheets.CharacterSheet"
+CHECK_OUTCOME_MODEL = "traits.CheckOutcome"
 TECHNIQUE_MODEL = "magic.Technique"
 COVENANT_MODEL = "covenants.Covenant"
 BUILDING_MODEL = "buildings.Building"
@@ -853,7 +854,7 @@ class BattleOutcomeMapping(SharedMemoryModel):
 
     outcome = models.CharField(max_length=30, choices=BattleOutcome.choices, unique=True)
     check_outcome = models.ForeignKey(
-        "traits.CheckOutcome",
+        CHECK_OUTCOME_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1126,7 +1127,7 @@ class CityDefenseDetails(SharedMemoryModel):
         help_text="The defended region. PROTECT prevents deleting an area with a defense project.",
     )
     outcome_tier = models.ForeignKey(
-        "traits.CheckOutcome",
+        CHECK_OUTCOME_MODEL,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -1158,7 +1159,7 @@ class CityDefenseTierThreshold(SharedMemoryModel):
         related_name="tier_thresholds",
     )
     outcome_tier = models.ForeignKey(
-        "traits.CheckOutcome",
+        CHECK_OUTCOME_MODEL,
         on_delete=models.PROTECT,
         related_name="city_defense_thresholds",
     )
@@ -1218,7 +1219,7 @@ class WarFundingDetails(SharedMemoryModel):
         help_text="The covenant whose military readiness this drive funds.",
     )
     outcome_tier = models.ForeignKey(
-        "traits.CheckOutcome",
+        CHECK_OUTCOME_MODEL,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -1250,7 +1251,7 @@ class WarFundingTierThreshold(SharedMemoryModel):
         related_name="tier_thresholds",
     )
     outcome_tier = models.ForeignKey(
-        "traits.CheckOutcome",
+        CHECK_OUTCOME_MODEL,
         on_delete=models.PROTECT,
         related_name="war_funding_thresholds",
     )

--- a/src/world/ceremonies/models.py
+++ b/src/world/ceremonies/models.py
@@ -12,6 +12,8 @@ from evennia.utils.idmapper.models import SharedMemoryModel
 
 from world.ceremonies.constants import CeremonyStatus, CeremonyTypeKey, SeanceOfferStatus
 
+_PERSONA_MODEL = "scenes.Persona"
+
 
 class CeremonyType(SharedMemoryModel):
     """A data-driven kind of ceremony (Funeral, Blessing, Sermon; later Wedding…)."""
@@ -41,7 +43,7 @@ class Ceremony(SharedMemoryModel):
         CeremonyType, on_delete=models.PROTECT, related_name="ceremonies"
     )
     officiant = models.ForeignKey(
-        "scenes.Persona", on_delete=models.PROTECT, related_name="ceremonies_officiated"
+        _PERSONA_MODEL, on_delete=models.PROTECT, related_name="ceremonies_officiated"
     )
     being = models.ForeignKey(
         "worship.WorshippedBeing", on_delete=models.PROTECT, related_name="ceremonies"
@@ -138,7 +140,7 @@ class CeremonyOffering(SharedMemoryModel):
         related_name="+",
     )
     offered_by = models.ForeignKey(
-        "scenes.Persona", on_delete=models.PROTECT, related_name="ceremony_offerings"
+        _PERSONA_MODEL, on_delete=models.PROTECT, related_name="ceremony_offerings"
     )
 
     class Meta:
@@ -153,7 +155,7 @@ class CeremonySpeech(SharedMemoryModel):
 
     ceremony = models.ForeignKey(Ceremony, on_delete=models.CASCADE, related_name="speeches")
     speaker = models.ForeignKey(
-        "scenes.Persona", on_delete=models.PROTECT, related_name="ceremony_speeches"
+        _PERSONA_MODEL, on_delete=models.PROTECT, related_name="ceremony_speeches"
     )
     success_level = models.IntegerField(
         null=True, blank=True, help_text="Speech check success level (null if unrolled)."

--- a/src/world/character_creation/models.py
+++ b/src/world/character_creation/models.py
@@ -44,6 +44,8 @@ from world.classes.models import PathStage
 
 logger = logging.getLogger(__name__)
 
+_SPECIES_MODEL = "species.Species"
+
 
 class CGPointBudget(NaturalKeyMixin, SharedMemoryModel):
     """
@@ -265,7 +267,7 @@ class Beginnings(NaturalKeyMixin, SharedMemoryModel):
         help_text="Whether family is selectable in Lineage stage (False = 'Unknown')",
     )
     allowed_species = models.ManyToManyField(
-        "species.Species",
+        _SPECIES_MODEL,
         blank=True,
         related_name="beginnings",
         help_text="Species available for this path. Parent species include all children.",
@@ -702,7 +704,7 @@ class CharacterDraft(SharedMemoryModel):
     )
 
     selected_species = models.ForeignKey(
-        "species.Species",
+        _SPECIES_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -801,7 +803,7 @@ class CharacterDraft(SharedMemoryModel):
     # are always band-null, so maternal dominance holds and this only unlocks the
     # other parent's palette in the appearance stage.
     second_parent_species = models.ForeignKey(
-        "species.Species",
+        _SPECIES_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,

--- a/src/world/checks/services.py
+++ b/src/world/checks/services.py
@@ -793,18 +793,47 @@ def _calculate_trait_points(
         # stat_count > 1: warning already logged, fall through to default.
 
     # Default path: stat_override is None or was ignored — byte-identical to pre-#2757.
-    total = 0
+    return sum(_weighted_trait_points(handler, ct_trait) for ct_trait in check_type_traits)
+
+
+def _weighted_trait_points(handler: "TraitHandler", ct_trait) -> int:
+    """One ``CheckTypeTrait``'s contribution: raw value x weight, converted to points."""
+    trait = cast(Trait, ct_trait.trait)
+    trait_value = handler.get_trait_value(cast(str, trait.name))
+    if trait_value <= 0:
+        return 0
+    weighted_value = int(trait_value * ct_trait.weight)
+    if weighted_value <= 0:
+        return 0
+    return PointConversionRange.calculate_points(trait.trait_type, weighted_value)
+
+
+def _stat_trait_count_and_weight(check_type_traits) -> tuple[int, Decimal]:
+    """How many STAT-type rows the check has, and the first one's weight (1.0 if none)."""
+    stat_weight: Decimal = Decimal("1.0")
+    stat_count = 0
     for ct_trait in check_type_traits:
-        trait = cast(Trait, ct_trait.trait)
-        trait_value = handler.get_trait_value(cast(str, trait.name))
-        if trait_value > 0:
-            weighted_value = int(trait_value * ct_trait.weight)
-            if weighted_value > 0:
-                total += PointConversionRange.calculate_points(trait.trait_type, weighted_value)
-    return total
+        if cast(Trait, ct_trait.trait).trait_type == TraitType.STAT:
+            stat_count += 1
+            if stat_count == 1:
+                stat_weight = ct_trait.weight
+    return stat_count, stat_weight
 
 
-def _calculate_trait_points_with_override(  # noqa: C901
+def _override_stat_value(handler: "TraitHandler", stat_override: str | int) -> Decimal:
+    """The value substituted for the check's STAT trait.
+
+    An ``int`` (0-10, #2879) is a weighted strength/agility blend where the int
+    is strength's share in tenths; a ``str`` names a single stat outright.
+    """
+    if not isinstance(stat_override, int):
+        return handler.get_trait_value(stat_override)
+    strength_value = handler.get_trait_value(PrimaryStat.STRENGTH.value)
+    agility_value = handler.get_trait_value(PrimaryStat.AGILITY.value)
+    return (strength_value * stat_override + agility_value * (10 - stat_override)) / Decimal(10)
+
+
+def _calculate_trait_points_with_override(
     handler: "TraitHandler",
     check_type: "CheckType",
     check_type_traits,
@@ -820,14 +849,7 @@ def _calculate_trait_points_with_override(  # noqa: C901
     single trait via the ``str`` path.
     """
     # Count STAT traits and borrow the first STAT weight for the override.
-    stat_weight: Decimal = Decimal("1.0")
-    stat_count = 0
-    for ct_trait in check_type_traits:
-        trait = cast(Trait, ct_trait.trait)
-        if trait.trait_type == TraitType.STAT:
-            stat_count += 1
-            if stat_count == 1:
-                stat_weight = ct_trait.weight
+    stat_count, stat_weight = _stat_trait_count_and_weight(check_type_traits)
 
     if stat_count > 1:
         logger.warning(
@@ -842,30 +864,17 @@ def _calculate_trait_points_with_override(  # noqa: C901
     total = 0
     # Substitute the override stat (borrowed weight if a STAT trait existed,
     # or weight 1.0 if the check had no STAT traits).
-    if isinstance(stat_override, int):
-        # #2879: weighted strength/agility blend. strength_tenths is the
-        # weight (0-10); agility's share is 10 minus it.
-        strength_value = handler.get_trait_value(PrimaryStat.STRENGTH.value)
-        agility_value = handler.get_trait_value(PrimaryStat.AGILITY.value)
-        override_value = (
-            strength_value * stat_override + agility_value * (10 - stat_override)
-        ) / Decimal(10)
-    else:
-        override_value = handler.get_trait_value(stat_override)
+    override_value = _override_stat_value(handler, stat_override)
     if override_value > 0:
         weighted_value = int(override_value * stat_weight)
         if weighted_value > 0:
             total += PointConversionRange.calculate_points(TraitType.STAT, weighted_value)
     # Add all non-STAT (SKILL) traits from the check's own composition.
-    for ct_trait in check_type_traits:
-        trait = cast(Trait, ct_trait.trait)
-        if trait.trait_type == TraitType.STAT:
-            continue
-        trait_value = handler.get_trait_value(cast(str, trait.name))
-        if trait_value > 0:
-            weighted_value = int(trait_value * ct_trait.weight)
-            if weighted_value > 0:
-                total += PointConversionRange.calculate_points(trait.trait_type, weighted_value)
+    total += sum(
+        _weighted_trait_points(handler, ct_trait)
+        for ct_trait in check_type_traits
+        if cast(Trait, ct_trait.trait).trait_type != TraitType.STAT
+    )
     return total
 
 

--- a/src/world/combat/models.py
+++ b/src/world/combat/models.py
@@ -70,12 +70,15 @@ from world.scenes.round_models import AbstractRound
 # Lazy model references (Django app_label.ModelName), extracted to satisfy S1192.
 ACCOUNT_DB_MODEL = "accounts.AccountDB"
 CHECK_TYPE_MODEL = "checks.CheckType"
+CHECK_OUTCOME_MODEL = "traits.CheckOutcome"
 CONSEQUENCE_POOL_MODEL = "actions.ConsequencePool"
 CHARACTER_SHEET_MODEL = "character_sheets.CharacterSheet"
 TECHNIQUE_MODEL = "magic.Technique"
 COMBAT_PARTICIPANT_MODEL = "combat.CombatParticipant"
 COMBAT_ENCOUNTER_MODEL = "combat.CombatEncounter"
 OBJECTS_OBJECTDB_MODEL = "objects.ObjectDB"
+
+_MUST_BE_NULL_FOR_KIND = "Must be null for this kind."
 POSITION_MODEL = "areas.Position"
 
 
@@ -1730,7 +1733,7 @@ class SustainedAction(SharedMemoryModel):
         ),
     )
     outcome_snapshot = models.ForeignKey(
-        "traits.CheckOutcome",
+        CHECK_OUTCOME_MODEL,
         on_delete=models.PROTECT,
         null=True,
         blank=True,
@@ -2031,13 +2034,13 @@ class CombatPullResolvedEffect(SharedMemoryModel):
         if self.scaled_value is None:
             raise ValidationError({"scaled_value": "Required for this kind."})
         if self.granted_capability is not None:
-            raise ValidationError({"granted_capability": "Must be null for this kind."})
+            raise ValidationError({"granted_capability": _MUST_BE_NULL_FOR_KIND})
         if self.capability_grant_value is not None:
-            raise ValidationError({"capability_grant_value": "Must be null for this kind."})
+            raise ValidationError({"capability_grant_value": _MUST_BE_NULL_FOR_KIND})
         if self.narrative_snippet:
             raise ValidationError({"narrative_snippet": "Must be empty for this kind."})
         if self.vital_target:
-            raise ValidationError({"vital_target": "Must be null for this kind."})
+            raise ValidationError({"vital_target": _MUST_BE_NULL_FOR_KIND})
 
     def _clean_flat_bonus(self) -> None:
         self._require_scaled_value_only()
@@ -2462,7 +2465,7 @@ class EncounterOutcomeMapping(SharedMemoryModel):
     outcome = models.CharField(max_length=20, choices=EncounterOutcome.choices)
     risk_level = models.CharField(max_length=20, choices=RiskLevel.choices)
     check_outcome = models.ForeignKey(
-        "traits.CheckOutcome",
+        CHECK_OUTCOME_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -3055,7 +3058,7 @@ class ClashContribution(SharedMemoryModel):
         ),
     )
     check_outcome = models.ForeignKey(
-        "traits.CheckOutcome",
+        CHECK_OUTCOME_MODEL,
         on_delete=models.PROTECT,
         related_name="+",
         help_text="The check outcome tier the PC rolled this round.",

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -5729,6 +5729,31 @@ def _apply_execute_multiplier(
     return max(0, int(damage_amount * factor))
 
 
+def _break_engagement_lock_on_defeat(opponent: CombatOpponent) -> None:
+    """Release the opponent's active engagement lock, if any, on its defeat (#2020)."""
+    from world.combat.constants import LockBreakReason  # noqa: PLC0415
+    from world.combat.engagement_locks import break_engagement_lock  # noqa: PLC0415
+
+    active_lock = EngagementLock.objects.filter(
+        opponent=opponent,
+        status=EngagementLockStatus.ACTIVE,
+    ).first()
+    if active_lock is not None:
+        break_engagement_lock(active_lock, reason=LockBreakReason.DEFEAT)
+
+
+def _accumulate_damage_threat(
+    opponent: CombatOpponent, source_sheet: CharacterSheet, damage_through: int
+) -> None:
+    """Credit post-soak damage to the dealer's ThreatRecord for this opponent (#2020)."""
+    participant = CombatParticipant.objects.filter(
+        encounter=opponent.encounter,
+        character_sheet=source_sheet,
+    ).first()
+    if participant is not None:
+        accumulate_threat(opponent.encounter, opponent, participant, damage_through)
+
+
 def apply_damage_to_opponent(  # noqa: PLR0913
     opponent: CombatOpponent,
     raw_damage: int,
@@ -5827,15 +5852,7 @@ def apply_damage_to_opponent(  # noqa: PLR0913
 
     # Break active engagement lock on opponent defeat (#2020).
     if defeated:
-        from world.combat.constants import LockBreakReason  # noqa: PLC0415
-        from world.combat.engagement_locks import break_engagement_lock  # noqa: PLC0415
-
-        active_lock = EngagementLock.objects.filter(
-            opponent=opponent,
-            status=EngagementLockStatus.ACTIVE,
-        ).first()
-        if active_lock is not None:
-            break_engagement_lock(active_lock, reason=LockBreakReason.DEFEAT)
+        _break_engagement_lock_on_defeat(opponent)
 
     opponent.save(update_fields=["health", "probing_current", "status"])
 
@@ -5846,12 +5863,7 @@ def apply_damage_to_opponent(  # noqa: PLR0913
     # Only post-soak, post-resistance damage (damage_through) contributes — the
     # real signal of who is hurting the NPC. No source_sheet = no threat record.
     if source_sheet is not None and damage_through > 0:
-        participant = CombatParticipant.objects.filter(
-            encounter=opponent.encounter,
-            character_sheet=source_sheet,
-        ).first()
-        if participant is not None:
-            accumulate_threat(opponent.encounter, opponent, participant, damage_through)
+        _accumulate_damage_threat(opponent, source_sheet, damage_through)
     del source_sheet
 
     return OpponentDamageResult(
@@ -8215,7 +8227,32 @@ def _maybe_record_npc_regard_on_defeat(
         )
 
 
-def _resolve_pc_action(  # noqa: C901, PLR0911, PLR0912
+#: Maneuvers that resolve wholly on their own, short-circuiting the technique
+#: pipeline in :func:`_resolve_pc_action`. COVER is deliberately absent — it
+#: falls through to the passives-only return, since its effect is the
+#: ``cover_bonus`` it contributes to the sheltered ally's flee check.
+_STANDALONE_MANEUVER_RESOLVERS: dict[
+    str, Callable[[CombatParticipant, CombatRoundAction], ActionOutcome]
+] = {
+    CombatManeuver.FLEE: _resolve_flee,
+    # Social/mental combat verbs (#2015): resolve as checks at round-tick.
+    CombatManeuver.RALLY: _resolve_rally,
+    CombatManeuver.DEMORALIZE: _resolve_demoralize,
+    CombatManeuver.TAUNT: _resolve_taunt,
+    CombatManeuver.PARLEY: _resolve_parley,
+    # On-use items as a combat maneuver (#2023): dispatches the existing
+    # UseItemAction as a primary maneuver (mutually exclusive with the focused
+    # technique, like FLEE/COVER). Using an item costs the round's focused action.
+    CombatManeuver.USE_ITEM: _resolve_use_item,
+    # JOUST (#1843): a bilateral opposed pass between two mounted, lance-armed
+    # duelists — resolved directly against the loser's mirror CombatOpponent,
+    # not through the normal per-target technique pipeline (there is no single
+    # "attacker vs one opponent" shape here).
+    CombatManeuver.JOUST: _resolve_joust,
+}
+
+
+def _resolve_pc_action(
     participant: CombatParticipant,
     action: CombatRoundAction,
     offense_check_fn: PerformCheckFn | None = None,
@@ -8233,35 +8270,9 @@ def _resolve_pc_action(  # noqa: C901, PLR0911, PLR0912
 
     Fatigue is applied after the action resolves (both combo and non-combo).
     """
-    # Flee resolves as its own graded check (#878). COVER deliberately falls
-    # through to the passives-only early return below — its effect is the
-    # cover_bonus it contributes to the ally's flee check.
-    if action.maneuver == CombatManeuver.FLEE:
-        return _resolve_flee(participant, action)
-
-    # Social/mental combat verbs (#2015): resolve as checks at round-tick.
-    if action.maneuver == CombatManeuver.RALLY:
-        return _resolve_rally(participant, action)
-    if action.maneuver == CombatManeuver.DEMORALIZE:
-        return _resolve_demoralize(participant, action)
-    if action.maneuver == CombatManeuver.TAUNT:
-        return _resolve_taunt(participant, action)
-    if action.maneuver == CombatManeuver.PARLEY:
-        return _resolve_parley(participant, action)
-
-    # On-use items as a combat maneuver (#2023): dispatches the existing
-    # UseItemAction as a primary maneuver (mutually exclusive with the
-    # focused technique, like FLEE/COVER). Using an item costs the
-    # round's focused action.
-    if action.maneuver == CombatManeuver.USE_ITEM:
-        return _resolve_use_item(participant, action)
-
-    # JOUST (#1843): a bilateral opposed pass between two mounted, lance-armed
-    # duelists — resolved directly against the loser's mirror CombatOpponent,
-    # not through the normal per-target technique pipeline below (there is no
-    # single "attacker vs one opponent" shape here). Returns immediately.
-    if action.maneuver == CombatManeuver.JOUST:
-        return _resolve_joust(participant, action)
+    standalone_resolver = _STANDALONE_MANEUVER_RESOLVERS.get(action.maneuver)
+    if standalone_resolver is not None:
+        return standalone_resolver(participant, action)
 
     # CHARGE (#1843): closes distance to the declared opponent, THEN falls
     # through to the normal weapon-attack pipeline below (no early return) —
@@ -8628,18 +8639,13 @@ def _resolve_actions(  # noqa: PLR0913 - resolution needs all check params
     """
     outcomes: list[ActionOutcome] = []
     for entity_type, entity in resolution_order:
-        if entity_type == ENTITY_TYPE_PC:
-            if not isinstance(entity, CombatParticipant):
-                continue
+        if entity_type == ENTITY_TYPE_PC and isinstance(entity, CombatParticipant):
             if entity.pk in sustaining_participant_ids:
                 continue
             action = pc_actions.get(entity.pk)
             if action is not None:
                 outcomes.append(_resolve_pc_action(entity, action, offense_check_fn))
-
-        elif entity_type == ENTITY_TYPE_NPC:
-            if not isinstance(entity, CombatOpponent):
-                continue
+        elif entity_type == ENTITY_TYPE_NPC and isinstance(entity, CombatOpponent):
             outcomes.extend(
                 _resolve_npc_action(entity, npc_action, defense_check_type, defense_check_fn)
                 for npc_action in npc_actions.get(entity.pk, [])

--- a/src/world/conditions/models.py
+++ b/src/world/conditions/models.py
@@ -40,6 +40,7 @@ _CONSEQUENCE_POOL_FK = "actions.ConsequencePool"
 _CONDITION_TEMPLATE_FK = "conditions.ConditionTemplate"
 _CONDITION_STAGE_FK = "conditions.ConditionStage"
 CHARACTER_SHEET_MODEL = "character_sheets.CharacterSheet"
+_POSITION_FK = "areas.Position"
 
 # =============================================================================
 # Lookup Tables (SharedMemoryModel - cached, rarely change)
@@ -1407,7 +1408,7 @@ class ConditionInstance(SharedMemoryModel):
 
     # === Cast-time position targeting (#2019) ===
     cast_destination = models.ForeignKey(
-        "areas.Position",
+        _POSITION_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1420,7 +1421,7 @@ class ConditionInstance(SharedMemoryModel):
         ),
     )
     cast_position_a = models.ForeignKey(
-        "areas.Position",
+        _POSITION_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1431,7 +1432,7 @@ class ConditionInstance(SharedMemoryModel):
         ),
     )
     cast_position_b = models.ForeignKey(
-        "areas.Position",
+        _POSITION_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,

--- a/src/world/covenants/models.py
+++ b/src/world/covenants/models.py
@@ -60,6 +60,7 @@ COVENANT_MODEL = "covenants.Covenant"
 COVENANT_ROLE_MODEL = "covenants.CovenantRole"
 CHARACTER_SHEET_MODEL = "character_sheets.CharacterSheet"
 CONDITION_TEMPLATE_MODEL = "conditions.ConditionTemplate"
+GIFT_MODEL = "magic.Gift"
 VOW_SITUATIONAL_PERK_MODEL = "covenants.VowSituationalPerk"
 
 
@@ -343,7 +344,7 @@ class CovenantRole(NaturalKeyMixin, AbstractSpecializedVariant, SharedMemoryMode
         ),
     )
     granted_gifts = models.ManyToManyField(
-        "magic.Gift",
+        GIFT_MODEL,
         through="CovenantRoleGiftGrant",
         blank=True,
         related_name="granted_by_roles",
@@ -1181,7 +1182,7 @@ class CovenantRoleGiftGrant(NaturalKeyMixin, SharedMemoryModel):
         related_name="gift_grants",
     )
     gift = models.ForeignKey(
-        "magic.Gift",
+        GIFT_MODEL,
         on_delete=models.CASCADE,
         related_name="role_grants",
     )
@@ -1205,7 +1206,7 @@ class CovenantRoleGiftGrant(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["covenant_role", "gift"]
-        dependencies = [COVENANT_ROLE_MODEL, "magic.Gift"]
+        dependencies = [COVENANT_ROLE_MODEL, GIFT_MODEL]
 
     def __str__(self) -> str:
         return f"{self.covenant_role.name} → {self.gift.name} (≥L{self.unlock_thread_level})"

--- a/src/world/gm/models.py
+++ b/src/world/gm/models.py
@@ -28,6 +28,8 @@ from world.societies.constants import RenownRisk
 if TYPE_CHECKING:
     from world.game_clock.models import GameWeek
 
+_SITUATION_KIND_MODEL = "gm.SituationKind"
+
 
 class GMProfile(SharedMemoryModel):
     """A player's GM identity: their level, stats, and approval date.
@@ -550,7 +552,7 @@ class CheckTypeSituationFit(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["check_type", "situation_kind"]
-        dependencies = ["checks.CheckType", "gm.SituationKind"]
+        dependencies = ["checks.CheckType", _SITUATION_KIND_MODEL]
 
     def __str__(self) -> str:
         return f"{self.check_type.name} fits {self.situation_kind.name}"
@@ -584,7 +586,7 @@ class SituationDifficultyGuide(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["situation_kind", "risk"]
-        dependencies = ["gm.SituationKind"]
+        dependencies = [_SITUATION_KIND_MODEL]
 
     def __str__(self) -> str:
         return (
@@ -633,7 +635,7 @@ class ConsequencePoolGuide(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["situation_kind", "pool"]
-        dependencies = ["gm.SituationKind", "actions.ConsequencePool"]
+        dependencies = [_SITUATION_KIND_MODEL, "actions.ConsequencePool"]
 
     def __str__(self) -> str:
         return f"{self.situation_kind.name} -> {self.pool.name} (advisory)"

--- a/src/world/items/crafting/models.py
+++ b/src/world/items/crafting/models.py
@@ -25,6 +25,8 @@ _CHECK_TYPE_FK = "checks.CheckType"
 _TRAIT_FK = "traits.Trait"
 _QUALITY_TIER_FK = "items.QualityTier"
 _ITEM_TEMPLATE_FK = "items.ItemTemplate"
+_MODIFIER_TARGET_FK = "mechanics.ModifierTarget"
+_ITEM_INSTANCE_FK = "items.ItemInstance"
 _CONSEQUENCE_FK = "checks.Consequence"
 
 
@@ -345,7 +347,7 @@ class CraftingRecipeModifier(SharedMemoryModel):
         related_name="modifier_outcomes",
     )
     target = models.ForeignKey(
-        "mechanics.ModifierTarget",
+        _MODIFIER_TARGET_FK,
         on_delete=models.CASCADE,
         related_name="+",
     )
@@ -381,7 +383,7 @@ class CraftedItemRecipe(SharedMemoryModel):
     """
 
     item_instance = models.ForeignKey(
-        "items.ItemInstance",
+        _ITEM_INSTANCE_FK,
         on_delete=models.CASCADE,
         related_name="crafted_recipes",
     )
@@ -421,12 +423,12 @@ class ItemAccent(SharedMemoryModel):
     """
 
     item_instance = models.ForeignKey(
-        "items.ItemInstance",
+        _ITEM_INSTANCE_FK,
         on_delete=models.CASCADE,
         related_name="accents",
     )
     target = models.ForeignKey(
-        "mechanics.ModifierTarget",
+        _MODIFIER_TARGET_FK,
         on_delete=models.PROTECT,
         related_name="item_accents",
         help_text="The styleable axis (is_styleable=True): allure, menace, …",
@@ -461,12 +463,12 @@ class AccentExclusion(SharedMemoryModel):
     """
 
     target_a = models.ForeignKey(
-        "mechanics.ModifierTarget",
+        _MODIFIER_TARGET_FK,
         on_delete=models.CASCADE,
         related_name="accent_exclusions_a",
     )
     target_b = models.ForeignKey(
-        "mechanics.ModifierTarget",
+        _MODIFIER_TARGET_FK,
         on_delete=models.CASCADE,
         related_name="accent_exclusions_b",
     )
@@ -507,7 +509,7 @@ class AccentArchetypeAllowance(SharedMemoryModel):
     """
 
     target = models.ForeignKey(
-        "mechanics.ModifierTarget",
+        _MODIFIER_TARGET_FK,
         on_delete=models.CASCADE,
         related_name="accent_archetype_allowances",
     )
@@ -555,12 +557,12 @@ class ItemRefinementDetails(SharedMemoryModel):
         related_name="item_refinement_details",
     )
     item_instance = models.ForeignKey(
-        "items.ItemInstance",
+        _ITEM_INSTANCE_FK,
         on_delete=models.CASCADE,
         related_name="refinement_projects",
     )
     accent_target = models.ForeignKey(
-        "mechanics.ModifierTarget",
+        _MODIFIER_TARGET_FK,
         on_delete=models.PROTECT,
         null=True,
         blank=True,

--- a/src/world/magic/models/appetites.py
+++ b/src/world/magic/models/appetites.py
@@ -12,6 +12,8 @@ rows for idempotency, DRAIN-phased crons.
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+_CHARACTER_SHEET_FK = "character_sheets.CharacterSheet"
+
 
 class AppetitePeriod(models.TextChoices):
     """How often an appetite upkeep drain fires."""
@@ -63,7 +65,7 @@ class AppetiteUpkeepReceipt(SharedMemoryModel):
     """
 
     character_sheet = models.ForeignKey(
-        "character_sheets.CharacterSheet",
+        _CHARACTER_SHEET_FK,
         on_delete=models.CASCADE,
         related_name="appetite_upkeep_receipts",
     )
@@ -101,12 +103,12 @@ class FeedingRecord(SharedMemoryModel):
     """
 
     feeder_sheet = models.ForeignKey(
-        "character_sheets.CharacterSheet",
+        _CHARACTER_SHEET_FK,
         on_delete=models.CASCADE,
         related_name="feedings_taken",
     )
     victim_sheet = models.ForeignKey(
-        "character_sheets.CharacterSheet",
+        _CHARACTER_SHEET_FK,
         on_delete=models.CASCADE,
         related_name="feedings_suffered",
     )

--- a/src/world/magic/models/touchstone_config.py
+++ b/src/world/magic/models/touchstone_config.py
@@ -8,6 +8,8 @@ from evennia.utils.idmapper.models import SharedMemoryModel
 
 from core.managers import ArxSharedMemoryManager
 
+_VERBOSE_NAME = "Touchstone Cast Config"
+
 
 class TouchstoneCastConfig(SharedMemoryModel):
     """Singleton (pk=1) tuning knobs for touchstone combat resonance.
@@ -29,8 +31,8 @@ class TouchstoneCastConfig(SharedMemoryModel):
     )
 
     class Meta:
-        verbose_name = "Touchstone Cast Config"
-        verbose_name_plural = "Touchstone Cast Config"
+        verbose_name = _VERBOSE_NAME
+        verbose_name_plural = _VERBOSE_NAME
 
     def __str__(self) -> str:
-        return "Touchstone Cast Config"
+        return _VERBOSE_NAME

--- a/src/world/magic/services/crossing.py
+++ b/src/world/magic/services/crossing.py
@@ -115,7 +115,6 @@ def active_crossing_effects(character: Character) -> list[CrossingEffectInfo]:
     For FACET-kind threads, only includes choices where the character is
     wearing an item with the anchor facet. Other kinds (TRAIT) are always-on.
     """
-    from world.magic.constants import TargetKind  # noqa: PLC0415
     from world.magic.models.crossing import CrossingChoice  # noqa: PLC0415
 
     sheet = character.sheet_data
@@ -130,22 +129,8 @@ def active_crossing_effects(character: Character) -> list[CrossingEffectInfo]:
     result: list[CrossingEffectInfo] = []
     for choice in choices:
         thread = choice.thread
-        if thread.target_kind == TargetKind.FACET:
-            # Wear-gate: only active if wearing an item with the anchor facet
-            # (equipped_items is an unconditional cached_property on Character).
-            matching = character.equipped_items.item_facets_for(thread.target_facet)
-            if not matching:
-                continue
-
-        if thread.target_kind == TargetKind.SANCTUM:
-            # Location-gate: only active if the character is in the sanctum's room
-            sanctum = thread.target_sanctum_details
-            if sanctum is None:
-                continue
-            sanctum_room = sanctum.feature_instance.room_profile.objectdb
-            if character.location != sanctum_room:
-                continue
-
+        if not _crossing_choice_is_live(character, thread):
+            continue
         result.append(
             CrossingEffectInfo(
                 name=choice.option.name,
@@ -157,3 +142,26 @@ def active_crossing_effects(character: Character) -> list[CrossingEffectInfo]:
             )
         )
     return result
+
+
+def _crossing_choice_is_live(character: Character, thread: Thread) -> bool:
+    """Whether a crossing choice's anchor gate is currently satisfied.
+
+    FACET threads are wear-gated (the character must be wearing an item
+    carrying the anchor facet); SANCTUM threads are location-gated (the
+    character must be standing in the sanctum's room). Other kinds (TRAIT)
+    are always-on.
+    """
+    from world.magic.constants import TargetKind  # noqa: PLC0415
+
+    if thread.target_kind == TargetKind.FACET:
+        # equipped_items is an unconditional cached_property on Character.
+        return bool(character.equipped_items.item_facets_for(thread.target_facet))
+
+    if thread.target_kind == TargetKind.SANCTUM:
+        sanctum = thread.target_sanctum_details
+        if sanctum is None:
+            return False
+        return character.location == sanctum.feature_instance.room_profile.objectdb
+
+    return True

--- a/src/world/mechanics/models.py
+++ b/src/world/mechanics/models.py
@@ -42,6 +42,7 @@ from world.scenes.action_constants import (
 
 _DAMAGE_TYPE_MODEL_PATH = "conditions.DamageType"
 _CONSEQUENCE_POOL_MODEL = "actions.ConsequencePool"
+_CHALLENGE_TEMPLATE_MODEL = "mechanics.ChallengeTemplate"
 
 
 class ModifierCategoryManager(NaturalKeyManager):
@@ -761,7 +762,7 @@ class Application(NaturalKeyMixin, SharedMemoryModel):
         help_text="Effect Property the source must carry to use this Application.",
     )
     default_template = models.ForeignKey(
-        "mechanics.ChallengeTemplate",
+        _CHALLENGE_TEMPLATE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1069,7 +1070,7 @@ class ChallengeApproach(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["challenge_template", "application"]
-        dependencies = ["mechanics.ChallengeTemplate", "mechanics.Application"]
+        dependencies = [_CHALLENGE_TEMPLATE_MODEL, "mechanics.Application"]
 
     def __str__(self) -> str:
         return self.display_name or self.application.name
@@ -1200,7 +1201,7 @@ class SituationChallengeLink(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["situation_template", "challenge_template"]
-        dependencies = ["mechanics.SituationTemplate", "mechanics.ChallengeTemplate"]
+        dependencies = ["mechanics.SituationTemplate", _CHALLENGE_TEMPLATE_MODEL]
 
     def __str__(self) -> str:
         return f"{self.situation_template.name} → {self.challenge_template.name}"

--- a/src/world/roster/services/heredity.py
+++ b/src/world/roster/services/heredity.py
@@ -139,16 +139,30 @@ def derivable_species(lines: list[ParentLine], *, fallback_maternal: Species) ->
 
     allowed: list[Species] = [maternal_species]
     chimeric_possible = False
-    for line in lines:
-        if line.is_dominant_role or line.species is None:
-            continue
-        line_tier = dominance_tier(line.band)
-        if line.species != maternal_species:
-            if line_tier > maternal_tier and line.species not in allowed:
-                allowed.append(line.species)
-            if line_tier >= CHIMERIC_MIN_TIER and maternal_tier >= CHIMERIC_MIN_TIER:
-                chimeric_possible = True
+    for species, line_tier in _competing_lines(lines, maternal_species):
+        if line_tier > maternal_tier and species not in allowed:
+            allowed.append(species)
+        if line_tier >= CHIMERIC_MIN_TIER and maternal_tier >= CHIMERIC_MIN_TIER:
+            chimeric_possible = True
     return SpeciesDerivation(allowed=allowed, chimeric_possible=chimeric_possible)
+
+
+def _competing_lines(
+    lines: list[ParentLine], maternal_species: Species
+) -> list[tuple[Species, int]]:
+    """(species, dominance tier) per non-dominant line that could widen the allowed set.
+
+    Only a line with a *declared* species differing from the maternal line's
+    can add a species or open the chimeric door; the dominant line and
+    undeclared parents contribute nothing.
+    """
+    competing: list[tuple[Species, int]] = []
+    for line in lines:
+        species = line.species
+        if line.is_dominant_role or species is None or species == maternal_species:
+            continue
+        competing.append((species, dominance_tier(line.band)))
+    return competing
 
 
 def _line_pins(line: ParentLine) -> dict[int, FormTraitOption]:

--- a/src/world/seeds/character_creation.py
+++ b/src/world/seeds/character_creation.py
@@ -430,6 +430,7 @@ _ORPHANED_TRADITION_MARKER_TAG = "orphaned-tradition-marker"
 #: Order and the Fractals of the Abyss" per the #2428 vision) is a lore-repo
 #: authoring pass; this row is a PLACEHOLDER, content-overridable.
 _METALLIC_ORDER_TRADITION_NAME = "Metallic Order"
+_DISADVANTAGE_CATEGORY_DESCRIPTION = "PLACEHOLDER: disadvantages that reimburse CG points."
 
 
 def wire_magic_learning_ap_cost_target():
@@ -1207,7 +1208,7 @@ def _seed_sun_sensitive_species() -> None:
         DistinctionCategory,
         {
             "name": "Drawbacks",
-            "description": "PLACEHOLDER: disadvantages that reimburse CG points.",
+            "description": _DISADVANTAGE_CATEGORY_DESCRIPTION,
         },
         slug="drawbacks",
     )
@@ -1368,7 +1369,7 @@ def _seed_appetite_content() -> None:
         DistinctionCategory,
         {
             "name": "Drawbacks",
-            "description": "PLACEHOLDER: disadvantages that reimburse CG points.",
+            "description": _DISADVANTAGE_CATEGORY_DESCRIPTION,
         },
         slug="drawbacks",
     )
@@ -1492,7 +1493,7 @@ def _seed_moon_content() -> None:
         DistinctionCategory,
         {
             "name": "Drawbacks",
-            "description": "PLACEHOLDER: disadvantages that reimburse CG points.",
+            "description": _DISADVANTAGE_CATEGORY_DESCRIPTION,
         },
         slug="drawbacks",
     )

--- a/src/world/seeds/proclamations.py
+++ b/src/world/seeds/proclamations.py
@@ -6,6 +6,8 @@ archetypes' deed-judgments). Axis magnitudes follow the ±2-typical rule.
 
 from __future__ import annotations
 
+_STRONG_HAND_STANCE = "The Strong Hand"
+
 # name, description, axis deltas (mercy, method, status, change, allegiance, power)
 _STANCES = [
     (
@@ -24,7 +26,7 @@ _STANCES = [
         {"mercy_delta": 2, "power_delta": 1},
     ),
     (
-        "The Strong Hand",
+        _STRONG_HAND_STANCE,
         "PLACEHOLDER Order is a kindness; enforce it.",
         {"mercy_delta": -2, "power_delta": -2},
     ),
@@ -76,7 +78,7 @@ _EDICT_KINDS = [
     (
         "Doubled Patrols",
         "PLACEHOLDER Steel on every road; little moves unseen.",
-        "The Strong Hand",
+        _STRONG_HAND_STANCE,
         -5,
         1,
         1_500,
@@ -100,7 +102,7 @@ _EDICT_KINDS = [
     (
         "Iron Curfew",
         "PLACEHOLDER The streets empty at dusk, by order.",
-        "The Strong Hand",
+        _STRONG_HAND_STANCE,
         -10,
         4,
         500,

--- a/src/world/seeds/provisioning_checks.py
+++ b/src/world/seeds/provisioning_checks.py
@@ -242,9 +242,7 @@ def _ensure_recipes(check_type, tiers: dict[str, object]) -> None:
     """The example ITEM_CREATE recipes + ingredients + skill caps."""
     from world.items.crafting.constants import CraftingRecipeKind  # noqa: PLC0415
     from world.items.crafting.models import (  # noqa: PLC0415
-        CraftingMaterialRequirement,
         CraftingRecipe,
-        CraftingSkillCap,
     )
     from world.items.models import (  # noqa: PLC0415
         ItemTemplate,
@@ -285,28 +283,43 @@ def _ensure_recipes(check_type, tiers: dict[str, object]) -> None:
                 "required_feature_kind": workshop_kind if workshop_gated else None,
             },
         )
-        for ingredient_name, quantity in ingredients:
-            ingredient, _created = ItemTemplate.objects.get_or_create(
-                name=ingredient_name,
-                defaults={
-                    "description": f"PLACEHOLDER: {ingredient_name.lower()} — cooking stock.",
-                    "is_active": True,
-                    "material_category": categories.get(
-                        _INGREDIENT_CATEGORY.get(ingredient_name, ""),
-                    ),
-                },
-            )
-            CraftingMaterialRequirement.objects.get_or_create(
-                recipe=recipe,
-                item_template=ingredient,
-                defaults={"quantity": quantity},
-            )
-        for min_skill, tier_name in _SKILL_CAP_LADDER:
-            tier = tiers.get(tier_name)
-            if tier is None:
-                continue
-            CraftingSkillCap.objects.get_or_create(
-                recipe=recipe,
-                min_skill_value=min_skill,
-                defaults={"max_quality_tier": tier},
-            )
+        _ensure_recipe_ingredients(recipe, ingredients, categories)
+        _ensure_recipe_skill_caps(recipe, tiers)
+
+
+def _ensure_recipe_ingredients(recipe, ingredients, categories: dict[str, object]) -> None:
+    """The recipe's material requirements, minting any missing ingredient template."""
+    from world.items.crafting.models import CraftingMaterialRequirement  # noqa: PLC0415
+    from world.items.models import ItemTemplate  # noqa: PLC0415
+
+    for ingredient_name, quantity in ingredients:
+        ingredient, _created = ItemTemplate.objects.get_or_create(
+            name=ingredient_name,
+            defaults={
+                "description": f"PLACEHOLDER: {ingredient_name.lower()} — cooking stock.",
+                "is_active": True,
+                "material_category": categories.get(
+                    _INGREDIENT_CATEGORY.get(ingredient_name, ""),
+                ),
+            },
+        )
+        CraftingMaterialRequirement.objects.get_or_create(
+            recipe=recipe,
+            item_template=ingredient,
+            defaults={"quantity": quantity},
+        )
+
+
+def _ensure_recipe_skill_caps(recipe, tiers: dict[str, object]) -> None:
+    """The recipe's skill-value -> max-quality-tier ladder, skipping unseeded tiers."""
+    from world.items.crafting.models import CraftingSkillCap  # noqa: PLC0415
+
+    for min_skill, tier_name in _SKILL_CAP_LADDER:
+        tier = tiers.get(tier_name)
+        if tier is None:
+            continue
+        CraftingSkillCap.objects.get_or_create(
+            recipe=recipe,
+            min_skill_value=min_skill,
+            defaults={"max_quality_tier": tier},
+        )

--- a/src/world/seeds/underworld.py
+++ b/src/world/seeds/underworld.py
@@ -120,6 +120,8 @@ def _seed_retaliation_crisis_type() -> None:
 BACK_ROOM_BOARD_NAME = "The Back Room Wall PLACEHOLDER"
 BACK_ROOM_OBJECT_KEY = "a wall of chalked marks PLACEHOLDER"
 ROUTE_TASK_NAME = "Run the Quiet Docks PLACEHOLDER"
+_GATHER_EVIDENCE_CHECK = "Gather Evidence"
+_TURF_WAR_CHECK = "Turf War"
 
 #: (name, summary, risk_tier, category, check name, money, item reward,
 #:  crime-watch slug on failure, feeds the turf project)
@@ -130,7 +132,7 @@ _MISSION_ROWS = (
         "docks without meeting anyone's eyes.",
         1,
         "Smuggling",
-        "Gather Evidence",
+        _GATHER_EVIDENCE_CHECK,
         80,
         "Duskpetal Resin",
         "smuggling",
@@ -142,7 +144,7 @@ _MISSION_ROWS = (
         "steady and the Workshop's door stays shut.",
         1,
         "Crime",
-        "Gather Evidence",
+        _GATHER_EVIDENCE_CHECK,
         20,
         "Dream Dust",
         "contraband",
@@ -153,7 +155,7 @@ _MISSION_ROWS = (
         "PLACEHOLDER: move the product through the fence while the corner is thick with buyers.",
         2,
         "Crime",
-        "Gather Evidence",
+        _GATHER_EVIDENCE_CHECK,
         150,
         None,
         "contraband",
@@ -163,7 +165,7 @@ _MISSION_ROWS = (
         "Send a Message",
         "PLACEHOLDER: the Ashfingers' collector works your street like he owns it. Correct him.",
         2,
-        "Turf War",
+        _TURF_WAR_CHECK,
         "Intimidation",
         60,
         None,
@@ -174,8 +176,8 @@ _MISSION_ROWS = (
         "Burn Their Stash",
         "PLACEHOLDER: what they cannot sell they cannot hold the corner with. Bring a light.",
         3,
-        "Turf War",
-        "Gather Evidence",
+        _TURF_WAR_CHECK,
+        _GATHER_EVIDENCE_CHECK,
         100,
         None,
         "arson",
@@ -187,7 +189,7 @@ _MISSION_ROWS = (
         "pier. Make it yours, permanently.",
         3,
         "Smuggling",
-        "Gather Evidence",
+        _GATHER_EVIDENCE_CHECK,
         400,
         None,
         "smuggling",
@@ -198,7 +200,7 @@ _MISSION_ROWS = (
         "PLACEHOLDER: they are coming to take the corner back tonight. Be "
         "standing on it when they arrive.",
         2,
-        "Turf War",
+        _TURF_WAR_CHECK,
         "Intimidation",
         80,
         None,
@@ -461,7 +463,7 @@ def _seed_route_task(template) -> None:
     )
     from world.traits.models import CheckOutcome  # noqa: PLC0415
 
-    check_type = CheckType.objects.filter(name="Gather Evidence").first()
+    check_type = CheckType.objects.filter(name=_GATHER_EVIDENCE_CHECK).first()
     if check_type is None:
         return
     task, _created = TaskTemplate.objects.get_or_create(

--- a/src/world/seeds/worship_content.py
+++ b/src/world/seeds/worship_content.py
@@ -24,10 +24,11 @@ CEREMONY_CHECK_TYPE = "Ceremony Rites"
 DEVOTION_ASPECT_NAME = "Devotion"
 PATH_OF_THE_CHOSEN = "Path of the Chosen"
 SECRET_INVESTIGATION_CATEGORY = "secret-investigation"  # noqa: S105 — consent category slug
+_CHURCH_LITURGY_TRADITION = "Church Liturgy"
 
 #: (specialization name, tradition name, tradition description) — PLACEHOLDER names.
 _TRADITIONS = [
-    ("Liturgy", "Church Liturgy", "PLACEHOLDER — formal rites of the mainline faiths."),
+    ("Liturgy", _CHURCH_LITURGY_TRADITION, "PLACEHOLDER — formal rites of the mainline faiths."),
     ("Spiritcalling", "Spiritcalling", "PLACEHOLDER — shamanic totem and spirit worship."),
     ("Druidry", "Druidry", "PLACEHOLDER — nature worship of the old green ways."),
     ("Occultism", "Occultism", "PLACEHOLDER — veiled rites of darker powers."),
@@ -35,8 +36,12 @@ _TRADITIONS = [
 
 #: (being name, tradition name, description) — PLACEHOLDER example beings.
 _BEINGS = [
-    ("The Shepherd", "Church Liturgy", "PLACEHOLDER — the mainline god of the flock."),
-    ("The Gray Sister", "Church Liturgy", "PLACEHOLDER — keeper of thresholds and the dead."),
+    ("The Shepherd", _CHURCH_LITURGY_TRADITION, "PLACEHOLDER — the mainline god of the flock."),
+    (
+        "The Gray Sister",
+        _CHURCH_LITURGY_TRADITION,
+        "PLACEHOLDER — keeper of thresholds and the dead.",
+    ),
     ("Old Antler", "Spiritcalling", "PLACEHOLDER — a great totem spirit of the wilds."),
     ("The Verdant", "Druidry", "PLACEHOLDER — the living green, worshipped in groves."),
     ("The Hollow Flame", "Occultism", "PLACEHOLDER — a dark power worshipped in secret."),

--- a/src/world/societies/houses/crisis_services.py
+++ b/src/world/societies/houses/crisis_services.py
@@ -9,6 +9,7 @@ an unjudged crisis never worsens, per the AFK-protection ruling).
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from datetime import timedelta
 import random
 from typing import TYPE_CHECKING
@@ -75,7 +76,7 @@ class CrisisServiceError(Exception):
 def pick_crisis_type(
     origin: str,
     *,
-    audiences: tuple[str, ...] = (CrisisAudience.DOMAIN,),
+    audiences: Sequence[str] = (CrisisAudience.DOMAIN,),
     valence: str = CrisisValence.THREAT,
     rng: random.Random | None = None,
 ) -> DomainCrisisType | None:
@@ -122,7 +123,7 @@ def open_crisis(  # noqa: PLR0913 — one target pair + the existing authoring k
         msg = "open_crisis takes exactly one of domain/org"
         raise CrisisServiceError(msg, user_message="Invalid crisis target.")
     if crisis_type is None and origin != CrisisOrigin.STAFF:
-        audiences = (CrisisAudience.DOMAIN,) if domain is not None else _org_audiences(org)
+        audiences = [CrisisAudience.DOMAIN] if domain is not None else _org_audiences(org)
         crisis_type = pick_crisis_type(origin, audiences=audiences, rng=rng)
     valence = crisis_type.valence if crisis_type else CrisisValence.THREAT
     open_of_kind = DomainCrisis.objects.filter(
@@ -144,13 +145,26 @@ def open_crisis(  # noqa: PLR0913 — one target pair + the existing authoring k
         origin=origin,
         surfaces_at=surfaces_at,
     )
-    if origin != CrisisOrigin.STAFF and crisis_type is not None:
-        options = list(crisis_type.options.all())
-        if len(options) == 1 and options[0].kind == CrisisResolutionKind.MISSION:
-            crisis.chosen_option = options[0]
-            crisis.chosen_at = timezone.now()
-            crisis.save(update_fields=["chosen_option", "chosen_at"])
+    _maybe_auto_mint_mission(crisis, origin, crisis_type)
     return crisis
+
+
+def _maybe_auto_mint_mission(
+    crisis: DomainCrisis, origin: str, crisis_type: DomainCrisisType | None
+) -> None:
+    """Pre-set the single MISSION option on an automated crisis with no judgment to make.
+
+    A STAFF-origin crisis never auto-chooses; neither does a typeless one, nor
+    one whose type offers a real menu.
+    """
+    if origin == CrisisOrigin.STAFF or crisis_type is None:
+        return
+    options = list(crisis_type.options.all())
+    if len(options) != 1 or options[0].kind != CrisisResolutionKind.MISSION:
+        return
+    crisis.chosen_option = options[0]
+    crisis.chosen_at = timezone.now()
+    crisis.save(update_fields=["chosen_option", "chosen_at"])
 
 
 def pay_cost_for(crisis: DomainCrisis, option: DomainCrisisTypeOption) -> int:
@@ -177,7 +191,7 @@ def crisis_options(crisis: DomainCrisis) -> list[dict]:
     ]
 
 
-def _org_audiences(org) -> tuple[str, ...]:
+def _org_audiences(org) -> list[str]:
     """Which type audiences an org-target draw includes (#2837)."""
     from world.currency.constants import IncomeStreamKind  # noqa: PLC0415
 
@@ -185,8 +199,8 @@ def _org_audiences(org) -> tuple[str, ...]:
         org.income_streams.filter(active=True, kind=IncomeStreamKind.CRIME_KICKUP).exists()
     )
     if criminal:
-        return (CrisisAudience.ORG, CrisisAudience.CRIMINAL_ORG)
-    return (CrisisAudience.ORG,)
+        return [CrisisAudience.ORG, CrisisAudience.CRIMINAL_ORG]
+    return [CrisisAudience.ORG]
 
 
 def _can_lead_org(persona: Persona, org) -> bool:
@@ -393,7 +407,7 @@ def _open_generated(
     rng: random.Random,
 ) -> DomainCrisis | None:
     """Ambient open with an explicit valence draw (open_crisis defaults to threat)."""
-    audiences = (CrisisAudience.DOMAIN,) if domain is not None else _org_audiences(org)
+    audiences = [CrisisAudience.DOMAIN] if domain is not None else _org_audiences(org)
     crisis_type = pick_crisis_type(
         CrisisOrigin.AMBIENT, audiences=audiences, valence=valence, rng=rng
     )

--- a/src/world/societies/models.py
+++ b/src/world/societies/models.py
@@ -38,6 +38,8 @@ from world.societies.constants import (
 from world.societies.renown_config import RenownAwardConfig
 from world.societies.types import ReputationTier
 
+_PROJECT_MODEL = "projects.Project"
+
 # Validators for principle fields (-5 to +5 range)
 PRINCIPLE_MIN = -5
 PRINCIPLE_MAX = 5
@@ -599,7 +601,7 @@ class OrganizationGiftGrant(SharedMemoryModel):
         help_text="The Gift this org has acquired.",
     )
     project = models.ForeignKey(
-        "projects.Project",
+        _PROJECT_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1937,7 +1939,7 @@ class GangTurfDetails(SharedMemoryModel):
     """
 
     project = models.OneToOneField(
-        "projects.Project",
+        _PROJECT_MODEL,
         on_delete=models.CASCADE,
         primary_key=True,
         related_name="gang_turf_details",
@@ -2055,7 +2057,7 @@ class PropagandaDetails(RenownAwardConfig):
     """
 
     project = models.OneToOneField(
-        "projects.Project",
+        _PROJECT_MODEL,
         on_delete=models.CASCADE,
         related_name="propaganda_details",
         primary_key=True,

--- a/src/world/species/factories.py
+++ b/src/world/species/factories.py
@@ -89,6 +89,7 @@ SUNLIGHT_STAGE_BURNING = "Burning"
 SUNLIGHT_STAGE_SEARING = "Searing"
 # PLACEHOLDER: every check suffers this per point of severity while exposed.
 SUNLIGHT_CHECK_PENALTY_PER_SEVERITY = -1
+_DISADVANTAGE_CATEGORY_DESCRIPTION = "PLACEHOLDER: disadvantages that reimburse CG points."
 
 
 def ensure_sunlight_exposure_content() -> "ConditionTemplate":
@@ -249,7 +250,7 @@ def ensure_sunlight_distinctions() -> tuple:
         slug="drawbacks",
         defaults={
             "name": "Drawbacks",
-            "description": "PLACEHOLDER: disadvantages that reimburse CG points.",
+            "description": _DISADVANTAGE_CATEGORY_DESCRIPTION,
         },
     )
     bane_tag, _created = DistinctionTag.objects.get_or_create(
@@ -317,7 +318,7 @@ def ensure_appetite_distinctions() -> tuple:
         slug="drawbacks",
         defaults={
             "name": "Drawbacks",
-            "description": "PLACEHOLDER: disadvantages that reimburse CG points.",
+            "description": _DISADVANTAGE_CATEGORY_DESCRIPTION,
         },
     )
     blood_tag, _created = DistinctionTag.objects.get_or_create(
@@ -407,7 +408,7 @@ def ensure_moon_bound_distinction() -> "Distinction":
         slug="drawbacks",
         defaults={
             "name": "Drawbacks",
-            "description": "PLACEHOLDER: disadvantages that reimburse CG points.",
+            "description": _DISADVANTAGE_CATEGORY_DESCRIPTION,
         },
     )
     tag, _created = DistinctionTag.objects.get_or_create(
@@ -538,7 +539,7 @@ def ensure_shade_distinction() -> "Distinction":
         slug="drawbacks",
         defaults={
             "name": "Drawbacks",
-            "description": "PLACEHOLDER: disadvantages that reimburse CG points.",
+            "description": _DISADVANTAGE_CATEGORY_DESCRIPTION,
         },
     )
     shade_tag, _created = DistinctionTag.objects.get_or_create(

--- a/src/world/species/sun_refuge.py
+++ b/src/world/species/sun_refuge.py
@@ -24,41 +24,55 @@ def find_sun_refuge(character, *, max_depth: int = SUN_REFUGE_MAX_DEPTH):
     Breadth-first over exits from the character's location. Among refuges at
     the same (minimal) depth, a non-publicly-listed room wins.
     """
-    from evennia.objects.models import ObjectDB  # noqa: PLC0415
-
-    from evennia_extensions.models import room_is_publicly_listed  # noqa: PLC0415
-
     origin = character.location
     if origin is None:
         return None
     visited: set[int] = {origin.pk}
     frontier: list[int] = [origin.pk]
-    rooms_by_pk: dict[int, object] = {}
     for _depth in range(max_depth):
         if not frontier:
             break
-        exits = ObjectDB.objects.filter(
-            db_location_id__in=frontier,
-            db_destination__isnull=False,
-        ).select_related("db_destination")
-        next_frontier: list[int] = []
-        candidates = []
-        for exit_obj in exits:
-            dest = exit_obj.db_destination
-            if dest.pk in visited:
-                continue
-            visited.add(dest.pk)
-            rooms_by_pk[dest.pk] = dest
-            next_frontier.append(dest.pk)
-            if _shade_only_safe(character, dest):
-                candidates.append(dest)
-        if candidates:
-            for room in candidates:
-                if not room_is_publicly_listed(room):
-                    return room
-            return candidates[0]
-        frontier = next_frontier
+        frontier, candidates = _expand_frontier(character, frontier, visited)
+        refuge = _preferred_refuge(candidates)
+        if refuge is not None:
+            return refuge
     return None
+
+
+def _expand_frontier(character, frontier: list[int], visited: set[int]):
+    """One BFS step: the next frontier's room pks, plus any refuges found in it.
+
+    ``visited`` is mutated in place, so a room is only ever considered once.
+    """
+    from evennia.objects.models import ObjectDB  # noqa: PLC0415
+
+    exits = ObjectDB.objects.filter(
+        db_location_id__in=frontier,
+        db_destination__isnull=False,
+    ).select_related("db_destination")
+    next_frontier: list[int] = []
+    candidates = []
+    for exit_obj in exits:
+        dest = exit_obj.db_destination
+        if dest.pk in visited:
+            continue
+        visited.add(dest.pk)
+        next_frontier.append(dest.pk)
+        if _shade_only_safe(character, dest):
+            candidates.append(dest)
+    return next_frontier, candidates
+
+
+def _preferred_refuge(candidates: list):
+    """The best refuge among equal-depth candidates: a private room, else the first."""
+    from evennia_extensions.models import room_is_publicly_listed  # noqa: PLC0415
+
+    if not candidates:
+        return None
+    for room in candidates:
+        if not room_is_publicly_listed(room):
+            return room
+    return candidates[0]
 
 
 def _shade_only_safe(character, room) -> bool:

--- a/src/world/stories/services/episodes.py
+++ b/src/world/stories/services/episodes.py
@@ -19,6 +19,56 @@ from world.stories.services.transitions import get_eligible_transitions
 from world.stories.types import AnyStoryProgress
 
 
+def _select_transition(
+    progress: AnyStoryProgress, chosen_transition: Transition | None
+) -> Transition:
+    """The transition this resolution fires, per steps 1-4 of ``resolve_episode``.
+
+    ``get_eligible_transitions`` raises ``ProgressionRequirementNotMetError``
+    when a progression gate is unmet — that propagates untouched (the player is
+    *blocked*, status stays ACTIVE). Reaching past it means the exception did
+    NOT fire, so an empty list is one of the two cases below.
+    """
+    eligible = get_eligible_transitions(progress)
+
+    if not eligible:
+        # An empty eligible list is NOT necessarily a frontier:
+        # get_eligible_transitions also returns [] when outbound transitions
+        # exist but no routing predicate is satisfied yet (a transient block,
+        # player mid-episode — NOT an authoring frontier). Only treat the
+        # genuine "no onward edges authored at all" case as a frontier and
+        # route through resolve_frontier (RESTING / WAITING_FOR_GM). In the
+        # routing-block case, status stays ACTIVE. Either way, re-raise so the
+        # NoEligibleTransitionError contract (view try/except, callers) is
+        # intact.
+        from world.stories.services.frontier import resolve_frontier  # noqa: PLC0415
+
+        if not progress.current_episode.outbound_transitions.exists():
+            resolve_frontier(progress)
+        msg = f"No eligible transitions from episode {progress.current_episode_id!r}."
+        raise NoEligibleTransitionError(msg)
+
+    if chosen_transition is not None:
+        if chosen_transition not in eligible:
+            msg = f"Transition {chosen_transition.pk!r} is not in the eligible set."
+            raise NoEligibleTransitionError(msg)
+        return chosen_transition
+
+    if len(eligible) > 1:
+        msg = f"{len(eligible)} eligible transitions — caller must pass chosen_transition."
+        raise AmbiguousTransitionError(msg)
+
+    # Exactly one eligible.
+    only = eligible[0]
+    if only.mode == TransitionMode.GM_CHOICE:
+        msg = (
+            f"The single eligible transition {only.pk!r} has mode GM_CHOICE; "
+            "caller must pass chosen_transition explicitly."
+        )
+        raise AmbiguousTransitionError(msg)
+    return only
+
+
 def resolve_episode(
     *,
     progress: AnyStoryProgress,
@@ -59,47 +109,7 @@ def resolve_episode(
            left untouched (documented follow-up).
         6. Return the EpisodeResolution instance.
     """
-    # get_eligible_transitions raises ProgressionRequirementNotMetError when a
-    # progression gate is unmet — that propagates here untouched (the player is
-    # *blocked*, status stays ACTIVE). Reaching the line below means the
-    # exception did NOT fire, so an empty list is one of two cases (see below).
-    eligible = get_eligible_transitions(progress)
-
-    if not eligible:
-        # An empty eligible list is NOT necessarily a frontier:
-        # get_eligible_transitions also returns [] when outbound transitions
-        # exist but no routing predicate is satisfied yet (a transient block,
-        # player mid-episode — NOT an authoring frontier). Only treat the
-        # genuine "no onward edges authored at all" case as a frontier and
-        # route through resolve_frontier (RESTING / WAITING_FOR_GM). In the
-        # routing-block case, status stays ACTIVE. Either way, re-raise so the
-        # NoEligibleTransitionError contract (view try/except, callers) is
-        # intact.
-        from world.stories.services.frontier import resolve_frontier  # noqa: PLC0415
-
-        if not progress.current_episode.outbound_transitions.exists():
-            resolve_frontier(progress)
-        msg = f"No eligible transitions from episode {progress.current_episode_id!r}."
-        raise NoEligibleTransitionError(msg)
-
-    if chosen_transition is not None:
-        if chosen_transition not in eligible:
-            msg = f"Transition {chosen_transition.pk!r} is not in the eligible set."
-            raise NoEligibleTransitionError(msg)
-        selected = chosen_transition
-    else:
-        if len(eligible) > 1:
-            msg = f"{len(eligible)} eligible transitions — caller must pass chosen_transition."
-            raise AmbiguousTransitionError(msg)
-        # Exactly one eligible.
-        only = eligible[0]
-        if only.mode == TransitionMode.GM_CHOICE:
-            msg = (
-                f"The single eligible transition {only.pk!r} has mode GM_CHOICE; "
-                "caller must pass chosen_transition explicitly."
-            )
-            raise AmbiguousTransitionError(msg)
-        selected = only
+    selected = _select_transition(progress, chosen_transition)
 
     era = Era.objects.get_active()
     episode = progress.current_episode

--- a/src/world/tasking/models.py
+++ b/src/world/tasking/models.py
@@ -26,6 +26,7 @@ from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.tasking.constants import TaskCategory, TaskStatus, TaskTargetKind
 
 _PERSONA_FK = "scenes.Persona"
+_CHECK_OUTCOME_FK = "traits.CheckOutcome"
 
 
 class TaskTemplateManager(NaturalKeyManager):
@@ -115,7 +116,7 @@ class TaskOutcomeRoute(SharedMemoryModel):
         related_name="outcome_routes",
     )
     outcome_tier = models.ForeignKey(
-        "traits.CheckOutcome",
+        _CHECK_OUTCOME_FK,
         on_delete=models.PROTECT,
         related_name="+",
         help_text="The check outcome this route fires on.",
@@ -559,7 +560,7 @@ class TaskFulfillment(SharedMemoryModel):
         help_text="The persona running the job: rolls dispatch, collects results.",
     )
     handler_check_outcome = models.ForeignKey(
-        "traits.CheckOutcome",
+        _CHECK_OUTCOME_FK,
         on_delete=models.PROTECT,
         null=True,
         blank=True,
@@ -571,7 +572,7 @@ class TaskFulfillment(SharedMemoryModel):
         help_text="Modifier the dispatch check contributes to the agent's resolution roll.",
     )
     resolved_outcome = models.ForeignKey(
-        "traits.CheckOutcome",
+        _CHECK_OUTCOME_FK,
         on_delete=models.PROTECT,
         null=True,
         blank=True,

--- a/src/world/tasking/spy_payouts.py
+++ b/src/world/tasking/spy_payouts.py
@@ -484,31 +484,32 @@ def _incriminate(task: OrgTask, fulfillment: TaskFulfillment, level: int) -> lis
     return []  # residue is never reported to the handler — that's the point
 
 
-def template_is_offensive(template) -> bool:
-    """Whether any route works AGAINST its target (#2833 consent gate).
+#: Per-target-kind "is this route offensive?" predicates (#2833 consent gate).
+#: Quashing gossip and soothing unrest (negative deltas) are defensive; reports,
+#: recruitment, agitation, and amplification are offense. Residue hits the
+#: handler, not the mark, so it has no entry here.
+_OFFENSIVE_ROUTE_PREDICATES = {
+    TaskTargetKind.PERSONA: lambda route: bool(
+        route.movements_report
+        or route.unmask_target
+        or route.recruit_target
+        or route.gossip_heat_delta > 0
+    ),
+    TaskTargetKind.DOMAIN: lambda route: bool(
+        route.domain_report or route.domain_unrest_delta > 0 or route.reveal_schemes
+    ),
+    TaskTargetKind.ORG: lambda route: bool(
+        route.organization_report or route.military_report or route.reveal_schemes
+    ),
+    TaskTargetKind.CRISIS: lambda route: bool(
+        route.crisis_severity_delta > 0 or route.exploit_crisis
+    ),
+}
 
-    Quashing gossip and soothing unrest (negative deltas) are defensive;
-    reports, recruitment, agitation, and amplification are offense.
-    Residue hits the handler, not the mark.
-    """
-    for route in template.outcome_routes.all():
-        if template.target_kind == TaskTargetKind.PERSONA and (
-            route.movements_report
-            or route.unmask_target
-            or route.recruit_target
-            or route.gossip_heat_delta > 0
-        ):
-            return True
-        if template.target_kind == TaskTargetKind.DOMAIN and (
-            route.domain_report or route.domain_unrest_delta > 0 or route.reveal_schemes
-        ):
-            return True
-        if template.target_kind == TaskTargetKind.ORG and (
-            route.organization_report or route.military_report or route.reveal_schemes
-        ):
-            return True
-        if template.target_kind == TaskTargetKind.CRISIS and (
-            route.crisis_severity_delta > 0 or route.exploit_crisis
-        ):
-            return True
-    return False
+
+def template_is_offensive(template) -> bool:
+    """Whether any route works AGAINST its target (#2833 consent gate)."""
+    is_offensive = _OFFENSIVE_ROUTE_PREDICATES.get(template.target_kind)
+    if is_offensive is None:
+        return False
+    return any(is_offensive(route) for route in template.outcome_routes.all())

--- a/src/world/tasking/views.py
+++ b/src/world/tasking/views.py
@@ -39,6 +39,9 @@ if TYPE_CHECKING:
     from rest_framework.request import Request
 
 
+_NO_ACTIVE_CHARACTER = "No active character."
+
+
 class TaskingPagination(PageNumberPagination):
     page_size = 50
 
@@ -153,7 +156,7 @@ class ListenerPostViewSet(
 
         persona = active_persona_for_request(request)
         if persona is None:
-            return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"detail": _NO_ACTIVE_CHARACTER}, status=status.HTTP_400_BAD_REQUEST)
         payload = ListenerPostCreateSerializer(data=request.data)
         payload.is_valid(raise_exception=True)
         data = payload.validated_data
@@ -178,7 +181,7 @@ class ListenerPostViewSet(
         post = self.get_object()
         persona = active_persona_for_request(request)
         if persona is None:
-            return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"detail": _NO_ACTIVE_CHARACTER}, status=status.HTTP_400_BAD_REQUEST)
         result = get_action("collect_harvest").run(
             persona.character_sheet.character, post_id=post.pk
         )
@@ -204,7 +207,7 @@ class CounterplayViewSet(viewsets.ViewSet):
 
         persona = active_persona_for_request(request)
         if persona is None:
-            return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"detail": _NO_ACTIVE_CHARACTER}, status=status.HTTP_400_BAD_REQUEST)
         result = get_action(action_key).run(persona.character_sheet.character, **kwargs)
         if not result.success:
             return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
@@ -340,7 +343,7 @@ class OrgTaskViewSet(
         task = self.get_object()
         persona = active_persona_for_request(request)
         if persona is None:
-            return Response({"detail": "No active character."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"detail": _NO_ACTIVE_CHARACTER}, status=status.HTTP_400_BAD_REQUEST)
         result = get_action("accept_org_task").run(
             persona.character_sheet.character, task_id=task.pk
         )
@@ -360,7 +363,7 @@ class OrgTaskViewSet(
         persona = active_persona_for_request(request)
         if persona is None:
             return Response(
-                {"detail": "No active character."},
+                {"detail": _NO_ACTIVE_CHARACTER},
                 status=status.HTTP_400_BAD_REQUEST,
             )
         payload = TaskAssignSerializer(data=request.data)

--- a/src/world/travel/services.py
+++ b/src/world/travel/services.py
@@ -315,8 +315,95 @@ def start_voyage(
     return voyage
 
 
+def _require_leader_in_transit(voyage: Voyage, caller) -> None:
+    """The shared advance/complete gate: the voyage is under way and caller leads it."""
+    if voyage.status == VoyageStatus.DRAFT:
+        raise VoyageError(user_message="You must depart first.")
+    if voyage.status != VoyageStatus.IN_TRANSIT:
+        raise VoyageNotInTransitError
+    if voyage.leader_id != caller.pk:
+        raise NotVoyageLeaderError
+
+
+def _leg_provisioning_ratio(voyage: Voyage) -> float | None:
+    """Ship crew provisioning for this leg (#2217); None for a landbound voyage."""
+    if voyage.ship is None:
+        return None
+
+    from world.agriculture.services import provision_ship_leg  # noqa: PLC0415
+
+    ratio = provision_ship_leg(voyage)
+    if ratio <= 0.0:
+        raise VoyageError(user_message="The crew is starving — you can't sail without provisions.")
+    return ratio
+
+
+def _compute_leg_ap_costs(
+    active_participants: list, route_edge, voyage: Voyage, provisioning_ratio: float | None
+) -> dict[int, int]:
+    """Per-participant AP cost for the leg; drops participants with no character sheet."""
+    costs: dict[int, int] = {}
+    for participant in active_participants:
+        try:
+            character_sheet = participant.persona.character_sheet
+        except (AttributeError, ObjectDoesNotExist):
+            participant.left_at = timezone.now()
+            participant.save()
+            continue
+        time = compute_travel_time(route_edge, voyage.travel_method, character_sheet, voyage.ship)
+        costs[participant.pk] = _with_provisioning_surcharge(
+            compute_ap_cost(time), provisioning_ratio
+        )
+    return costs
+
+
+def _with_provisioning_surcharge(ap_cost: int, provisioning_ratio: float | None) -> int:
+    """Short rations make the leg harder: scale AP by the unmet provisioning fraction."""
+    if provisioning_ratio is None or provisioning_ratio >= 1.0:
+        return ap_cost
+
+    from world.agriculture.services.production import get_food_config  # noqa: PLC0415
+
+    config = get_food_config()
+    surcharge = (1.0 - provisioning_ratio) * config.ship_provisioning_ap_surcharge / 100
+    return math.ceil(ap_cost * (1 + surcharge))
+
+
+def _move_participant_to_room(participant, next_room) -> None:
+    """Walk a participant's character object into the next hub's room."""
+    char_obj = _resolve_character_object(participant.persona)
+    if char_obj is None or next_room is None:
+        return
+
+    from flows.scene_data_manager import SceneDataManager  # noqa: PLC0415
+    from flows.service_functions.movement import move_object  # noqa: PLC0415
+
+    sdm = SceneDataManager()
+    char_state = sdm.initialize_state_for_object(char_obj)
+    room_state = sdm.initialize_state_for_object(next_room)
+    move_object(char_state, room_state, quiet=False)
+
+
+def _advance_participants(active_participants: list, caller, costs: dict[int, int], next_room):
+    """Charge each non-caller their AP (leaving behind those who can't pay) and move the rest.
+
+    The caller has already paid by the time this runs, so they are only counted
+    and moved.
+    """
+    for participant in active_participants:
+        if participant.persona_id != caller.pk:
+            ap = costs.get(participant.pk, 0)
+            if ap > 0 and not _spend_ap(participant.persona, ap):
+                participant.left_at = timezone.now()
+                participant.save()
+                continue
+        participant.legs_traveled += 1
+        participant.save()
+        _move_participant_to_room(participant, next_room)
+
+
 @transaction.atomic
-def advance_leg(voyage: Voyage, caller) -> None:  # noqa: C901, PLR0912, PLR0915
+def advance_leg(voyage: Voyage, caller) -> None:
     """Pay AP for next leg, move all participants to next hub room.
 
     Only the voyage leader may call this. Each participant's ActionPointPool.spend()
@@ -335,13 +422,7 @@ def advance_leg(voyage: Voyage, caller) -> None:  # noqa: C901, PLR0912, PLR0915
         .get(pk=voyage.pk)
     )
 
-    if voyage.status == VoyageStatus.DRAFT:
-        raise VoyageError(user_message="You must depart first.")
-    if voyage.status != VoyageStatus.IN_TRANSIT:
-        raise VoyageNotInTransitError
-
-    if voyage.leader_id != caller.pk:
-        raise NotVoyageLeaderError
+    _require_leader_in_transit(voyage, caller)
 
     next_leg_index = voyage.current_leg_index + 1
     if next_leg_index >= len(voyage.route_hubs):
@@ -354,18 +435,8 @@ def advance_leg(voyage: Voyage, caller) -> None:  # noqa: C901, PLR0912, PLR0915
     if route_edge is None:
         raise VoyageError(user_message="The route ahead seems to have vanished.")
 
-    # Ship crew provisioning (#2217)
-    provisioning_ratio = None
-    if voyage.ship is not None:
-        from world.agriculture.services import provision_ship_leg  # noqa: PLC0415
+    provisioning_ratio = _leg_provisioning_ratio(voyage)
 
-        provisioning_ratio = provision_ship_leg(voyage)
-        if provisioning_ratio <= 0.0:
-            raise VoyageError(
-                user_message="The crew is starving — you can't sail without provisions."
-            )
-
-    # Compute AP cost for each participant
     active_participants = list(
         voyage.participants.filter(left_at__isnull=True).select_related("persona")
     )
@@ -375,59 +446,15 @@ def advance_leg(voyage: Voyage, caller) -> None:  # noqa: C901, PLR0912, PLR0915
     if caller_participant is None:
         raise VoyageError(user_message="You're not part of this voyage.")
 
-    # Compute costs for each participant
-    costs: dict[int, int] = {}
-    for participant in active_participants:
-        try:
-            character_sheet = participant.persona.character_sheet
-        except (AttributeError, ObjectDoesNotExist):
-            participant.left_at = timezone.now()
-            participant.save()
-            continue
-        time = compute_travel_time(route_edge, voyage.travel_method, character_sheet, voyage.ship)
-        costs[participant.pk] = compute_ap_cost(time)
-        if provisioning_ratio is not None and provisioning_ratio < 1.0:
-            from world.agriculture.services.production import (  # noqa: PLC0415
-                get_food_config,
-            )
-
-            config = get_food_config()
-            surcharge = (1.0 - provisioning_ratio) * config.ship_provisioning_ap_surcharge / 100
-            costs[participant.pk] = math.ceil(costs[participant.pk] * (1 + surcharge))
+    costs = _compute_leg_ap_costs(active_participants, route_edge, voyage, provisioning_ratio)
 
     # Check caller can afford first — if not, fail atomically
     caller_cost = costs.get(caller_participant.pk, 0)
-    if caller_cost > 0:
-        if not _spend_ap(caller, caller_cost):
-            raise VoyageError(user_message="You can't afford the AP for this leg.")
+    if caller_cost > 0 and not _spend_ap(caller, caller_cost):
+        raise VoyageError(user_message="You can't afford the AP for this leg.")
 
-    # Now process other participants
     next_hub = TravelHub.objects.get(pk=next_hub_id)
-    next_room = next_hub.room_profile.objectdb
-
-    for participant in active_participants:
-        if participant.persona_id == caller.pk:
-            participant.legs_traveled += 1
-            participant.save()
-        else:
-            ap = costs.get(participant.pk, 0)
-            if ap > 0 and not _spend_ap(participant.persona, ap):
-                participant.left_at = timezone.now()
-                participant.save()
-                continue
-            participant.legs_traveled += 1
-            participant.save()
-
-        # Move character to next hub room
-        char_obj = _resolve_character_object(participant.persona)
-        if char_obj is not None and next_room is not None:
-            from flows.scene_data_manager import SceneDataManager  # noqa: PLC0415
-            from flows.service_functions.movement import move_object  # noqa: PLC0415
-
-            sdm = SceneDataManager()
-            char_state = sdm.initialize_state_for_object(char_obj)
-            room_state = sdm.initialize_state_for_object(next_room)
-            move_object(char_state, room_state, quiet=False)
+    _advance_participants(active_participants, caller, costs, next_hub.room_profile.objectdb)
 
     voyage.current_leg_index = next_leg_index
 

--- a/src/world/vitals/models.py
+++ b/src/world/vitals/models.py
@@ -31,6 +31,7 @@ from world.vitals.constants import (
 # fields below. Centralized to avoid the duplicated-literal SonarCloud smell
 # (python:S1192).
 _CONSEQUENCE_POOL_FK = "actions.ConsequencePool"
+_CHARACTER_SHEET_FK = "character_sheets.CharacterSheet"
 
 
 class CharacterVitals(SharedMemoryModel):
@@ -43,7 +44,7 @@ class CharacterVitals(SharedMemoryModel):
     """
 
     character_sheet = models.OneToOneField(
-        "character_sheets.CharacterSheet",
+        _CHARACTER_SHEET_FK,
         on_delete=models.CASCADE,
         related_name="vitals",
     )
@@ -341,13 +342,13 @@ class CarriedBody(SharedMemoryModel):
     """
 
     carrier = models.OneToOneField(
-        "character_sheets.CharacterSheet",
+        _CHARACTER_SHEET_FK,
         on_delete=models.CASCADE,
         related_name="carrying_body",
         help_text="The character doing the carrying.",
     )
     carried = models.OneToOneField(
-        "character_sheets.CharacterSheet",
+        _CHARACTER_SHEET_FK,
         on_delete=models.CASCADE,
         related_name="carried_by",
         help_text="The character being carried.",

--- a/src/world/vitals/services.py
+++ b/src/world/vitals/services.py
@@ -1934,37 +1934,51 @@ def tick_round_for_targets(
             result = process_round_end(target)
         _apply_round_tick_damage(target, result)
     if timing == ROUND_TICK_END:
-        from world.fatigue.services import tick_fatigue_collapse_for_targets  # noqa: PLC0415
+        _tick_round_end_for_targets(target_list)
 
-        for target in target_list:
-            try:
-                sheet = target.sheet_data
-            except (AttributeError, ObjectDoesNotExist):
-                continue
-            advance_bleed_out(sheet)
-            # #2287: unconscious characters get one free wake roll per round.
-            attempt_wake(sheet, in_combat_tick=True)
-        # Non-cast over-capacity exhaustion collapse (acute tier, #520 Phase 5).
-        tick_fatigue_collapse_for_targets(target_list)
-        # Action-driven plummet descent + impact (#1228). Function-local import
-        # avoids a circular import (positioning -> vitals).
-        from world.areas.positioning.plummet import advance_plummet  # noqa: PLC0415
 
-        advance_plummet(target_list)
+# OBJECTDB_PARAM kept: mirrors tick_round_for_targets' own signature — a round tick
+# spans every kind of object that can occupy a room, not just characters.
+def _tick_round_end_for_targets(target_list: list[ObjectDB]) -> None:  # noqa: OBJECTDB_PARAM
+    """The end-of-round half of the tick: bleed-out, collapse, plummet, room expiry."""
+    from world.fatigue.services import tick_fatigue_collapse_for_targets  # noqa: PLC0415
 
-        # #2019: expire conjured obstacles + zone hazards in the target rooms.
-        # #2209: ramparts expire on the same per-round tick.
-        from world.areas.positioning.services import (  # noqa: PLC0415
-            expire_obstacle_rounds,
-            expire_rampart_rounds,
-        )
-        from world.room_features.trap_services import tick_zone_hazards  # noqa: PLC0415
+    for target in target_list:
+        try:
+            sheet = target.sheet_data
+        except (AttributeError, ObjectDoesNotExist):
+            continue
+        advance_bleed_out(sheet)
+        # #2287: unconscious characters get one free wake roll per round.
+        attempt_wake(sheet, in_combat_tick=True)
+    # Non-cast over-capacity exhaustion collapse (acute tier, #520 Phase 5).
+    tick_fatigue_collapse_for_targets(target_list)
+    # Action-driven plummet descent + impact (#1228). Function-local import
+    # avoids a circular import (positioning -> vitals).
+    from world.areas.positioning.plummet import advance_plummet  # noqa: PLC0415
 
-        rooms_seen: set[int] = set()
-        for target in target_list:
-            room = target.db_location
-            if room is not None and room.id not in rooms_seen:
-                rooms_seen.add(room.id)
-                expire_obstacle_rounds(room)
-                expire_rampart_rounds(room)
-                tick_zone_hazards(room)
+    advance_plummet(target_list)
+    _expire_room_round_effects(target_list)
+
+
+# OBJECTDB_PARAM kept: the same round-tick target list as above — any object type
+# may be present in a ticking room.
+def _expire_room_round_effects(target_list: list[ObjectDB]) -> None:  # noqa: OBJECTDB_PARAM
+    """Per-round expiry in each distinct room the targets occupy.
+
+    #2019: conjured obstacles + zone hazards. #2209: ramparts ride the same tick.
+    """
+    from world.areas.positioning.services import (  # noqa: PLC0415
+        expire_obstacle_rounds,
+        expire_rampart_rounds,
+    )
+    from world.room_features.trap_services import tick_zone_hazards  # noqa: PLC0415
+
+    rooms_seen: set[int] = set()
+    for target in target_list:
+        room = target.db_location
+        if room is not None and room.id not in rooms_seen:
+            rooms_seen.add(room.id)
+            expire_obstacle_rounds(room)
+            expire_rampart_rounds(room)
+            tick_zone_hazards(room)

--- a/src/world/worship/models.py
+++ b/src/world/worship/models.py
@@ -21,6 +21,7 @@ from world.worship.constants import MiracleTrigger
 
 # Verbose name reused across Meta verbose_name / verbose_name_plural / __str__ (python:S1192).
 CHOSEN_FAVOR_CONFIG_VERBOSE = "Chosen Favor Config"
+CHARACTER_SHEET_MODEL = "character_sheets.CharacterSheet"
 
 
 class PatronageValence(models.TextChoices):
@@ -78,7 +79,7 @@ class WorshippedBeing(SharedMemoryModel):
         default=0, help_text="Monotonic total worship ever received (audit)."
     )
     avatar_sheet = models.OneToOneField(
-        "character_sheets.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -100,7 +101,7 @@ class WorshipGrant(SharedMemoryModel):
     being = models.ForeignKey(WorshippedBeing, on_delete=models.PROTECT, related_name="grants")
     amount = models.PositiveIntegerField()
     granted_by = models.ForeignKey(
-        "character_sheets.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -125,7 +126,7 @@ class DevotionStanding(SharedMemoryModel):
     """
 
     character_sheet = models.ForeignKey(
-        "character_sheets.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="devotion_standings",
     )
@@ -175,7 +176,7 @@ class WorshipDeclaration(SharedMemoryModel):
     """
 
     character_sheet = models.OneToOneField(
-        "character_sheets.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="worship_declaration",
     )
@@ -361,7 +362,7 @@ class MiraclePerformance(SharedMemoryModel):
         WorshippedBeing, on_delete=models.PROTECT, related_name="miracle_performances"
     )
     target_character = models.ForeignKey(
-        "character_sheets.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,


### PR DESCRIPTION
Clears every open `sonarcloud`-labelled issue (50 of them, all severity `high`)
across three rules. **No behaviour changes** — this is a readability/duplication
sweep, and each fix was chosen so the before/after are provably equivalent.

## `python:S1192` — duplicated string literal (31 issues)

Each flagged literal is hoisted to a module constant holding the identical value.

- **Model-label strings** (`"traits.CheckOutcome"`, `"character_sheets.CharacterSheet"`,
  `"mechanics.ModifierTarget"`, …) follow the `_<NAME>_MODEL` / `_<NAME>_FK`
  convention already in use in `world/justice`, `world/travel`, `world/currency`,
  `world/npc_services` and `actions/models/effect_configs.py`.
- **Player-facing message literals** (`"You're not in a room."`,
  `"You are not in an active combat round."`, …) become `_<REASON>_MESSAGE`
  constants next to the ones each file already had (`_NOT_PART_OF_BUILDING_MESSAGE`,
  `_MSG_NO_SUCH_PROJECT`, `_NO_ACCOUNT`).
- **Seed natural-key names** (`"Gather Evidence"`, `"Turf War"`, `"Church Liturgy"`,
  `"The Strong Hand"`) become constants — which is also a small correctness win,
  since these are exact-match lookup keys and a typo in one of six copies is
  silent.

`arx manage check` and `makemigrations --dry-run` both come back clean: the
constants hold byte-identical values, so no field definition changed and no
migration is generated.

## `python:S3776` — cognitive complexity (17 issues) + `typescript:S3776` (1)

Three refactor shapes, applied per site:

**if/elif ladders keyed on one discriminator become lookup dicts.**
`CmdVoyage.func` (28→) routes its subverbs through `_BARE_SUBCOMMANDS` plus
one handler method each; `_resolve_pc_action` (19→) dispatches its seven
standalone maneuvers through `_STANDALONE_MANEUVER_RESOLVERS`;
`template_is_offensive` (17→) becomes `_OFFENSIVE_ROUTE_PREDICATES` keyed by
`TaskTargetKind`. In every case only one branch could ever match, so the dict
is exactly equivalent.

**Long procedures split at their natural seams.** `advance_leg` (30→) →
`_require_leader_in_transit` / `_leg_provisioning_ratio` / `_compute_leg_ap_costs`
/ `_advance_participants` / `_move_participant_to_room`;
`tick_round_for_targets` (16→) → `_tick_round_end_for_targets` /
`_expire_room_round_effects`; `resolve_episode` (18→) → `_select_transition`;
`open_crisis` (17→) → `_maybe_auto_mint_mission`; `find_sun_refuge` (21→) →
`_expand_frontier` / `_preferred_refuge`; `_ensure_recipes` (17→) →
`_ensure_recipe_ingredients` / `_ensure_recipe_skill_caps`;
`apply_damage_to_opponent` (17→) → `_break_engagement_lock_on_defeat` /
`_accumulate_damage_threat`; `_show_status` (23→) → three per-state renderers.

**Guard/derivation clusters hoisted into named helpers**, each carrying its
rationale in a docstring rather than an inline comment block:
`_crossing_choice_is_live`, `_weighted_trait_points` /
`_stat_trait_count_and_weight` / `_override_stat_value`, `_competing_lines`,
`_usage_message` / `_validate_rank`, and — on the frontend —
`isControlHidden` + an `EndorsementAffordance` subcomponent that owns the
retract / endorsed-✓ / picker triple.

## `python:S8495` — inconsistent tuple length (1 issue)

`crisis_services._org_audiences` returned a 1- or 2-tuple. Its only consumer is
`audience__in=audiences`, so the value is a *collection*, not a fixed-shape
tuple: it now returns `list[str]`, and `pick_crisis_type` widens its parameter
to `Sequence[str]`.

## One thing worth a second look

`GMAwardDistinctionAction.execute` validated an explicit `rank=` kwarg and then
never used it — `_execute_add` routes through the sheet-update-request
framework, which takes no rank. That is pre-existing and untouched here, but the
extracted helper is now named `_validate_rank` and says so in its docstring, so
the gap is visible instead of looking like a dropped variable. Worth a follow-up
decision on whether `rank=` should be applied or rejected outright.

## Verification

| Suite | Result |
|---|---|
| `world.combat` + `world.vitals` | 2302 tests, **OK** |
| `actions` + `commands` | 2721 tests, 34 errors — all pre-existing (see below) |
| `world.magic`/`stories`/`tasking`/`species`/`seeds`/`societies` | 5769 tests, 22 errors — all pre-existing |
| `world.travel` + `world.checks` + `world.roster` | 650 tests, 1 error — a `@tag("postgres")` test |
| frontend `pnpm test` | 3037 tests, **OK** |

Also: `pnpm typecheck` / `pnpm lint` / `pnpm build` clean; `arx manage check`
and `makemigrations --dry-run` clean after the model-constant pass; the full
pre-commit hook set (ruff, ty, annotation + custom linters) on every changed
file.

**The 56 SQLite-tier errors are pre-existing and unrelated.** Every one is
`no such table` for a `managed=False` model whose backing object is created by
a `CREATE MATERIALIZED VIEW` RunSQL migration — `areas_areaclosure` and
`societies_covenantlegendsummary` — which SQLite cannot execute. Verified, not
assumed: the same modules were run on a detached worktree at `acddcc19c` and
the error sets diffed **identical** on both sides (17/18 for the `actions`
modules, 16/106 for the `societies` modules). CI's Postgres parity tier is the
real gate for these.

Worth noting separately: the `actions` ones are *not* `@tag("postgres")`, so
`just test-fast` doesn't skip them either — those modules appear to be
genuinely unrunnable on the fast tier today. Pre-existing gap, flagged rather
than fixed here.

Closes #2908
Closes #2909
Closes #2910
Closes #2911
Closes #2912
Closes #2913
Closes #2914
Closes #2915
Closes #2916
Closes #2917
Closes #2918
Closes #2919
Closes #2920
Closes #2921
Closes #2922
Closes #2923
Closes #2924
Closes #2925
Closes #2926
Closes #2927
Closes #2928
Closes #2929
Closes #2930
Closes #2931
Closes #2932
Closes #2933
Closes #2934
Closes #2935
Closes #2936
Closes #2937
Closes #2938
Closes #2939
Closes #2940
Closes #2941
Closes #2942
Closes #2943
Closes #2944
Closes #2945
Closes #2946
Closes #2947
Closes #2948
Closes #2949
Closes #2950
Closes #2951
Closes #2952
Closes #2953
Closes #2954
Closes #2955
Closes #2956
Closes #2957

🤖 Generated with [Claude Code](https://claude.com/claude-code)
