### PR TITLE
Content loads never overwrite credited rows; sample seeding requires an empty content universe

### DIFF
--- a/docs/adr/0201-credited-rows-are-frozen-against-loads.md
+++ b/docs/adr/0201-credited-rows-are-frozen-against-loads.md
@@ -43,8 +43,11 @@ name is dropped and logged, never the row.
 **Trade-offs / accepted cost:**
 - No sync bookkeeping means the freeze cannot distinguish "someone hand-edited this row in the
   live DB and never exported it" from "the repo's fixture genuinely moved past what's in the DB" -
-  both look identical (a credited row, a differing incoming value) and both route through the same
-  resolution page. Ruled acceptable by Tehom, 2026-08-05, on #3017.
+  both look identical (a credited row, a differing incoming value), and each path reports it
+  through its own channel rather than one shared resolution page: the fixture pipeline surfaces
+  it on the admin's Load Conflicts page, `grid_import.py` through `GridImportResult.reports`, and
+  `world.weather.seed` through its own return value and log. Ruled acceptable by Tehom,
+  2026-08-05, on #3017.
 - The sample-content gate is per-press enforcement, not a standing database-wide invariant: it
   runs once, inside one `seed_dev_database()` call, between the content load and the cluster loop.
   A direct cluster-seeder call outside that call - the test-only helpers in

--- a/docs/adr/0201-credited-rows-are-frozen-against-loads.md
+++ b/docs/adr/0201-credited-rows-are-frozen-against-loads.md
@@ -1,0 +1,70 @@
+# ADR-0201: Credited rows are frozen against loads; sample content only seeds an empty universe
+
+**Decision:** `written_by` (null = placeholder row, set = a human touched it) is the sole
+provenance signal on every `CreditedContent` row. `_upsert_fixture_object` freezes a credited row
+whenever the incoming corpus value differs from the DB on ANY set field - not just prose - rather
+than overwriting it; the only way back to the repo version is a per-row, typed-confirmation
+delete-then-reload in the admin's Load Conflicts pages, never a bulk resolve. The guard applies
+wherever `CreditedContent` shows up, not only the fixture-JSON/markdown pipeline:
+`grid_import.py`'s `_ensure_ambient_group_trigger` freezes a credited `TriggerDefinition` on its
+digest-collision refresh branch, reporting through `GridImportResult.reports`
+(`FlowDefinition` needs no guard - it is only ever get-or-created, never updated, in this module).
+`world.weather.seed.upsert_weather_emits` freezes a credited `WeatherEmit` the same way, returning
+conflicts through the same shape the fixture loader uses. Separately, `SEED_SAMPLE_CONTENT`
+sample invention is refused once any `CONTENT_MODELS` table already has a row within the same
+`seed_dev_database()` press (`assert_sampling_allowed()`, called between the content load and the
+cluster loop), so an invented row can never mix into a real content universe.
+
+**Why:** a free-text or best-effort merge can't tell a byte-identical re-export from a genuine
+edit apart from noise, and this repo has no sync bookkeeping (ADR-0007 rules out a JSON diff
+column, and a per-field dirty marker was explicitly considered and rejected below). Once a human
+has set `written_by`, the safest default is to touch nothing and force a deliberate, one-row
+confirmation rather than silently pick a side. The weather path needed its own credit-name
+resolution (`_resolve_credit_names`) added alongside the freeze: a raw fixture credit
+(`written_by` as a natural-key list, e.g. `["Apostate"]`) crashed `update_or_create` with a bare
+`ValueError` before this task, since `WeatherEmit.written_by` is a real FK and Django's descriptor
+rejects a list outright - every row carrying a credit would have failed to load at all. The fix
+mirrors `content_fixtures._resolve_or_drop_credit_fields`'s #2980 rule: an unresolvable credit
+name is dropped and logged, never the row.
+
+**Rejected:**
+- **Prose-only guard scope.** Freezing only the prose fields on a credited row would leave the
+  same row half-frozen, half-overwritten field by field on every load - the guard exists to
+  protect a human's editorial pass over the whole row, not just its text, so a mechanical or flag
+  field differing freezes the row exactly the same as a prose field.
+- **Two-way diff/sync bookkeeping.** Tracking a per-field dirty/edited marker so the loader could
+  tell "an unexported staff DB tweak" apart from "the repo genuinely moved on" was rejected as
+  complexity this repo cannot afford pre-launch. The freeze-plus-manual-resolve shape is cheap and
+  correct even though it cannot distinguish the two cases automatically.
+- **Keeping the lore repo's `authored_by` frontmatter as a second provenance system.** The lore
+  repo strips it instead (lore-repo issue #60), so `written_by`/`written_on` on the row itself is
+  the only place credit lives, never a second source that could drift from the DB.
+
+**Trade-offs / accepted cost:**
+- No sync bookkeeping means the freeze cannot distinguish "someone hand-edited this row in the
+  live DB and never exported it" from "the repo's fixture genuinely moved past what's in the DB" -
+  both look identical (a credited row, a differing incoming value) and both route through the same
+  resolution page. Ruled acceptable by Tehom, 2026-08-05, on #3017.
+- The sample-content gate is per-press enforcement, not a standing database-wide invariant: it
+  runs once, inside one `seed_dev_database()` call, between the content load and the cluster loop.
+  A direct cluster-seeder call outside that call - the test-only helpers in
+  `world/seeds/tests/press_helpers.py` - sits outside the gate by design, so this is not a claim
+  that no code path can ever write sample rows alongside real content, only that the one press a
+  live server takes cannot.
+- The read-only conflict scan (`core_management.load_conflicts.scan_load_conflicts`) and the
+  admin's single-entry delete-then-reload resolve each object in isolation - no deferred-retry
+  pass and no grid-bundle load, unlike `load_world_content`'s full sequence. A row whose incoming
+  FK target is itself new in the same corpus update may therefore fail to surface as a conflict,
+  or fail to reload, until a full load has brought that target in first. The divergence is
+  one-directional - it can under-report a conflict, never invent a false one - and the upsert
+  guard inside `_upsert_fixture_object` still protects the row regardless of which path notices it
+  first; documented in `load_conflicts.py`'s own module docstring.
+- `CreditedContent` is inherited uniformly by every content model, so the freeze reaches two rows
+  populated exclusively by generated, content-addressed grid-import automation, never by human
+  authoring: `FlowDefinition` never needed a guard (create-or-fetch-unchanged only), and
+  `TriggerDefinition`'s guard defends a branch that only fires on a sha1 digest collision -
+  defensive width, not a response to an observed incident.
+
+> Status: accepted · Source: #3017, Tehom's ruling 2026-08-05 · Related: ADR-0196 (content credit
+> is a row mixin), ADR-0168/ADR-0171 (CONTENT_MODELS is the seed boundary), ADR-0191 (export
+> addition gate), ADR-0142 (content vs config boundary)

--- a/docs/adr/0201-credited-rows-are-frozen-against-loads.md
+++ b/docs/adr/0201-credited-rows-are-frozen-against-loads.md
@@ -64,6 +64,13 @@ name is dropped and logged, never the row.
   authoring: `FlowDefinition` never needed a guard (create-or-fetch-unchanged only), and
   `TriggerDefinition`'s guard defends a branch that only fires on a sha1 digest collision -
   defensive width, not a response to an observed incident.
