### PR TITLE
Bootstrap the devcontainer DB from model state instead of replaying migrations

### DIFF
--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -164,17 +164,17 @@ print(
     "re-run this",
     file=sys.stderr,
 )
-print("[post-create] script (or 'just dc-build'):", file=sys.stderr)
 print(
-    f"[post-create]   PGPASSWORD={db['PASSWORD']} dropdb -h {db['HOST']} -U {db['USER']} "
-    f"{db['NAME']}",
+    "[post-create] script (or 'just dc-build'). PGPASSWORD is the password from "
+    "DATABASE_URL",
     file=sys.stderr,
 )
 print(
-    f"[post-create]   PGPASSWORD={db['PASSWORD']} createdb -h {db['HOST']} -U {db['USER']} "
-    f"{db['NAME']}",
+    "[post-create] in src/.env - export it yourself (never printed here), then:",
     file=sys.stderr,
 )
+print(f"[post-create]   dropdb -h {db['HOST']} -U {db['USER']} {db['NAME']}", file=sys.stderr)
+print(f"[post-create]   createdb -h {db['HOST']} -U {db['USER']} {db['NAME']}", file=sys.stderr)
 sys.exit(1)
 PY
 

--- a/.devcontainer/post-create.sh
+++ b/.devcontainer/post-create.sh
@@ -89,10 +89,128 @@ uv run pre-commit install
 uv run pre-commit install --hook-type pre-push
 
 # Wait for the db service (bounded — never hang first-run forever), then
-# apply schema (test-only DB, safe to recreate).
+# build the schema.
 timeout 90 bash -c 'until pg_isready -h db -U arxii -d arxiidev >/dev/null 2>&1; do sleep 1; done' \
   || { echo "db service did not become ready within 90s" >&2; exit 1; }
-uv run arx manage migrate
+
+# --- Stale-database guard (#2977) ------------------------------------------
+#
+# build_schema.py (invoked below) assumes an empty target - its own
+# docstring says so - and its internal idempotency check only asks whether
+# arxii_interaction is already partitioned; it does not check schema
+# *identity*. Pointed at a database that isn't empty and wasn't built by
+# this exact path, it would either collide (DuplicateTable, for tables that
+# already exist) or silently graft new tables next to stale ones without
+# reconciling the columns of whatever's already there against current model
+# state, producing a half-built database that looks fine until something
+# queries the wrong half.
+#
+# "Already built by this path" is judged the same way build_schema.py's own
+# `_schema_already_built()` does: arxii_interaction exists and is
+# partitioned (relkind = 'p'). That's deliberately narrower than "has any
+# arxii_* table at all" - a database with SOME arxii_* tables can still be a
+# half-finished `migrate` run sitting next to pre-#2906 debris (observed on
+# this exact machine: arxiidev currently holds 100 orphaned `scenes_*`
+# tables from before #2906 alongside 421 `arxii_*` tables from an
+# interrupted replay, with only 7 of 103 arxii migrations recorded as
+# applied), and that state must refuse too, not be waved through just
+# because some arxii_* tables happen to exist.
+#
+# Refuse rather than auto-drop: CLAUDE.md's "preserve the dev database" rule
+# exists precisely to stop tooling from destroying a developer's data, so
+# the default here is to instruct, not act.
+uv run python - <<'PY' || { echo "[post-create] refusing to bootstrap into a stale database (see message above)" >&2; exit 1; }
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("src"))
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "server.conf.settings")
+import django  # noqa: E402
+
+django.setup()
+
+from django.conf import settings  # noqa: E402
+from django.db import connection  # noqa: E402
+
+db = settings.DATABASES["default"]
+
+with connection.cursor() as cursor:
+    cursor.execute("SELECT count(*) FROM pg_tables WHERE schemaname = 'public'")
+    (table_count,) = cursor.fetchone()
+    cursor.execute("SELECT relkind FROM pg_class WHERE relname = 'arxii_interaction'")
+    row = cursor.fetchone()
+
+already_built = row is not None and row[0] == "p"
+if table_count == 0 or already_built:
+    sys.exit(0)
+
+print(
+    f"[post-create] target database {db['NAME']!r} is non-empty and was not built by "
+    "tools/build_schema.py",
+    file=sys.stderr,
+)
+print(
+    "[post-create] (arxii_interaction is not partitioned). Bootstrapping into it would "
+    "either collide",
+    file=sys.stderr,
+)
+print(
+    "[post-create] with existing tables or silently graft new ones next to stale/incomplete "
+    "ones, so",
+    file=sys.stderr,
+)
+print(
+    "[post-create] this refuses instead of guessing. Drop and recreate the database, then "
+    "re-run this",
+    file=sys.stderr,
+)
+print("[post-create] script (or 'just dc-build'):", file=sys.stderr)
+print(
+    f"[post-create]   PGPASSWORD={db['PASSWORD']} dropdb -h {db['HOST']} -U {db['USER']} "
+    f"{db['NAME']}",
+    file=sys.stderr,
+)
+print(
+    f"[post-create]   PGPASSWORD={db['PASSWORD']} createdb -h {db['HOST']} -U {db['USER']} "
+    f"{db['NAME']}",
+    file=sys.stderr,
+)
+sys.exit(1)
+PY
+
+# Build the schema straight from current model state instead of replaying
+# the full migration chain (#2977, continuing ADR-0083 which already moved
+# CI and both test tiers onto this path - the devcontainer was the last
+# environment still replaying). Measured on this box: ~5m21s versus
+# ~27m00s for `arx manage migrate` (#2906/#2977). Migration replay's cost
+# is dominated by Django's per-operation ProjectState re-rendering, not
+# real DDL, and build_schema.py skips that machinery by disabling
+# migrations and creating tables straight from model state, then applying
+# the raw partition/composite-FK/materialized-view SQL. It also runs the
+# two idempotent seed functions that plain `migrate` never does (ADR-0083's
+# trade-offs section): without them, `_get_social_engagement_category()`
+# (world/scenes/action_services.py) hard-fails on a missing row the first
+# time a scene-action-accept flow runs.
+uv run python tools/build_schema.py
+
+# build_schema.py disables migrations entirely while it runs, which means
+# it leaves NO django_migrations table at all. Left that way, the next real
+# `arx manage migrate` would see nothing recorded as applied and try to
+# CREATE TABLE every model from scratch, failing with DuplicateTable.
+# `--fake` records every migration in the chain as applied without
+# touching the schema (the schema is already there, built above), so the
+# ledger matches reality and a later incremental migration - e.g. after
+# `git pull` picks up a new migration file - applies normally instead of
+# trying to replay history that already happened by another route.
+uv run arx manage migrate --fake
+
+# Escape hatch: to exercise the real migration chain locally (e.g.
+# reproducing a migration-only bug), point DATABASE_URL at a fresh empty
+# database and run `uv run arx manage migrate` directly instead of the two
+# commands above. CI's nightly workflow
+# (.github/workflows/nightly-migration-replay.yml) is the standing coverage
+# for that path; this script no longer exercises it on every container
+# create.
 
 # Install required plugins idempotently. claude plugin commands are CLI-
 # safe (no Claude Code session needed). The named volume at

