### PR TITLE
planned-systems.md ledger accuracy: mark 12 shipped entries DONE, cite the newly filed #2985-#3004

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -80,8 +80,8 @@ limits, IC-vs-UI placement, etc. — see [`design-tenets.md`](design-tenets.md).
 | [Capabilities & Challenges](capabilities-and-challenges.md) | in-progress | Properties, capabilities, applications, action generation, challenges, situations |
 | [Combat](combat.md) | in-progress | Party combat (Phases 1–9 + clash + web UI + escalation/passives/aftermath complete; NPC-tier gap tracked), battle scenes, duels |
 | [Missions & Living Grid](missions.md) | in-progress | Branching narrative quests, world consequences, co-op group beats, support moves |
-| [Crafting, Fashion & Economy](crafting-economy.md) | not-started | Crafting, fashion-resonance loop, housing, shops, domains, ships |
-| [Items & Equipment](items-equipment.md) | not-started | Worn items, body slots, item stats, fashion integration |
+| [Crafting, Fashion & Economy](crafting-economy.md) | in-progress | Crafting expressiveness arc (#2881) + market/fence + fashion cachet economy (#2959) shipped; housing purchase, p2p trade (#2990), harvesting (#2998) remain |
+| [Items & Equipment](items-equipment.md) | in-progress | Worn items, body slots, layered coverage + Reveal (#2965) shipped; body markings (#2985) and visible-equipment web polish remain |
 | [Rooms, Buildings & Estates](rooms-and-estates.md) | skeleton | What ownership of rooms/buildings/estates unlocks — servants, decoration, vaults, special-purpose rooms |
 | [Relationships & Bonds](relationships.md) | in-progress | Relationship types, situational mods, soul tethers, party bonds |
 | [RP Interaction & Scenes](rp-scenes.md) | in-progress | Rich text editor, action-attached poses, scene engagement, three-mode round framework |

--- a/docs/roadmap/planned-systems.md
+++ b/docs/roadmap/planned-systems.md
@@ -15,25 +15,26 @@ PLANNED-UNBUILT tier here. Where a planned system *does* already have an issue/m
 **Status key:** `intent` = no code; `partial` = a piece exists (named here) but the core is unbuilt;
 `unrecorded` = surfaced from design conversation, not previously in any doc/issue.
 
+> **Last full verification: 2026-08-05** — every entry below was checked against code (not docs) in
+> the ledger-accuracy sweep. Twelve entries previously listed as unbuilt had in fact shipped; the
+> still-unbuilt remainder was filed as issues #2985–#3004 and each is cited inline. ✅ DONE entries
+> are kept as one-liners for provenance; their detail lives in the system docs.
+
 ---
 
 ## Cross-cutting primitives (build once, reused widely)
 
 - **Damage/condition immunity & vulnerability framework** — "people who can't drown," vampires harmed
   by sunlight, fire-immune species, etc. `partial` — **#1740/#1588** built the core unified seam
-  (`resolve_damage_type_resistance`; combat/traps/DoT-tick net condition + gift-thread resistance
-  against a `damage_type`, immunity = high resistance not boolean, ADR-0073) plus the first live
-  trigger (Sunlight Exposure). Aquatic ("can't drown") is now built via **#1714**: vehicle
-  hull-breach/living-mount-defeat ejection routes real participants' drowning/falling damage
-  through `resolve_damage_type_resistance` against a `Drowning`/`Falling` `DamageType`
-  (`ensure_drowning_damage_type`/`ensure_falling_damage_type`), so a species/gift with high
-  resistance to that damage type is effectively immune; abstract `BattleUnit`s instead check a
-  flat presence-only `flying`/`aquatic` `Property`. Other species-specific triggers beyond
-  sunlight and the vehicle-hazard pair are still unbuilt. The companion mitigation layer (an
-  ally or a location granting cover against a hazard) shipped as **#1744** (ADR-0069): Succor
-  maneuver + location `DAMAGE_TYPE` cascade axis.
-- **Perception-override / altered-reality scene mode** — "who perceives what is real." Reused by
-  dreamstates, illusions, and disguise/guise. A scene variety over the `SceneRound` seam. `intent`.
+  (`resolve_damage_type_resistance`; immunity = high resistance not boolean, ADR-0073) plus the first
+  live trigger (Sunlight Exposure); **#1714** routed vehicle-hazard drowning/falling through it;
+  **#1744** (ADR-0069) shipped the companion/location mitigation layer. Species-specific triggers
+  beyond sunlight and the vehicle-hazard pair are still unbuilt.
+- **Perception-override / altered-reality primitive** — "who perceives what is real." The two intended
+  consumers each shipped as *separate mechanisms*: dreams as a room layer (`world/dreams` — sleep/wake/
+  dreamwalk, peril branching) and illusion/disguise as form overlays (`DisguiseKind`,
+  `ConcealmentLevel`, pierce contest). The shared seam — a scene where different participants perceive
+  different realities — is still unbuilt, and `SceneRound` has no mode/variety axis. `intent` — **#2997**.
 
 ## Scenes & RP
 
@@ -42,206 +43,160 @@ PLANNED-UNBUILT tier here. Where a planned system *does* already have an issue/m
 - **Provisional, EPHEMERAL-by-default scenes + explicit keep-vs-discard agency** — never auto-persist
   RP; the player decides what is kept. Summary draft→agreed exists; scene-level keep/discard does not.
   `partial` — #1309, ADR-0006.
-- **Auto-close an empty scene** on room-empty / logout / disconnect. `intent` — #1361.
+- ✅ **Auto-close an empty scene** — DONE (#1361).
 - **Intimate / private relationship scene variety** — a distinct scene mode (and mechanics) for the
-  scenes where relationships are tested and capstones created. `intent` — `unrecorded`-adjacent (rp-scenes.md mentions it).
+  scenes where relationships are tested and capstones created. `intent`.
 - **GM-run-table as a live scene variety** — today `GMTable` is only a membership grouping, not a live
   scene mode a player-GM runs. `intent`.
-- **Dreamstate scene variety** — altered-reality scene. `intent`, `unrecorded`. Uses perception-override.
-- **Illusionary scene variety** — false/perceived reality. `intent`, `unrecorded`. Uses perception-override.
-- **Community pose-of-the-scene voting / award** — beyond the automatic scene XP. `intent`.
-- **New-player onboarding tutorial** (#1035); **friend list / "looking for RP" finder**; rich-text
-  composer / conversation threading. `intent`.
+- **Dreamstate / illusionary scene varieties** — superseded in part: dreams shipped as a room layer and
+  disguise as form overlays (see the perception-override entry above). What remains is the scene-level
+  shared-altered-reality mode — **#2997**. Dreams also have **zero web surface** — **#3003**.
+- **Community pose-of-the-scene voting / award** — `partial`: `WeeklyVote`/`VoteButton` are built but
+  unwired (#2161).
+- ✅ **New-player onboarding tutorial** — DONE (#1035; T1–T7 mission chain + e2e journey). Still
+  `intent`: **friend list / "looking for RP" finder**; rich-text composer / conversation threading.
 
 ## Combat depth
 
 - **Ranged / reach / archery** — `partial`, NOT greenfield. Technique targeting already has range
-  bands (`SAME`=melee / `ADJACENT`=reach / `ANY`=ranged, `world/magic/models/techniques.py:295`), a
-  `RANGED` weapon class (`world/items/constants.py:84`), and a `bow`→`archery` skill mapping. What's
-  missing is the full ranged-combat mechanics: positioning/range enforcement, line-of-sight, distinct
+  bands (`SAME`/`ADJACENT`/`ANY`, `world/magic/models/techniques.py`), a `RANGED` weapon class, and a
+  `bow`→`archery` skill mapping. Missing: positioning/range enforcement, line-of-sight, distinct
   archery actions. `partial`, `unrecorded`.
-- **Mounts** — mounted movement/combat. `intent`, `unrecorded`.
+- **Mounts** — `partial`: mounted **combat** is DONE (#1843 — mount/dismount companion actions, charge
+  + joust, mounted bonus/lance penalty, STABLES room feature). Mounted **movement** (travel-speed or
+  room-transit effect while mounted) is still unbuilt; the `travel_speed` ModifierTarget exists with
+  no source populating it.
 - **Verticality / flying / rooftops** — vertical space and an aerial layer player surface (a
   positioning `enter_aerial` path exists internally but no player surface). `intent`, `unrecorded`.
-- **Knockback + trap-into-combat hazards** — #1317.
-- **Out-of-combat reactive interpose / DANGER-round arming** — #1316.
-- **Shapeshift (voluntary + rage) + combat profiles** — #1111, **DONE**: an "alternate self"
-  mechanism — a bundle of optional facets (form + stats + abilities + persona + control-state)
-  swapped together on assumption, reverted together. `assume_alternate_self` /
-  `revert_alternate_self` services; `in_control` is a derived `@cached_property` (not stored —
-  ADR-0014) that is False while any active condition's category is `alters_behavior` (rage/
-  possession/charm). Assumption is NOT `in_control`-gated; revert IS (`RevertBlockedError`);
-  clearing the condition re-derives `in_control=True` and unblocks a later self-revert (decoupled).
-  Strictly-one-active (`AlternateSelfActiveError`); cross-sheet `form`/`persona` FKs rejected
-  (`FormOwnershipError` / `ActivePersonaError`) — never an uncaught 500. Berserk's category was
-  wired to `alters_behavior=True`, reusing the existing Fury lever (#567: Berserk +
-  `RestoreSenseAction` calm-down) rather than building a parallel rage/calm-down. `ShiftFormAction`
-  / `RevertFormAction` (REGISTRY `target_type=SELF`) wrap the services; telnet `CmdForm`
-  (`form shift`/`form revert`) and the web `AlternateSelfViewSet` + `FormSwitcher` both dispatch
-  via `dispatch_player_action` → `action.run()` (ADR-0001). `PersonaType.ALTERNATE` added.
-- **Transformation cause-paths** — #1604, **DONE**: the at-will `form shift` command was
-  the only path to `assume_alternate_self`; the technique-driven and involuntary-trigger
-  cause-paths were never built. Added a single seam, `trigger_transformation(sheet, alt, *,
-  cause, instance_value=1.0)` (`world/forms/services/transformation.py`), that both new paths
-  call and that scales each granted `CharacterModifier.value` by the persistent per-character
-  `AlternateSelf.tuning_value` baseline × the per-instance `instance_value` (÷ `SCALE=10`;
-  neutral case short-circuits to identity). The **technique path**: an
-  `EffectKind.ASSUME_ALTERNATE_SELF` pull effect (new) whose `ThreadPullEffect.target_form` FK
-  names the form; at cast resolution the success band selects a `FormCombatProfile` by the new
-  `depth` field (fail→lowest, mid→middle, crit→highest) and sets `instance_value` (1.0/1.5/2.0).
-  The **involuntary-trigger path**: a reactive condition fires `CONDITION_APPLIED` → a flow
-  `CALL_SERVICE_FUNCTION` step invokes the registered `flow_trigger_transformation` wrapper
-  (`flows/service_functions/forms.py`), which resolves the alt by `(sheet, form__name)`; a
-  resist-check branch authors the "fail a check to *not* change" journey. The at-will command is
-  retained but gated behind a seeded `at_will_shifting` capability
-  (`HoldsCapabilityPrerequisite`) — a niche escape hatch. Revert-blocked-while-raging (the
-  #1111 invariant) is exercised end-to-end by the trigger test. Gift-level modulation of the
-  resist check is deferred to #1578 (specialization engine).
-- **Combo mechanics — fuller rules** — combos exist (upgrade/revert); the exact rules need design. `partial`, `unrecorded`.
-- **Soulfray-risk accept + fury commit** — player-chosen combat risk decisions. #1454, **DONE**:
-  party-combat casts carry the player's `confirm_soulfray_risk` + fury (`fury_commitment` tier +
-  `fury_anchor`) on the `CombatRoundAction` declaration; `resolve_combat_technique` honors them
-  (soulfray gate no longer hardcoded; fury via the shared `run_fury_for_action` consumer → control
-  penalty + intensity bonus, Berserk on lost control, `Interaction.fury_committed` audit). Telnet
-  `cast … fury=<tier> anchor=<name>` reaches the same dispatch seam the web uses; declining a risky
-  cast is free re-declare.
+- ✅ **Knockback + trap-into-combat hazards** — DONE (#1317).
+- ✅ **Out-of-combat reactive interpose / DANGER-round arming** — DONE (#1316).
+- ✅ **Shapeshift (voluntary + rage) + combat profiles** — DONE (#1111; `assume_alternate_self` /
+  `revert_alternate_self`, derived `in_control`, `ShiftFormAction`/`RevertFormAction`, ADR-0014).
+- ✅ **Transformation cause-paths** — DONE (#1604; `trigger_transformation` seam, technique
+  `ASSUME_ALTERNATE_SELF` effect, involuntary trigger via flows, at-will gated by capability).
+- **Combo mechanics — fuller rules** — combos exist (upgrade/revert); the exact rules need design.
+  `partial`, `unrecorded`.
+- ✅ **Soulfray-risk accept + fury commit** — DONE (#1454).
 - **Duels** — non-lethal PvP + lethal PC-vs-significant-NPC. Milestone #8; NPC-tier lethality gap M#10
-  (ADR-0023/0038/0040). (The duel *Actions* exist and are web-dispatchable — see the audit's WEB-ONLY row.)
+  (ADR-0023/0038/0040). (The duel *Actions* exist and are web-dispatchable.)
 
 ## Magic & progression
 
-- **Spell system** — learnable, path-independent magic usable by quiescent characters. No `Spell`
-  model. `intent` (character-progression.md, magic glossary).
-- ✅ **Post-CG Gift acquisition** — LANDED via two paths: path-crossing grant (`grant_path_magic`,
-  #1579) and the player-facing XP-buy/teaching-offer surface (`PurchaseGiftUnlockAction` +
-  `AcceptTechniqueOfferAction`, telnet `learn`, web `/api/magic/gift-unlocks/purchase/` +
-  `/api/magic/technique-offers/accept/`, #2116). See `player-capability-ledger.md`.
-- **Trainer system** — find trainers, costs, tiers. `intent`.
+- **Spell system** — learnable, path-independent hedge magic usable by quiescent characters. No `Spell`
+  model; all casting still flows Gift/Path/Technique/Thread. `intent` — **#3001**.
+- ✅ **Post-CG Gift acquisition** — DONE (#1579 path-crossing grant; #2116 XP-buy/teaching-offer
+  surface: `learn`, `/api/magic/gift-unlocks/purchase/`).
+- ✅ **Trainer system** — DONE (#2440 TRAIN effect: NPC teaches a technique for AP + coin;
+  `NPCRole.teaches_tradition`, per-technique offers with costs; seeded Academy Trainer +
+  tradition-gated trainers + ghost tutelage #2460; Training Room AP discount). Check-based technique
+  learning follow-ups remain open: #2739/#2740/#2741.
 - **Path discovery / research / switching** — beyond listing next options. `intent`.
-- **Resonance→aspect mapping** so path investment rewards magic checks (placeholder `Arcana` today). #1363, `partial`.
-- **Aspect-in-magic — DESIGN-CLARIFICATION, not an unbuilt system.** `Aspect`/`PathAspect`/
-  `_calculate_aspect_bonus` are **built and live** as a *path-competence* check bonus
-  (`world/classes/models.py:277,309`, `world/checks/services.py:161`). The open question (#1363): magic
-  checks only seed a placeholder `Arcana` aspect, so path investment does ~nothing for magic — decide
-  whether/how magic should use the aspect dimension, or drop it for magic. **Not** "build Aspects." Note:
-  mapping resonance→aspect was *rejected* (closed #1357) as double-counting `power_terms`. `partial`.
-- **Soulfray progression** (warp stage-advance / aftermath / treatment) — #712, `partial`.
+- ✅ **Resonance→aspect / aspect-in-magic** — resolved (#1363 closed; resonance→aspect mapping was
+  rejected earlier as double-counting, #1357).
+- ✅ **Soulfray progression** — DONE (#712).
 - **Multi-target per-target consent state machine** — ADR-0045, `partial`.
 - **ResonanceGrantReversal** — endorsements are currently irreversible. `intent` (named in code).
 
 ## Gift & resonance economy (ADR-0050–0057)
 
-The 2026-06-27 design discussion produced a connected set of decisions (ADRs 0050–0057). The machinery
-below is **designed (ADR)** — the Major/Minor taxonomy keystone has landed (#1577); the rest is unbuilt.
-Build to the ADR; these are not open questions. See
-[`player-capability-ledger.md`](player-capability-ledger.md) for tiers and sequencing.
+Designed as a connected set (ADRs 0050–0057); most of it has now landed. See
+[`player-capability-ledger.md`](player-capability-ledger.md).
 
-- ✅ **Major/Minor gift taxonomy** — LANDED (#1577). `Gift.kind` column (`GiftKind`: `MAJOR` =
-  CG-chosen, `MINOR` = shared/acquirable; default `MAJOR`, db_index). The keystone the rest of the
-  economy hangs off. ADR-0050. Supersedes the bare "Post-CG Gift acquisition" intent above: acquirable
-  powers + species abilities are Minor Gifts via the gift pipeline. (Acquisition machinery itself is
-  still #1580/#1581 — this PR is the taxonomy column only.)
-- **Species abilities as Minor Gifts** — khati/vampire/lycan/lineage powers delivered as species-granted
-  Minor Gifts, no bespoke per-species system. ADR-0050. (See Species & racial framework below.)
-- **GIFT thread anchor + per-target-kind cost** — add a `GIFT` `TargetKind` (+ `target_gift` FK +
-  constraint quartet) and a per-kind cost axis (cost is tier/level/path only today); gift-threads are
-  the costliest kind. ADR-0051. `intent`.
-- **Gift resonance from the woven thread** — a gift's affinity is read from its gift-thread resonance
-  instead of the fixed `Gift.resonances` M2M (moves `power_terms`/`resonance_environment`/`defilement`
-  consumers). ADR-0052. `partial`.
-- **The one specialization engine** — generalize `resolve_effective_role` (the only working
-  axis-combination) into a shared `(entity × resonance [× thread level]) → customized capability`
-  primitive over Gift/Path/Covenant-Role, derive-on-read. **`priority:now` keystone.** ADR-0055,
-  ADR-0016. Consumes the dead `TechniqueStyle.allowed_paths` link.
-- **XP-unlock contract** — XP buys unlocks that gate, never grant, across the economy (reuse
-  `*Unlock`/`Character*Unlock` + `ExperiencePointsData`). ADR-0053. Mostly a contract + new unlock rows
-  (acquire-gift, threadweaving-for-gift).
+- ✅ **Major/Minor gift taxonomy** — DONE (#1577; `Gift.kind`, ADR-0050).
+- ✅ **Species abilities as Minor Gifts** — DONE (#1580; `SpeciesGiftGrant` + `provision_species_gifts`,
+  seeded vampire/lycan/dhampir sun-sensitivity, Wolf's Fury, Hunger, shade content; gift-lineage reach
+  #2891). Content authoring continues — #2764.
+- **GIFT thread anchor + per-target-kind cost** — a `GIFT` `TargetKind` + per-kind cost axis;
+  gift-threads the costliest kind. ADR-0051. `intent`.
+- **Gift resonance from the woven thread** — a gift's affinity read from its gift-thread resonance
+  instead of the fixed `Gift.resonances` M2M. ADR-0052. `partial`.
+- ✅ **The one specialization engine** — DONE (#1578; resonance × {gift, path, role} → customized
+  techniques, ADR-0055/0016).
+- ✅ **XP-unlock contract** — wired (#2131 closed the inert/unreachable spend loops; ADR-0053).
 - **Signature technique-thread** — re-scope `TargetKind.TECHNIQUE` to a per-technique signature delta
-  (own resonance, may diverge → discordant signature). ADR-0056. `partial`.
-- **Fall / Redemption conversion service** — resonance-type conversion (Celestial→Abyssal gains;
-  Abyssal→Primal/Celestial loses) without violating the monotonic `lifetime_earned` invariant. ADR-0054.
-  `intent` (no conversion primitive today).
-- **Covenant of the Court** — new `CovenantType.COURT` (leader + servants across ≥1 power-tier gulf),
-  reusing the covenant substrate (CovenantRank + role-power + sub-role specialization). ADR-0057.
-  `partial`.
+  (own resonance, may diverge → discordant signature). ADR-0056. `partial` (the sibling gift-thread
+  specialization #1581 landed).
+- **Fall / Redemption conversion service** — resonance-type conversion without violating the monotonic
+  `lifetime_earned` invariant. ADR-0054. `intent` — the conversion-table defect is one of the four
+  tracked on #2967.
+- **Covenant of the Court** — new `CovenantType.COURT` reusing the covenant substrate. ADR-0057. `partial`.
 
 ## Relationships, covenants & collectives
 
-- **Relationship mechanics made live** — the relationship-building loop is built but NO-SURFACE (see
-  audit); separately, the *mechanical* payoffs are unbuilt: mechanical-bonus consumed in checks,
-  teamwork/combo/coordination gating, RelationshipUpdate + decay/freeze cron, and the consent/deceit
-  safety layer (privacy MVP-gating). `intent` / `partial`.
-- **Adventuring-party model** — group formation, shared legend, coordination. `intent`.
-- **NPC reputation model** — −1000..1000 standing for shops/factions. `intent`.
-- **Org-level ritual-leadership permissions** — #708.
-- **Society politics** — army/military, territory control, alliances/betrayal/warfare, leadership
-  succession, world-event influence. `intent`, partly recorded (societies.md).
-- **Battle / army / warfare system** — war covenants exist (banner-call rise, `battle_binding`) but have
-  **nowhere to resolve into**: no Battle/Army/Regiment/skirmish model. The obvious missing partner to
-  war covenants. `intent`, `unrecorded`.
+- **Relationship mechanics** — `partial`, and much further along than previously recorded: the
+  mechanical payoffs ARE consumed (`bond_combat_bonus`/`bond_bonus`/`relationship_gated_contributions`
+  read by combat clash/services and scene action services), and decay is computed-on-read over
+  `DECAY_DAYS` (no cron needed). Still unbuilt: teamwork/coordination gating (needs a group scope —
+  see adventuring party), the consent/deceit safety layer, and the content passes listed in
+  [relationships.md](relationships.md).
+- **Adventuring-party model** — group formation, shared legend, coordination. Missions/voyages/consent
+  each carry their own membership slice; no party primitive. `intent` — **#2992**.
+- ✅ **NPC reputation model** — DONE (`NpcRegard` −1000..1000 + `NpcRegardEvent` + config, with
+  society/organization twins). Gap: **shops never read it** — no standing-based pricing or access.
+  **#2995**.
+- ✅ **Org-level ritual-leadership permissions** — DONE (#708).
+- **Society politics** — mostly built since last recorded: territory (gang turf + crime cascade),
+  warfare (see below), leadership succession (houses `SuccessionLaw`/`Title`/`FealtyEdge` + heredity),
+  world-event influence (proclamations/propaganda/obligations). Still unbuilt: a **general
+  alliance/treaty/betrayal instrument between orgs** — the only formal inter-org pact is
+  `MarriagePact`. **#2999**.
+- ✅ **Battle / army / warfare system** — DONE (`world/military`: `MilitaryUnit`/`Army` + services;
+  `world/battles`: staging, resolution, fortifications, vehicles, war funding, city defense). War
+  covenants now have somewhere to resolve into.
 
 ## Crafting, economy, items, estates
 
-- **Item-creation pipeline** — recipe → new `ItemInstance` with stats/facets; today the engine only
-  *attaches* facets to existing items. #1125, `intent`.
-- **Materials / resources + harvesting loop** — #1125, `intent`.
+- ✅ **Item-creation pipeline** — DONE (`ItemCreateHandler` mints `ItemInstance` from
+  `CraftingRecipeKind.ITEM_CREATE`; expressiveness arc #2881 added accents/ladders/refinement).
+- **Materials / resources + harvesting loop** — `partial`: materials exist as crafting *requirements*
+  (`MaterialCategory`, `CraftingMaterialRequirement`), but no player loop *produces* them —
+  `world/agriculture` yields food only. Personal gathering (foraging/mining/salvage) is `intent` —
+  **#2998**. Domain-level production is #2540's territory.
 - **Recipe acquisition** (discover / learn / buy, skill-gated) — `intent`.
-- **Crafting-station durability + repair economy** — #1234, `intent`.
-- **Crafting Action + telnet command** — the currency/crafting service layers are deep but have zero
-  Actions/commands (see audit NO-SURFACE). `intent`.
-- **Store / shop / vendor + player↔player trade / barter / auction** — #923, `intent`.
-- **Ship system** — vessels, crew, sea travel, mission integration. Connects to **boats / sea travel /
-  drowning** and the immunity framework (who can't drown). `partial` — **#1714** built the first
-  concrete slice: a battle-time-only `BattleVehicle` (ship/airship/dragon/kraken), reachable only
-  inside a `Battle` and discarded with it. **#1832** shipped the persistent half: `ShipDetails`
-  (a per-kind `Building` extension, ADR-0086) with commission/upgrade/repair Projects,
-  ship-as-sanctum, and `materialize_ship_as_battle_vehicle` bridging into #1714's battle vehicle —
-  see [ships.md](../systems/ships.md). Still `intent`: crew as named NPCs (today `crew_capacity`
-  is a number), out-of-combat sea travel, cargo-as-tracked-goods, and mission integration.
-- **Servant / retriever NPC entity**; **vault security / access lists / theft**;
-  **building→neighborhood→domain progression** (#696); **room-feature systems** (Library/Lab/Training
-  Room/Command Center/Granary/Cannon Deck — #675, only Sanctum real); **future Project kinds** (#673).
-  `intent`.
-- **Touchstone items + magical reagents + personal attunement framework** — `partial`. #707
-  shipped the framework (ADR-0087). Resonance-tied items (`ItemTemplate.tied_resonance`/`resonance_tier`, a new
-  `ResonanceTier` potency axis independent of crafting `QualityTier`); two-stage personal
-  **attunement** (`attune_touchstone()`, seeded "Rite of Attunement" ritual — binds an
-  `ItemInstance` to a character without consuming it); `RitualComponentRequirement`
-  touchstone-mode (dynamic resonance match against the performer's own claimed Resonance, or
-  a specific `resonance_context` — e.g. Sanctification's founding Resonance) alongside its
-  existing template-mode, both resolved/consumed by the shared
-  `resolve_and_consume_ritual_components()` helper; Ritual of Sanctification's two rituals now
-  carry real touchstone + generic-reagent requirements; FACET_ATTACH crafting seeded with a
-  generic reagent material requirement (content-only, zero service-layer change); narrative
-  acquisition (`grant_touchstone_item_to_character()` + staff `CmdGrantItem` + Mission
-  `DeedRewardSink.ITEM` reward sink — no shop/merchant system exists in this codebase, so
-  GM-grant and mission-reward are the only acquisition channels). See
-  [magic.md](../systems/magic.md) ("Touchstones + reagents") and
-  [items.md](../systems/items.md) ("Touchstones + reagents" / "Narrative acquisition").
-  Seeded content is **framework-proving only** (one touchstone template, three generic
-  reagents) — a full per-resonance/per-tier catalog is separate content-authoring work.
-  Follow-up: **#1859** (leveled/Path-scaled component requirements — Ritual of the Durance,
-  Rite of Weaving/Imbuing — `needs-design`, blocked on this landing).
-- **Asset / Companion subsystem** — #672. **Companion/familiar half shipped**
-  (generic bound-creature substrate + Beastlord beast-binding, see
-  [companions.md](../systems/companions.md)); still `intent`: **gifts/paths
-  built around companionship** beyond the one shipped Gift. The **NPCAsset
-  informant/contact promotion mechanic** — #1872 — **shipped** (see
-  [INDEX.md](../systems/INDEX.md) "Assets" section); still `intent`:
-  distinction-granted starting assets (`needs-design`), asset gameplay loops
-  (tasking/intel/income), compromise/loss lifecycle, voluntary asset
-  sharing, guard/fan/minor-ally variants — none yet filed as separate
-  follow-up issues.
+- ✅ **Crafting-station durability + repair economy** — DONE (#1234).
+- ✅ **Crafting Action + telnet command** — DONE (#1866/#1931 closed the coverage gap).
+- **Store / shop / vendor + player↔player trade** — `partial`: the market shipped (stalls, NPC stock,
+  PC ware listings, fence #2862, finishing/service offers, fashion showcase economy #2959). Still
+  absent: **negotiated two-sided player↔player trade, barter, auction** — the only direct channel is
+  one-way `give`. **#2990**.
+- **Ship system** — `partial`: battle vehicles (#1714), persistent ships + upgrades/repair +
+  ship-as-sanctum (#1832), and **out-of-combat sea travel** (`Voyage` + actions + telnet) are all
+  built. Still `intent`: **crew as named NPCs and cargo as tracked goods** — both are PLACEHOLDER
+  integers on `ShipDetails`. **#3000**.
+- **Servants, vaults, estates** — split by verification:
+  - ✅ **Vault security / access lists / theft** — DONE (`VaultDetails` + `VaultAccessEntry` +
+    vault services, org vaults with holdings/transit; `steal`/`steal_permitted` +
+    `TheftNotPermitted` gate).
+  - **Servant daily-life behaviors** — fetch shipped (#2276); meal/bath prep, message-carrying,
+    announcing visitors, guard/doorman duty, and `assign_servant`/`unassign_servant` remain.
+    **#2989**.
+  - **Building→neighborhood→domain progression** — #696 (open).
+  - ✅ **Room-feature systems** — DONE far beyond Sanctum: Library, Training Room, Lab, Command
+    Center, Granary, Siege Deck, Bank, Notice Board, Town Crier, Social Hub, Vault, Brig, Stables,
+    Workshop of Iniquity — all registered, seeded, with live effects. (#675/#673 closed.)
+  - **Property purchase + decoration economy** — the *acquisition front door* (buy land/rooms,
+    commission construction with coin) and the furnishing loop (decor → room stats read in scenes)
+    are unbuilt over shipped substrate. **#2991**.
+- **Touchstone items + magical reagents + personal attunement framework** — `partial`. #707 shipped
+  the framework (ADR-0087); a full per-resonance/per-tier catalog is separate content-authoring work.
+  Follow-up: #1859 (leveled/Path-scaled component requirements).
+- **Asset / Companion subsystem** — #672 (closed as umbrella). Companion/familiar half shipped;
+  NPCAsset informant promotion shipped (#1872). Still `intent`: gifts/paths built around
+  companionship beyond the one shipped Gift; distinction-granted starting assets; asset gameplay
+  loops (tasking/intel/income); compromise/loss lifecycle; voluntary sharing; guard/fan/minor-ally
+  variants.
 
 ## Species & racial framework
 
-- **Species/racial framework** — `world/species` has the species gift substrate
-  (`SpeciesGiftGrant` + `provision_species_gifts`, #1580) and the environmental
-  vulnerability framework (vampire↔sunlight as `ConditionDamageOverTime` riding the
-  peril pipeline, #1740; see ADR-0073). Still **absent**: **racial gifts** (seeded
-  species Minor Gift data), **growing stronger at racial abilities** (racial
-  progression), and broader **status vulnerabilities** beyond sunlight. `intent`,
-  `unrecorded`.
+- **Species/racial framework** — the substrate AND seeded ability content shipped (`SpeciesGiftGrant`
+  + provisioning #1580, sun-sensitive species, moon content #2845, appetite/shade content;
+  environmental vulnerability via #1740). Content authoring continues on #2764. Still unbuilt, the
+  two *mechanics* halves — **#2993**:
+  - **Language mechanics** — `Language` + `grants_species_languages` exist and #2463 authored
+    content, but nothing grants languages to characters: no per-character storage, no CG/heredity
+    grant path, no speech integration.
+  - **Racial progression** — "growing stronger at racial abilities"; no species-scoped advancement
+    track exists in `world/progression`.
 
 ## GM tooling, missions, knowledge
 
@@ -249,36 +204,54 @@ Build to the ADR; these are not open questions. See
 - **GM trust→risk leveling curve**; **live Situation/Encounter session resolvers** (beyond the GM-mark
   placeholder); **cross-table GM availability marketplace**. `intent`.
 - **Mission player journey on `action.run()`** — mission play runs only through a ViewSet today
-  (ADR-0001 gap); plus group invite/consent handshake (#887), categorical room binding (#888),
-  player discovery board, mission→beat completion engine, instanced-room wiring (#886), real reward
-  sinks (#932). `partial`.
-- **Clue/investigation journal UI** (#1143); more clue trigger sources (resonance / past-life, #1160);
-  secret/scandal clue kinds. `intent` / `partial`.
+  (ADR-0001 gap); plus group invite/consent handshake (#887) and player discovery board. (The
+  formerly-listed instanced-room wiring #886, categorical room binding #888, and reward sinks #932
+  have all closed.) `partial`.
+- **Clue/investigation journal UI** — a web surface for held clues + research pursuit; still listed in
+  [investigation-discovery.md](investigation-discovery.md). Passive trigger sources landed (#1160
+  closed); past-life/scandal clue kinds remain. `partial`.
 - **Collaborative research** (start/contribute project) and **codex teaching** (accept/cancel) — service
-  layers exist, no player surface (see audit). `partial`.
-- **Returning-player wrap-up of FORECLOSED threads** — #1188, ADR-0039. `intent`.
-- **Achievement content + notification delivery** — the engine is built but unfed and silent. `intent`.
+  layers exist, no player surface. `partial`.
+- ✅ **Returning-player wrap-up of FORECLOSED threads** — DONE (#1188, ADR-0039).
+- **Achievement content + notification delivery** — the engine is built and stat hooks are wired, but
+  definitions are thin and **delivery is silent** (no personal/room/gamewide announcement on earn).
+  Ongoing content tracking: #2377, #2831. `partial`.
+- **GM trap placement/arming** — only disarm exists; `Trap.is_armed` is set only programmatically.
+  `intent` — **#3002**.
+
+## World texture (registered 2026-08-05)
+
+The "world feels inhabited" cluster — promised by design-tenets/ADRs or left as the unbuilt half of a
+shipped system, now each filed:
+
+- **Body markings** — tattoos/scars/brands as skin-layer features riding the shipped coverage/reveal
+  pipeline (#2965/#2846 anticipate them in code comments). `intent` — **#2985**.
+- **Gossip & rumor authoring** — tidings is read-only and derived (no models); missions' RUMOR reward
+  sink is a stub; relationship gossip unbuilt. `intent` — **#2986**.
+- **Bystander reaction menus** — ADR-0032's witness pop-up choice trees; witness-approach substrate
+  shipped (#1824), the interactive half didn't. `intent` — **#2987**.
+- **Ambient room texture** — roaming flavor emits + room-state risk telegraphing ("a seedy district
+  can spawn pickpockets"); feeder stats exist, no consumer. `intent` — **#2988**.
+- **Mood/stance system** — declared expressive state instead of pose-parsing (design-tenets). `intent`
+  — **#2994**.
+- **Block/mute system** — the OOC safety primitive staff-inbox/journals/ooc-social all depend on.
+  `intent` — **#2996**.
+- **IC calendar lore + festivals** — lore month names + feast-day cycle over the shipped clock/
+  `FeastDay` hook. `intent` — **#2762**.
+- **Web surfaces for dreams & kinship** — both backends fully built, telnet/CG-only. `partial` —
+  **#3003**.
+- **Dead wires sweep** — scene-dp award (broken + uncalled), level-change hook (uncalled), goals XP
+  (recorded, never granted), boundaries seed cluster (unwired), FACET_ATTACH production seed path
+  (missing). **#3004**.
 
 ## Doors, traps & misc
 
-- **Door lock/unlock** — **DONE (#1866).** Room-owner/tenant gated (no
-  key-item system); `LockAction`/`UnlockAction` set a `db.locked` attribute
-  on the Exit, checked by `ExitState.can_traverse`. `CmdLock`/`CmdUnlock`
-  (`src/commands/door.py`) are the telnet face.
-- **Trap arming/placement** — only disarm exists; the GM side of the trap loop is unbuilt. `intent`.
+- ✅ **Door lock/unlock** — DONE (#1866; `LockAction`/`UnlockAction` + `CmdLock`/`CmdUnlock`).
 - **Persona minting** (create/edit/delete an identity) — reserved for future IC flows. `intent`.
-- **Tidings posting/reacting/commenting** — feed is read-only; no authoring model. `intent` — #1450.
-- **Scandal reach & containment — BUILT (#1464, ADR-0082):** acts fork at deed birth into
-  contained Secrets or society awareness (archetype-dot scandal judgment, containment check,
-  fame-scaled spread). **Civic-hub reader BUILT (#1450, closes the epic):** Notice Board / Town
-  Crier RoomFeatureKinds gate a local tidings slice (`hub_feed_for_room`: room → area →
-  `societies_for_area`) surfaced as arrival echo, `tidings local`, and a web room-panel block;
-  crier install places a Functionary. **Witness handling BUILT (#1824):** the declared
-  capability list (`WITNESS_APPROACHES` + `witness_approaches_for`) replaces the containment
-  auto-pick when an approach is declared (bribery attempt tags its own CrimeKind); act-time
-  Stealth witness-reduction is wired end-to-end via the mission approach fan (a Stealth
-  `ChallengeApproach` → `concealed` deed). Still open: an async prompted-choice containment
-  UX at fork time (service param is live; needs its own design); venue vitality (PC-owned
-  RP hubs) is its own future umbrella.
+- **Tidings posting/reacting/commenting** — feed is read-only; no authoring model. `intent` — **#2986**
+  (folded into gossip & rumor authoring; supersedes #1450's reader-side epic).
+- **Scandal reach & containment — BUILT (#1464, ADR-0082)** with civic-hub reader (#1450) and witness
+  handling (#1824). Still open: an async prompted-choice containment UX at fork time; venue vitality
+  (PC-owned RP hubs) is its own future umbrella.
 - **Roster release / end-tenure**; **events RSVP-accept** (invitee response); **projects activation
   service** — small but real gaps where one half of a loop is unbuilt. `intent`.

--- a/docs/systems/narrative.md
+++ b/docs/systems/narrative.md
@@ -161,14 +161,14 @@ Recipients resolve by story scope:
 
 ---
 
-## Frontend Roadmap (Phase 4)
+## Frontend (shipped)
 
-The React frontend will surface narrative messages in two places:
-
-- **Inline main-text stream** — messages get a distinct `|R` (light red) color tag so the webclient can style them apart from normal scene messages
-- **Messages section of character sheet** — paginated, filterable, searchable; unread counter from `acknowledged_at=null` rows
-
-Both are frontend concerns; the backend exposes `/api/narrative/my-messages/` and `/api/narrative/deliveries/{id}/acknowledge/` as the minimum needed to drive them.
+The React surface lives in `frontend/src/narrative/`: `MessagesSection.tsx` +
+`MessageRow.tsx` (paginated message list off `/api/narrative/my-messages/`),
+`UnreadNarrativeBadge.tsx` (unread counter from `acknowledged_at=null` rows),
+`SendGemitDialog.tsx`, and per-category muting via `CategoryMuteToggles.tsx` /
+`MuteSettingsPage.tsx`. Acknowledge goes through
+`/api/narrative/deliveries/{id}/acknowledge/`.
 
 ---
 


### PR DESCRIPTION
## What

A full code-verification sweep of `docs/roadmap/planned-systems.md` found 12 entries still listed as "no code yet" that have in fact shipped — trainers (#2440), battles/military, NPC regard, mounted combat (#1843), item-creation (`ItemCreateHandler`), room features (all kinds), vault security, sea travel (`Voyage`), the onboarding tutorial (#1035), relationship mechanical payoffs, the specialization engine (#1578), and species Minor Gift seeding (#1580).

- Compressed shipped entries to ✅ DONE one-liners (detail lives in system docs)
- Updated `partial` entries to name what actually exists vs remains
- Cited the freshly filed issues #2985–#3004 for everything still waiting, plus a new "World texture" section for the 2026-08-05 registrations
- Fix-on-sight: `docs/systems/narrative.md`'s Phase-4 frontend roadmap already shipped (`frontend/src/narrative/`) — replaced with as-built; ROADMAP.md's `not-started` cells for Items and Crafting/Fashion were stale

Per Docs-Are-Directives: the ledger was actively misleading — it is the doc agents consult before designing "new" systems.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)