+- The admin's generic Import Data surface (`web.admin.services.execute_import`, merge or
+  replace) does not run the credited-row freeze and can overwrite a credited row's fields with no
+  credit check at all. This is a deliberate bypass, not a gap: it is superuser-only disaster
+  recovery tooling with its own dry-run diff preview (`analyze_fixture`) shown before any write,
+  operating at whole-model granularity rather than the per-field content pipeline the freeze
+  protects. An operator restoring from a known-good export is expected to accept the overwrite
+  they are previewing, not be blocked by the same guard that protects an unattended content load.
 
 > Status: accepted · Source: #3017, Tehom's ruling 2026-08-05 · Related: ADR-0196 (content credit
 > is a row mixin), ADR-0168/ADR-0171 (CONTENT_MODELS is the seed boundary), ADR-0191 (export

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -85,6 +85,7 @@ treat those names as hints to confirm, not gospel.
 - [0196 - Content credit is a row mixin; contributors are content](0196-content-credit-is-a-row-mixin-and-contributors-are-content.md) (#2980; related ADR-0010, ADR-0146)
 - [0197 - Traps ride situations, and a GM manages them rather than authoring them](0197-traps-ride-situations-and-are-managed-not-authored.md) (#3002; applies ADR-0110; relates to #1895, #2865)
 - [0200 - Schema-construction paths are held equivalent by a nightly diff, names excluded](0200-schema-paths-are-diff-gated.md) (#2982; related ADR-0083, ADR-0195, ADR-0018)
+- [0201 - Credited rows are frozen against loads; sample content only seeds an empty universe](0201-credited-rows-are-frozen-against-loads.md) (#3017; extends ADR-0196; related ADR-0168, ADR-0171, ADR-0191, ADR-0142)
 
 ### Resolution
 - [0019 — Unified resolution: one roll path, data-sourced difficulty, graded outcomes](0019-unified-resolution-one-roll-path.md)

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -6588,6 +6588,16 @@ Admin-hosted, superuser-only HTMX dashboards for difficulty tuning/simulation an
   models on a first pass. `tools/prose_report.py` (`just prose-report`) walks a
   content-repo checkout with no Django and no database and reports the
   writer/reviewer backlog per domain.
+- **Load conflicts (#3017, ADR-0201):** a credited row (`written_by` set) whose incoming corpus
+  value differs from the DB on any field is frozen rather than overwritten -
+  `content_fixtures._upsert_fixture_object` skips the write and reports a one-line diagnostic in
+  `result.conflicts`; the admin's Load Conflicts pages (`web/admin/content_conflict_views.py`)
+  are the only way back, via a typed-natural-key delete-then-reload, one row at a time, never a
+  bulk resolve. The same freeze reaches `grid_import`'s credited `TriggerDefinition` refresh
+  branch and `world.weather.seed`'s credited `WeatherEmit` upserts. Separately,
+  `world.seeds.sample_content.assert_sampling_allowed()` refuses `SEED_SAMPLE_CONTENT` invention
+  once any `CONTENT_MODELS` table already has a row within the same `seed_dev_database()` press.
+  See `src/core_management/CLAUDE.md`'s "Load conflicts" section and ADR-0201.
 - **Grid content export/import (#2436/#2448):** rooms/areas are no longer deferred —
   `Area`/`RoomProfile` gained permanent identity keys (`slug`/`fixture_key`) and a
   `GridOrigin` export gate (see the Areas section above). `core_management.grid_export.
@@ -6629,7 +6639,9 @@ Admin-hosted, superuser-only HTMX dashboards for difficulty tuning/simulation an
   `content_fixtures.py`. A health report (per-source skip counts, known-drift count, and
   every unexpected skip verbatim) always prints after the load summary, `--strict` or not,
   so a silent-skip regression (the #2501 root cause — 350 rows dropped with no signal) is
-  visible even on a plain `--load`. `--strict` requires `--load`.
+  visible even on a plain `--load`. `--strict` requires `--load`. A credited-row load conflict
+  (#3017, ADR-0201) never affects the `--strict` exit code - it is a distinct outcome from a
+  skip, reported separately.
   `CONTENT_MODELS` (`core_management/content_export.py`) also gained
   `mechanics.application`, `mechanics.prerequisite`, `mechanics.property`, and
   `mechanics.propertycategory` — the loader was already dynamic (any `NaturalKeyMixin`

--- a/docs/systems/weather.md
+++ b/docs/systems/weather.md
@@ -70,6 +70,11 @@ content repo and loads via the **`weather` seed cluster**
 and no-ops — the cron then runs against an empty transition graph, which is a
 content-authoring gap rather than a seeder bug. `tools/load_weather_seed.py`
 remains for out-of-band reloads. A credited `WeatherEmit` (`written_by` set) whose incoming
-corpus text differs is frozen rather than overwritten - `seed.upsert_weather_emits` reports the
-conflict instead of writing it (#3017, ADR-0201); the only way back is the admin's Load
-Conflicts pages.
+corpus content or credit differs is frozen rather than overwritten - `seed.upsert_weather_emits`
+reports the conflict instead of writing it (#3017, ADR-0201). This freeze is reported by the seed
+loader itself (its return value, surfaced via log/CLI), not the admin's Load Conflicts page:
+that page's scan (`core_management.load_conflicts.scan_load_conflicts`) only reads the
+content-repo's exported `fixtures/`/markdown corpus, so a weather-seed conflict shows there only
+when the divergent value also lives in that exported copy. The override is deleting the row and
+re-running the seed (or the delete-then-reload flow on the admin page, when the row does surface
+there).

--- a/docs/systems/weather.md
+++ b/docs/systems/weather.md
@@ -69,4 +69,7 @@ content repo and loads via the **`weather` seed cluster**
 `WEATHER_SEED_PATH` or `<content repo>/weather`. A missing corpus logs a warning
 and no-ops — the cron then runs against an empty transition graph, which is a
 content-authoring gap rather than a seeder bug. `tools/load_weather_seed.py`
-remains for out-of-band reloads.
+remains for out-of-band reloads. A credited `WeatherEmit` (`written_by` set) whose incoming
+corpus text differs is frozen rather than overwritten - `seed.upsert_weather_emits` reports the
+conflict instead of writing it (#3017, ADR-0201); the only way back is the admin's Load
+Conflicts pages.

--- a/src/core_management/CLAUDE.md
+++ b/src/core_management/CLAUDE.md
@@ -140,3 +140,51 @@ prose-report`) report the writer/reviewer backlog by scanning a content-repo
 checkout directly, no Django and no database, the same contract
 `content_health.py` keeps: `uv run python tools/prose_report.py
 [--content-path /path/to/checkout]`.
+
+## Load conflicts (#3017, ADR-0201)
+
+A credited row (`written_by` set) whose incoming corpus value differs from what's on disk is
+never silently overwritten by a load. `_upsert_fixture_object` runs `_credited_conflicts`
+between the case-insensitive lookup and the write: if the row is credited and any incoming
+field (not just prose) differs, the write is skipped, `OUTCOME_CONFLICT` is returned, and a
+one-line diagnostic lands in `result.conflicts`. An uncredited row, or a credited row whose
+incoming values are byte-for-byte identical, upserts exactly as before. The guard applies
+everywhere `CreditedContent` is written, not only the fixture-JSON/markdown pipeline:
+`grid_import._ensure_ambient_group_trigger` freezes a credited `TriggerDefinition` on its
+digest-collision refresh branch (`FlowDefinition` is create-only in that module, so it needs no
+guard) and reports via `GridImportResult.reports`; `world.weather.seed.upsert_weather_emits`
+freezes a credited `WeatherEmit` the same way and returns its own `conflicts` list. Four
+surfaces expose this:
+
+- **The upsert guard itself** - `content_fixtures._upsert_fixture_object` /
+  `grid_import._ensure_ambient_group_trigger` / `weather.seed.upsert_weather_emits` - the single
+  point that actually refuses a write.
+- **The CLI** - `tools/build_content_fixtures.py --load` prints every conflict after the load
+  summary, same as it prints skips.
+- **The admin flash** - `web/admin/content_load_views.py`'s "Load private content repo" run
+  surfaces `world_result.conflicts` as flash messages after a load.
+- **The admin resolve pages** - `web/admin/content_conflict_views.py` (`_content_conflicts/`,
+  `_content_conflict/`, `_content_conflict_resolve/`) lists every current conflict via
+  `core_management.load_conflicts.scan_load_conflicts` (a read-only rerun of the same
+  resolution sequence, never writing), shows one conflict's field-by-field diff, and resolves it
+  with a typed-natural-key-confirmed delete-then-reload in one transaction. No bulk resolve
+  exists - clearing a human's credited edit is a one-row, one-confirmation action every time.
+
+Conflicts never affect `--strict`'s exit code - `--strict` (#2501) gates on unexplained
+`result.skipped` entries against `KNOWN_DRIFT.txt`; a conflict is a distinct outcome
+(`OUTCOME_CONFLICT`, not `OUTCOME_SKIPPED`) and is reported separately.
+
+`scan_load_conflicts` and the admin's single-entry reload resolve each object in isolation - no
+deferred-retry pass, no grid-bundle load, unlike `load_world_content`'s full sequence - so a row
+whose incoming FK target is itself new in the same corpus update may not surface as a conflict
+(or reload cleanly) until a full load brings that target in first. One-directional: it can
+under-report a conflict, never invent one, and the upsert guard is unaffected either way. See
+`load_conflicts.py`'s module docstring and ADR-0201.
+
+Separately, `world.seeds.sample_content.assert_sampling_allowed()` refuses `SEED_SAMPLE_CONTENT`
+invention once any `CONTENT_MODELS` table already has a row within the same
+`seed_dev_database()` press - called between the content load and the cluster loop, so a sample
+row can never mix into a real content universe within one press. This is per-press enforcement,
+not a standing database-wide invariant: the test-only cluster-seeder helpers in
+`world/seeds/tests/press_helpers.py` call a single cluster directly and sit outside this gate by
+design.

--- a/src/core_management/content_fixtures.py
+++ b/src/core_management/content_fixtures.py
@@ -164,6 +164,7 @@ OUTCOME_CREATED = "created"
 OUTCOME_UPDATED = "updated"
 OUTCOME_SKIPPED = "skipped"
 OUTCOME_DEFERRED = "deferred"
+OUTCOME_CONFLICT = "conflict"
 
 
 class ContentError(Exception):
@@ -215,6 +216,10 @@ class BuildResult:
     # missing NaturalKeyMixin, etc.). Collected during build, surfaced to the
     # operator by the CLI / admin button.
     skipped: list[str] = field(default_factory=list)
+    # Credited rows (written_by set) whose incoming values differ - left
+    # untouched by the load, resolved only via the admin delete-then-reload
+    # flow (#3017). Separate from ``skipped``: not a corpus-health failure.
+    conflicts: list[str] = field(default_factory=list)
 
 
 def parse_content_file(path: Path, domain: str) -> ContentEntry:
@@ -1065,30 +1070,85 @@ def _case_insensitive_lookup(model, lookup: dict) -> dict:
     return result
 
 
-def _get_or_create_case_insensitive(model, lookup: dict, fields: dict) -> tuple:
-    """Match an existing row by natural key case-insensitively, or create one.
+def _find_existing_case_insensitive(model, lookup: dict):
+    """Return the existing row matching *lookup* case-insensitively, or None.
 
-    Returns ``(instance, created)``. A hand-rolled get/create instead of
-    ``update_or_create`` (#2687): Django's ``update_or_create`` can't take an
-    ``__iexact`` lookup — it drops ``LOOKUP_SEP`` keys when building the
-    create-path params, so the row would be created with that field unset.
+    A hand-rolled get instead of folding this into ``update_or_create``
+    (#2687): Django's ``update_or_create`` can't take an ``__iexact`` lookup -
+    it drops ``LOOKUP_SEP`` keys when building the create-path params, so the
+    row would be created with that field unset.
 
-    Split out of ``_upsert_fixture_object`` (#2687 review) both to keep the
-    ``try`` scoped to ONLY the lookup — a ``model.DoesNotExist`` raised from
-    inside a custom ``save()`` override on the update path must not be
-    misclassified as "row not found" and silently retried as a create — and to
-    keep ``_upsert_fixture_object``'s own branch count (ruff PLR0912) at parity
-    with the single ``update_or_create`` call it replaces.
+    Kept as its own function, scoped to ONLY the lookup (#2687 review) - a
+    ``model.DoesNotExist`` raised from inside a custom ``save()`` override on
+    the update path must not be misclassified as "row not found" and silently
+    retried as a create.
     """
     try:
-        instance = model.objects.get(**_case_insensitive_lookup(model, lookup))
+        return model.objects.get(**_case_insensitive_lookup(model, lookup))
     except model.DoesNotExist:
-        return model.objects.create(**lookup, **fields), True
+        return None
 
+
+def _apply_or_create(model, existing, lookup: dict, fields: dict) -> tuple:
+    """Apply *fields* to *existing*, or create a new row with the fixture's casing.
+
+    Returns ``(instance, created)``. Split out of the old
+    ``_get_or_create_case_insensitive`` (#3017) so the credited-row conflict
+    check in ``_upsert_fixture_object`` can run between the lookup
+    (``_find_existing_case_insensitive``) and the write - a conflict must
+    never reach this function at all.
+    """
+    if existing is None:
+        return model.objects.create(**lookup, **fields), True
     for field_name, value in fields.items():
-        setattr(instance, field_name, value)
-    instance.save()
-    return instance, False
+        setattr(existing, field_name, value)
+    existing.save()
+    return existing, False
+
+
+def fields_differing(model, instance, resolved_fields: dict) -> list[str]:
+    """Names of fields in *resolved_fields* whose values differ from *instance*.
+
+    Values must already be resolved/coerced (FKs are model instances, scalars
+    are field-native types). FKs compare by pk via ``attname`` so an idmapper
+    instance and a freshly resolved one never false-positive.
+    """
+    differing: list[str] = []
+    for name, value in resolved_fields.items():
+        field_obj = model._meta.get_field(name)  # noqa: SLF001
+        if field_obj.is_relation:
+            current = getattr(instance, field_obj.attname)
+            incoming = value.pk if value is not None else None
+        else:
+            current = getattr(instance, name)
+            incoming = field_obj.to_python(value)
+        if current != incoming:
+            differing.append(name)
+    return differing
+
+
+def _credited_conflicts(model, existing, fields: dict, resolved_m2m: dict) -> list[str]:
+    """Differing field names when *existing* is a credited row, else [].
+
+    Only a row that is both (a) an instance of a ``CreditedContent`` subclass
+    and (b) actually has ``written_by`` set is guarded (#3017) - an
+    uncredited row upserts exactly as before. The any-diff rule applies to
+    every incoming field, not just prose: a mechanical/flag field differing
+    freezes the row the same as a prose field, since the guard exists to
+    protect a human's editorial pass over the whole row, not just its text.
+    """
+    from world.contributors.models import CreditedContent  # noqa: PLC0415
+
+    if existing is None or not issubclass(model, CreditedContent):
+        return []
+    if existing.written_by_id is None:
+        return []
+    differing = fields_differing(model, existing, fields)
+    for name, instances in resolved_m2m.items():
+        current = set(getattr(existing, name).values_list("pk", flat=True))
+        if current != {inst.pk for inst in instances}:
+            differing.append(name)
+    return differing
 
 
 def _coerce_scalar_fields(model, fields: dict) -> None:
@@ -1282,9 +1342,28 @@ def _upsert_fixture_object(  # noqa: C901 — one branch per distinct skip reaso
         _coerce_scalar_fields(model, fields)
         # Case-insensitive upsert (#2687): match an existing row regardless of
         # casing, but write a NEW row with the fixture's own casing. See
-        # _get_or_create_case_insensitive's docstring for why this can't be a
+        # _find_existing_case_insensitive's docstring for why this can't be a
         # plain update_or_create call.
-        instance, created = _get_or_create_case_insensitive(model, lookup, fields)
+        existing = _find_existing_case_insensitive(model, lookup)
+        # Credited-row guard (#3017): a row a human has credited (written_by
+        # set) whose incoming values differ from what's on disk is left
+        # untouched rather than silently overwritten - the only way back is
+        # the admin's typed-confirmation delete-then-reload flow. An
+        # uncredited row, or a credited row whose incoming values are
+        # byte-for-byte identical, upserts exactly as before this guard.
+        conflict_fields = _credited_conflicts(model, existing, fields, resolved_m2m)
+        if conflict_fields:
+            location = source_path if source_path is not None else model._meta.label  # noqa: SLF001
+            key_display = ", ".join(str(v) for v in lookup.values())
+            result.conflicts.append(
+                f"{location}: {model.__name__} [{key_display}] is credited "
+                "(written_by is set) and differs from the incoming entry on: "
+                f"{', '.join(conflict_fields)}. The row was left untouched. To "
+                "take the repo version, resolve it in admin (Load conflicts): "
+                "delete the row with typed confirmation and it reloads from the corpus."
+            )
+            return OUTCOME_CONFLICT
+        instance, created = _apply_or_create(model, existing, lookup, fields)
     except UnresolvedNaturalKeyError as exc:
         # Must be caught before the broader ContentError clause below (it's a
         # subclass) — this is the ONLY failure mode ever deferred.
@@ -1427,6 +1506,8 @@ def load_entries(
                 updated_count += 1
             elif outcome == OUTCOME_DEFERRED:
                 deferred.append((obj, source_path))
+            # OUTCOME_SKIPPED / OUTCOME_CONFLICT: message already appended to
+            # result.skipped / result.conflicts - no counter to bump.
     return created_count, updated_count, deferred
 
 
@@ -1441,6 +1522,10 @@ class WorldLoadResult:
     pass (visibility into how much the content-then-grid ordering mattered
     this run). ``skipped`` is the terminal skip list: an object still
     unresolved after retrying stopped making progress is a genuine gap, not a race.
+    ``conflicts`` is separate from ``skipped``: a credited row (written_by
+    set) whose incoming values differ was left untouched (#3017) - not a
+    corpus-health failure, just a row waiting on the admin delete-then-reload
+    flow to take the repo's version.
     """
 
     created: int
@@ -1448,6 +1533,7 @@ class WorldLoadResult:
     grid: GridImportResult
     skipped: list[str]
     deferred_resolved: int
+    conflicts: list[str]
 
 
 def _retry_deferred(
@@ -1494,7 +1580,11 @@ def _retry_deferred(
                 deferred_resolved += 1
             elif outcome == OUTCOME_DEFERRED:
                 still_pending.append((obj, source_path))
-            # OUTCOME_SKIPPED: message already appended to result.skipped.
+            # OUTCOME_SKIPPED / OUTCOME_CONFLICT: message already appended to
+            # result.skipped / result.conflicts. A conflict is terminal on
+            # first detection (the guard runs only after every FK resolved),
+            # so it is never re-deferred here - it falls through exactly like
+            # OUTCOME_SKIPPED, not appended to still_pending.
         return still_pending
 
     pending = deferred
@@ -1563,6 +1653,7 @@ def load_world_content(content_root: Path) -> WorldLoadResult:
         grid=grid,
         skipped=result.skipped,
         deferred_resolved=deferred_resolved,
+        conflicts=result.conflicts,
     )
 
 

--- a/src/core_management/grid_import.py
+++ b/src/core_management/grid_import.py
@@ -947,7 +947,7 @@ def _ensure_ambient_group_trigger(
     ``TriggerDefinition`` carries ``CreditedContent`` (#3017): a row whose
     ``written_by`` a staff admin has set is never overwritten here even when its
     ``base_filter_condition`` would otherwise be refreshed (the digest-collision
-    branch above) — the row is left untouched and the conflict is appended to
+    branch above) - the row is left untouched and the conflict is appended to
     ``result.reports``, same freeze the fixture loader and the weather seed apply
     to their own credited rows. ``FlowDefinition`` (also ``CreditedContent``) is
     only ever created-or-fetched-unchanged in this function (``get_or_create``

--- a/src/core_management/grid_import.py
+++ b/src/core_management/grid_import.py
@@ -841,6 +841,7 @@ def _import_ambient_lines(
     bundles: list[tuple[Path, dict]],
     area_by_path: dict[Path, Area],
     room_by_fixture_key: dict[str, RoomProfile],
+    result: GridImportResult,
 ) -> None:
     """Pass: per-bundle AmbientEmoteLine/AmbientEmoteCondition rows, then derive + install
     condition-group Triggers (#2471 v2).
@@ -896,7 +897,7 @@ def _import_ambient_lines(
                 created_lines.append(line)
 
             _install_ambient_triggers(
-                area, bundle_room_fixture_keys, room_by_fixture_key, created_lines
+                area, bundle_room_fixture_keys, room_by_fixture_key, created_lines, result
             )
 
 
@@ -927,7 +928,11 @@ def _ensure_ambient_trigger(room_objectdb: object, trigger_def: object) -> None:
 
 
 def _ensure_ambient_group_trigger(
-    scope: str, scope_key: str, compiled_filter: dict | None, line_ids: list[int]
+    scope: str,
+    scope_key: str,
+    compiled_filter: dict | None,
+    line_ids: list[int],
+    result: GridImportResult,
 ) -> object:
     """Idempotently create (or refresh) the derived TriggerDefinition for one condition
     group (#2471 v2). Name is deterministic from (scope, scope_key, filter digest), so
@@ -938,6 +943,15 @@ def _ensure_ambient_group_trigger(
     FlowDefinition/TriggerDefinition row-set is created rather than migrating the old
     one in place; the old (now-orphaned) rows are never deleted or deactivated — same
     report-never-delete deferral as this file's other sidecar types, not a bug.
+
+    ``TriggerDefinition`` carries ``CreditedContent`` (#3017): a row whose
+    ``written_by`` a staff admin has set is never overwritten here even when its
+    ``base_filter_condition`` would otherwise be refreshed (the digest-collision
+    branch above) — the row is left untouched and the conflict is appended to
+    ``result.reports``, same freeze the fixture loader and the weather seed apply
+    to their own credited rows. ``FlowDefinition`` (also ``CreditedContent``) is
+    only ever created-or-fetched-unchanged in this function (``get_or_create``
+    with no field updates on the existing-row path), so it needs no guard.
     """
     import hashlib  # noqa: PLC0415
     import json  # noqa: PLC0415
@@ -977,8 +991,14 @@ def _ensure_ambient_group_trigger(
         },
     )
     if not created and trigger_def.base_filter_condition != compiled_filter:
-        trigger_def.base_filter_condition = compiled_filter
-        trigger_def.save(update_fields=["base_filter_condition"])
+        if trigger_def.written_by_id is not None:
+            result.reports.append(
+                f"TriggerDefinition [{trigger_def.name}] is credited (written_by is set) "
+                "and differs from the grid pipeline's value. Row left untouched (#3017)."
+            )
+        else:
+            trigger_def.base_filter_condition = compiled_filter
+            trigger_def.save(update_fields=["base_filter_condition"])
     return trigger_def
 
 
@@ -1069,6 +1089,7 @@ def _install_group_triggers(
     groups: dict[tuple[str, str, str], list],
     bundle_room_fixture_keys: list[str],
     room_by_fixture_key: dict[str, RoomProfile],
+    result: GridImportResult,
 ) -> None:
     """Derive and install Triggers for each ambient condition group.
 
@@ -1080,6 +1101,8 @@ def _install_group_triggers(
         groups: The grouped lines from ``_group_ambient_lines``.
         bundle_room_fixture_keys: Fixture keys for every room in this bundle.
         room_by_fixture_key: Rooms imported in pass 2, keyed by fixture key.
+        result: Import outcome accumulator; a credited ``TriggerDefinition``
+            conflict (#3017) is appended to ``result.reports``.
     """
     import json  # noqa: PLC0415
 
@@ -1088,7 +1111,7 @@ def _install_group_triggers(
     for (scope, scope_key, compiled_json), group_lines in groups.items():
         compiled = json.loads(compiled_json)
         line_ids = [line.pk for line in group_lines]
-        trigger_def = _ensure_ambient_group_trigger(scope, scope_key, compiled, line_ids)
+        trigger_def = _ensure_ambient_group_trigger(scope, scope_key, compiled, line_ids, result)
         if scope == _AMBIENT_SCOPE_ROOM:
             _ensure_ambient_trigger(room_by_fixture_key[scope_key].objectdb, trigger_def)
         else:
@@ -1106,6 +1129,7 @@ def _install_ambient_triggers(
     bundle_room_fixture_keys: list[str],
     room_by_fixture_key: dict[str, RoomProfile],
     lines: list,
+    result: GridImportResult,
 ) -> None:
     """Group freshly-imported lines by compiled filter, derive/install Triggers (#2471 v2).
 
@@ -1119,7 +1143,7 @@ def _install_ambient_triggers(
         profile.objectdb_id: fixture_key for fixture_key, profile in room_by_fixture_key.items()
     }
     groups = _group_ambient_lines(lines, area, room_fixture_by_id)
-    _install_group_triggers(groups, bundle_room_fixture_keys, room_by_fixture_key)
+    _install_group_triggers(groups, bundle_room_fixture_keys, room_by_fixture_key, result)
 
 
 def _report_missing_clue_and_anchor_sidecars(
@@ -1213,7 +1237,7 @@ def load_grid_bundles(content_root: Path | None = None) -> GridImportResult:
     _import_exits(bundles, room_by_fixture_key, result)
     _report_orphaned_exits(bundles, result)
     _import_sidecars(bundles, area_by_path, room_by_fixture_key)
-    _import_ambient_lines(bundles, area_by_path, room_by_fixture_key)
+    _import_ambient_lines(bundles, area_by_path, room_by_fixture_key, result)
     _report_missing_authored(area_by_slug, room_by_fixture_key, result)
     _import_clue_and_anchor_sidecars(bundles, room_by_fixture_key, result)
     _report_missing_clue_and_anchor_sidecars(bundles, result)

--- a/src/core_management/load_conflicts.py
+++ b/src/core_management/load_conflicts.py
@@ -32,6 +32,7 @@ notices it.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import hashlib
 from pathlib import Path
 
 from core_management.content_fixtures import (
@@ -72,6 +73,31 @@ class LoadConflict:
     model_name: str
     natural_key: str
     fields: list[tuple[str, str, str]]
+
+    @property
+    def digest(self) -> str:
+        """Stable hash of the reviewed diff (#3017 GET/POST staleness fix).
+
+        The admin detail page hands this back to the resolve view as a
+        hidden field alongside the typed natural key. If the corpus or the
+        DB row changes between the detail GET and the resolve POST, a fresh
+        ``find_load_conflict`` call produces a different digest and the
+        resolve view refuses rather than silently applying corpus values the
+        operator never actually reviewed - the row is still a genuine
+        conflict at POST time, so a bare re-fetch-and-compare wouldn't catch
+        this the way it does for a conflict that resolved out from under the
+        request.
+
+        Computed over ``model_label``, ``natural_key``, and every
+        ``(field name, db display, incoming display)`` triple in order -
+        exactly what the detail page rendered, nothing more. Uses ``\\x1f``
+        (unit separator) as the field delimiter so no display value's own
+        content can forge a collision the way a plain ``, ``/``|`` join could.
+        """
+        parts = [self.model_label, self.natural_key]
+        parts.extend(f"{name}\x1f{db}\x1f{incoming}" for name, db, incoming in self.fields)
+        payload = "\x1e".join(parts)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()
 
 
 def _truncate(text: str) -> str:

--- a/src/core_management/load_conflicts.py
+++ b/src/core_management/load_conflicts.py
@@ -1,0 +1,203 @@
+"""Read-only scan that recomputes credited-row load conflicts (#3017).
+
+``content_fixtures._upsert_fixture_object`` freezes a credited row (a row
+whose ``written_by`` is set) when the incoming fixture value differs from
+what's on disk, and records a one-line diagnostic in ``BuildResult.conflicts``
+- but only for whatever a real load run just touched, and only as prose. This
+module reruns the exact same resolution sequence *without ever writing*, so a
+later admin page can list every current conflict on demand (not just the ones
+surfaced by the last load) with structured per-field detail instead of a
+prose blob.
+
+Deliberately imports ``core_management.content_fixtures``'s private helpers
+(``_extract_natural_key``, ``_pop_m2m_fields``, ``_resolve_or_drop_credit_fields``,
+``_resolve_natural_key_fields``, ``_resolve_m2m_fields``, ``_coerce_scalar_fields``,
+``_find_existing_case_insensitive``, ``_credited_conflicts``) - this is
+deliberate, not a layering violation: same package, and the alternative is a
+second hand-maintained copy of the resolution sequence that WILL drift from
+the one the real load path uses. ``content_fixtures`` stays the single source
+of resolution semantics; this module only reads what it produces.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from core_management.content_fixtures import (
+    BuildResult,
+    ContentError,
+    _coerce_scalar_fields,
+    _credited_conflicts,
+    _extract_natural_key,
+    _find_existing_case_insensitive,
+    _pop_m2m_fields,
+    _resolve_m2m_fields,
+    _resolve_natural_key_fields,
+    _resolve_or_drop_credit_fields,
+    build_all,
+    resolve_fixture_model,
+)
+
+#: Display strings longer than this are truncated with a trailing "..." so a
+#: multi-thousand-character prose field doesn't blow up the admin list view.
+DISPLAY_TRUNCATE_LENGTH = 200
+
+
+@dataclass
+class LoadConflict:
+    """One credited row whose incoming corpus value differs from the DB.
+
+    ``model_label`` is the fixture object's own ``"model"`` key (whatever
+    ``content_fixtures._fixture_model_label`` wrote at build time), not a
+    freshly recomputed one - it's the value an admin view would round-trip
+    back through ``resolve_fixture_model``. ``natural_key`` is a display
+    string, ``", ".join(str(v) for v in lookup.values())`` - the same form
+    ``_upsert_fixture_object`` puts in its own conflict message. ``fields`` is
+    one ``(field name, db display, incoming display)`` triple per differing
+    field, both sides truncated to ``DISPLAY_TRUNCATE_LENGTH`` characters.
+    """
+
+    model_label: str
+    model_name: str
+    natural_key: str
+    fields: list[tuple[str, str, str]]
+
+
+def _truncate(text: str) -> str:
+    if len(text) > DISPLAY_TRUNCATE_LENGTH:
+        return text[:DISPLAY_TRUNCATE_LENGTH] + "..."
+    return text
+
+
+def _field_display(
+    model, existing, name: str, fields: dict, resolved_m2m: dict[str, list]
+) -> tuple[str, str]:
+    """Return ``(db display, incoming display)`` strings for one differing field.
+
+    A many-to-many field's current value comes from the live relation
+    (``getattr(existing, name).all()``) since it was popped out of ``fields``
+    before this module ever saw it; the incoming side is the already-resolved
+    instance list in ``resolved_m2m``. A to-one relation shows ``str()`` of
+    each side's related instance - the current one fetched fresh via
+    ``getattr(existing, name)`` (never written to), the incoming one already
+    resolved to an instance in ``fields``. A plain scalar shows ``str()`` of
+    each side's already-coerced value.
+    """
+    field_obj = model._meta.get_field(name)  # noqa: SLF001
+    if field_obj.many_to_many:
+        current = ", ".join(str(v) for v in getattr(existing, name).all())
+        incoming = ", ".join(str(v) for v in resolved_m2m.get(name, []))
+        return _truncate(current), _truncate(incoming)
+    if field_obj.is_relation:
+        current_value = getattr(existing, name)
+        incoming_value = fields.get(name)
+        current = str(current_value) if current_value is not None else "None"
+        incoming = str(incoming_value) if incoming_value is not None else "None"
+        return _truncate(current), _truncate(incoming)
+    current = str(getattr(existing, name))
+    incoming = str(fields.get(name))
+    return _truncate(current), _truncate(incoming)
+
+
+def _scan_object(obj: dict, source_path: Path | None) -> LoadConflict | None:
+    """Mirror ``_upsert_fixture_object``'s resolution sequence; never writes.
+
+    Returns ``None`` on any skip condition the real load path would also
+    skip on (stale model, bad natural key, unresolved FK, schema drift, a
+    constraint the DB would reject) - the load path already reports those as
+    skips elsewhere; this scan only cares about actual credited-row conflicts.
+    """
+    from django.core.exceptions import FieldError, ValidationError  # noqa: PLC0415
+    from django.db import IntegrityError  # noqa: PLC0415
+
+    try:
+        model = resolve_fixture_model(obj["model"])
+    except LookupError:
+        return None
+
+    fields = dict(obj["fields"])
+    fields.pop("pk", None)
+    try:
+        lookup = _extract_natural_key(model, fields, source_path)
+    except ContentError:
+        return None
+
+    m2m_fields = _pop_m2m_fields(model, fields)
+
+    # Same as _upsert_fixture_object: credit fields resolve separately and
+    # never fail the row. The result is a throwaway - this scan doesn't
+    # surface per-credit-field resolution diagnostics, only conflicts.
+    _resolve_or_drop_credit_fields(model, fields, source_path, BuildResult())
+
+    try:
+        _resolve_natural_key_fields(model, lookup, source_path)
+        _resolve_natural_key_fields(model, fields, source_path)
+        resolved_m2m = _resolve_m2m_fields(model, m2m_fields, source_path)
+        _coerce_scalar_fields(model, fields)
+        # Case-insensitive lookup only - never a write, never .save(), never
+        # _apply_or_create. The DB side of every display below is read from
+        # `existing` before (and without) any mutation.
+        existing = _find_existing_case_insensitive(model, lookup)
+        conflict_fields = _credited_conflicts(model, existing, fields, resolved_m2m)
+    except (
+        ContentError,
+        ValueError,
+        TypeError,
+        FieldError,
+        ValidationError,
+        IntegrityError,
+        model.DoesNotExist,
+    ):
+        return None
+
+    if not conflict_fields:
+        return None
+
+    triples = [
+        (name, *_field_display(model, existing, name, fields, resolved_m2m))
+        for name in conflict_fields
+    ]
+    natural_key = ", ".join(str(v) for v in lookup.values())
+    return LoadConflict(
+        model_label=obj["model"],
+        model_name=model.__name__,
+        natural_key=natural_key,
+        fields=triples,
+    )
+
+
+def scan_load_conflicts(content_root: Path) -> list[LoadConflict]:
+    """Recompute every current credited-row load conflict under ``content_root``.
+
+    Runs ``build_all`` (parses/validates every domain, exactly as a real load
+    would) then, per object, the same resolve-and-check sequence
+    ``_upsert_fixture_object`` runs before it would write - but stops short of
+    ``_apply_or_create``/``.save()``/``.set()`` every time, so this function
+    never mutates the database. Safe to call on every admin page load.
+    """
+    conflicts: list[LoadConflict] = []
+    result = build_all(content_root)
+    for output_path, objects in result.fixtures.items():
+        paths = result.source_paths.get(output_path, [])
+        for obj, source_path in zip(objects, paths, strict=False):
+            conflict = _scan_object(obj, source_path)
+            if conflict is not None:
+                conflicts.append(conflict)
+    return conflicts
+
+
+def find_load_conflict(
+    content_root: Path, model_label: str, natural_key: str
+) -> LoadConflict | None:
+    """Return the one conflict matching ``(model_label, natural_key)``, if any.
+
+    A thin filter over ``scan_load_conflicts`` - the admin resolve view looks
+    up one specific conflict (the one a staff member is about to act on) by
+    the same two fields the list view displays, so this is the round-trip
+    lookup for that click.
+    """
+    for conflict in scan_load_conflicts(content_root):
+        if conflict.model_label == model_label and conflict.natural_key == natural_key:
+            return conflict
+    return None

--- a/src/core_management/load_conflicts.py
+++ b/src/core_management/load_conflicts.py
@@ -17,6 +17,16 @@ deliberate, not a layering violation: same package, and the alternative is a
 second hand-maintained copy of the resolution sequence that WILL drift from
 the one the real load path uses. ``content_fixtures`` stays the single source
 of resolution semantics; this module only reads what it produces.
+
+Caveat (Task 3 review): this scan, and any single-entry reload built on it,
+resolves each object in isolation - there is no deferred-retry pass and no
+grid-bundle load, unlike ``load_world_content``'s full sequence. So a row
+whose incoming FK target is itself new in the same corpus update may not
+show up as a conflict (or reload cleanly) until after a full load brings
+that target in. The divergence is one-directional: it can under-report a
+conflict, never invent one, and the upsert guard in
+``_upsert_fixture_object`` still protects the row regardless of which path
+notices it.
 """
 
 from __future__ import annotations

--- a/src/core_management/tests/test_grid_import.py
+++ b/src/core_management/tests/test_grid_import.py
@@ -285,3 +285,100 @@ class GridImportTests(TestCase):
             any("orphan" in line for line in result.reports),
             f"expected an orphan report, got: {result.reports}",
         )
+
+
+class AmbientTriggerCreditGuardTests(TestCase):
+    """``TriggerDefinition`` carries ``CreditedContent`` (#3017): the digest-collision
+    refresh branch in ``_ensure_ambient_group_trigger`` must never overwrite a row a
+    human has credited. A genuine sha1 digest collision cannot be forced from a
+    round-trip test, so these call the private helper directly against a row
+    pre-seeded under the exact name the helper would compute - the same
+    "existing row found, content differs" shape a real collision produces,
+    without depending on breaking sha1.
+    """
+
+    @staticmethod
+    def _trigger_name(compiled_filter: dict) -> str:
+        import hashlib
+        import json
+
+        digest = hashlib.sha1(  # noqa: S324 (content-addressing, not security)
+            json.dumps(compiled_filter, sort_keys=True).encode()
+        ).hexdigest()[:12]
+        return f"moved_ambient_room_taproom_{digest}"
+
+    def test_credited_trigger_definition_survives_a_differing_refresh(self) -> None:
+        from core_management.grid_import import GridImportResult, _ensure_ambient_group_trigger
+        from flows.constants import EventName
+        from flows.models import FlowDefinition
+        from flows.models.triggers import TriggerDefinition
+        from world.contributors.factories import ContentContributorFactory
+
+        compiled_filter = {"target": 5}
+        name = self._trigger_name(compiled_filter)
+        flow = FlowDefinition.objects.create(name=name)
+        credited = TriggerDefinition.objects.create(
+            name=name,
+            event_name=EventName.MOVED,
+            flow_definition=flow,
+            base_filter_condition={"target": 999},
+            written_by=ContentContributorFactory(),
+        )
+
+        result = GridImportResult()
+        returned = _ensure_ambient_group_trigger("room", "taproom", compiled_filter, [1, 2], result)
+
+        credited.refresh_from_db()
+        self.assertEqual(credited.base_filter_condition, {"target": 999})
+        self.assertEqual(returned.pk, credited.pk)
+        self.assertEqual(len(result.reports), 1)
+        self.assertIn(f"TriggerDefinition [{name}]", result.reports[0])
+        self.assertIn("#3017", result.reports[0])
+
+    def test_uncredited_trigger_definition_still_refreshes(self) -> None:
+        from core_management.grid_import import GridImportResult, _ensure_ambient_group_trigger
+        from flows.constants import EventName
+        from flows.models import FlowDefinition
+        from flows.models.triggers import TriggerDefinition
+
+        compiled_filter = {"target": 5}
+        name = self._trigger_name(compiled_filter)
+        flow = FlowDefinition.objects.create(name=name)
+        uncredited = TriggerDefinition.objects.create(
+            name=name,
+            event_name=EventName.MOVED,
+            flow_definition=flow,
+            base_filter_condition={"target": 999},
+        )
+
+        result = GridImportResult()
+        _ensure_ambient_group_trigger("room", "taproom", compiled_filter, [1, 2], result)
+
+        uncredited.refresh_from_db()
+        self.assertEqual(uncredited.base_filter_condition, compiled_filter)
+        self.assertEqual(result.reports, [])
+
+    def test_identical_credited_value_is_a_quiet_noop(self) -> None:
+        from core_management.grid_import import GridImportResult, _ensure_ambient_group_trigger
+        from flows.constants import EventName
+        from flows.models import FlowDefinition
+        from flows.models.triggers import TriggerDefinition
+        from world.contributors.factories import ContentContributorFactory
+
+        compiled_filter = {"target": 5}
+        name = self._trigger_name(compiled_filter)
+        flow = FlowDefinition.objects.create(name=name)
+        credited = TriggerDefinition.objects.create(
+            name=name,
+            event_name=EventName.MOVED,
+            flow_definition=flow,
+            base_filter_condition=compiled_filter,
+            written_by=ContentContributorFactory(),
+        )
+
+        result = GridImportResult()
+        _ensure_ambient_group_trigger("room", "taproom", compiled_filter, [1, 2], result)
+
+        credited.refresh_from_db()
+        self.assertEqual(credited.base_filter_condition, compiled_filter)
+        self.assertEqual(result.reports, [])

--- a/src/core_management/tests/test_load_conflict_guard.py
+++ b/src/core_management/tests/test_load_conflict_guard.py
@@ -1,0 +1,203 @@
+"""Content loads never overwrite credited rows (#3017).
+
+A row a human has credited (``written_by`` set) whose incoming values differ
+from what's already on disk must be left untouched by the load, not silently
+overwritten - the credit is a signal that a person has already made an
+editorial pass, and a regenerated corpus value should never clobber it. This
+covers the guard end-to-end: ``build_all`` -> ``load_entries`` -> a real
+``CreditedContent`` row, same seam ``CreditEndToEndLoadTests`` in
+``test_content_fixtures.py`` exercises for the credit-write path itself.
+"""
+
+from pathlib import Path
+import tempfile
+
+from django.test import TestCase
+
+from core_management.content_fixtures import build_all, load_entries
+from world.contributors.factories import ContentContributorFactory
+from world.items.models import ItemTemplate
+from world.traits.models import Trait
+
+
+def _write(root: Path, rel: str, text: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+class LoadConflictGuardTests(TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def test_credited_row_with_differing_prose_field_is_left_untouched(self) -> None:
+        ContentContributorFactory(name="Tehom")
+        _write(
+            self.root,
+            "skills/performance.md",
+            '---\nname: Performance\ncategory: social\nwritten_by: "Tehom"\n---\nHuman words.\n',
+        )
+        created, updated, _ = load_entries(build_all(self.root))
+        assert (created, updated) == (1, 0)
+        trait = Trait.objects.get(name="Performance")
+        assert trait.written_by is not None
+        assert trait.description == "Human words."
+
+        _write(
+            self.root,
+            "skills/performance.md",
+            "---\n"
+            "name: Performance\n"
+            "category: social\n"
+            'written_by: "Tehom"\n'
+            "---\n"
+            "Regenerated words.\n",
+        )
+        result = build_all(self.root)
+        created, updated, _ = load_entries(result)
+
+        # The conflict is terminal on first detection - no counter bumps.
+        assert (created, updated) == (0, 0)
+        assert len(result.conflicts) == 1
+        assert "description" in result.conflicts[0]
+
+        trait.refresh_from_db()
+        assert trait.description == "Human words."
+
+    def test_credited_row_with_differing_mechanical_field_is_left_untouched(self) -> None:
+        ContentContributorFactory(name="Tehom")
+        _write(
+            self.root,
+            "items/iron_longsword.md",
+            "---\n"
+            "name: Iron Longsword\n"
+            "value: 40\n"
+            'written_by: "Tehom"\n'
+            "---\n"
+            "A well-balanced blade, plain but serviceable.\n",
+        )
+        created, updated, _ = load_entries(build_all(self.root))
+        assert (created, updated) == (1, 0)
+        item = ItemTemplate.objects.get(name="Iron Longsword")
+        assert item.written_by is not None
+        assert item.value == 40
+
+        _write(
+            self.root,
+            "items/iron_longsword.md",
+            "---\n"
+            "name: Iron Longsword\n"
+            "value: 999\n"
+            'written_by: "Tehom"\n'
+            "---\n"
+            "A well-balanced blade, plain but serviceable.\n",
+        )
+        result = build_all(self.root)
+        created, updated, _ = load_entries(result)
+
+        assert (created, updated) == (0, 0)
+        assert len(result.conflicts) == 1
+        assert "value" in result.conflicts[0]
+
+        item.refresh_from_db()
+        assert item.value == 40
+
+    def test_credited_row_with_identical_values_is_a_quiet_noop(self) -> None:
+        ContentContributorFactory(name="Tehom")
+        entry = '---\nname: Performance\ncategory: social\nwritten_by: "Tehom"\n---\nHuman words.\n'
+        _write(self.root, "skills/performance.md", entry)
+        created, updated, _ = load_entries(build_all(self.root))
+        assert (created, updated) == (1, 0)
+
+        # Same file, reloaded - incoming values are byte-for-byte identical.
+        result = build_all(self.root)
+        created, updated, _ = load_entries(result)
+
+        assert (created, updated) == (0, 1)
+        assert result.conflicts == []
+        trait = Trait.objects.get(name="Performance")
+        assert trait.description == "Human words."
+
+    def test_uncredited_row_still_upserts(self) -> None:
+        _write(
+            self.root,
+            "skills/performance.md",
+            "---\nname: Performance\ncategory: social\n---\nHuman words.\n",
+        )
+        created, updated, _ = load_entries(build_all(self.root))
+        assert (created, updated) == (1, 0)
+        trait = Trait.objects.get(name="Performance")
+        assert trait.written_by is None
+
+        _write(
+            self.root,
+            "skills/performance.md",
+            "---\nname: Performance\ncategory: social\n---\nRegenerated words.\n",
+        )
+        result = build_all(self.root)
+        created, updated, _ = load_entries(result)
+
+        assert (created, updated) == (0, 1)
+        assert result.conflicts == []
+        trait.refresh_from_db()
+        assert trait.description == "Regenerated words."
+
+    def test_differing_credit_fields_alone_freeze_the_row(self) -> None:
+        ContentContributorFactory(name="Alice")
+        ContentContributorFactory(name="Bob")
+        _write(
+            self.root,
+            "skills/performance.md",
+            '---\nname: Performance\ncategory: social\nwritten_by: "Alice"\n---\nHuman words.\n',
+        )
+        created, updated, _ = load_entries(build_all(self.root))
+        assert (created, updated) == (1, 0)
+        trait = Trait.objects.get(name="Performance")
+        assert trait.written_by.name == "Alice"
+
+        # Same description - only the credited author differs.
+        _write(
+            self.root,
+            "skills/performance.md",
+            '---\nname: Performance\ncategory: social\nwritten_by: "Bob"\n---\nHuman words.\n',
+        )
+        result = build_all(self.root)
+        created, updated, _ = load_entries(result)
+
+        assert (created, updated) == (0, 0)
+        assert len(result.conflicts) == 1
+        assert "written_by" in result.conflicts[0]
+
+        trait.refresh_from_db()
+        assert trait.written_by.name == "Alice"
+
+    def test_conflict_message_names_model_key_and_fields(self) -> None:
+        ContentContributorFactory(name="Tehom")
+        _write(
+            self.root,
+            "skills/performance.md",
+            '---\nname: Performance\ncategory: social\nwritten_by: "Tehom"\n---\nHuman words.\n',
+        )
+        load_entries(build_all(self.root))
+
+        _write(
+            self.root,
+            "skills/performance.md",
+            "---\n"
+            "name: Performance\n"
+            "category: social\n"
+            'written_by: "Tehom"\n'
+            "---\n"
+            "Regenerated words.\n",
+        )
+        result = build_all(self.root)
+        load_entries(result)
+
+        assert len(result.conflicts) == 1
+        message = result.conflicts[0]
+        assert "Trait" in message
+        assert "Performance" in message
+        assert "description" in message

--- a/src/core_management/tests/test_load_conflicts_scan.py
+++ b/src/core_management/tests/test_load_conflicts_scan.py
@@ -1,0 +1,130 @@
+"""Tests for the read-only credited-row conflict scan (#3017).
+
+``scan_load_conflicts``/``find_load_conflict`` recompute the same
+credited-row conflicts ``_upsert_fixture_object`` would detect on a real
+load, but by reading only - the admin conflict-list page (a later task)
+calls this on every page load, so it must never write to the database.
+"""
+
+from pathlib import Path
+import tempfile
+
+from django.test import TestCase
+
+from core_management.content_fixtures import build_all, load_entries, resolve_fixture_model
+from core_management.load_conflicts import find_load_conflict, scan_load_conflicts
+from world.contributors.factories import ContentContributorFactory
+from world.traits.models import Trait
+
+
+def _write(root: Path, rel: str, text: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+class LoadConflictsScanTests(TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def _seed_credited_row(self) -> None:
+        ContentContributorFactory(name="Tehom")
+        _write(
+            self.root,
+            "skills/performance.md",
+            '---\nname: Performance\ncategory: social\nwritten_by: "Tehom"\n---\nHuman words.\n',
+        )
+        created, updated, _ = load_entries(build_all(self.root))
+        assert (created, updated) == (1, 0)
+
+    def test_scan_finds_a_differing_credited_row(self) -> None:
+        self._seed_credited_row()
+        _write(
+            self.root,
+            "skills/performance.md",
+            "---\n"
+            "name: Performance\n"
+            "category: social\n"
+            'written_by: "Tehom"\n'
+            "---\n"
+            "Regenerated words.\n",
+        )
+
+        conflicts = scan_load_conflicts(self.root)
+
+        assert len(conflicts) == 1
+        conflict = conflicts[0]
+        assert conflict.model_name == "Trait"
+        assert conflict.natural_key == "Performance"
+        assert resolve_fixture_model(conflict.model_label) is Trait
+        assert ("description", "Human words.", "Regenerated words.") in conflict.fields
+
+    def test_scan_mutates_nothing(self) -> None:
+        self._seed_credited_row()
+        _write(
+            self.root,
+            "skills/performance.md",
+            "---\n"
+            "name: Performance\n"
+            "category: social\n"
+            'written_by: "Tehom"\n'
+            "---\n"
+            "Regenerated words.\n",
+        )
+
+        scan_load_conflicts(self.root)
+
+        trait = Trait.objects.get(name="Performance")
+        assert trait.description == "Human words."
+
+    def test_find_load_conflict_round_trips(self) -> None:
+        self._seed_credited_row()
+        _write(
+            self.root,
+            "skills/performance.md",
+            "---\n"
+            "name: Performance\n"
+            "category: social\n"
+            'written_by: "Tehom"\n'
+            "---\n"
+            "Regenerated words.\n",
+        )
+        [conflict] = scan_load_conflicts(self.root)
+
+        found = find_load_conflict(self.root, conflict.model_label, conflict.natural_key)
+
+        assert found is not None
+        assert found.model_label == conflict.model_label
+        assert found.natural_key == conflict.natural_key
+        assert found.fields == conflict.fields
+
+    def test_find_load_conflict_returns_none_for_unknown_key(self) -> None:
+        self._seed_credited_row()
+
+        assert find_load_conflict(self.root, "arxii.trait", "Nonexistent") is None
+
+    def test_scan_skips_uncredited_rows(self) -> None:
+        _write(
+            self.root,
+            "skills/performance.md",
+            "---\nname: Performance\ncategory: social\n---\nHuman words.\n",
+        )
+        created, updated, _ = load_entries(build_all(self.root))
+        assert (created, updated) == (1, 0)
+
+        _write(
+            self.root,
+            "skills/performance.md",
+            "---\nname: Performance\ncategory: social\n---\nRegenerated words.\n",
+        )
+
+        assert scan_load_conflicts(self.root) == []
+
+    def test_scan_skips_identical_credited_rows(self) -> None:
+        self._seed_credited_row()
+        # File on disk is unchanged - incoming values are byte-for-byte identical.
+
+        assert scan_load_conflicts(self.root) == []

--- a/src/integration_tests/pipeline/test_tutorial_chain_e2e.py
+++ b/src/integration_tests/pipeline/test_tutorial_chain_e2e.py
@@ -72,7 +72,7 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 from evennia.utils.idmapper import models as idmapper_models
 
 from actions.definitions.npc_services import resolve_npc_offer, start_npc_interaction
@@ -107,9 +107,9 @@ from world.npc_services.constants import SummonsStatus
 from world.npc_services.models import NPCServiceOffer, OfferSummons
 from world.npc_services.summons import respond_to_summons
 from world.seeds.character_creation import ensure_canonical_fallback_room
-from world.seeds.database import seed_dev_database
 from world.seeds.game_content.tutorial import seed_tutorial_dev
 from world.seeds.tests.content_stub import stub_content_root
+from world.seeds.tests.press_helpers import seed_dev_database_with_sample_topup
 from world.traits.factories import TraitFactory
 
 
@@ -132,9 +132,14 @@ def _said(caller: object) -> str:
     return "\n".join(chunks)
 
 
-@override_settings(SEED_SAMPLE_CONTENT=True)  # missions.* tutorial-chain content gates on #2698
 class TutorialChainJourneyE2ETests(TestCase):
-    """Walk the seeded T1-T7 tutorial chain end to end over the telnet seam."""
+    """Walk the seeded T1-T7 tutorial chain end to end over the telnet seam.
+
+    missions.* tutorial-chain content gates on #2698 (SEED_SAMPLE_CONTENT).
+    seed_dev_database() itself now refuses sampling once the stub content
+    root's own load makes the universe non-empty (#3017), so this presses via
+    seed_dev_database_with_sample_topup() instead of an ambient override.
+    """
 
     @stub_content_root()
     def setUp(self) -> None:
@@ -145,7 +150,7 @@ class TutorialChainJourneyE2ETests(TestCase):
         # exactly as a real deploy seeds them (cluster ordering in
         # world.seeds.clusters). Mirrors test_tutorial_seed.py's setup.
         # seed_tutorial_dev() re-run is idempotent and returns the templates.
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
         result = seed_tutorial_dev()
         (
             self.t1,

--- a/src/integration_tests/pipeline/test_tutorial_chain_e2e.py
+++ b/src/integration_tests/pipeline/test_tutorial_chain_e2e.py
@@ -72,7 +72,7 @@ from __future__ import annotations
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
-from django.test import TestCase
+from django.test import TestCase, tag
 from evennia.utils.idmapper import models as idmapper_models
 
 from actions.definitions.npc_services import resolve_npc_offer, start_npc_interaction
@@ -228,7 +228,11 @@ class TutorialChainJourneyE2ETests(TestCase):
             .first()
         )
 
+    @tag("postgres")
     def test_full_tutorial_chain_journey_over_telnet(self) -> None:  # noqa: PLR0915 - one journey
+        """PG-only: the T4/T5 Academy Registrar offer materializes an NPC via
+        name_culture_for_room(), which walks the areas_areaclosure materialized
+        view (PG-only) - mirrors test_gossip_telnet_e2e.py's tag rationale."""
         persona = self.sheet.primary_persona
 
         # --- T1: Arrival (ROOM_TRIGGER) -----------------------------------

--- a/src/web/admin/CLAUDE.md
+++ b/src/web/admin/CLAUDE.md
@@ -42,6 +42,36 @@ copy says so.
   hint to set `CONTENT_REPO_PATH` in `src/.env` (the Import Data upload
   remains the path for ad-hoc fixture files either way).
 
+### Load Conflict Resolution (#3017)
+
+**Purpose:** the admin-side counterpart to the credited-row load guard in
+`core_management.content_fixtures._upsert_fixture_object` — a credited row
+(`written_by` set) whose incoming corpus value differs from the DB is left
+untouched by a load rather than silently overwritten. This surface lists
+every current such conflict and resolves one at a time by deleting the row
+and reloading it from the corpus, gated on typing the row's own natural key
+back exactly. Deliberately no bulk resolve: clearing a human's credited edit
+is a one-row, one-typed-confirmation action every time.
+
+- `content_conflict_views.py` — `content_conflicts` (GET, list every current
+  conflict via `core_management.load_conflicts.scan_load_conflicts`),
+  `content_conflict_detail` (GET, one conflict's field-by-field diff plus the
+  typed-confirmation form; querystring `model` + `key`), and
+  `content_conflict_resolve` (POST, superuser-only; refuses a wrong typed key
+  with the row untouched, otherwise deletes the row and reloads exactly that
+  one entry from the corpus inside one transaction — a `ProtectedError` or a
+  failed reload rolls the whole thing back and flashes an error). All three
+  resolve the content-repo path via the same `resolve_content_root()` as the
+  load view.
+- `templates/admin/content_conflicts.html`, `content_conflict_detail.html` —
+  mirror `content_load_confirm.html`'s structure: plain tables, no JS.
+- URLs: `_content_conflicts/` → `admin_content_conflicts` (GET list);
+  `_content_conflict/` → `admin_content_conflict_detail` (GET detail,
+  `?model=&key=`); `_content_conflict_resolve/` →
+  `admin_content_conflict_resolve` (POST resolve).
+- The Game Setup hub's "Load private content repo" step links here beside
+  the load/export/push links.
+
 ### Content-Repo Export & Push (PR #2425; grid bundles added #2436/#2448)
 
 **Purpose:** the maintainers'-only inverse of the content-repo load above —
@@ -182,6 +212,11 @@ Defined in `services.py` as `HARDCODED_EXCLUDED_APPS` (canonical location, impor
 - `_seed_run/` - POST: runs `seed_dev_database()` then redirects to the Game Setup hub (superuser)
 - `_content_load/` - "Load private content repo" confirm page (superuser; #1220)
 - `_content_load_run/` - POST: builds + upserts the external content repo, then redirects to the Game Setup hub (superuser)
+- `_content_conflicts/` - "Load conflicts" list page (superuser; #3017)
+- `_content_conflict/` - one conflict's field-by-field diff + typed-confirmation
+  form (superuser; `?model=&key=`)
+- `_content_conflict_resolve/` - POST: typed-confirmation delete-then-reload
+  for one conflict (superuser)
 - `_content_export/` - "Export to content repo" preview page (superuser; PR #2425), model inventory + grid area/room counts
 - `_content_export_run/` - POST: writes flat fixtures + grid bundles to the content repo (superuser)
 - `_content_push/` - "Push content to lore repo" preview page (superuser; PR #2425), git status/diff-stat

--- a/src/web/admin/CLAUDE.md
+++ b/src/web/admin/CLAUDE.md
@@ -71,6 +71,11 @@ is a one-row, one-typed-confirmation action every time.
   `admin_content_conflict_resolve` (POST resolve).
 - The Game Setup hub's "Load private content repo" step links here beside
   the load/export/push links.
+- This guard does not reach the generic Import Data surface below (`services.execute_import`):
+  its merge/replace pipeline can overwrite a credited row's fields with no credit check at all.
+  That is deliberate, not a gap - Import Data is superuser-only disaster-recovery tooling with
+  its own dry-run diff preview, not the content pipeline this freeze protects. See ADR-0201's
+  trade-offs section and the "Export/Import System" section below.
 
 ### Content-Repo Export & Push (PR #2425; grid bundles added #2436/#2448)
 

--- a/src/web/admin/content_conflict_views.py
+++ b/src/web/admin/content_conflict_views.py
@@ -1,0 +1,267 @@
+"""Superuser-only admin surface for credited-row load conflicts (#3017).
+
+Mirrors the ``content_load_views`` pattern: ``@staff_member_required`` plus an
+explicit ``is_superuser`` check, ``resolve_content_root()`` for the private
+content-repo path, and the same error-message-plus-redirect idiom on every
+bail-out. Where this differs is the shape of the fix: a load conflict is a
+credited row (``written_by`` set) whose incoming corpus value differs from
+what's on disk - ``content_fixtures._upsert_fixture_object`` freezes the row
+rather than overwriting it. The only way back to the repo version is here:
+list every current conflict (``core_management.load_conflicts
+.scan_load_conflicts``), inspect one row's field-by-field diff, and - only
+after typing the row's own natural key back, character for character - delete
+the row and reload it from the corpus in one transaction. There is
+deliberately no bulk-resolve anywhere: a credited row is a human's editorial
+pass, and clearing it is a one-row, one-confirmation action every time.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlencode
+
+from django.contrib import messages
+from django.contrib.admin.views.decorators import staff_member_required
+from django.core.exceptions import PermissionDenied
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.shortcuts import render
+from django.urls import reverse
+from django.views.decorators.http import require_GET, require_POST
+
+
+def _detail_url(model_label: str, key: str) -> str:
+    """Build the conflict-detail URL for one ``(model_label, key)`` pair."""
+    query = urlencode({"model": model_label, "key": key})
+    return f"{reverse('admin_content_conflict_detail')}?{query}"
+
+
+def _instance_for_conflict(model, content_root, conflict):
+    """Fetch the live DB row a conflict refers to, by natural key.
+
+    Re-runs just enough of the scan plumbing to recompute the lookup dict
+    (never the display string, which is lossy for a multi-field natural key):
+    locates the matching corpus object, re-extracts its natural key the same
+    way ``load_conflicts._scan_object`` does, then reuses
+    ``_find_existing_case_insensitive`` - the exact lookup the real load path
+    uses - to fetch the row. Raises ``ContentError`` if the corpus entry or
+    the DB row is gone (a second admin tab resolved it first, or the corpus
+    changed underneath this request).
+    """
+    from core_management.content_fixtures import (  # noqa: PLC0415
+        ContentError,
+        _extract_natural_key,
+        _find_existing_case_insensitive,
+    )
+
+    entry = _locate_corpus_entry(content_root, conflict.model_label, conflict.natural_key)
+    if entry is None:
+        gone_from_corpus_msg = (
+            f"{conflict.model_name} [{conflict.natural_key}] is no longer in the corpus. "
+            "Nothing was changed."
+        )
+        raise ContentError(gone_from_corpus_msg)
+    obj, source_path = entry
+    fields = dict(obj["fields"])
+    fields.pop("pk", None)
+    lookup = _extract_natural_key(model, fields, source_path)
+    instance = _find_existing_case_insensitive(model, lookup)
+    if instance is None:
+        gone_from_db_msg = (
+            f"{conflict.model_name} [{conflict.natural_key}] no longer exists in the "
+            "database. Nothing was changed."
+        )
+        raise ContentError(gone_from_db_msg)
+    return instance
+
+
+def _reload_single_entry(model_label: str, natural_key: str, content_root) -> str:
+    """Re-run ``build_all`` and upsert exactly the one entry this conflict names.
+
+    Returns the outcome string ``_upsert_fixture_object`` returns
+    (``"created"``, ``"updated"``, ``"skipped"``, ``"deferred"``, or
+    ``"conflict"``) - the caller (``content_conflict_resolve``) treats
+    anything other than ``"created"`` as a failed reload and rolls the whole
+    transaction back, since the row was just deleted specifically to make
+    room for a fresh corpus-sourced create.
+    """
+    from core_management.content_fixtures import (  # noqa: PLC0415
+        BuildResult,
+        ContentError,
+        _upsert_fixture_object,
+        resolve_fixture_model,
+    )
+
+    model = resolve_fixture_model(model_label)
+    entry = _locate_corpus_entry(content_root, model_label, natural_key)
+    if entry is None:
+        gone_from_corpus_msg = (
+            f"{model_label} [{natural_key}] is no longer in the corpus - reload cannot recreate it."
+        )
+        raise ContentError(gone_from_corpus_msg)
+    obj, source_path = entry
+    return _upsert_fixture_object(model, obj, source_path, BuildResult())
+
+
+def _locate_corpus_entry(content_root, model_label: str, natural_key: str):
+    """Find the corpus fixture object matching ``(model_label, natural_key)``.
+
+    Returns ``(obj, source_path)`` or ``None``. Computes each candidate's
+    natural-key display string on a throwaway copy of its fields (mirroring
+    ``load_conflicts._scan_object``, never mutating the real ``obj``) so the
+    match is against exactly the same string ``scan_load_conflicts`` would
+    have shown for this row.
+    """
+    from core_management.content_fixtures import (  # noqa: PLC0415
+        ContentError,
+        _extract_natural_key,
+        build_all,
+        resolve_fixture_model,
+    )
+
+    model = resolve_fixture_model(model_label)
+    result = build_all(content_root)
+    for output_path, objects in result.fixtures.items():
+        paths = result.source_paths.get(output_path, [])
+        for obj, source_path in zip(objects, paths, strict=False):
+            if obj.get("model") != model_label:
+                continue
+            fields = dict(obj["fields"])
+            fields.pop("pk", None)
+            try:
+                lookup = _extract_natural_key(model, fields, source_path)
+            except ContentError:
+                continue
+            if ", ".join(str(v) for v in lookup.values()) == natural_key:
+                return obj, source_path
+    return None
+
+
+@staff_member_required
+@require_GET
+def content_conflicts(request: HttpRequest) -> HttpResponse:
+    """List every current credited-row load conflict under the content repo."""
+    if not request.user.is_superuser:
+        raise PermissionDenied
+
+    from core_management.content_repo import resolve_content_root  # noqa: PLC0415
+    from core_management.load_conflicts import scan_load_conflicts  # noqa: PLC0415
+
+    content_root = resolve_content_root()
+    if content_root is None:
+        messages.error(
+            request,
+            "CONTENT_REPO_PATH is not set. Add it to src/.env pointing at your "
+            "local checkout of the private content repository.",
+        )
+        return HttpResponseRedirect(reverse("admin_game_setup"))
+
+    context = {
+        "title": "Load conflicts",
+        "conflicts": scan_load_conflicts(content_root),
+    }
+    return render(request, "admin/content_conflicts.html", context)
+
+
+@staff_member_required
+@require_GET
+def content_conflict_detail(request: HttpRequest) -> HttpResponse:
+    """Show one conflict's field-by-field diff and the typed-confirmation form."""
+    if not request.user.is_superuser:
+        raise PermissionDenied
+
+    from core_management.content_repo import resolve_content_root  # noqa: PLC0415
+    from core_management.load_conflicts import find_load_conflict  # noqa: PLC0415
+
+    content_root = resolve_content_root()
+    if content_root is None:
+        messages.error(
+            request,
+            "CONTENT_REPO_PATH is not set. Add it to src/.env pointing at your "
+            "local checkout of the private content repository.",
+        )
+        return HttpResponseRedirect(reverse("admin_game_setup"))
+
+    model_label = request.GET.get("model", "")
+    key = request.GET.get("key", "")
+    conflict = find_load_conflict(content_root, model_label, key)
+    if conflict is None:
+        messages.info(request, f"{model_label} [{key}] is no longer in conflict.")
+        return HttpResponseRedirect(reverse("admin_content_conflicts"))
+
+    context = {
+        "title": "Load conflict",
+        "conflict": conflict,
+        "model_label": model_label,
+        "key": key,
+        "resolve_url": reverse("admin_content_conflict_resolve"),
+    }
+    return render(request, "admin/content_conflict_detail.html", context)
+
+
+@staff_member_required
+@require_POST
+def content_conflict_resolve(request: HttpRequest) -> HttpResponse:
+    """Delete a credited row and reload it from the corpus, after typed confirmation.
+
+    Runs entirely inside one transaction: the delete and the reload either
+    both land or neither does. A wrong typed key never touches the row at
+    all - the mismatch check runs before the transaction opens.
+    """
+    if not request.user.is_superuser:
+        raise PermissionDenied
+
+    from django.db import transaction  # noqa: PLC0415
+    from django.db.models import ProtectedError  # noqa: PLC0415
+
+    from core_management.content_fixtures import (  # noqa: PLC0415
+        OUTCOME_CREATED,
+        ContentError,
+        resolve_fixture_model,
+    )
+    from core_management.content_repo import resolve_content_root  # noqa: PLC0415
+    from core_management.load_conflicts import find_load_conflict  # noqa: PLC0415
+
+    content_root = resolve_content_root()
+    if content_root is None:
+        messages.error(
+            request,
+            "CONTENT_REPO_PATH is not set. Add it to src/.env pointing at your "
+            "local checkout of the private content repository.",
+        )
+        return HttpResponseRedirect(reverse("admin_game_setup"))
+
+    model_label = request.POST.get("model", "")
+    key = request.POST.get("key", "")
+    detail_url = _detail_url(model_label, key)
+
+    conflict = find_load_conflict(content_root, model_label, key)
+    if conflict is None:
+        messages.info(request, f"{model_label} [{key}] is no longer in conflict.")
+        return HttpResponseRedirect(reverse("admin_content_conflicts"))
+
+    if request.POST.get("typed_key", "") != conflict.natural_key:
+        messages.error(request, "Typed key does not match. Nothing was changed.")
+        return HttpResponseRedirect(detail_url)
+
+    model = resolve_fixture_model(model_label)
+    try:
+        with transaction.atomic():
+            instance = _instance_for_conflict(model, content_root, conflict)
+            instance.delete()
+            outcome = _reload_single_entry(model_label, conflict.natural_key, content_root)
+            if outcome != OUTCOME_CREATED:
+                reload_failed_msg = (
+                    f"Reload after delete did not recreate the row (outcome: {outcome}). "
+                    "Transaction rolled back; the original row is untouched."
+                )
+                raise ContentError(reload_failed_msg)
+    except ProtectedError as exc:
+        messages.error(request, f"Cannot delete: other rows protect this one ({exc.args[0]}).")
+        return HttpResponseRedirect(detail_url)
+    except ContentError as exc:
+        messages.error(request, str(exc))
+        return HttpResponseRedirect(detail_url)
+
+    messages.success(
+        request, f"{conflict.model_name} [{conflict.natural_key}] now matches the repo."
+    )
+    return HttpResponseRedirect(reverse("admin_content_conflicts"))

--- a/src/web/admin/content_conflict_views.py
+++ b/src/web/admin/content_conflict_views.py
@@ -101,6 +101,54 @@ def _reload_single_entry(model_label: str, natural_key: str, content_root) -> st
     return _upsert_fixture_object(model, obj, source_path, BuildResult())
 
 
+def _delete_and_reload(model, model_label: str, content_root, conflict) -> str | None:
+    """Delete the conflict's row and reload it from the corpus in one transaction.
+
+    Returns ``None`` on success, or a user-facing error message on failure -
+    the transaction has already rolled back by the time this returns, so a
+    ``ProtectedError``, a ``ContentError`` from either helper, or a raw
+    database error all leave the original row untouched. Split out of
+    ``content_conflict_resolve`` (ruff C901) so that view's own branching
+    (superuser gate, content-root check, digest check, typed-key check) stays
+    separate from this transaction's three-way exception handling.
+    """
+    from django.db import (  # noqa: PLC0415
+        Error as DjangoDbError,
+        transaction,
+    )
+    from django.db.models import ProtectedError  # noqa: PLC0415
+
+    from core_management.content_fixtures import (  # noqa: PLC0415
+        OUTCOME_CREATED,
+        ContentError,
+    )
+
+    try:
+        with transaction.atomic():
+            instance = _instance_for_conflict(model, content_root, conflict)
+            instance.delete()
+            outcome = _reload_single_entry(model_label, conflict.natural_key, content_root)
+            if outcome != OUTCOME_CREATED:
+                reload_failed_msg = (
+                    f"Reload after delete did not recreate the row (outcome: {outcome}). "
+                    "Transaction rolled back; the original row is untouched."
+                )
+                raise ContentError(reload_failed_msg)
+    except ProtectedError as exc:
+        return f"Cannot delete: other rows protect this one ({exc.args[0]})."
+    except ContentError as exc:
+        return str(exc)
+    except DjangoDbError as exc:
+        # Mirrors content_load_views.content_load_run: an unmigrated or
+        # unreachable DB is the one environmental failure mode left once
+        # ContentError/ProtectedError are both ruled out.
+        return (
+            f"Database error while resolving conflict: {exc} "
+            "(hint: run `arx manage migrate` to bring the dev DB schema up to date)."
+        )
+    return None
+
+
 def _locate_corpus_entry(content_root, model_label: str, natural_key: str):
     """Find the corpus fixture object matching ``(model_label, natural_key)``.
 
@@ -154,9 +202,18 @@ def content_conflicts(request: HttpRequest) -> HttpResponse:
         )
         return HttpResponseRedirect(reverse("admin_game_setup"))
 
+    conflicts = scan_load_conflicts(content_root)
     context = {
         "title": "Load conflicts",
-        "conflicts": scan_load_conflicts(content_root),
+        "conflicts": conflicts,
+        # Pre-built (conflict, detail_url) pairs so the template never has to
+        # assemble a querystring itself - keeps every template line well
+        # under the 100-char limit without splitting a URL across lines
+        # (which would embed whitespace inside an href attribute value).
+        "conflict_rows": [
+            {"conflict": c, "detail_url": _detail_url(c.model_label, c.natural_key)}
+            for c in conflicts
+        ],
     }
     return render(request, "admin/content_conflicts.html", context)
 
@@ -204,19 +261,18 @@ def content_conflict_resolve(request: HttpRequest) -> HttpResponse:
 
     Runs entirely inside one transaction: the delete and the reload either
     both land or neither does. A wrong typed key never touches the row at
-    all - the mismatch check runs before the transaction opens.
+    all - the mismatch check runs before the transaction opens. Same for a
+    stale digest (#3017 review): the detail page hands back a hash of the
+    diff it rendered, and if the corpus or the DB row changed between that
+    GET and this POST, the row is still a genuine conflict - so a bare
+    re-fetch-and-compare wouldn't catch it - but the diff the operator typed
+    the key against is no longer the diff this POST would apply. Refuse and
+    send them back to review the current diff.
     """
     if not request.user.is_superuser:
         raise PermissionDenied
 
-    from django.db import transaction  # noqa: PLC0415
-    from django.db.models import ProtectedError  # noqa: PLC0415
-
-    from core_management.content_fixtures import (  # noqa: PLC0415
-        OUTCOME_CREATED,
-        ContentError,
-        resolve_fixture_model,
-    )
+    from core_management.content_fixtures import resolve_fixture_model  # noqa: PLC0415
     from core_management.content_repo import resolve_content_root  # noqa: PLC0415
     from core_management.load_conflicts import find_load_conflict  # noqa: PLC0415
 
@@ -238,27 +294,20 @@ def content_conflict_resolve(request: HttpRequest) -> HttpResponse:
         messages.info(request, f"{model_label} [{key}] is no longer in conflict.")
         return HttpResponseRedirect(reverse("admin_content_conflicts"))
 
+    if request.POST.get("digest", "") != conflict.digest:
+        messages.error(
+            request, "The corpus or row changed since you reviewed this diff. Review it again."
+        )
+        return HttpResponseRedirect(detail_url)
+
     if request.POST.get("typed_key", "") != conflict.natural_key:
         messages.error(request, "Typed key does not match. Nothing was changed.")
         return HttpResponseRedirect(detail_url)
 
     model = resolve_fixture_model(model_label)
-    try:
-        with transaction.atomic():
-            instance = _instance_for_conflict(model, content_root, conflict)
-            instance.delete()
-            outcome = _reload_single_entry(model_label, conflict.natural_key, content_root)
-            if outcome != OUTCOME_CREATED:
-                reload_failed_msg = (
-                    f"Reload after delete did not recreate the row (outcome: {outcome}). "
-                    "Transaction rolled back; the original row is untouched."
-                )
-                raise ContentError(reload_failed_msg)
-    except ProtectedError as exc:
-        messages.error(request, f"Cannot delete: other rows protect this one ({exc.args[0]}).")
-        return HttpResponseRedirect(detail_url)
-    except ContentError as exc:
-        messages.error(request, str(exc))
+    error_msg = _delete_and_reload(model, model_label, content_root, conflict)
+    if error_msg is not None:
+        messages.error(request, error_msg)
         return HttpResponseRedirect(detail_url)
 
     messages.success(

--- a/src/web/admin/content_load_views.py
+++ b/src/web/admin/content_load_views.py
@@ -45,7 +45,9 @@ def content_load_run(request: HttpRequest) -> HttpResponse:
     purely to read ``placeholder_counts`` for the flash message — cheap,
     side-effect-free parsing (not a second load); ``load_world_content`` does
     the actual content-fixtures -> grid-bundles -> deferred-retry sequence
-    (#2448) and owns every create/update/skip/grid count reported below.
+    (#2448) and owns every create/update/skip/conflict/grid count reported
+    below. A conflict (#3017) is a credited row a re-run's incoming values
+    differ from - left untouched, not a skip, flashed as its own warning.
     """
     if not request.user.is_superuser:
         raise PermissionDenied
@@ -97,6 +99,7 @@ def content_load_run(request: HttpRequest) -> HttpResponse:
         if world_result.deferred_resolved
         else ""
     )
+    conflict_msg = f", {len(world_result.conflicts)} conflicts" if world_result.conflicts else ""
     grid = world_result.grid
     grid_created = grid.created_areas + grid.created_rooms + grid.created_exits
     grid_updated = grid.updated_areas + grid.updated_rooms + grid.updated_exits
@@ -106,10 +109,12 @@ def content_load_run(request: HttpRequest) -> HttpResponse:
     messages.success(
         request,
         f"Content load: {world_result.created} created, {world_result.updated} updated, "
-        f"{placeholders} placeholder entries{skip_msg}{deferred_msg}{grid_msg}",
+        f"{placeholders} placeholder entries{skip_msg}{deferred_msg}{conflict_msg}{grid_msg}",
     )
     for skip in world_result.skipped:
         messages.warning(request, skip)
+    for conflict in world_result.conflicts:
+        messages.warning(request, f"CONFLICT: {conflict}")
     for report in grid.reports:
         messages.warning(request, report)
     return HttpResponseRedirect(reverse("admin_game_setup"))

--- a/src/web/admin/tests/test_content_conflict_views.py
+++ b/src/web/admin/tests/test_content_conflict_views.py
@@ -4,8 +4,9 @@ Mirrors ``test_content_load_views.py``'s structure: a superuser-only gate on
 every view, a real tmp content root standing in for a checkout, and the same
 credited-row conflict manufacture pattern ``test_load_conflicts_scan.py``
 uses. The resolve view is the interesting one - it must refuse a wrong typed
-key with the row untouched, delete-then-reload on the right one, and roll
-back cleanly on a ``ProtectedError``.
+key with the row untouched, refuse a stale digest (the diff changed between
+the detail GET and this POST) with the row untouched, delete-then-reload on
+a matching key and digest, and roll back cleanly on a ``ProtectedError``.
 """
 
 from pathlib import Path
@@ -17,6 +18,8 @@ from django.test import TestCase
 from django.urls import reverse
 from evennia.accounts.models import AccountDB
 
+from core_management.load_conflicts import find_load_conflict
+from web.admin.content_conflict_views import _detail_url
 from world.contributors.factories import ContentContributorFactory
 from world.traits.models import Trait
 
@@ -63,6 +66,37 @@ class TestContentConflictViews(TestCase):
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.url, reverse("admin_game_setup"))
 
+    def test_detail_page_without_content_root_redirects(self) -> None:
+        self.client.force_login(self.super)
+        with mock.patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop("CONTENT_REPO_PATH", None)
+            resp = self.client.get(
+                reverse("admin_content_conflict_detail"),
+                {"model": "arxii.trait", "key": "Performance"},
+            )
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, reverse("admin_game_setup"))
+
+    def test_resolve_without_content_root_redirects(self) -> None:
+        self.client.force_login(self.super)
+        with mock.patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop("CONTENT_REPO_PATH", None)
+            resp = self.client.post(
+                reverse("admin_content_conflict_resolve"),
+                {
+                    "model": "arxii.trait",
+                    "key": "Performance",
+                    "typed_key": "Performance",
+                    "digest": "irrelevant",
+                },
+            )
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, reverse("admin_game_setup"))
+
 
 class TestContentConflictConfigured(TestCase):
     """A tmp dir standing in for a content-repo checkout, with one credited conflict."""
@@ -98,6 +132,12 @@ class TestContentConflictConfigured(TestCase):
             "---\n"
             "Regenerated words.\n",
         )
+
+    def _current_digest(self) -> str:
+        """The digest ``find_load_conflict`` would compute right now."""
+        conflict = find_load_conflict(self.root, "arxii.trait", "Performance")
+        assert conflict is not None
+        return conflict.digest
 
     def test_conflicts_page_lists_credited_diffs(self) -> None:
         self._seed_conflict()
@@ -136,11 +176,17 @@ class TestContentConflictConfigured(TestCase):
 
     def test_resolve_refuses_wrong_typed_key(self) -> None:
         self._seed_conflict()
+        digest = self._current_digest()
         self.client.force_login(self.super)
         with mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)}):
             resp = self.client.post(
                 reverse("admin_content_conflict_resolve"),
-                {"model": "arxii.trait", "key": "Performance", "typed_key": "Not Performance"},
+                {
+                    "model": "arxii.trait",
+                    "key": "Performance",
+                    "typed_key": "Not Performance",
+                    "digest": digest,
+                },
             )
         self.assertEqual(resp.status_code, 302)
         messages = [str(m) for m in resp.wsgi_request._messages]
@@ -150,14 +196,87 @@ class TestContentConflictConfigured(TestCase):
         self.assertEqual(trait.description, "Human words.")
         self.assertIsNotNone(trait.written_by_id)
 
+    def test_resolve_refuses_stale_digest(self) -> None:
+        """The diff changing between the detail GET and this POST is refused (#3017 review).
+
+        Manufacture the conflict, GET the detail page (capturing the digest
+        it rendered), mutate the corpus again so the diff the operator
+        reviewed is no longer current, then POST with the stale digest and
+        the (still correct) typed key. The row must stay untouched, and a
+        second POST with the now-current digest must resolve cleanly - the
+        digest check is about staleness, not about permanently blocking the
+        row.
+        """
+        self._seed_conflict()
+        self.client.force_login(self.super)
+        with mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)}):
+            detail_resp = self.client.get(
+                reverse("admin_content_conflict_detail"),
+                {"model": "arxii.trait", "key": "Performance"},
+            )
+        stale_digest = detail_resp.context["conflict"].digest
+
+        _write(
+            self.root,
+            "skills/performance.md",
+            "---\n"
+            "name: Performance\n"
+            "category: social\n"
+            'written_by: "Tehom"\n'
+            "---\n"
+            "Yet more regenerated words.\n",
+        )
+
+        with mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)}):
+            resp = self.client.post(
+                reverse("admin_content_conflict_resolve"),
+                {
+                    "model": "arxii.trait",
+                    "key": "Performance",
+                    "typed_key": "Performance",
+                    "digest": stale_digest,
+                },
+            )
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, _detail_url("arxii.trait", "Performance"))
+        messages = [str(m) for m in resp.wsgi_request._messages]
+        self.assertTrue(any("changed since you reviewed" in m for m in messages))
+
+        trait = Trait.objects.get(name="Performance")
+        self.assertEqual(trait.description, "Human words.")
+        self.assertIsNotNone(trait.written_by_id)
+
+        # Happy path: a matching (current) digest still resolves.
+        fresh_digest = self._current_digest()
+        with mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)}):
+            resp = self.client.post(
+                reverse("admin_content_conflict_resolve"),
+                {
+                    "model": "arxii.trait",
+                    "key": "Performance",
+                    "typed_key": "Performance",
+                    "digest": fresh_digest,
+                },
+            )
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, reverse("admin_content_conflicts"))
+        trait = Trait.objects.get(name="Performance")
+        self.assertEqual(trait.description, "Yet more regenerated words.")
+
     def test_resolve_deletes_and_reloads_from_corpus(self) -> None:
         self._seed_conflict()
         original_pk = Trait.objects.get(name="Performance").pk
+        digest = self._current_digest()
         self.client.force_login(self.super)
         with mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)}):
             resp = self.client.post(
                 reverse("admin_content_conflict_resolve"),
-                {"model": "arxii.trait", "key": "Performance", "typed_key": "Performance"},
+                {
+                    "model": "arxii.trait",
+                    "key": "Performance",
+                    "typed_key": "Performance",
+                    "digest": digest,
+                },
             )
         self.assertEqual(resp.status_code, 302)
         self.assertEqual(resp.url, reverse("admin_content_conflicts"))
@@ -170,6 +289,7 @@ class TestContentConflictConfigured(TestCase):
 
     def test_resolve_reports_protected_fk(self) -> None:
         self._seed_conflict()
+        digest = self._current_digest()
         self.client.force_login(self.super)
         with (
             mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)}),
@@ -184,7 +304,12 @@ class TestContentConflictConfigured(TestCase):
             mock_instance_for_conflict.return_value = mock_instance
             resp = self.client.post(
                 reverse("admin_content_conflict_resolve"),
-                {"model": "arxii.trait", "key": "Performance", "typed_key": "Performance"},
+                {
+                    "model": "arxii.trait",
+                    "key": "Performance",
+                    "typed_key": "Performance",
+                    "digest": digest,
+                },
             )
         self.assertEqual(resp.status_code, 302)
         messages = [str(m) for m in resp.wsgi_request._messages]

--- a/src/web/admin/tests/test_content_conflict_views.py
+++ b/src/web/admin/tests/test_content_conflict_views.py
@@ -1,0 +1,195 @@
+"""Tests for the admin load-conflict list/detail/resolve surface (#3017).
+
+Mirrors ``test_content_load_views.py``'s structure: a superuser-only gate on
+every view, a real tmp content root standing in for a checkout, and the same
+credited-row conflict manufacture pattern ``test_load_conflicts_scan.py``
+uses. The resolve view is the interesting one - it must refuse a wrong typed
+key with the row untouched, delete-then-reload on the right one, and roll
+back cleanly on a ``ProtectedError``.
+"""
+
+from pathlib import Path
+import tempfile
+from unittest import mock
+
+from django.db.models import ProtectedError
+from django.test import TestCase
+from django.urls import reverse
+from evennia.accounts.models import AccountDB
+
+from world.contributors.factories import ContentContributorFactory
+from world.traits.models import Trait
+
+
+def _write(root: Path, rel: str, text: str) -> Path:
+    path = root / rel
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+    return path
+
+
+class TestContentConflictViews(TestCase):
+    """Superuser-only gate on all three views; unconfigured repo bails cleanly."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.super = AccountDB.objects.create_superuser("rootadmin", "root@example.com", "pw-123456")
+        cls.staff = AccountDB.objects.create_user("staffer", "s@example.com", "pw-123456")
+        cls.staff.is_staff = True
+        cls.staff.save()
+
+    def test_conflicts_page_requires_superuser(self) -> None:
+        self.client.force_login(self.staff)
+        resp = self.client.get(reverse("admin_content_conflicts"))
+        self.assertEqual(resp.status_code, 403)
+
+    def test_detail_page_requires_superuser(self) -> None:
+        self.client.force_login(self.staff)
+        resp = self.client.get(reverse("admin_content_conflict_detail"))
+        self.assertEqual(resp.status_code, 403)
+
+    def test_resolve_requires_superuser(self) -> None:
+        self.client.force_login(self.staff)
+        resp = self.client.post(reverse("admin_content_conflict_resolve"))
+        self.assertEqual(resp.status_code, 403)
+
+    def test_conflicts_page_without_content_root_redirects(self) -> None:
+        self.client.force_login(self.super)
+        with mock.patch.dict("os.environ", {}, clear=False):
+            import os
+
+            os.environ.pop("CONTENT_REPO_PATH", None)
+            resp = self.client.get(reverse("admin_content_conflicts"))
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, reverse("admin_game_setup"))
+
+
+class TestContentConflictConfigured(TestCase):
+    """A tmp dir standing in for a content-repo checkout, with one credited conflict."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.super = AccountDB.objects.create_superuser("rootadmin", "root@example.com", "pw-123456")
+
+    def setUp(self) -> None:
+        self.content = tempfile.TemporaryDirectory()
+        self.addCleanup(self.content.cleanup)
+        self.root = Path(self.content.name)
+
+    def _seed_conflict(self) -> None:
+        from core_management.content_fixtures import build_all, load_entries
+
+        ContentContributorFactory(name="Tehom")
+        _write(
+            self.root,
+            "skills/performance.md",
+            '---\nname: Performance\ncategory: social\nwritten_by: "Tehom"\n---\nHuman words.\n',
+        )
+        created, updated, _ = load_entries(build_all(self.root))
+        assert (created, updated) == (1, 0)
+
+        _write(
+            self.root,
+            "skills/performance.md",
+            "---\n"
+            "name: Performance\n"
+            "category: social\n"
+            'written_by: "Tehom"\n'
+            "---\n"
+            "Regenerated words.\n",
+        )
+
+    def test_conflicts_page_lists_credited_diffs(self) -> None:
+        self._seed_conflict()
+        self.client.force_login(self.super)
+        with mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)}):
+            resp = self.client.get(reverse("admin_content_conflicts"))
+        self.assertEqual(resp.status_code, 200)
+        conflicts = resp.context["conflicts"]
+        self.assertEqual(len(conflicts), 1)
+        self.assertEqual(conflicts[0].natural_key, "Performance")
+        self.assertContains(resp, "Performance")
+
+    def test_detail_page_shows_field_diff(self) -> None:
+        self._seed_conflict()
+        self.client.force_login(self.super)
+        with mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)}):
+            resp = self.client.get(
+                reverse("admin_content_conflict_detail"),
+                {"model": "arxii.trait", "key": "Performance"},
+            )
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Human words.")
+        self.assertContains(resp, "Regenerated words.")
+
+    def test_detail_page_reports_conflict_gone(self) -> None:
+        self.client.force_login(self.super)
+        with mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)}):
+            resp = self.client.get(
+                reverse("admin_content_conflict_detail"),
+                {"model": "arxii.trait", "key": "Nonexistent"},
+            )
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, reverse("admin_content_conflicts"))
+        messages = [str(m) for m in resp.wsgi_request._messages]
+        self.assertTrue(any("no longer in conflict" in m for m in messages))
+
+    def test_resolve_refuses_wrong_typed_key(self) -> None:
+        self._seed_conflict()
+        self.client.force_login(self.super)
+        with mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)}):
+            resp = self.client.post(
+                reverse("admin_content_conflict_resolve"),
+                {"model": "arxii.trait", "key": "Performance", "typed_key": "Not Performance"},
+            )
+        self.assertEqual(resp.status_code, 302)
+        messages = [str(m) for m in resp.wsgi_request._messages]
+        self.assertTrue(any("does not match" in m for m in messages))
+
+        trait = Trait.objects.get(name="Performance")
+        self.assertEqual(trait.description, "Human words.")
+        self.assertIsNotNone(trait.written_by_id)
+
+    def test_resolve_deletes_and_reloads_from_corpus(self) -> None:
+        self._seed_conflict()
+        original_pk = Trait.objects.get(name="Performance").pk
+        self.client.force_login(self.super)
+        with mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)}):
+            resp = self.client.post(
+                reverse("admin_content_conflict_resolve"),
+                {"model": "arxii.trait", "key": "Performance", "typed_key": "Performance"},
+            )
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, reverse("admin_content_conflicts"))
+        messages = [str(m) for m in resp.wsgi_request._messages]
+        self.assertTrue(any("now matches the repo" in m for m in messages))
+
+        trait = Trait.objects.get(name="Performance")
+        self.assertEqual(trait.description, "Regenerated words.")
+        self.assertNotEqual(trait.pk, original_pk)
+
+    def test_resolve_reports_protected_fk(self) -> None:
+        self._seed_conflict()
+        self.client.force_login(self.super)
+        with (
+            mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)}),
+            mock.patch(
+                "web.admin.content_conflict_views._instance_for_conflict"
+            ) as mock_instance_for_conflict,
+        ):
+            mock_instance = mock.MagicMock()
+            mock_instance.delete.side_effect = ProtectedError(
+                "Cannot delete some instances because they are referenced", []
+            )
+            mock_instance_for_conflict.return_value = mock_instance
+            resp = self.client.post(
+                reverse("admin_content_conflict_resolve"),
+                {"model": "arxii.trait", "key": "Performance", "typed_key": "Performance"},
+            )
+        self.assertEqual(resp.status_code, 302)
+        messages = [str(m) for m in resp.wsgi_request._messages]
+        self.assertTrue(any("Cannot delete" in m for m in messages))
+
+        trait = Trait.objects.get(name="Performance")
+        self.assertEqual(trait.description, "Human words.")
+        self.assertIsNotNone(trait.written_by_id)