--- a/docs/adr/0083-ci-schema-from-models.md
+++ b/docs/adr/0083-ci-schema-from-models.md
@@ -47,5 +47,18 @@ a plain `arx manage migrate`-built environment does not invoke the idempotent se
 `tools/build_schema.py` does — so a deploy pipeline must call them explicitly, or lookups like
 `scenes/action_services._get_social_engagement_category()` hard-fail on the missing row.
 
+**Update (#2977):** the devcontainer's `post-create.sh` joined this path too, closing
+the last environment still replaying the full chain on every fresh build (measured
+~5-9 minutes via `build_schema.py` versus ~27-29 minutes for `arx manage migrate`
+replay on this box). Unlike a throwaway test database, a devcontainer database is
+long-lived, so `build_schema.py` alone isn't enough - it disables migrations while it
+runs and leaves no `django_migrations` table at all, which would make the next real
+`arx manage migrate` try to recreate every table from scratch. `post-create.sh`
+follows it with `arx manage migrate --fake`, which records every migration in the
+chain as applied without touching the schema, so a later incremental migration
+applies normally instead of colliding. `post-create.sh` also refuses to bootstrap
+into a database that is non-empty and wasn't built by this path (detect and refuse,
+never auto-drop - see `docs/devcontainer-setup.md`).
+
 > Status: accepted · Source: CI-speedup branch, task 5 · Related: ADR-0013 (schema-only
 > migrations pre-production), ADR-0021 (merge queue + single-leaf migration guard)

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -547,7 +547,7 @@ tooling never drops a developer's database automatically, even a stale one.
 One consequence worth knowing about ahead of time: because the migration chain is
 currently missing the `arxii_interaction` partition rewrite and its composite FK
 constraints (a pre-existing gap from the #2906 squash, unrelated to this bootstrap
-change - see #<N>), a database built by a **fully successful**
+change - see #2982), a database built by a **fully successful**
 `arx manage migrate` also ends up with an unpartitioned `arxii_interaction`. That
 means this guard refuses it too, reporting it as "not built by
 tools/build_schema.py" even though nothing actually failed. That's arguably correct

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -107,13 +107,27 @@ just dc-up
 
 The first run is slow — it builds the Docker image, bakes the mise toolchain (Python,
 Node, uv, pnpm) into the image layer, installs Python and frontend dependencies, and
-runs database migrations. This can take a few minutes. Subsequent starts are fast
+builds the database schema. This can take a few minutes. Subsequent starts are fast
 because the image layer is cached and only the firewall re-initialization runs.
-(#2906 flattened every first-party app's migration history into `world/migrations/`
-- 102 files, not one; measurement showed the win comes from topologically inlining
-deferred FKs down to the schema's true floor, not from fewer apps. Fresh `migrate`
-is about 1.30x faster than before the collapse, roughly 27 minutes versus 35 on this
-box - a real but modest improvement, still the long pole here. See ADR-0195.)
+
+(#2977: `post-create.sh` builds the schema straight from current model state via
+`tools/build_schema.py` instead of replaying the full migration chain, then runs
+`arx manage migrate --fake` to populate `django_migrations` so later incremental
+migrations still apply normally - continuing ADR-0083, which already moved CI and
+both test tiers onto this path. Measured on this box: ~5-9 minutes for the new path
+versus ~27-29 minutes for a full `arx manage migrate` replay (#2906 measured 27 vs 35
+minutes pre/post the single-app collapse - #2906 flattened every first-party app's
+migration history into `world/migrations/`, 102 files, not one; see ADR-0195 - the
+squash itself only trims a further ~1.3x because migration replay's cost is
+Django's per-operation state re-rendering, not real DDL, and `build_schema.py` skips
+that machinery entirely rather than shrinking it). If the target database is
+non-empty and wasn't built by `build_schema.py`, `post-create.sh` refuses instead of
+grafting onto it - see "Stale bootstrap database" in Troubleshooting below. To
+exercise the real migration chain locally instead (e.g. reproducing a
+migration-only bug), point `DATABASE_URL` at a fresh empty database and run `uv run
+arx manage migrate` directly; CI's nightly workflow
+(`.github/workflows/nightly-migration-replay.yml`) is the standing coverage for that
+path.)
 
 **Get a shell inside the container:**
 
@@ -511,6 +525,22 @@ Subsequent starts skip the build and are much faster.
 script waits up to 90 seconds for the db service. If the container exits with "db
 service did not become ready within 90s", run `just dc-up` again; Docker sometimes
 needs a moment on first run.
+
+**Stale bootstrap database** (`post-create.sh` refuses with "target database ...
+is non-empty and was not built by tools/build_schema.py") - the schema-from-models
+bootstrap (#2977) assumes an empty target, or one it already built itself; anything
+else (an old pre-#2906 database, or one built by some other route) gets refused
+rather than silently grafted onto. The failure message names the exact commands, but
+in short: drop and recreate the database, then re-run `post-create.sh` (or `just
+dc-build`):
+
+```bash
+PGPASSWORD=arxii dropdb -h db -U arxii arxiidev
+PGPASSWORD=arxii createdb -h db -U arxii arxiidev
+```
+
+This is deliberate, not a bug - CLAUDE.md's "preserve the dev database" rule means
+tooling never drops a developer's database automatically, even a stale one.
 
 **Network call hangs or fails inside the container** — a needed host is not in the
 firewall allowlist. Check `.devcontainer/init-firewall.sh`, add the host, then

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -532,15 +532,28 @@ bootstrap (#2977) assumes an empty target, or one it already built itself; anyth
 else (an old pre-#2906 database, or one built by some other route) gets refused
 rather than silently grafted onto. The failure message names the exact commands, but
 in short: drop and recreate the database, then re-run `post-create.sh` (or `just
-dc-build`):
+dc-build`). `PGPASSWORD` is the password from `DATABASE_URL` in `src/.env` - export
+it yourself (the failure message never prints it):
 
 ```bash
-PGPASSWORD=arxii dropdb -h db -U arxii arxiidev
-PGPASSWORD=arxii createdb -h db -U arxii arxiidev
+export PGPASSWORD=... # the password from DATABASE_URL in src/.env
+dropdb -h db -U arxii arxiidev
+createdb -h db -U arxii arxiidev
 ```
 
 This is deliberate, not a bug - CLAUDE.md's "preserve the dev database" rule means
 tooling never drops a developer's database automatically, even a stale one.
+
+One consequence worth knowing about ahead of time: because the migration chain is
+currently missing the `arxii_interaction` partition rewrite and its composite FK
+constraints (a pre-existing gap from the #2906 squash, unrelated to this bootstrap
+change - see #<N>), a database built by a **fully successful**
+`arx manage migrate` also ends up with an unpartitioned `arxii_interaction`. That
+means this guard refuses it too, reporting it as "not built by
+tools/build_schema.py" even though nothing actually failed. That's arguably correct
+- such a database genuinely has the less-correct schema - but it's surprising if
+you hit it after a clean `migrate`. It resolves itself once the migration chain
+regains the partition/composite-FK SQL.
 
 **Network call hangs or fails inside the container** — a needed host is not in the
 firewall allowlist. Check `.devcontainer/init-firewall.sh`, add the host, then


### PR DESCRIPTION
Closes #2977

Bootstraps the devcontainer database from current model state (`tools/build_schema.py`) instead of replaying the migration chain, continuing ADR-0083 - which already moved CI and both test tiers onto that path and confined full replay to the nightly workflow. The devcontainer was the last environment still replaying.

## It fixes a correctness bug, not just slowness

ADR-0083's trade-offs section already recorded this:

> a plain `arx manage migrate`-built environment does not invoke the idempotent seed functions ... so a deploy pipeline must call them explicitly, or lookups like `scenes/action_services._get_social_engagement_category()` hard-fail on the missing row.

`post-create.sh` ran plain `migrate` and seeded nothing afterwards, so **every devcontainer database has been missing those rows**, and that function has a live caller at `world/scenes/action_services.py:1039`. `build_schema.py` runs both seed functions itself, so switching closes the gap.

Timing, same session: **~9m01s** for the new path versus **~29m** for replay (this box ran slower than the issue's 5m21s/27m00s baseline; the ratio is what matters).

## The part that actually needed designing

`build_schema.py` sets `MIGRATION_MODULES = _DisableMigrations()` and has **zero** fake/record steps, so it leaves **no `django_migrations` table at all**. Confirmed against the existing `test_arxiidev`, built exactly that way: 1221 tables, and `django_migrations` does not exist.

Harmless for a throwaway test database. For a long-lived dev database it is not: the next real migration would find nothing applied and try to create tables that already exist. So the bootstrap now runs `arx manage migrate --fake` after the build, recording the chain without touching the schema.

**This was verified by observation, not reasoning** - a throwaway no-op migration was added and `migrate` applied *only* that one (`Applying arxii.0104_throwaway_2977_ledger_probe... OK`), then reverted.

## Stale-database guard

`build_schema.py` assumes an empty target and its idempotency check only asks whether `arxii_interaction` is partitioned - it does not check schema *identity*. Pointed at a stale database it would graft new tables next to old ones.

The guard **refuses and instructs** rather than auto-dropping. CLAUDE.md's "preserve the dev database" rule exists to stop tooling destroying a developer's data, and that was the ratified call on the issue.

It judges "already built by this path" the same way `build_schema.py` itself does (partitioned `arxii_interaction`), deliberately narrower than "has any `arxii_*` table" - a half-finished replay sitting next to pre-#2906 debris must refuse too. That exact state exists on the development machine right now, and was used as a live test case.

## Verification

| Check | Result |
|---|---|
| Ledger works - a later migration applies alone, not a replay | **observed** |
| `social_engagement` row present after new path, absent after plain `migrate` | **observed** - proves bug and fix in one comparison |
| Guard: empty proceeds, already-built proceeds, stale refuses | **observed**, incl. against the real half-migrated database |
| Schema equivalence vs. the `migrate` path | close, with one **pre-existing** divergence - see below |

All database work used throwaway databases, with the resolved target name printed and asserted before every mutation. `arxiidev` was never touched. (Note `DATABASE_URL=... uv run arx manage <cmd>` silently ignores the override - the `arx` CLI re-reads `src/.env` - so verification drove Django directly.)

## One thing this surfaced, filed separately

Schema equivalence is close but not exact, because of a defect this PR did not introduce: **#2906's squash dropped the `arxii_interaction` partition rewrite and combat's composite-FK SQL from the migration chain and never restored them**, unlike the five materialized views. Verified - zero migrations contain that SQL. A fully successful `arx manage migrate` therefore builds an unpartitioned interaction table; `build_schema.py` builds the correct one.

Filed as **#2982**, kept out of this PR because re-expressing a table *rewrite* as a migration needs care about ordering against `POST_PARTITION_COLUMNS`. This PR is unaffected - it produces the more-correct schema.

Knock-on documented rather than hidden: until #2982 lands, the guard will also refuse a database built by a *successful* `migrate`, since that database genuinely lacks the partition. `docs/devcontainer-setup.md` says so and references #2982.

## Notes

- Plain `arx manage migrate` against an empty database remains the documented escape hatch for exercising the real chain locally; `.github/workflows/nightly-migration-replay.yml` is the standing coverage.
- A first pass of the guard's refusal message interpolated the database password into stderr - the output a developer pastes into an issue. Fixed; it now references `DATABASE_URL` in `src/.env`. The full diff was re-scanned for any other credential in an output path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
