### PR TITLE
Contributor rows load before the credits that name them

### DIFF
--- a/src/core_management/CLAUDE.md
+++ b/src/core_management/CLAUDE.md
@@ -123,6 +123,12 @@ absent key stays absent rather than clearing an existing credit, the same
 "omission means leave this column alone" rule every other optional field
 follows.
 
+``load_entries`` hoists ``ContentContributor`` objects to the front of the
+pass: credit resolution is drop-not-defer, so a frontmatter ``written_by``
+naming a contributor authored in the same corpus update would otherwise lose
+its credit on a fresh database's single Big Button load and only recover it
+on the next one.
+
 **Known asymmetry:** `NPCRole`, `ItemTemplate`, `BuildingKind` and `DecorationKind`
 carry `CreditedContent` and are authored through `DOMAIN_BUILDERS` (`npc_roles/`,
 `items/`, `building_kinds/`, `decoration_kinds/`) same as every other domain, but

--- a/src/core_management/content_fixtures.py
+++ b/src/core_management/content_fixtures.py
@@ -1487,7 +1487,21 @@ def load_entries(
     created_count = 0
     updated_count = 0
     deferred: list[tuple[dict, Path | None]] = []
-    for output_path, objects in result.fixtures.items():
+
+    # ContentContributor rows load before everything else. Credit fields are
+    # the one drop-not-defer resolution path (#2980: a bad byline drops the
+    # credit, never the row), so an entry whose ``written_by`` names a
+    # contributor that loads LATER in this same pass would lose its credit on
+    # the first load and only pick it up on the next one - which on a fresh
+    # database (the Big Button presses once) means silently uncredited rows.
+    # The markdown domains build before the raw fixture JSON, so without this
+    # reorder every frontmatter credit hits exactly that window. Contributors
+    # are dependency-free by design (ADR-0010), so hoisting them is safe.
+    def _contributors_first(item: tuple[str, list[dict]]) -> bool:
+        _, objects = item
+        return not all(obj.get("model", "").endswith(".contentcontributor") for obj in objects)
+
+    for output_path, objects in sorted(result.fixtures.items(), key=_contributors_first):
         paths = result.source_paths.get(output_path, [])
         for obj, source_path in zip(objects, paths, strict=False):
             try:

--- a/src/core_management/tests/test_content_fixtures.py
+++ b/src/core_management/tests/test_content_fixtures.py
@@ -1316,6 +1316,41 @@ class CreditEndToEndLoadTests(TestCase):
         self.addCleanup(self.tmp.cleanup)
         self.root = Path(self.tmp.name)
 
+    def test_contributor_rows_load_before_the_credits_that_name_them(self) -> None:
+        """One pass suffices even when the contributor arrives in the same corpus.
+
+        Markdown domains build (and so used to load) before the raw fixture
+        JSON, and credit resolution is drop-not-defer - so a frontmatter
+        ``written_by`` naming a contributor authored in
+        ``fixtures/contributors/`` lost its credit on the first load and only
+        picked it up on the next. On a fresh database the Big Button presses
+        once, which made that a silent de-crediting of every markdown credit.
+        ``load_entries`` now hoists contributor objects to the front.
+        """
+        _write(
+            self.root,
+            "skills/juggling.md",
+            "---\n"
+            "name: Juggling\n"
+            "category: social\n"
+            'written_by: "Newperson"\n'
+            "---\n"
+            "PLACEHOLDER Keeping several objects aloft at once.\n",
+        )
+        _write(
+            self.root,
+            "fixtures/contributors/contentcontributor.json",
+            '[{"model": "contributors.contentcontributor",'
+            ' "fields": {"name": "Newperson", "notes": ""}}]\n',
+        )
+        result = build_all(self.root)
+        load_entries(result)
+
+        trait = Trait.objects.get(name="Juggling")
+        assert trait.written_by is not None
+        assert trait.written_by.name == "Newperson"
+        assert not [s for s in result.skipped if "not applied" in s]
+
     def test_written_by_and_written_on_land_on_the_row(self) -> None:
         from world.contributors.factories import ContentContributorFactory
 


### PR DESCRIPTION
A fresh database's single Big Button load silently dropped every markdown-frontmatter credit whose ContentContributor row arrived in the same corpus update: credit resolution is deliberately drop-not-defer (#2980 - a bad byline drops the credit, never the row), and the markdown domains build before the raw fixture JSON, so the contributor row did not exist yet when the credit resolved. The second load healed it, but a fresh install only presses once.

Found in the wild while landing the lore repo's provenance consolidation (ArxII-lore#62): its new contributors fixture hit exactly this window - 11 credits dropped with diagnostics on the first load, applied on the second.

Fix: `load_entries` hoists `contributors.contentcontributor` objects to the front of the pass. Contributors are dependency-free by design (ADR-0010) so the reorder is safe; the sort is stable so every other output keeps its existing order. One new end-to-end test pins the single-pass behavior (credited markdown entry + contributor fixture in one corpus, one load, credit applied, no drop diagnostic). `core_management.tests.test_content_fixtures` 63/63, guard + scan modules 12/12, ruff clean.

No spec issue: single-cause defect fix scoped to one function, found and verified during lore #60; filed straight as a PR per the fold-in rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)