--- a/src/web/admin/tests/test_content_load_views.py
+++ b/src/web/admin/tests/test_content_load_views.py
@@ -10,6 +10,7 @@ from django.urls import reverse
 from evennia.accounts.models import AccountDB
 
 from world.buildings.models import DecorationKind
+from world.contributors.factories import ContentContributorFactory
 from world.traits.models import Trait
 
 GOOD_SKILL = """---
@@ -124,3 +125,59 @@ class TestContentLoadConfigured(TestCase):
         self.assertTrue(
             any("does not exist" in str(m) or "invalid" in str(m).lower() for m in messages)
         )
+
+
+class TestContentLoadConflicts(TestCase):
+    """A credited row a re-run's incoming content differs from is left untouched (#3017).
+
+    The flash must surface it, not silently drop it: the admin's only way back
+    to the repo version is the typed-confirmation delete-then-reload flow, and
+    an operator can't reach for that if the flash never says a conflict happened.
+    """
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.super = AccountDB.objects.create_superuser("rootadmin", "root@example.com", "pw-123456")
+
+    def setUp(self) -> None:
+        self.content = tempfile.TemporaryDirectory()
+        self.addCleanup(self.content.cleanup)
+        self.root = Path(self.content.name)
+
+    def test_run_flashes_conflict_count_and_one_warning_per_conflict(self) -> None:
+        ContentContributorFactory(name="Tehom")
+        _write(
+            self.root,
+            "skills/performance.md",
+            '---\nname: Performance\ncategory: social\nwritten_by: "Tehom"\n---\nHuman words.\n',
+        )
+        self.client.force_login(self.super)
+        with mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)}):
+            self.client.post(reverse("admin_content_load_run"))
+        trait = Trait.objects.get(name="Performance")
+        self.assertIsNotNone(trait.written_by)
+
+        # Same credited row, incoming description now differs.
+        _write(
+            self.root,
+            "skills/performance.md",
+            "---\n"
+            "name: Performance\n"
+            "category: social\n"
+            'written_by: "Tehom"\n'
+            "---\n"
+            "Regenerated words.\n",
+        )
+        with mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)}):
+            resp = self.client.post(reverse("admin_content_load_run"))
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, reverse("admin_game_setup"))
+
+        messages = list(resp.wsgi_request._messages)
+        self.assertTrue(any("1 conflicts" in str(m) for m in messages))
+        conflict_warnings = [str(m) for m in messages if str(m).startswith("CONFLICT:")]
+        self.assertEqual(len(conflict_warnings), 1)
+        self.assertIn("Performance", conflict_warnings[0])
+
+        trait.refresh_from_db()
+        self.assertEqual(trait.description, "Human words.")

--- a/src/web/admin/urls.py
+++ b/src/web/admin/urls.py
@@ -3,6 +3,11 @@
 from django.urls import path
 
 from web.admin import arx_admin_site
+from web.admin.content_conflict_views import (
+    content_conflict_detail,
+    content_conflict_resolve,
+    content_conflicts,
+)
 from web.admin.content_export_views import content_export_preview, content_export_run
 from web.admin.content_load_views import content_load_confirm, content_load_run
 from web.admin.content_push_views import content_push_preview, content_push_run
@@ -48,6 +53,17 @@ urlpatterns = [
     path("_seed_run/", seed_run, name="admin_seed_run"),
     path("_content_load/", content_load_confirm, name="admin_content_load"),
     path("_content_load_run/", content_load_run, name="admin_content_load_run"),
+    path("_content_conflicts/", content_conflicts, name="admin_content_conflicts"),
+    path(
+        "_content_conflict/",
+        content_conflict_detail,
+        name="admin_content_conflict_detail",
+    ),
+    path(
+        "_content_conflict_resolve/",
+        content_conflict_resolve,
+        name="admin_content_conflict_resolve",
+    ),
     path(
         "_content_export/",
         content_export_preview,

--- a/src/web/templates/admin/content_conflict_detail.html
+++ b/src/web/templates/admin/content_conflict_detail.html
@@ -1,0 +1,75 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}{{ title }} | {% translate 'Site administration' %}{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+    &rsaquo; <a href="{% url 'admin_game_setup' %}">Game Setup</a>
+    &rsaquo; <a href="{% url 'admin_content_conflicts' %}">Load conflicts</a>
+    &rsaquo; {{ title }}
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+
+    <div class="module" style="padding: 15px; margin-bottom: 20px;">
+        <h2 style="margin-top: 0;">{{ conflict.model_name }}: {{ conflict.natural_key }}</h2>
+        <p>
+            This row is credited (written-by is set) and the content repo's
+            current values differ from what is in the database. The row was
+            left untouched by the last load.
+        </p>
+    </div>
+
+    <div class="module" style="padding: 15px; margin-bottom: 20px;">
+        <table>
+            <thead>
+                <tr>
+                    <th>Field</th>
+                    <th>Database value</th>
+                    <th>Repo value</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for name, db_value, repo_value in conflict.fields %}
+                <tr>
+                    <td>{{ name }}</td>
+                    <td><pre>{{ db_value }}</pre></td>
+                    <td><pre>{{ repo_value }}</pre></td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+
+    <div class="module" style="padding: 15px;">
+        <p>
+            To take the repo version, delete this row and reload it from the
+            repo. Type the natural key exactly as shown above
+            (<code>{{ conflict.natural_key }}</code>) to confirm. There is no
+            bulk-resolve - this action affects only this one row.
+        </p>
+        <form method="post" action="{{ resolve_url }}">
+            {% csrf_token %}
+            <input type="hidden" name="model" value="{{ model_label }}">
+            <input type="hidden" name="key" value="{{ key }}">
+            <p>
+                <label for="typed_key">Type the natural key to confirm:</label>
+                <input type="text" id="typed_key" name="typed_key" size="60">
+            </p>
+            <div class="submit-row" style="padding: 12px;">
+                <input type="submit" value="Delete and reload from repo" class="default"
+                       style="padding: 10px 20px;">
+                <a href="{% url 'admin_content_conflicts' %}"
+                   style="padding: 10px 20px; margin-left: 10px;">
+                    Cancel
+                </a>
+            </div>
+        </form>
+    </div>
+
+</div>
+{% endblock %}

--- a/src/web/templates/admin/content_conflict_detail.html
+++ b/src/web/templates/admin/content_conflict_detail.html
@@ -56,6 +56,7 @@
             {% csrf_token %}
             <input type="hidden" name="model" value="{{ model_label }}">
             <input type="hidden" name="key" value="{{ key }}">
+            <input type="hidden" name="digest" value="{{ conflict.digest }}">
             <p>
                 <label for="typed_key">Type the natural key to confirm:</label>
                 <input type="text" id="typed_key" name="typed_key" size="60">

--- a/src/web/templates/admin/content_conflicts.html
+++ b/src/web/templates/admin/content_conflicts.html
@@ -1,0 +1,62 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}{{ title }} | {% translate 'Site administration' %}{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+    &rsaquo; <a href="{% url 'admin_game_setup' %}">Game Setup</a>
+    &rsaquo; {{ title }}
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+
+    <div class="module" style="padding: 15px; margin-bottom: 20px;">
+        <h2 style="margin-top: 0;">Load conflicts</h2>
+        <p>
+            A credited row (one with a written-by set) that the content repo's
+            current values differ from is left untouched by a content load,
+            not silently overwritten. Each row below is one such conflict.
+            Resolving one deletes the row and reloads it from the repo -
+            typed confirmation required, one row at a time.
+        </p>
+    </div>
+
+    <div class="module" style="padding: 15px;">
+        {% if conflicts %}
+        <table>
+            <thead>
+                <tr>
+                    <th>Model</th>
+                    <th>Natural key</th>
+                    <th>Differing fields</th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for conflict in conflicts %}
+                <tr>
+                    <td>{{ conflict.model_name }}</td>
+                    <td><code>{{ conflict.natural_key }}</code></td>
+                    <td>
+                        {% for triple in conflict.fields %}{{ triple.0 }}{% if not forloop.last %}, {% endif %}{% endfor %}
+                    </td>
+                    <td>
+                        <a href="{% url 'admin_content_conflict_detail' %}?model={{ conflict.model_label|urlencode }}&amp;key={{ conflict.natural_key|urlencode }}">
+                            Review
+                        </a>
+                    </td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+        {% else %}
+        <p>No load conflicts right now.</p>
+        {% endif %}
+    </div>
+
+</div>
+{% endblock %}

--- a/src/web/templates/admin/content_conflicts.html
+++ b/src/web/templates/admin/content_conflicts.html
@@ -37,17 +37,17 @@
                 </tr>
             </thead>
             <tbody>
-                {% for conflict in conflicts %}
+                {% for row in conflict_rows %}
                 <tr>
-                    <td>{{ conflict.model_name }}</td>
-                    <td><code>{{ conflict.natural_key }}</code></td>
+                    <td>{{ row.conflict.model_name }}</td>
+                    <td><code>{{ row.conflict.natural_key }}</code></td>
                     <td>
-                        {% for triple in conflict.fields %}{{ triple.0 }}{% if not forloop.last %}, {% endif %}{% endfor %}
+                        {% for triple in row.conflict.fields %}
+                            {{ triple.0 }}{% if not forloop.last %}, {% endif %}
+                        {% endfor %}
                     </td>
                     <td>
-                        <a href="{% url 'admin_content_conflict_detail' %}?model={{ conflict.model_label|urlencode }}&amp;key={{ conflict.natural_key|urlencode }}">
-                            Review
-                        </a>
+                        <a href="{{ row.detail_url }}">Review</a>
                     </td>
                 </tr>
                 {% endfor %}

--- a/src/web/templates/admin/game_setup.html
+++ b/src/web/templates/admin/game_setup.html
@@ -37,6 +37,11 @@
         <a href="{% url 'admin_content_push' %}">Push to lore repo</a>
         commits and pushes exported fixtures to the content repo's
         <code>origin main</code>.
+        <br>
+        <a href="{% url 'admin_content_conflicts' %}">Load conflicts</a>
+        lists credited rows a load left untouched because the repo's
+        incoming values differ - resolve one at a time with a typed
+        confirmation.
       {% else %}
         set <code>CONTENT_REPO_PATH</code> in <code>src/.env</code> to enable
         this step. Until then, the

--- a/src/world/battles/tests/test_seed_staging_catalog.py
+++ b/src/world/battles/tests/test_seed_staging_catalog.py
@@ -11,7 +11,7 @@ it (cluster ordering in ``world.seeds.clusters``).
 
 from __future__ import annotations
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from world.battles.constants import BattleSideRole, FortificationKind, UnitQuality
 from world.battles.models import (
@@ -22,6 +22,7 @@ from world.battles.models import (
 )
 from world.seeds.database import seed_dev_database
 from world.seeds.tests.content_stub import stub_content_root
+from world.seeds.tests.press_helpers import seed_dev_database_with_sample_topup
 
 
 class SeedBattleStagingCatalogTests(TestCase):
@@ -61,7 +62,6 @@ class SeedBattleStagingCatalogTests(TestCase):
         self.assertFalse(places["Gate Approach"].fortifications.exists())
         self.assertFalse(places["Inner Court"].fortifications.exists())
 
-    @override_settings(SEED_SAMPLE_CONTENT=True)
     @stub_content_root()
     def test_seeds_three_unit_templates_with_distinct_quality(self) -> None:
         """mechanics.Property/PropertyCategory and conditions.CapabilityType are
