### PR TITLE
Dramatic Moment: fall back to the anima-ritual resonance when no thread resolves one

### DIFF
--- a/src/world/magic/services/gain.py
+++ b/src/world/magic/services/gain.py
@@ -832,10 +832,22 @@ def _resolve_moment_resonance(
 ) -> Resonance | None:
     """Resolve which resonance a dramatic moment grants, or None to skip the grant.
 
-    Explicit argument first, then the thread the character wove into the
-    entrance technique's gift (via ``gift_resonances_for``, the ADR-0052
-    derive-on-read seam), then the moment type's authored override. Only a
-    resonance the character has actually claimed can be granted.
+    In order, taking the first the character has actually claimed:
+
+    1. an explicit *resonance* (the manual GM tag names one);
+    2. the resonance woven into the entrance technique's gift, via
+       ``gift_resonances_for`` (the ADR-0052 derive-on-read seam);
+    3. the moment type's authored override;
+    4. the character's anima-ritual resonance — their "main" one.
+
+    Step 4 exists because step 2 can come up empty even for a technique-driven
+    entrance. ``grant_gift_to_character`` skips thread provisioning entirely
+    when no resonance was chosen at CG, and ``gift_resonances_for`` then falls
+    back to the gift's authored supported set — which is empty for every
+    authored gift, since an empty set means "unrestricted". A character can
+    therefore hold a gift, know its techniques, and have no gift thread to read
+    a resonance from. Their anima ritual is the one place a "main" resonance is
+    always recorded, so it is the last resort before granting nothing.
     """
     from world.magic.specialization.services import gift_resonances_for  # noqa: PLC0415
 
@@ -849,6 +861,9 @@ def _resolve_moment_resonance(
         candidates.extend(gift_resonances_for(character_sheet.character, technique.gift))
     if moment_type.resonance_id:
         candidates.append(moment_type.resonance)
+    main = _anima_ritual_resonance(character_sheet)
+    if main is not None:
+        candidates.append(main)
 
     for candidate in candidates:
         if CharacterResonance.objects.filter(
@@ -856,6 +871,24 @@ def _resolve_moment_resonance(
         ).exists():
             return candidate
     return None
+
+
+def _anima_ritual_resonance(character_sheet: CharacterSheet) -> Resonance | None:
+    """The character's anima-ritual resonance — their 'main' one, if authored.
+
+    The anima ritual is per-character and carries a ``RitualCheckConfig`` whose
+    ``resonance`` is optional, so this is best-effort: no ritual, or no
+    resonance on its config, simply yields no candidate.
+    """
+    from world.magic.services.anima import get_character_anima_ritual  # noqa: PLC0415
+
+    ritual = get_character_anima_ritual(character_sheet.character)
+    if ritual is None:
+        return None
+    # ``check_config_or_none`` is the model's own ReverseOneToOneOrNone
+    # descriptor; the sidecar is optional, so don't reinvent the guard.
+    config = ritual.check_config_or_none
+    return config.resonance if config is not None else None
 
 
 def create_dramatic_moment_tag(  # noqa: PLR0913 - cohesive params describing one tag event

--- a/src/world/magic/tests/test_dramatic_moment.py
+++ b/src/world/magic/tests/test_dramatic_moment.py
@@ -153,6 +153,37 @@ class CreateDramaticMomentTagServiceTest(TestCase):
             ).exists()
         )
 
+    def test_falls_back_to_the_anima_ritual_resonance(self):
+        """With nothing else to go on, the moment grants their 'main' resonance.
+
+        A character can hold a gift, know its techniques, and still have NO gift
+        thread: ``grant_gift_to_character`` skips thread provisioning when no
+        resonance was chosen at CG, and ``gift_resonances_for`` then falls back
+        to the gift's supported set, which is empty for every authored gift
+        (empty means unrestricted). Without this fallback such a character earns
+        renown but never any resonance.
+        """
+        from world.magic.factories import RitualCheckConfigFactory
+
+        # A type pinning nothing, and no technique/explicit resonance supplied.
+        moment_type = DramaticMomentTypeFactory(resonance=None, resonance_amount=15)
+        RitualCheckConfigFactory(
+            ritual__author_account=self.sheet.character.db_account,
+            resonance=self.resonance,
+        )
+
+        create_dramatic_moment_tag(
+            character_sheet=self.sheet,
+            moment_type=moment_type,
+            tagged_by=self.tagger,
+            scene=None,
+        )
+
+        claimed = CharacterResonance.objects.get(
+            character_sheet=self.sheet, resonance=self.resonance
+        )
+        self.assertEqual(claimed.lifetime_earned, 15)
+
     def test_explicit_resonance_wins_over_the_types_own(self):
         """The manual GM tag names the resonance, and it beats the type's.
 


### PR DESCRIPTION
Closes the last gap in the Dramatic Moment resolution chain from #2968, per the
2026-08-04 ruling.

> "if they don't have a thread into the technique besides their latent thread so lack a
> resonance there, we should probably fall back to the resonance of their gift thread.
> Though maybe we'd just go with their anima ritual resonance for their 'main' resonance
> if it's not defined."

## Two parts of that were already covered

Worth stating, because it changes where the fix belongs:

- **The gift-thread fallback already exists.** Step 2 of the resolver *is*
  `gift_resonances_for`, which reads the woven GIFT thread.
- **`Thread.resonance` is non-nullable**, so a latent thread always *has* a resonance.
  "A latent thread lacking a resonance" cannot happen.

## The real hole: a gift with no thread at all

`grant_gift_to_character` skips provisioning entirely when no resonance was chosen at CG:

```python
if resonance is not None:
    provision_latent_gift_thread(sheet, gift, resonance=resonance)
```

`gift_resonances_for` then falls back to the gift's authored supported set — which is
**empty for all 17 authored gifts**, since #2968 made an empty set mean *unrestricted*. So
it returns `[]`; and with the moment type's own resonance now blank by default, **nothing
resolved and no resonance was granted.**

Net effect before this PR: a character could hold a gift, know its techniques, cast them,
make a technique entrance, and earn renown — while never earning a single resonance unit
from any of it.

## The fix

A fourth step in the resolution order — the character's **anima-ritual resonance**, their
"main" one:

1. an explicit `resonance` (the manual GM tag)
2. the resonance woven into the entrance technique's gift
3. the moment type's authored override
4. **the anima-ritual resonance** ← new

taking the first the character has actually claimed. The anima ritual is per-character and
its `RitualCheckConfig.resonance` is the one place a main resonance is always recorded, so
it is the last resort before granting nothing.

Read through `Ritual.check_config_or_none` — the model's own `ReverseOneToOneOrNone`
descriptor — rather than a `getattr` guard or a fresh query. The sidecar is optional, and
that descriptor already existed for exactly this; the repo's `getattr-literal` hook would
have rejected the guard anyway.

## Verification

- `ruff` and `ty` clean; every pre-commit hook passes.
- `world.magic.tests.test_dramatic_moment` — **17 tests, OK**, including a new case
  proving a character with **no gift thread** and an **unpinned** moment type now earns
  their main resonance rather than nothing.

## Note for the tracking issue

The underlying oddity — that a character can hold a gift with **no GIFT thread**, because
CG allows finishing without a resonance pick — is left alone here. It is a character-creation
question rather than a Dramatic Moment one, and worth deciding separately: either CG should
require the pick, or `grant_gift_to_character` should choose a default. Noted on #2967.