@@ -71,8 +71,13 @@ class SeedBattleStagingCatalogTests(TestCase):
         the CapabilityType half of this was already unauthored-in-stub before
         this slice (conditions.* landed first); the assertion was silently
         never reached because it followed the now-also-gated property check.
+
+        seed_dev_database() itself now refuses SEED_SAMPLE_CONTENT once the
+        stub content root's own load has populated any CONTENT_MODELS table
+        (#3017) - so this presses once with sampling off, then tops up the
+        gap via seed_dev_database_with_sample_topup() (see press_helpers.py).
         """
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
 
         names = ["Levy Spears", "Veteran Pikemen", "Raider Skirmishers"]
         templates = {t.name: t for t in BattleUnitTemplate.objects.filter(name__in=names)}

--- a/src/world/battles/tests/test_war_funding_seeds.py
+++ b/src/world/battles/tests/test_war_funding_seeds.py
@@ -7,21 +7,30 @@ placeholder values, plus idempotency (re-running is a no-op).
 
 from __future__ import annotations
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from world.projects.constants import ProjectKind
 from world.projects.models import ContributionMethod
 from world.seeds.database import seed_dev_database
 from world.seeds.tests.content_stub import stub_content_root
+from world.seeds.tests.press_helpers import seed_dev_database_with_sample_topup
 
 
-@override_settings(SEED_SAMPLE_CONTENT=True)  # backing check-content seeds gate on #2698
 class SeedWarFundingContributionMethodsTests(TestCase):
-    """The WAR_FUNDING ContributionMethod seed row shape and idempotency."""
+    """The WAR_FUNDING ContributionMethod seed row shape and idempotency.
+
+    Backing check-content seeds gate on #2698 (SEED_SAMPLE_CONTENT). Since
+    #3017's hard gate, seed_dev_database() itself refuses sampling once the
+    stub content root has loaded anything, so the first press runs via
+    seed_dev_database_with_sample_topup() (press_helpers.py) - a normal press
+    followed by a sampling-on top-up of every cluster seeder. Re-presses after
+    that (idempotency checks) use plain seed_dev_database(): sampling is off
+    by default, but everything needed already exists from the top-up.
+    """
 
     @stub_content_root()
     def test_seeds_three_methods(self) -> None:
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
 
         methods = ContributionMethod.objects.filter(kind=ProjectKind.WAR_FUNDING).order_by("name")
         self.assertEqual(methods.count(), 3)
@@ -40,7 +49,7 @@ class SeedWarFundingContributionMethodsTests(TestCase):
 
     @stub_content_root()
     def test_seed_is_idempotent(self) -> None:
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
         seed_dev_database()
 
         self.assertEqual(

--- a/src/world/missions/tests/test_seed_missions.py
+++ b/src/world/missions/tests/test_seed_missions.py
@@ -12,7 +12,7 @@ seeds them (cluster ordering in ``world.seeds.clusters``).
 
 from __future__ import annotations
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from evennia_extensions.factories import CharacterFactory
 from world.character_sheets.factories import CharacterSheetFactory
@@ -20,10 +20,10 @@ from world.missions.models import MissionGiver, MissionNode, MissionTemplate
 from world.missions.services.opportunities import opportunities_for_character
 from world.seeds.database import seed_dev_database
 from world.seeds.tests.content_stub import stub_content_root
+from world.seeds.tests.press_helpers import seed_dev_database_with_sample_topup
 from world.traits.models import CheckOutcome
 
 
-@override_settings(SEED_SAMPLE_CONTENT=True)  # missions.* demo content gates on #2698
 class SeedMissionsDevTests(TestCase):
     """The "missions" cluster's row shape + idempotency."""
 
@@ -39,7 +39,7 @@ class SeedMissionsDevTests(TestCase):
 
     @stub_content_root()
     def test_seeds_one_board_giver_and_three_open_templates(self) -> None:
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
 
         # #2862 added a second BOARD giver (the covert Back Room Wall) — fetch
         # the starter board by name, same scoping the template set already uses.
@@ -73,7 +73,7 @@ class SeedMissionsDevTests(TestCase):
 
     @stub_content_root()
     def test_rerun_is_idempotent_no_op(self) -> None:
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
         giver_count = MissionGiver.objects.count()
         template_count = MissionTemplate.objects.count()
         node_count = MissionNode.objects.count()
@@ -86,7 +86,7 @@ class SeedMissionsDevTests(TestCase):
 
     @stub_content_root()
     def test_rerun_preserves_staff_edit_to_template(self) -> None:
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
         template = MissionTemplate.objects.first()
         template.summary = "Staff-rewritten summary."
         template.save(update_fields=["summary"])
@@ -97,7 +97,6 @@ class SeedMissionsDevTests(TestCase):
         self.assertEqual(template.summary, "Staff-rewritten summary.")
 
 
-@override_settings(SEED_SAMPLE_CONTENT=True)  # missions.* demo content gates on #2698
 class MissionOpportunitiesFromSeededStartingRoomTests(TestCase):
     """The symptom fix: `mission opportunities` shows content from spawn (#2121)."""
 
@@ -105,7 +104,7 @@ class MissionOpportunitiesFromSeededStartingRoomTests(TestCase):
     def test_here_group_non_empty_at_the_seeded_starting_room(self) -> None:
         from world.seeds.character_creation import ensure_canonical_fallback_room
 
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
         room = ensure_canonical_fallback_room()
 
         character = CharacterFactory()

--- a/src/world/missions/tests/test_tutorial_seed.py
+++ b/src/world/missions/tests/test_tutorial_seed.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from world.missions.constants import DeedRewardSink, ExternalAct, GiverKind, OptionKind
 from world.missions.models import (
@@ -29,9 +29,9 @@ from world.missions.models import (
 from world.npc_services.constants import OfferKind
 from world.npc_services.models import MissionOfferDetails, NPCRole, NPCServiceOffer
 from world.seeds.character_creation import ensure_canonical_fallback_room
-from world.seeds.database import seed_dev_database
 from world.seeds.game_content.tutorial import seed_tutorial_dev
 from world.seeds.tests.content_stub import stub_content_root
+from world.seeds.tests.press_helpers import seed_dev_database_with_sample_topup
 
 _T1_NAME = "Arrival"
 _T2_NAME = "What the Walls Remember"
@@ -47,14 +47,13 @@ def _gate_for(template: MissionTemplate) -> dict:
     return {"leaf": "has_completed_mission", "params": {"template_id": template.pk}}
 
 
-@override_settings(SEED_SAMPLE_CONTENT=True)  # missions.* tutorial-chain content gates on #2698
 class SeedTutorialDevTests(TestCase):
     """Row shape of the T1-T7 chain + idempotency."""
 
     @classmethod
     def setUpTestData(cls) -> None:
         with stub_content_root():
-            seed_dev_database()
+            seed_dev_database_with_sample_topup()
         cls.t1 = MissionTemplate.objects.get(name=_T1_NAME)
         cls.t2 = MissionTemplate.objects.get(name=_T2_NAME)
         cls.t3 = MissionTemplate.objects.get(name=_T3_NAME)
@@ -244,7 +243,6 @@ class SeedTutorialDevTests(TestCase):
             self.assertTrue(option.node.is_entry)
 
 
-@override_settings(SEED_SAMPLE_CONTENT=True)  # missions.* tutorial-chain content gates on #2698
 class MissionOptionRouteQueryHelperTests(TestCase):
     """Sanity: the chain's routes are structurally reachable via ORM lookups
     the way the reward-emission engine walks them (no orphaned FKs)."""
@@ -252,7 +250,7 @@ class MissionOptionRouteQueryHelperTests(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         with stub_content_root():
-            seed_dev_database()
+            seed_dev_database_with_sample_topup()
 
     def test_every_chain_template_has_exactly_one_entry_node(self) -> None:
         for name in (_T1_NAME, _T2_NAME, _T3_NAME, _T4_NAME, _T5_NAME, _T6_NAME, _T7_NAME):
@@ -269,7 +267,6 @@ class MissionOptionRouteQueryHelperTests(TestCase):
             self.assertIsNone(route.target_node_id)
 
 
-@override_settings(SEED_SAMPLE_CONTENT=True)  # missions.* tutorial-chain content gates on #2698
 class AuditLegendFloorTutorialChainTests(TestCase):
     """``audit_legend_floor`` (#2051 risk-floor guard) reports no violations
     for the seeded T1-T7 chain templates (#1035 review fold-in F2) — a
@@ -280,7 +277,7 @@ class AuditLegendFloorTutorialChainTests(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         with stub_content_root():
-            seed_dev_database()
+            seed_dev_database_with_sample_topup()
 
     def test_no_legend_floor_violations_for_tutorial_chain(self) -> None:
         # Management commands are discovered per INSTALLED_APP, so #2906's collapse

--- a/src/world/npc_services/tests/test_settle_obligation_offer.py
+++ b/src/world/npc_services/tests/test_settle_obligation_offer.py
@@ -10,7 +10,7 @@ is that caller.
 
 from __future__ import annotations
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from world.currency.models import FavorTokenDetails
 from world.currency.services import mint_favor_token
@@ -22,6 +22,7 @@ from world.npc_services.factories import NPCRoleFactory, NPCServiceOfferFactory
 from world.npc_services.services import resolve_offer, start_interaction
 from world.scenes.factories import PersonaFactory
 from world.seeds.tests.content_stub import stub_content_root
+from world.seeds.tests.press_helpers import seed_dev_database_with_sample_topup
 from world.societies.constants import ObligationState
 from world.societies.factories import OrganizationFactory, OrganizationObligationFactory
 
@@ -128,8 +129,10 @@ class SettleObligationLoopEndToEndTests(TestCase):
     # "Commoner", "The Fool" — which the Big Button only creates with
     # SEED_SAMPLE_CONTENT on (#2698). Opting in here keeps that third-party
     # path covered; a maintainer press (flag off) seeds config only and those
-    # named rows come from the content repo instead.
-    @override_settings(SEED_SAMPLE_CONTENT=True)
+    # named rows come from the content repo instead. seed_dev_database()
+    # itself now refuses SEED_SAMPLE_CONTENT once the stub content root's own
+    # load makes the universe non-empty (#3017), so this presses once
+    # (sampling off) then tops up via seed_dev_database_with_sample_topup().
     @stub_content_root()
     def test_settle_at_registrar_unblocks_train_offer(self) -> None:  # noqa: PLR0915
         from evennia.accounts.models import AccountDB
@@ -145,7 +148,6 @@ class SettleObligationLoopEndToEndTests(TestCase):
             ACADEMY_REGISTRAR_ROLE_NAME,
         )
         from world.seeds.character_creation import DEFAULT_STAT_NAMES, ensure_shroudwatch_academy
-        from world.seeds.database import seed_dev_database
         from world.societies.models import OrganizationObligation
         from world.societies.obligation_services import has_open_obligation
         from world.tarot.models import TarotCard
@@ -159,7 +161,7 @@ class SettleObligationLoopEndToEndTests(TestCase):
         # technique to pick from the one the generalist trainer's TRAIN offer
         # teaches (below) — the post-settle TRAIN attempt would otherwise
         # refuse as "you already know this" rather than proving a new grant.
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
         academy = ensure_shroudwatch_academy()
 
         area = CharacterDraft._meta.get_field("selected_area").related_model.objects.get(

--- a/src/world/progression/tests/test_seed_durance_officiants.py
+++ b/src/world/progression/tests/test_seed_durance_officiants.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 
 from unittest import mock
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from world.classes.factories import CharacterClassFactory
 from world.classes.models import Path, PathStage
@@ -31,6 +31,7 @@ from world.progression.seeds import (
 from world.progression.services.advancement import convene_durance_at_site
 from world.seeds.database import seed_dev_database
 from world.seeds.tests.content_stub import stub_content_root
+from world.seeds.tests.press_helpers import seed_dev_database_with_sample_topup
 
 _CHECK_PATH = "world.progression.services.spends.check_requirements_for_unlock"
 
@@ -39,11 +40,15 @@ class SeedDurancePrerequisitesTests(TestCase):
     """seed_dev_database() (magic + progression clusters) content shape."""
 
     @stub_content_root()
-    @override_settings(SEED_SAMPLE_CONTENT=True)
     def test_ritual_of_the_durance_is_seeded_by_name(self) -> None:
         """ "Ritual of the Durance" is content-repo-owned (#2698) — sample
-        content must be on for the stub root to yield the row this asserts."""
-        seed_dev_database()
+        content must be on for the stub root to yield the row this asserts.
+
+        seed_dev_database() itself now refuses SEED_SAMPLE_CONTENT once the
+        stub content root's own load makes the universe non-empty (#3017), so
+        this presses once (sampling off) then tops up via
+        seed_dev_database_with_sample_topup()."""
+        seed_dev_database_with_sample_topup()
         self.assertTrue(Ritual.objects.filter(name="Ritual of the Durance").exists())
 
     @stub_content_root()
@@ -85,13 +90,15 @@ class SeedDurationOfficiantsIdempotencyTests(TestCase):
         self.assertEqual(site.officiant.current_level, 20)
 
 
-@override_settings(SEED_SAMPLE_CONTENT=True)
 class FirstDuranceWithNoLiveOfficiantTests(TestCase):
     """The symptom fix: the first-ever Durance needs no live higher-level PC (#2121).
 
     "Ritual of the Durance" is content-repo-owned (#2698); ``SEED_SAMPLE_CONTENT``
     opts this suite into the sample-seeding path so ``convene_durance_at_site``
-    has a real Ritual row to fire.
+    has a real Ritual row to fire. seed_dev_database() itself now refuses
+    SEED_SAMPLE_CONTENT once the stub content root's own load makes the
+    universe non-empty (#3017), so this presses via
+    seed_dev_database_with_sample_topup() instead of an ambient override.
     """
 
     @stub_content_root()
@@ -99,7 +106,7 @@ class FirstDuranceWithNoLiveOfficiantTests(TestCase):
         from world.character_sheets.factories import CharacterSheetFactory
         from world.seeds.character_creation import ensure_canonical_fallback_room
 
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
         self.room = ensure_canonical_fallback_room()
         self.path = Path.objects.get(name=_DURANCE_OFFICIANT_PATH_NAMES[0])
         self.assertEqual(self.path.stage, PathStage.PROSPECT)

--- a/src/world/seeds/crafting_materials.py
+++ b/src/world/seeds/crafting_materials.py
@@ -62,11 +62,17 @@ def seed_crafting_materials() -> None:
         )
         categories[name] = category
 
+    skipped = 0
     for category_name, name, value, grade in _MATERIALS:
+        existing = ItemTemplate.objects.filter(name=name).first()
+        if existing is not None and existing.written_by_id is not None:
+            logger.info("Skipping credited ItemTemplate %r - a human has written this row.", name)
+            skipped += 1
+            continue
         ItemTemplate.objects.update_or_create(
             name=name,
             defaults={
-                "description": f"PLACEHOLDER: {name.lower()} — crafting material.",
+                "description": f"PLACEHOLDER: {name.lower()} - crafting material.",
                 "is_active": True,
                 "value": value,
                 "material_category": categories[category_name],
@@ -74,9 +80,10 @@ def seed_crafting_materials() -> None:
             },
         )
     logger.info(
-        "Seeded %s material categories and %s generic material templates.",
+        "Seeded %s material categories and %s generic material templates (%s skipped, credited).",
         len(categories),
-        len(_MATERIALS),
+        len(_MATERIALS) - skipped,
+        skipped,
     )
     seed_accent_axes()
     seed_craft_skills()

--- a/src/world/seeds/database.py
+++ b/src/world/seeds/database.py
@@ -43,6 +43,7 @@ from core_management.content_fixtures import ContentError, load_world_content
 from core_management.content_repo import resolve_content_root
 from world.seeds.clusters import CLUSTER_SEEDERS, seeded_models
 from world.seeds.config_prerequisites import CONFIG_PREREQUISITES
+from world.seeds.sample_content import assert_sampling_allowed
 from world.seeds.types import SeedReport
 
 _MISSING_CONTENT_ROOT_MSG = (
@@ -95,6 +96,9 @@ def seed_dev_database(*, verbose: bool = False) -> SeedReport:
     report.clusters["content"] = load_content_first()
     if verbose:
         print(f"  content: +{report.clusters['content']} rows")
+
+    # Sample content may only be invented into an empty content universe (#3017).
+    assert_sampling_allowed()
 
     for name, seeder in CLUSTER_SEEDERS.items():
         before = _row_count()

--- a/src/world/seeds/sample_content.py
+++ b/src/world/seeds/sample_content.py
@@ -60,10 +60,14 @@ def assert_sampling_allowed() -> None:
     """Refuse sample invention against a non-empty content universe (#3017).
 
     Called by ``seed_dev_database()`` between the content load and the cluster
-    loop. A database that has ever loaded real content has rows in some
-    ``CONTENT_MODELS`` table, so sampling can never mix invented rows into it;
-    the downstream guards (test_no_content_slop, the ADR-0191 addition gate)
-    become defense in depth instead of the only line.
+    loop: within a single press, once any ``CONTENT_MODELS`` table has a row
+    (authored, or just loaded by this same press), sampling is refused for the
+    rest of that press, so it can never mix invented rows into a real content
+    universe; the downstream guards (test_no_content_slop, the ADR-0191
+    addition gate) become defense in depth instead of the only line. This
+    enforcement is scoped to a ``seed_dev_database()`` call, not a standing
+    database-wide invariant - a direct cluster-seeder call (test-only; see
+    ``world.seeds.tests.press_helpers``) sits outside this gate by design.
     """
     if not sample_content_enabled():
         return

--- a/src/world/seeds/sample_content.py
+++ b/src/world/seeds/sample_content.py
@@ -56,6 +56,36 @@ def sample_content_enabled() -> bool:
     return bool(settings.SEED_SAMPLE_CONTENT)
 
 
+def assert_sampling_allowed() -> None:
+    """Refuse sample invention against a non-empty content universe (#3017).
+
+    Called by ``seed_dev_database()`` between the content load and the cluster
+    loop. A database that has ever loaded real content has rows in some
+    ``CONTENT_MODELS`` table, so sampling can never mix invented rows into it;
+    the downstream guards (test_no_content_slop, the ADR-0191 addition gate)
+    become defense in depth instead of the only line.
+    """
+    if not sample_content_enabled():
+        return
+    from core_management.content_export import CONTENT_MODELS  # noqa: PLC0415
+    from core_management.content_fixtures import (  # noqa: PLC0415
+        ContentError,
+        resolve_fixture_model,
+    )
+
+    nonempty = sorted(
+        label for label in CONTENT_MODELS if resolve_fixture_model(label).objects.exists()
+    )
+    if nonempty:
+        message = (
+            "ARXII_SEED_SAMPLE_CONTENT is enabled but the database already has "
+            f"content rows in: {', '.join(nonempty)}. Sample content may only be "
+            "invented into an empty content universe - turn sampling off, or start "
+            "from a fresh database with no content repo configured."
+        )
+        raise ContentError(message)
+
+
 def authored_or_sample[M: Model](
     model: type[M], defaults: dict[str, Any] | None, **lookup: Any
 ) -> M | None:

--- a/src/world/seeds/tests/press_helpers.py
+++ b/src/world/seeds/tests/press_helpers.py
@@ -1,0 +1,42 @@
+"""Press-then-sample-topup helper for tests hit by the #3017 hard gate.
+
+``seed_dev_database()`` now refuses ``SEED_SAMPLE_CONTENT`` once any
+``CONTENT_MODELS`` row exists anywhere - including a row the SAME call's own
+content load just created (``world.seeds.sample_content.assert_sampling_allowed``,
+#3017). Several tests want BOTH the stub content root loaded (so
+content-dependent seeders have something to find) AND unrelated content gaps
+the stub doesn't cover sample-invented (e.g. a CheckType a battles/missions
+seed looks up) - a single ``seed_dev_database()`` call can no longer do both.
+
+The fix mirrors the exemption the hard gate itself carries: it only fires
+inside ``seed_dev_database()``, never against a direct cluster-seeder call
+(see ``sample_content.py``'s docstring). So press once with sampling off -
+``authored_or_sample()`` skips and logs a missing row rather than raising, so
+the press still completes - then re-run every cluster seeder directly with
+sampling on. Cluster seeders are idempotent (``get_or_create`` /
+``update_or_create``), so the second pass only fills in what the first pass
+skipped; nothing already seeded is touched twice.
+"""
+
+from __future__ import annotations
+
+from django.test import override_settings
+
+from world.seeds.clusters import CLUSTER_SEEDERS
+from world.seeds.database import seed_dev_database
+from world.seeds.types import SeedReport
+
+
+def seed_dev_database_with_sample_topup() -> SeedReport:
+    """Press once (sampling off), then top up content gaps with sampling on.
+
+    Returns the first press's :class:`SeedReport` (the topup pass's own
+    per-cluster deltas aren't tracked - callers that need row-count deltas
+    from the topup pass should call the specific cluster seeder directly
+    instead of this helper).
+    """
+    report = seed_dev_database()
+    with override_settings(SEED_SAMPLE_CONTENT=True):
+        for seeder in CLUSTER_SEEDERS.values():
+            seeder()
+    return report

--- a/src/world/seeds/tests/test_clusters.py
+++ b/src/world/seeds/tests/test_clusters.py
@@ -160,7 +160,6 @@ class TestClusterRegistry(TestCase):
         db_value = CGExplanation.objects.filter(key="origin_heading").values("text").get()
         self.assertEqual(db_value["text"], "staff-edited")
 
-    @override_settings(SEED_SAMPLE_CONTENT=True)
     def test_every_active_beginning_has_a_seeded_tradition(self) -> None:
         """Seed-integrity regression net (#2426 whole-branch-review finding).
 
@@ -173,10 +172,13 @@ class TestClusterRegistry(TestCase):
         stub content root carries an equivalent-shaped stand-in.
         """
         from world.character_creation.models import Beginnings
-        from world.seeds.database import seed_dev_database
+        from world.seeds.tests.press_helpers import seed_dev_database_with_sample_topup
 
+        # seed_dev_database() itself refuses SEED_SAMPLE_CONTENT once the stub
+        # content root's own load makes the universe non-empty (#3017), so
+        # this presses once (sampling off) then tops up any gaps.
         with stub_content_root():
-            seed_dev_database()
+            seed_dev_database_with_sample_topup()
 
         beginnings = Beginnings.objects.filter(is_active=True)
         self.assertTrue(beginnings.exists(), "expected at least one active seeded Beginning")

--- a/src/world/seeds/tests/test_crafting_materials_seed.py
+++ b/src/world/seeds/tests/test_crafting_materials_seed.py
@@ -1,7 +1,10 @@
 """Seed test for the generic material ladders (#2878 Phase F)."""
 
+import datetime
+
 from django.test import TestCase
 
+from world.contributors.factories import ContentContributorFactory
 from world.items.models import ItemTemplate, MaterialCategory
 from world.seeds.crafting_materials import seed_crafting_materials
 
@@ -22,3 +25,34 @@ class CraftingMaterialsSeedTests(TestCase):
         seed_crafting_materials()
         for absent in ("Alaricite", "Steelsilk", "Precious Stone", "Hazeweed"):
             self.assertFalse(ItemTemplate.objects.filter(name__iexact=absent).exists())
+
+    def test_credited_item_template_survives_a_re_press(self) -> None:
+        seed_crafting_materials()
+        silk = ItemTemplate.objects.get(name="Silk")
+        contributor = ContentContributorFactory()
+        silk.written_by = contributor
+        silk.written_on = datetime.date(2026, 1, 1)
+        silk.description = "A human wrote this description of silk."
+        silk.value = 999999
+        silk.save()
+
+        seed_crafting_materials()
+
+        silk.refresh_from_db()
+        self.assertEqual(silk.written_by_id, contributor.pk)
+        self.assertEqual(silk.description, "A human wrote this description of silk.")
+        self.assertEqual(silk.value, 999999)
+
+    def test_uncredited_item_template_still_refreshes(self) -> None:
+        seed_crafting_materials()
+        silk = ItemTemplate.objects.get(name="Silk")
+        silk.description = "Some stale placeholder text."
+        silk.value = 1
+        silk.save()
+
+        seed_crafting_materials()
+
+        silk.refresh_from_db()
+        self.assertIsNone(silk.written_by_id)
+        self.assertEqual(silk.description, "PLACEHOLDER: silk - crafting material.")
+        self.assertEqual(silk.value, 625)

--- a/src/world/seeds/tests/test_idempotency.py
+++ b/src/world/seeds/tests/test_idempotency.py
@@ -1,7 +1,8 @@
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from world.seeds.database import seed_dev_database
 from world.seeds.tests.content_stub import stub_content_root
+from world.seeds.tests.press_helpers import seed_dev_database_with_sample_topup
 
 
 class TestSeedIdempotency(TestCase):
@@ -38,7 +39,6 @@ class TestSeedIdempotency(TestCase):
             )
 
     @stub_content_root()
-    @override_settings(SEED_SAMPLE_CONTENT=True)
     def test_edit_survives_reseed(self) -> None:
         """A staff edit to a SEEDER-OWNED row survives the next Big Button press.
 
@@ -51,10 +51,16 @@ class TestSeedIdempotency(TestCase):
         (get_or_create, never update_or_create), so it asserts on a row the
         seeder genuinely owns: ``ThreadPullCost`` is tuning data and is
         deliberately absent from ``CONTENT_MODELS``.
+
+        ``seed_dev_database()`` itself now refuses ``SEED_SAMPLE_CONTENT`` once
+        the stub content root's own load makes the universe non-empty (#3017),
+        so the first press uses ``seed_dev_database_with_sample_topup()``
+        instead of an ambient override; the reseed under test stays a plain
+        ``seed_dev_database()`` call.
         """
         from world.magic.models import ThreadPullCost
 
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
         cost = ThreadPullCost.objects.order_by("pk").first()
         assert cost is not None
         # Short on purpose: ThreadPullCost.label is varchar(32), which SQLite
@@ -66,7 +72,6 @@ class TestSeedIdempotency(TestCase):
         self.assertEqual(cost.label, "STAFF-EDITED")
 
     @stub_content_root()
-    @override_settings(SEED_SAMPLE_CONTENT=True)
     def test_edited_cg_row_survives_reseed(self) -> None:
         """The #651 non-overwrite gate for the character_creation cluster.
 
@@ -74,10 +79,16 @@ class TestSeedIdempotency(TestCase):
         on for the stub root to yield a "Human" row here — the invariant under
         test (staff edits survive re-seed) is otherwise unrelated to that
         gating.
+
+        ``seed_dev_database()`` itself now refuses ``SEED_SAMPLE_CONTENT`` once
+        the stub content root's own load makes the universe non-empty (#3017),
+        so the first press uses ``seed_dev_database_with_sample_topup()``
+        instead of an ambient override; the reseed under test stays a plain
+        ``seed_dev_database()`` call.
         """
         from world.species.models import Species
 
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
         sp = Species.objects.get(name="Human")
         sp.description = "HAND-EDITED"
         sp.save()

--- a/src/world/seeds/tests/test_playable_slice.py
+++ b/src/world/seeds/tests/test_playable_slice.py
@@ -7,20 +7,30 @@ factory-built character's check resolving. The full character-creation
 pipeline and a live multi-round encounter are Phase 2, out of scope here.
 """
 
-from django.test import TestCase, override_settings
+from django.test import TestCase
 
 from world.character_sheets.factories import CharacterSheetFactory
 from world.seeds.database import seed_dev_database
 from world.seeds.tests.content_stub import stub_content_root
+from world.seeds.tests.press_helpers import seed_dev_database_with_sample_topup
 
 
-@override_settings(SEED_SAMPLE_CONTENT=True)  # combat check-content seeds gate on #2698
 class TestPlayableSlice(TestCase):
+    """Combat check-content seeds gate on #2698 (SEED_SAMPLE_CONTENT).
+
+    Since #3017's hard gate, a press against the stub content root must run
+    via seed_dev_database_with_sample_topup() (press_helpers.py) rather than
+    plain seed_dev_database() under an ambient SEED_SAMPLE_CONTENT=True
+    override - the stub's own load already makes the content universe
+    non-empty, so sampling inside the same seed_dev_database() call is now
+    refused (#3017).
+    """
+
     @stub_content_root()
     def test_resolution_tables_seeded(self) -> None:
         from world.traits.models import CheckRank, ResultChart
 
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
         self.assertGreater(CheckRank.objects.count(), 0)
         self.assertGreater(ResultChart.objects.count(), 0)
 
@@ -28,7 +38,7 @@ class TestPlayableSlice(TestCase):
     def test_combat_resolution_content_present(self) -> None:
         from world.checks.models import CheckType
 
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
         # penetration + flee CheckTypes seeded by the combat cluster
         self.assertTrue(CheckType.objects.filter(name__in=["penetration", "flee"]).exists())
 
@@ -51,7 +61,7 @@ class TestPlayableSlice(TestCase):
             Trait,
         )
 
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
         ResultChart.clear_cache()
         Trait.flush_instance_cache()
         CharacterTraitValue.flush_instance_cache()
@@ -76,14 +86,14 @@ class TestPlayableSlice(TestCase):
         self.assertIsInstance(result.outcome, CheckOutcome)
 
 
-@override_settings(SEED_SAMPLE_CONTENT=True)
 class TestSeededCharacterCreation(TestCase):
     """The #1333 proof: a clean DB seeded via the Big Button can run CG.
 
     Builds a CharacterDraft against the SEEDED CG-world content (not test-only
     rows) and asserts ``finalize_character`` produces a CharacterSheet + primary
     Persona without raising. This is the test that closes the "fresh DB cannot
-    run character creation" gap.
+    run character creation" gap. See TestPlayableSlice's docstring above for
+    why this presses via seed_dev_database_with_sample_topup() (#3017).
     """
 
     @stub_content_root()
@@ -100,7 +110,7 @@ class TestSeededCharacterCreation(TestCase):
         from world.tarot.models import TarotCard
         from world.traits.models import Trait, TraitType
 
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
 
         area = CharacterDraft._meta.get_field("selected_area").related_model.objects.get(
             name="Arx City"
@@ -210,7 +220,7 @@ class TestSeededCharacterCreation(TestCase):
 
         from world.character_creation.models import Beginnings, CharacterDraft
 
-        seed_dev_database()
+        seed_dev_database_with_sample_topup()
 
         beginnings = list(Beginnings.objects.filter(is_active=True))
         self.assertTrue(

--- a/src/world/seeds/tests/test_sample_gate.py
+++ b/src/world/seeds/tests/test_sample_gate.py
@@ -1,0 +1,66 @@
+"""Sample content may only ever be invented into an empty content universe (#3017).
+
+``assert_sampling_allowed()`` (``world.seeds.sample_content``) is the hard gate:
+called by ``seed_dev_database()`` right after the content load and before the
+cluster-seeder loop, it refuses to let ``SEED_SAMPLE_CONTENT`` invent rows once
+any ``CONTENT_MODELS`` table has ever gained a row - whether that row was
+authored (loaded from a real content repo checkout) or came from the SAME call's
+own content load (a stub or starter content root). Without this, sample rows can
+mix into a real content universe indistinguishably from authored ones, which is
+exactly how twelve invented resonances shipped into the lore corpus as if
+authored (see ADR-0191).
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase, override_settings
+
+from core_management.content_fixtures import ContentError
+from world.contributors.models import ContentContributor
+from world.projects.models import ContributionMethod
+from world.seeds.database import seed_dev_database
+from world.seeds.sample_content import assert_sampling_allowed
+from world.seeds.tests.content_stub import stub_content_root
+
+
+class AssertSamplingAllowedTests(TestCase):
+    """Unit coverage of the gate function itself, independent of the press."""
+
+    def test_sampling_off_never_raises(self) -> None:
+        # SEED_SAMPLE_CONTENT defaults off; content rows present or not, the
+        # gate is a no-op when sampling itself is not enabled.
+        ContentContributor.objects.create(name="Someone Credited")
+        assert_sampling_allowed()  # must not raise
+
+    @override_settings(SEED_SAMPLE_CONTENT=True)
+    def test_sampling_on_empty_universe_passes(self) -> None:
+        # No CONTENT_MODELS rows exist anywhere - the universe is empty, so
+        # sampling is allowed.
+        assert_sampling_allowed()  # must not raise
+
+    @override_settings(SEED_SAMPLE_CONTENT=True)
+    def test_sampling_with_existing_content_rows_raises(self) -> None:
+        ContentContributor.objects.create(name="Someone Credited")
+
+        with self.assertRaises(ContentError) as ctx:
+            assert_sampling_allowed()
+
+        message = str(ctx.exception)
+        self.assertIn("contributors.contentcontributor", message)
+        self.assertNotIn("?", message)
+        self.assertNotIn("—", message)
+
+
+class PressWithSamplingAndLoadedContentTests(TestCase):
+    """Integration: the full Big Button refuses to mix sampling with a real load."""
+
+    @override_settings(SEED_SAMPLE_CONTENT=True)
+    @stub_content_root()
+    def test_press_with_sampling_and_loaded_content_raises(self) -> None:
+        with self.assertRaises(ContentError):
+            seed_dev_database()
+
+        # The gate fires between the content load and the cluster loop, so no
+        # cluster seeder ran at all - ContributionMethod (created only by the
+        # war-funding cluster seeder, never by the content load) stays empty.
+        self.assertFalse(ContributionMethod.objects.exists())

--- a/src/world/seeds/weather_content.py
+++ b/src/world/seeds/weather_content.py
@@ -68,5 +68,7 @@ def seed_weather_content() -> None:
             "an empty transition graph until it is authored."
         )
         return
-    counts = load_weather_seed(fixtures_dir)
+    counts, conflicts = load_weather_seed(fixtures_dir)
     logger.info("Weather corpus loaded: %s", counts)
+    for line in conflicts:
+        logger.warning(line)

--- a/src/world/weather/CLAUDE.md
+++ b/src/world/weather/CLAUDE.md
@@ -142,10 +142,15 @@ Services (`world.weather.services`):
   (`--fixtures-dir` or `WEATHER_SEED_PATH`); not a management command. Existing rows predate the
   re-key and carry `key=NULL` until the content-repo pass assigns one; the corpus rows themselves
   are not this repo's job (#2980). `upsert_weather_emits` freezes a credited emit (`written_by`
-  set) whose incoming text differs instead of overwriting it, reporting the conflict in its
-  return value rather than writing it (#3017, ADR-0201) - resolved only via the admin's Load
-  Conflicts pages, same as the fixture pipeline. It also resolves a raw fixture credit
-  (`written_by`/`reviewed_by` as a natural-key list) via `_resolve_credit_names` before the
+  set) whose incoming content OR credit differs instead of overwriting it - the credit fields
+  themselves are part of the comparison for a credited row, so a matching-content row with a
+  differing incoming credit freezes too, not just a differing-text row - reporting the conflict
+  in its return value rather than writing it (#3017, ADR-0201). This freeze is reported by the
+  seed loader itself (log/CLI via its return value), not the admin's Load Conflicts page: that
+  page's scan only reads the content-repo's exported `fixtures/`/markdown corpus, so a
+  weather-seed conflict surfaces there only when the divergent value also lives in that exported
+  copy. The override is deleting the row and re-running the seed. It also resolves a raw fixture
+  credit (`written_by`/`reviewed_by` as a natural-key list) via `_resolve_credit_names` before the
   write, dropping an unresolvable name rather than raising (mirrors #2980's
   drop-the-credit-never-the-row rule).
 - **Wind as a mechanic** (flyers/arrows/gale spells, driven by the active weather's WIND) —

--- a/src/world/weather/CLAUDE.md
+++ b/src/world/weather/CLAUDE.md
@@ -141,7 +141,13 @@ Services (`world.weather.services`):
   `loaddata`. Invoke via the tools wrapper `tools/load_weather_seed.py`
   (`--fixtures-dir` or `WEATHER_SEED_PATH`); not a management command. Existing rows predate the
   re-key and carry `key=NULL` until the content-repo pass assigns one; the corpus rows themselves
-  are not this repo's job (#2980).
+  are not this repo's job (#2980). `upsert_weather_emits` freezes a credited emit (`written_by`
+  set) whose incoming text differs instead of overwriting it, reporting the conflict in its
+  return value rather than writing it (#3017, ADR-0201) - resolved only via the admin's Load
+  Conflicts pages, same as the fixture pipeline. It also resolves a raw fixture credit
+  (`written_by`/`reviewed_by` as a natural-key list) via `_resolve_credit_names` before the
+  write, dropping an unresolvable name rather than raising (mirrors #2980's
+  drop-the-credit-never-the-row rule).
 - **Wind as a mechanic** (flyers/arrows/gale spells, driven by the active weather's WIND) —
   combat/technique consumer, **Tehom's domain**; filed as **#1555** (`needs-design`). The WIND
   *provider* side is done (`felt_exposure(room, WIND)` / `current_conditions`).

--- a/src/world/weather/seed.py
+++ b/src/world/weather/seed.py
@@ -185,10 +185,15 @@ def upsert_weather_emits(objects: list[dict]) -> tuple[int, int, list[str]]:
     (``written_by`` set) whose incoming content differs from the seed corpus is
     left untouched instead of silently overwritten (#3017) - the same freeze
     ``core_management.content_fixtures`` applies to the fixture-loader path.
-    An uncredited row, or a credited row whose incoming values are identical,
-    upserts exactly as before this guard. Returns ``(created, updated,
-    conflicts)``: ``conflicts`` names every credited row the corpus left
-    untouched.
+    The comparison includes the credit fields themselves for a credited row, so
+    a matching-content row whose incoming ``written_by``/``reviewed_by`` differs
+    also freezes rather than silently accepting a new credit - the same
+    differing-credit-fields-alone-conflict rule the fixture path applies. An
+    uncredited row still accepts an incoming credit normally; that is the usual
+    crediting path, not a conflict. An uncredited row, or a credited row whose
+    incoming values (content and credit alike) are identical, upserts exactly
+    as before this guard. Returns ``(created, updated, conflicts)``:
+    ``conflicts`` names every credited row the corpus left untouched.
 
     A fixture row's own ``written_by``/``reviewed_by`` (its authored credit, not the
     guard above) is resolved from a natural-key ref via ``_resolve_credit_names``
@@ -198,7 +203,6 @@ def upsert_weather_emits(objects: list[dict]) -> tuple[int, int, list[str]]:
     from core_management.content_fixtures import fields_differing  # noqa: PLC0415
     from world.weather.models import WeatherEmit  # noqa: PLC0415
 
-    credit_keys = ("written_by", "reviewed_by", "written_on", "reviewed_on")
     created = updated = 0
     conflicts: list[str] = []
     for obj in objects:
@@ -208,8 +212,7 @@ def upsert_weather_emits(objects: list[dict]) -> tuple[int, int, list[str]]:
         _resolve_credit_names(fields, key)
         existing = WeatherEmit.objects.filter(key=key).first()
         if existing is not None and existing.written_by_id is not None:
-            comparable = {k: v for k, v in fields.items() if k not in credit_keys}
-            incoming = {"weather_type": weather_type, **comparable}
+            incoming = {"weather_type": weather_type, **fields}
             if fields_differing(WeatherEmit, existing, incoming):
                 conflicts.append(
                     f"WeatherEmit [{key}] is credited (written_by is set) and differs "

--- a/src/world/weather/seed.py
+++ b/src/world/weather/seed.py
@@ -30,12 +30,18 @@ ORM, via deferred imports.
 from __future__ import annotations
 
 import json
+import logging
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from pathlib import Path
 
     from world.weather.models import WeatherType
+
+logger = logging.getLogger(__name__)
+
+# The two CreditedContent name FKs a WeatherEmit fixture row may itself carry.
+_CREDIT_NAME_KEYS = ("written_by", "reviewed_by")
 
 # Seed files, in dependency order (types before the rows that reference them).
 WEATHER_TYPES_FILE = "weather_types.json"
@@ -61,6 +67,43 @@ def _resolve_weather_type(ref: object) -> WeatherType:
     if isinstance(ref, (list, tuple)):
         return WeatherType.objects.get_by_natural_key(*ref)
     return WeatherType.objects.get_by_natural_key(ref)
+
+
+def _resolve_credit_names(fields: dict, key: str | None) -> None:
+    """Resolve ``written_by``/``reviewed_by`` in place from a natural-key ref to a
+    ``ContentContributor`` instance, in the same list-or-bare-value shape
+    ``_resolve_weather_type`` accepts for ``weather_type``.
+
+    A fixture row can carry these two credit fields directly (a writer crediting a
+    line at authoring time, not the guard's own comparison). Passed unresolved, a raw
+    list/name reaches ``update_or_create``'s ``defaults`` and Django's FK descriptor
+    raises ``ValueError`` on assignment - the row fails to load entirely over a credit
+    typo. Mirrors ``core_management.content_fixtures._resolve_or_drop_credit_fields``'s
+    #2980 rule: drop the credit, never the row. A value that fails to resolve is
+    removed from *fields* and logged; every other field still loads normally.
+    """
+    from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
+
+    from world.contributors.models import ContentContributor  # noqa: PLC0415
+
+    for name in _CREDIT_NAME_KEYS:
+        if name not in fields:
+            continue
+        ref = fields[name]
+        if ref is None or isinstance(ref, ContentContributor):
+            continue
+        natural_key = ref if isinstance(ref, (list, tuple)) else (ref,)
+        try:
+            fields[name] = ContentContributor.objects.get_by_natural_key(*natural_key)
+        except ObjectDoesNotExist:
+            del fields[name]
+            logger.warning(
+                "WeatherEmit [%s]: credit %r not applied - ContentContributor %r not "
+                "found. The row still loads; only the credit is missing.",
+                key,
+                name,
+                ref,
+            )
 
 
 def upsert_weather_types(objects: list[dict]) -> tuple[int, int]:
@@ -146,6 +189,11 @@ def upsert_weather_emits(objects: list[dict]) -> tuple[int, int, list[str]]:
     upserts exactly as before this guard. Returns ``(created, updated,
     conflicts)``: ``conflicts`` names every credited row the corpus left
     untouched.
+
+    A fixture row's own ``written_by``/``reviewed_by`` (its authored credit, not the
+    guard above) is resolved from a natural-key ref via ``_resolve_credit_names``
+    before the write - see that function's docstring for the drop-the-credit-never-
+    the-row handling of an unresolvable name.
     """
     from core_management.content_fixtures import fields_differing  # noqa: PLC0415
     from world.weather.models import WeatherEmit  # noqa: PLC0415
@@ -157,6 +205,7 @@ def upsert_weather_emits(objects: list[dict]) -> tuple[int, int, list[str]]:
         fields = _fields(obj)
         weather_type = _resolve_weather_type(fields.pop("weather_type"))
         key = fields.pop("key")
+        _resolve_credit_names(fields, key)
         existing = WeatherEmit.objects.filter(key=key).first()
         if existing is not None and existing.written_by_id is not None:
             comparable = {k: v for k, v in fields.items() if k not in credit_keys}

--- a/src/world/weather/seed.py
+++ b/src/world/weather/seed.py
@@ -131,25 +131,47 @@ def upsert_weather_transitions(objects: list[dict]) -> tuple[int, int]:
     return created, updated
 
 
-def upsert_weather_emits(objects: list[dict]) -> tuple[int, int]:
+def upsert_weather_emits(objects: list[dict]) -> tuple[int, int, list[str]]:
     """Upsert ``WeatherEmit`` rows keyed on ``key`` - the line's stable identity.
 
     Keyed on the authored ``key`` rather than the text (#2980), so rewriting a
     placeholder line updates the row it belongs to. Keying on the text, as this
     did until #2980, made every rewrite a new row and left the placeholder behind.
+
+    ``WeatherEmit`` carries ``CreditedContent``: a row a human has credited
+    (``written_by`` set) whose incoming content differs from the seed corpus is
+    left untouched instead of silently overwritten (#3017) - the same freeze
+    ``core_management.content_fixtures`` applies to the fixture-loader path.
+    An uncredited row, or a credited row whose incoming values are identical,
+    upserts exactly as before this guard. Returns ``(created, updated,
+    conflicts)``: ``conflicts`` names every credited row the corpus left
+    untouched.
     """
+    from core_management.content_fixtures import fields_differing  # noqa: PLC0415
     from world.weather.models import WeatherEmit  # noqa: PLC0415
 
+    credit_keys = ("written_by", "reviewed_by", "written_on", "reviewed_on")
     created = updated = 0
+    conflicts: list[str] = []
     for obj in objects:
         fields = _fields(obj)
         weather_type = _resolve_weather_type(fields.pop("weather_type"))
         key = fields.pop("key")
+        existing = WeatherEmit.objects.filter(key=key).first()
+        if existing is not None and existing.written_by_id is not None:
+            comparable = {k: v for k, v in fields.items() if k not in credit_keys}
+            incoming = {"weather_type": weather_type, **comparable}
+            if fields_differing(WeatherEmit, existing, incoming):
+                conflicts.append(
+                    f"WeatherEmit [{key}] is credited (written_by is set) and differs "
+                    "from the seed corpus. Row left untouched (#3017)."
+                )
+                continue
         _, was_created = WeatherEmit.objects.update_or_create(
             key=key, defaults={"weather_type": weather_type, **fields}
         )
         created, updated = (created + 1, updated) if was_created else (created, updated + 1)
-    return created, updated
+    return created, updated, conflicts
 
 
 def upsert_feast_days(objects: list[dict]) -> tuple[int, int]:
@@ -179,14 +201,19 @@ def _read(fixtures_dir: Path, filename: str) -> list[dict]:
     return json.loads(path.read_text(encoding="utf-8"))
 
 
-def load_weather_seed(fixtures_dir: Path) -> dict[str, tuple[int, int]]:
-    """Re-seed the weather corpus from a fixtures dir, idempotently. Returns per-model counts.
+def load_weather_seed(fixtures_dir: Path) -> tuple[dict[str, tuple[int, int]], list[str]]:
+    """Re-seed the weather corpus from a fixtures dir, idempotently.
 
     Reads ``weather_types.json`` → ``weather_type_exposures.json`` → ``weather_emits.json`` →
     ``feast_days.json`` (optional) in dependency order and upserts each. Safe to run repeatedly:
     unchanged rows report as updates, not duplicates.
+
+    Returns ``(counts, conflicts)``: ``counts`` is the per-model ``(created, updated)`` tally;
+    ``conflicts`` lists every credited ``WeatherEmit`` (#3017) the corpus tried to overwrite and
+    left untouched instead (see ``upsert_weather_emits``). Every other model has no credited-row
+    guard, so it never contributes to ``conflicts``.
     """
-    return {
+    counts: dict[str, tuple[int, int]] = {
         "weather_types": upsert_weather_types(_read(fixtures_dir, WEATHER_TYPES_FILE)),
         "weather_type_exposures": upsert_weather_type_exposures(
             _read(fixtures_dir, WEATHER_TYPE_EXPOSURES_FILE)
@@ -197,6 +224,10 @@ def load_weather_seed(fixtures_dir: Path) -> dict[str, tuple[int, int]]:
         "weather_transitions": upsert_weather_transitions(
             _read(fixtures_dir, WEATHER_TRANSITIONS_FILE)
         ),
-        "weather_emits": upsert_weather_emits(_read(fixtures_dir, WEATHER_EMITS_FILE)),
-        "feast_days": upsert_feast_days(_read(fixtures_dir, FEAST_DAYS_FILE)),
     }
+    emits_created, emits_updated, conflicts = upsert_weather_emits(
+        _read(fixtures_dir, WEATHER_EMITS_FILE)
+    )
+    counts["weather_emits"] = (emits_created, emits_updated)
+    counts["feast_days"] = upsert_feast_days(_read(fixtures_dir, FEAST_DAYS_FILE))
+    return counts, conflicts

--- a/src/world/weather/tests/test_seed.py
+++ b/src/world/weather/tests/test_seed.py
@@ -260,6 +260,132 @@ class UpsertWeatherEmitsCreditGuardTests(TestCase):
         self.assertEqual(conflicts, [])
 
 
+class UpsertWeatherEmitsRawCreditFieldTests(TestCase):
+    """A fixture row can itself carry credit fields (``written_by``/``reviewed_by`` as a
+    natural-key list, e.g. ``["Apostate"]``) - the loader's own credit, distinct from the
+    guard's comparison. This must resolve to a ``ContentContributor`` instance before the
+    write, not pass the raw list straight into ``update_or_create``'s defaults (#3017
+    review finding).
+    """
+
+    def setUp(self) -> None:
+        upsert_weather_types(TYPES)
+
+    def test_credited_row_with_matching_content_accepts_new_credit(self) -> None:
+        """Scenario (a): content matches (no freeze), fixture also carries credit values -
+        the credit write must actually land as a resolved instance, not raise or corrupt.
+        """
+        from world.contributors.factories import ContentContributorFactory
+
+        old_contributor = ContentContributorFactory(name="Old Writer")
+        new_contributor = ContentContributorFactory(name="New Writer")
+        existing = WeatherEmit.objects.create(
+            weather_type=WeatherType.objects.get(name="Storm"),
+            key="storm-001",
+            text="Rain lashes down in sheets.",
+            weight=2,
+            in_summer=True,
+            at_day=True,
+            written_by=old_contributor,
+        )
+        rows = [
+            {
+                "fields": {
+                    "weather_type": ["Storm"],
+                    "key": "storm-001",
+                    "text": "Rain lashes down in sheets.",
+                    "weight": 2,
+                    "in_summer": True,
+                    "at_day": True,
+                    "written_by": [new_contributor.name],
+                }
+            }
+        ]
+
+        created, updated, conflicts = upsert_weather_emits(rows)
+
+        existing.refresh_from_db()
+        self.assertEqual(conflicts, [])
+        self.assertEqual((created, updated), (0, 1))
+        self.assertEqual(existing.written_by, new_contributor)
+
+    def test_uncredited_row_receiving_fixture_credit_updates(self) -> None:
+        """Scenario (b): an uncredited existing row receiving fixture credit values."""
+        from world.contributors.factories import ContentContributorFactory
+
+        contributor = ContentContributorFactory(name="First Credit")
+        existing = WeatherEmit.objects.create(
+            weather_type=WeatherType.objects.get(name="Storm"),
+            key="storm-001",
+            text="A placeholder line.",
+            weight=1,
+        )
+        rows = [
+            {
+                "fields": {
+                    "weather_type": ["Storm"],
+                    "key": "storm-001",
+                    "text": "Rain lashes down in sheets.",
+                    "weight": 2,
+                    "written_by": [contributor.name],
+                }
+            }
+        ]
+
+        created, updated, conflicts = upsert_weather_emits(rows)
+
+        existing.refresh_from_db()
+        self.assertEqual(conflicts, [])
+        self.assertEqual((created, updated), (0, 1))
+        self.assertEqual(existing.written_by, contributor)
+        self.assertEqual(existing.text, "Rain lashes down in sheets.")
+
+    def test_fresh_create_with_credit_field_resolves(self) -> None:
+        """A brand-new row can carry a resolved credit straight from its first load."""
+        from world.contributors.factories import ContentContributorFactory
+
+        contributor = ContentContributorFactory(name="Fresh Writer")
+        rows = [
+            {
+                "fields": {
+                    "weather_type": ["Storm"],
+                    "key": "storm-999",
+                    "text": "A brand new line.",
+                    "written_by": [contributor.name],
+                }
+            }
+        ]
+
+        created, updated, conflicts = upsert_weather_emits(rows)
+
+        self.assertEqual(conflicts, [])
+        self.assertEqual((created, updated), (1, 0))
+        row = WeatherEmit.objects.get(key="storm-999")
+        self.assertEqual(row.written_by, contributor)
+
+    def test_unresolvable_credit_is_dropped_not_raised(self) -> None:
+        """An unresolvable ``written_by`` drops the credit key rather than corrupting the
+        row or raising (#2980's drop-the-credit-never-the-row rule).
+        """
+        rows = [
+            {
+                "fields": {
+                    "weather_type": ["Storm"],
+                    "key": "storm-998",
+                    "text": "Another new line.",
+                    "written_by": ["Nobody By This Name"],
+                }
+            }
+        ]
+
+        created, updated, conflicts = upsert_weather_emits(rows)
+
+        self.assertEqual(conflicts, [])
+        self.assertEqual((created, updated), (1, 0))
+        row = WeatherEmit.objects.get(key="storm-998")
+        self.assertIsNone(row.written_by)
+
+
 class WeatherEmitKeyIdentityTests(TestCase):
     """A rewritten emit updates its row instead of forking a new one (#2980)."""
 

--- a/src/world/weather/tests/test_seed.py
+++ b/src/world/weather/tests/test_seed.py
@@ -271,9 +271,10 @@ class UpsertWeatherEmitsRawCreditFieldTests(TestCase):
     def setUp(self) -> None:
         upsert_weather_types(TYPES)
 
-    def test_credited_row_with_matching_content_accepts_new_credit(self) -> None:
-        """Scenario (a): content matches (no freeze), fixture also carries credit values -
-        the credit write must actually land as a resolved instance, not raise or corrupt.
+    def test_credited_row_with_differing_credit_freezes(self) -> None:
+        """Content matches, but the fixture's ``written_by`` differs from the row's -
+        the credit fields are part of the comparison for a credited row, so this is a
+        differing-field conflict like any other and the row freezes untouched (#3017).
         """
         from world.contributors.factories import ContentContributorFactory
 
@@ -305,9 +306,49 @@ class UpsertWeatherEmitsRawCreditFieldTests(TestCase):
         created, updated, conflicts = upsert_weather_emits(rows)
 
         existing.refresh_from_db()
+        self.assertEqual((created, updated), (0, 0))
+        self.assertEqual(len(conflicts), 1)
+        self.assertIn("WeatherEmit [storm-001]", conflicts[0])
+        self.assertEqual(existing.written_by, old_contributor)
+
+    def test_credited_row_with_unresolvable_credit_and_matching_content_updates(self) -> None:
+        """An unresolvable ``written_by`` is dropped before the comparison runs (#2980's
+        drop-the-credit-never-the-row rule), so it is absent from the comparison entirely -
+        a credited row whose other fields match still upserts rather than freezing on a
+        phantom credit diff (#3017).
+        """
+        from world.contributors.factories import ContentContributorFactory
+
+        old_contributor = ContentContributorFactory(name="Existing Writer")
+        existing = WeatherEmit.objects.create(
+            weather_type=WeatherType.objects.get(name="Storm"),
+            key="storm-001",
+            text="Rain lashes down in sheets.",
+            weight=2,
+            in_summer=True,
+            at_day=True,
+            written_by=old_contributor,
+        )
+        rows = [
+            {
+                "fields": {
+                    "weather_type": ["Storm"],
+                    "key": "storm-001",
+                    "text": "Rain lashes down in sheets.",
+                    "weight": 2,
+                    "in_summer": True,
+                    "at_day": True,
+                    "written_by": ["Nobody By This Name"],
+                }
+            }
+        ]
+
+        created, updated, conflicts = upsert_weather_emits(rows)
+
+        existing.refresh_from_db()
         self.assertEqual(conflicts, [])
         self.assertEqual((created, updated), (0, 1))
-        self.assertEqual(existing.written_by, new_contributor)
+        self.assertEqual(existing.written_by, old_contributor)
 
     def test_uncredited_row_receiving_fixture_credit_updates(self) -> None:
         """Scenario (b): an uncredited existing row receiving fixture credit values."""

--- a/src/world/weather/tests/test_seed.py
+++ b/src/world/weather/tests/test_seed.py
@@ -350,6 +350,45 @@ class UpsertWeatherEmitsRawCreditFieldTests(TestCase):
         self.assertEqual((created, updated), (0, 1))
         self.assertEqual(existing.written_by, old_contributor)
 
+    def test_credited_row_reasserting_same_credit_and_content_is_a_quiet_noop(self) -> None:
+        """A routine reseed of an already-credited row - fixture re-asserts the SAME
+        resolvable ``written_by`` natural key plus identical content - must not false-freeze
+        under the widened comparison: no conflict, no change, the row upserts quietly.
+        """
+        from world.contributors.factories import ContentContributorFactory
+
+        contributor = ContentContributorFactory(name="Steady Writer")
+        existing = WeatherEmit.objects.create(
+            weather_type=WeatherType.objects.get(name="Storm"),
+            key="storm-001",
+            text="Rain lashes down in sheets.",
+            weight=2,
+            in_summer=True,
+            at_day=True,
+            written_by=contributor,
+        )
+        rows = [
+            {
+                "fields": {
+                    "weather_type": ["Storm"],
+                    "key": "storm-001",
+                    "text": "Rain lashes down in sheets.",
+                    "weight": 2,
+                    "in_summer": True,
+                    "at_day": True,
+                    "written_by": [contributor.name],
+                }
+            }
+        ]
+
+        created, updated, conflicts = upsert_weather_emits(rows)
+
+        existing.refresh_from_db()
+        self.assertEqual(conflicts, [])
+        self.assertEqual((created, updated), (0, 1))
+        self.assertEqual(existing.written_by, contributor)
+        self.assertEqual(existing.text, "Rain lashes down in sheets.")
+
     def test_uncredited_row_receiving_fixture_credit_updates(self) -> None:
         """Scenario (b): an uncredited existing row receiving fixture credit values."""
         from world.contributors.factories import ContentContributorFactory

--- a/src/world/weather/tests/test_seed.py
+++ b/src/world/weather/tests/test_seed.py
@@ -120,13 +120,15 @@ class UpsertWeatherEmitsTests(TestCase):
         upsert_weather_types(TYPES)
 
     def test_reload_does_not_duplicate_keyless_emits(self) -> None:
-        created, updated = upsert_weather_emits(EMITS)
+        created, updated, conflicts = upsert_weather_emits(EMITS)
         assert (created, updated) == (2, 0)
+        assert conflicts == []
         assert WeatherEmit.objects.count() == 2
 
         # The bug under test: a second load must NOT create 2 more rows.
-        created, updated = upsert_weather_emits(EMITS)
+        created, updated, conflicts = upsert_weather_emits(EMITS)
         assert (created, updated) == (0, 2)
+        assert conflicts == []
         assert WeatherEmit.objects.count() == 2
 
     def test_edited_emit_weight_and_flags_update_in_place(self) -> None:
@@ -164,8 +166,9 @@ class UpsertWeatherEmitsTests(TestCase):
                 },
             },
         ]
-        created, updated = upsert_weather_emits(rewritten)
+        created, updated, conflicts = upsert_weather_emits(rewritten)
         assert (created, updated) == (0, 1)
+        assert conflicts == []
         assert WeatherEmit.objects.count() == 2  # no fork, no orphaned placeholder
         assert WeatherEmit.objects.get(key="storm-001").text == "A different line entirely."
 
@@ -182,9 +185,79 @@ class UpsertWeatherEmitsTests(TestCase):
                 },
             },
         ]
-        created, updated = upsert_weather_emits(new_line)
+        created, updated, conflicts = upsert_weather_emits(new_line)
         assert (created, updated) == (1, 0)
+        assert conflicts == []
         assert WeatherEmit.objects.count() == 3
+
+
+class UpsertWeatherEmitsCreditGuardTests(TestCase):
+    """``WeatherEmit`` carries ``CreditedContent``: a credited row's content must survive a
+    re-seed that would otherwise overwrite it (#3017), mirroring the fixture loader's guard.
+    """
+
+    def setUp(self) -> None:
+        upsert_weather_types(TYPES)
+
+    def test_credited_emit_with_differing_text_is_left_untouched(self) -> None:
+        from world.contributors.factories import ContentContributorFactory
+
+        contributor = ContentContributorFactory()
+        credited = WeatherEmit.objects.create(
+            weather_type=WeatherType.objects.get(name="Storm"),
+            key="storm-001",
+            text="A writer's polished line.",
+            weight=5,
+            written_by=contributor,
+        )
+
+        created, updated, conflicts = upsert_weather_emits(EMITS)
+
+        credited.refresh_from_db()
+        self.assertEqual(credited.text, "A writer's polished line.")
+        self.assertEqual(credited.weight, 5)
+        self.assertEqual((created, updated), (1, 0))  # only clear-001 was created
+        self.assertEqual(len(conflicts), 1)
+        self.assertIn("WeatherEmit [storm-001]", conflicts[0])
+        self.assertIn("#3017", conflicts[0])
+
+    def test_uncredited_emit_still_updates(self) -> None:
+        uncredited = WeatherEmit.objects.create(
+            weather_type=WeatherType.objects.get(name="Storm"),
+            key="storm-001",
+            text="A placeholder line.",
+            weight=1,
+        )
+
+        created, updated, conflicts = upsert_weather_emits(EMITS)
+
+        uncredited.refresh_from_db()
+        self.assertEqual(uncredited.text, "Rain lashes down in sheets.")
+        self.assertEqual((created, updated), (1, 1))
+        self.assertEqual(conflicts, [])
+
+    def test_identical_credited_emit_is_a_quiet_noop(self) -> None:
+        from world.contributors.factories import ContentContributorFactory
+
+        contributor = ContentContributorFactory()
+        # Matches EMITS's storm-001 fixture row exactly (see module constant above).
+        storm_text = "Rain lashes down in sheets."
+        credited = WeatherEmit.objects.create(
+            weather_type=WeatherType.objects.get(name="Storm"),
+            key="storm-001",
+            text=storm_text,
+            weight=2,
+            in_summer=True,
+            at_day=True,
+            written_by=contributor,
+        )
+
+        created, updated, conflicts = upsert_weather_emits(EMITS)
+
+        credited.refresh_from_db()
+        self.assertEqual(credited.text, storm_text)
+        self.assertEqual((created, updated), (1, 1))  # storm-001 upserts, clear-001 creates
+        self.assertEqual(conflicts, [])
 
 
 class WeatherEmitKeyIdentityTests(TestCase):
@@ -205,12 +278,14 @@ class WeatherEmitKeyIdentityTests(TestCase):
                 }
             }
         ]
-        created, updated = upsert_weather_emits(rows)
+        created, updated, conflicts = upsert_weather_emits(rows)
         self.assertEqual((created, updated), (1, 0))
+        self.assertEqual(conflicts, [])
 
         rows[0]["fields"]["text"] = "Thunder walks the rooftops."
-        created, updated = upsert_weather_emits(rows)
+        created, updated, conflicts = upsert_weather_emits(rows)
         self.assertEqual((created, updated), (0, 1))
+        self.assertEqual(conflicts, [])
         self.assertEqual(WeatherEmit.objects.filter(weather_type=weather_type).count(), 1)
         self.assertEqual(
             WeatherEmit.objects.get(key="stormy-001").text,
@@ -222,7 +297,7 @@ class WeatherEmitKeyIdentityTests(TestCase):
         upsert_weather_emits(
             [{"fields": {"weather_type": ["Stormy"], "key": "stormy-001", "text": "One."}}]
         )
-        created, _updated = upsert_weather_emits(
+        created, _updated, _conflicts = upsert_weather_emits(
             [{"fields": {"weather_type": ["Stormy"], "key": "stormy-002", "text": "Two."}}]
         )
         self.assertEqual(created, 1)
@@ -262,19 +337,21 @@ class LoadWeatherSeedFromDirTests(TestCase):
             tmp_path = Path(tmp)
             self._write_corpus(tmp_path)
 
-            counts = load_weather_seed(tmp_path)
+            counts, conflicts = load_weather_seed(tmp_path)
             assert counts["weather_types"] == (2, 0)
             assert counts["weather_type_exposures"] == (2, 0)
             assert counts["weather_emits"] == (2, 0)
             assert counts["feast_days"] == (1, 0)
+            assert conflicts == []
             assert WeatherType.objects.count() == 2
             assert WeatherEmit.objects.count() == 2
             assert FeastDay.objects.count() == 1
 
             # Re-seed: everything updates, nothing duplicates.
-            counts = load_weather_seed(tmp_path)
+            counts, conflicts = load_weather_seed(tmp_path)
             assert counts["weather_emits"] == (0, 2)
             assert counts["feast_days"] == (0, 1)
+            assert conflicts == []
             assert WeatherEmit.objects.count() == 2
             assert FeastDay.objects.count() == 1
 
@@ -285,7 +362,8 @@ class LoadWeatherSeedFromDirTests(TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             (tmp_path / "weather_types.json").write_text(json.dumps(TYPES), encoding="utf-8")
-            counts = load_weather_seed(tmp_path)
+            counts, conflicts = load_weather_seed(tmp_path)
             assert counts["weather_types"] == (2, 0)
             assert counts["feast_days"] == (0, 0)
+            assert conflicts == []
             assert FeastDay.objects.count() == 0

--- a/tools/build_content_fixtures.py
+++ b/tools/build_content_fixtures.py
@@ -141,10 +141,14 @@ def _print_load_report(world_result: WorldLoadResult, content_root: Path) -> boo
     """Print the ``--load`` summary + health report; return the health verdict.
 
     Summary covers content counts, grid counts, deferred, and skips (as
-    before). The health report (#2501) always follows: it groups
+    before), plus a conflicts section (#3017): credited rows (written_by
+    set) whose incoming values differed and were left untouched. Conflicts
+    are deliberate freezes, not corpus drift - they are reported for
+    operator visibility only and never fed into the health report below.
+    The health report (#2501) always follows: it groups
     ``world_result.skipped`` against ``fixtures/KNOWN_DRIFT.txt`` so expected,
     pre-existing drift doesn't drown out a genuinely new regression. The
-    returned bool is ``True`` iff every skip matched a known-drift pattern —
+    returned bool is ``True`` iff every skip matched a known-drift pattern -
     ``_run`` uses it to decide the ``--strict`` exit code.
     """
     print(f"loaded: {world_result.created} created, {world_result.updated} updated.")
@@ -165,6 +169,15 @@ def _print_load_report(world_result: WorldLoadResult, content_root: Path) -> boo
     if world_result.skipped:
         print(f"skipped: {len(world_result.skipped)} object(s):")
         for msg in world_result.skipped:
+            print(f"  {msg}")
+    if world_result.conflicts:
+        # Deliberate freezes (#3017), not corpus drift: a credited row a
+        # human already edited is left untouched when a re-run's incoming
+        # values differ. Reported here for operator visibility only - never
+        # folded into KNOWN_DRIFT.txt or the --strict exit code below, both
+        # of which track genuine skips.
+        print(f"Conflicts (credited rows left untouched): {len(world_result.conflicts)} object(s):")
+        for msg in world_result.conflicts:
             print(f"  {msg}")
 
     patterns = load_known_drift(content_root)

--- a/tools/load_weather_seed.py
+++ b/tools/load_weather_seed.py
@@ -72,9 +72,11 @@ def main() -> int:
     django.setup()
     from world.weather.seed import load_weather_seed  # noqa: PLC0415
 
-    counts = load_weather_seed(fixtures_dir)
+    counts, conflicts = load_weather_seed(fixtures_dir)
     for model, (created, updated) in counts.items():
         print(f"{model}: {created} created, {updated} updated.")
+    for line in conflicts:
+        print(f"CONFLICT: {line}")
     return 0
 
 


### PR DESCRIPTION
Closes #3017

## Summary

Content loads never overwrite credited rows: any differing field on a row whose written_by is set freezes the whole row into a conflicts report (CLI + admin flash), and the only override is a per-row, typed-confirmation, digest-guarded delete-then-reload page in admin - no bulk resolve exists. The freeze covers all three write paths that touch CreditedContent rows (fixture/markdown upsert, grid TriggerDefinition refresh, weather emits - the last also gaining credit-name resolution that fixes a real crash on raw natural-key credit refs, plus a credited-row skip in the crafting-materials seeder). Sample seeding now hard-refuses to run once any CONTENT_MODELS table has rows within a press. ADR-0201 records the rulings, the accepted costs (no sync bookkeeping, scan isolation, per-press gate scope), and the one deliberate bypass: admin Import Data remains an undocumented-no-longer, superuser-only disaster-recovery overwrite path - flagged for a future guard if Tehom wants one.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #3017 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main cleanly (branch not yet pushed); no conflicts, no migration files on this branch.

<!-- last-addressed-comment: 0 -->