### PR TITLE
Row-level content export from admin with session-batch PR flow

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -71,7 +71,7 @@ sonar.sourceEncoding=UTF-8
 # this file is unverified — carried here to test it. If issues still surface for
 # these rules after this lands on main, move them to the SonarCloud UI
 # (Administration > Analysis Scope > "Ignore Issues on Multiple Criteria").
-sonar.issue.ignore.multicriteria=drf_validators,custom_makemigrations
+sonar.issue.ignore.multicriteria=drf_validators,custom_makemigrations,admin_object_tools_li
 #   python:S3516 ("method always returns the same value") fires on idiomatic DRF
 #   validators/updaters that return their input (validate -> attrs, validate_x -> x,
 #   update -> instance). Scoped to serializer modules only.
@@ -82,3 +82,10 @@ sonar.issue.ignore.multicriteria.drf_validators.resourceKey=**/*serializers.py
 #   to suppress phantom Evennia migrations.
 sonar.issue.ignore.multicriteria.custom_makemigrations.ruleKey=pythonenterprise:S8443
 sonar.issue.ignore.multicriteria.custom_makemigrations.resourceKey=**/management/commands/makemigrations.py
+#   Web:ItemTagNotWithinContainerTagCheck is a fragment-analysis false positive
+#   for our admin overrides: {% block object-tools-items %} renders INSIDE
+#   Django's stock admin `<ul class="object-tools">` (see admin/base_site or
+#   Django's own change_form.html), so a bare <li> at block top level is the
+#   correct and only valid Django idiom here. change_list.html does the same.
+sonar.issue.ignore.multicriteria.admin_object_tools_li.ruleKey=Web:ItemTagNotWithinContainerTagCheck
+sonar.issue.ignore.multicriteria.admin_object_tools_li.resourceKey=src/web/templates/admin/*.html

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -6598,6 +6598,14 @@ Admin-hosted, superuser-only HTMX dashboards for difficulty tuning/simulation an
   `world.seeds.sample_content.assert_sampling_allowed()` refuses `SEED_SAMPLE_CONTENT` invention
   once any `CONTENT_MODELS` table already has a row within the same `seed_dev_database()` press.
   See `src/core_management/CLAUDE.md`'s "Load conflicts" section and ADR-0201.
+- **Row-level export and content session (#3018):** a superuser-only "Export to content repo"
+  button on any change form (`web/templates/admin/change_form.html`, gated by
+  `web/admin/templatetags/content_export_tags.py`'s `CONTENT_MODELS`/`MARKDOWN_EXPORT_DOMAINS`
+  membership check) writes `core_management.content_export.export_single_row()`'s output onto a
+  shared branch (`core_management.content_session.SESSION_BRANCH`), one commit per row behind a
+  digest-guarded diff confirm, then bundles the accumulated commits into a single pull request
+  via the shared `core_management.github_rest` REST client. See the "Row export and content
+  session" section in `src/web/admin/CLAUDE.md` and `src/core_management/CLAUDE.md`.
 - **Grid content export/import (#2436/#2448):** rooms/areas are no longer deferred —
   `Area`/`RoomProfile` gained permanent identity keys (`slug`/`fixture_key`) and a
   `GridOrigin` export gate (see the Areas section above). `core_management.grid_export.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,6 +134,21 @@ external = ["STRING_LITERAL", "PREFETCH_STRING", "SHARED_MEMORY", "USE_FILTERSET
     "EM101",   # string literal in exception — user-facing error text
     "EM102",   # f-string in exception — formatted git error output
 ]
+# Content session module - same subprocess-git-CLI shape as content_push.py
+"src/core_management/content_session.py" = [
+    "S603",    # subprocess without shell check - git CLI calls
+    "S607",    # partial executable path - git is always on PATH
+    "TRY003",  # long exception messages - user-facing error text
+    "EM101",   # string literal in exception - user-facing error text
+    "EM102",   # f-string in exception - formatted git error output
+]
+# Shared GitHub REST client - HTTP error text is inherently descriptive
+"src/core_management/github_rest.py" = [
+    "TRY003",  # long exception messages - user-facing error text
+    "EM101",   # string literal in exception - user-facing error text
+    "EM102",   # f-string in exception - formatted status-code error text
+    "PLR2004", # magic values - 200/300 are the HTTP success-range bounds
+]
 "src/web/admin/content_push_views.py" = [
     "S603",    # subprocess without shell check — git CLI calls
     "S607",    # partial executable path — git is always on PATH

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,6 +126,14 @@ external = ["STRING_LITERAL", "PREFETCH_STRING", "SHARED_MEMORY", "USE_FILTERSET
     "S607",    # partial executable path for git CLI in tests
 ]
 
+# Shared git fixture helper for content-session tests (#3018) - not itself a
+# test_*.py module, so it needs the same subprocess-git-CLI exemption spelled
+# out separately.
+"src/core_management/tests/_git_fixtures.py" = [
+    "S603",    # subprocess calls in test setup
+    "S607",    # partial executable path for git CLI in tests
+]
+
 # Content push module — subprocess git calls are its core function
 "src/core_management/content_push.py" = [
     "S603",    # subprocess without shell check — git CLI calls

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -62,7 +62,7 @@ sonar.sourceEncoding=UTF-8
 
 # Rule-scoped ignores for confirmed architectural false positives.
 # These suppress at analysis time so they never become GitHub issues.
-sonar.issue.ignore.multicriteria=drf_validators,custom_makemigrations
+sonar.issue.ignore.multicriteria=drf_validators,custom_makemigrations,admin_object_tools_li
 #   python:S3516 ("method always returns the same value") fires on idiomatic DRF
 #   validators/updaters that return their input (validate -> attrs, validate_x -> x,
 #   update -> instance). Scoped to serializer modules only.
@@ -73,3 +73,10 @@ sonar.issue.ignore.multicriteria.drf_validators.resourceKey=**/*serializers.py
 #   to suppress phantom Evennia migrations.
 sonar.issue.ignore.multicriteria.custom_makemigrations.ruleKey=pythonenterprise:S8443
 sonar.issue.ignore.multicriteria.custom_makemigrations.resourceKey=**/management/commands/makemigrations.py
+#   Web:ItemTagNotWithinContainerTagCheck is a fragment-analysis false positive
+#   for our admin overrides: {% block object-tools-items %} renders INSIDE
+#   Django's stock admin `<ul class="object-tools">` (see admin/base_site or
+#   Django's own change_form.html), so a bare <li> at block top level is the
+#   correct and only valid Django idiom here. change_list.html does the same.
+sonar.issue.ignore.multicriteria.admin_object_tools_li.ruleKey=Web:ItemTagNotWithinContainerTagCheck
+sonar.issue.ignore.multicriteria.admin_object_tools_li.resourceKey=src/web/templates/admin/*.html

--- a/src/core_management/CLAUDE.md
+++ b/src/core_management/CLAUDE.md
@@ -194,3 +194,38 @@ row can never mix into a real content universe within one press. This is per-pre
 not a standing database-wide invariant: the test-only cluster-seeder helpers in
 `world/seeds/tests/press_helpers.py` call a single cluster directly and sit outside this gate by
 design.
+
+## Row-level export and content session (#3018)
+
+`content_export.export_single_row(instance, content_root=...) -> RowExportResult` is the
+row-scoped sibling of `export_to_content_repo`: it writes exactly one instance's corpus form
+(flat JSON via the normal serializer path, or markdown for a `MARKDOWN_EXPORT_DOMAINS` model)
+into the target file(s) an ordinary export would have used, and reports whether the row's
+natural key was already present (`is_addition`) or is being refused outright
+(`RowExportResult.refused` - the model is not corpus-owned, or `EXPORT_FILTERS` excludes this
+particular row). It never commits anything itself; that is `content_session.commit_row_export`'s
+job, one layer up.
+
+`content_session.py` turns a sequence of these single-row writes into one reviewable batch: a
+fixed branch, `content-export-session`, created fresh off `origin/main` (or reused while its
+pull request is still open), holding one small commit per confirmed row. Git state is the only
+truth this tracks - there is no database table recording which rows are pending - so
+`ensure_session_branch` refuses to start on a dirty working tree, which is what keeps at most
+one row export pending at a time across browsers and operators. `open_session_pr` pushes the
+branch and opens (or reuses) its pull request through `core_management.github_rest
+.github_request`, a small shared client both this module and the player-submissions GitHub-issue
+filer use - `settings.GITHUB_ISSUE_TOKEN` (falling back to the `GH_TOKEN` env var), owner/repo
+parsed from the checkout's own `origin` remote URL rather than named anywhere in code. Error
+messages from that client never echo the response body, only the status code, since GitHub can
+echo request details (including a private repo name) back in an error body and this text
+reaches admin flashes verbatim.
+
+`content_push.push_content_to_repo`'s corpus-wide commit now stages `content/` alongside
+`fixtures/` (`_GIT_CONTENT_PATHSPECS`) - previously only `fixtures/` was staged, so the four
+markdown prose domains never traveled with a whole-corpus push even though `export_to_content_
+repo` already wrote them.
+
+The admin surface driving all of this - the change-form button, the digest-guarded diff/confirm
+pages, and the session page's open-pull-request form - lives in `web/admin/content_row_export_
+views.py`, `web/admin/content_session_views.py`, and `web/templates/admin/change_form.html`.
+See `web/admin/CLAUDE.md`'s "Row export and content session" section for that side of the flow.

--- a/src/core_management/content_export.py
+++ b/src/core_management/content_export.py
@@ -607,7 +607,17 @@ def export_single_row(instance, *, content_root: Path) -> RowExportResult:
     model = type(instance)
     model_name = model.__name__.lower()
     model_label = f"{domain_of(model)}.{model_name}"
-    if model_label not in CONTENT_MODELS and model_label not in MARKDOWN_EXPORT_DOMAINS:
+    # Defense-in-depth against a path-traversal taint finding (pythonsecurity:S2083):
+    # re-derive the label by looking it up IN the allowlist constants themselves,
+    # rather than trusting the string built above. `canonical` is then a value that
+    # provably originates from CONTENT_MODELS/MARKDOWN_EXPORT_DOMAINS, not from
+    # `model`/`instance`, so every path segment derived from it below breaks the
+    # taint chain a static analyzer traces back to the request - not just a
+    # runtime membership check, but a guarantee visible to taint analysis too.
+    canonical = next((known for known in CONTENT_MODELS if known == model_label), None)
+    if canonical is None:
+        canonical = next((known for known in MARKDOWN_EXPORT_DOMAINS if known == model_label), None)
+    if canonical is None:
         return RowExportResult(
             [],
             False,
@@ -615,6 +625,8 @@ def export_single_row(instance, *, content_root: Path) -> RowExportResult:
             "",
             refused=(f"{model.__name__} is not a content model; the content repo does not own it."),
         )
+    model_label = canonical
+    canonical_domain, _, canonical_name = canonical.partition(".")
     predicate = EXPORT_FILTERS.get(model_label)
     if predicate is not None and not model.objects.filter(pk=instance.pk, **predicate).exists():
         return RowExportResult(
@@ -641,6 +653,9 @@ def export_single_row(instance, *, content_root: Path) -> RowExportResult:
         for v in ([record["fields"].get(f) for f in key_fields] if key_fields else [instance.pk])
     )
 
+    # spec["domain"]/content_slug() are hardcoded allowlist constants and a
+    # sanitized slug respectively, not request-derived - the markdown path is
+    # already taint-safe without further changes here.
     spec = MARKDOWN_EXPORT_DOMAINS.get(model_label)
     if spec is not None:
         out_path = _markdown_entry_path(content_root, spec, record["fields"])
@@ -649,8 +664,11 @@ def export_single_row(instance, *, content_root: Path) -> RowExportResult:
         out_path.write_text(render_entry_markdown(record["fields"], spec), encoding="utf-8")
         return RowExportResult([out_path], is_addition, model_label, key_display)
 
-    out_dir = content_root / "fixtures" / domain_of(model)
-    out_path = out_dir / f"{model_name}.json"
+    # Path segments below come from `canonical` (allowlist-derived), not from
+    # `domain_of(model)`/`model_name` (model-class-derived), so the sink is
+    # anchored to the allowlist rather than to `model`.
+    out_dir = content_root / "fixtures" / canonical_domain
+    out_path = out_dir / f"{canonical_name}.json"
     # Case-folded comparison throughout (_record_key_folded, not _record_key):
     # this is a read-modify-write merge against one file, and the loader
     # matches natural keys case-insensitively (#2687) - see that helper's

--- a/src/core_management/content_export.py
+++ b/src/core_management/content_export.py
@@ -655,9 +655,27 @@ def export_single_row(instance, *, content_root: Path) -> RowExportResult:
     # this is a read-modify-write merge against one file, and the loader
     # matches natural keys case-insensitively (#2687) - see that helper's
     # docstring for why this path must diverge from the corpus-wide gate.
+    is_addition = _merge_record_into_fixture_file(out_path, record, key_fields)
+    return RowExportResult([out_path], is_addition, model_label, key_display)
+
+
+def _merge_record_into_fixture_file(
+    out_path: Path, record: dict, key_fields: list[str] | None
+) -> bool:
+    """Read-modify-write one record into a JSON fixture file; return is_addition.
+
+    Extracted from ``export_single_row`` to keep that function under the
+    complexity ceiling; behavior is unchanged. An existing record whose
+    case-folded natural key (``_record_key_folded``) matches ``record`` is
+    replaced in place; otherwise ``record`` is appended. The return value is
+    True when the row's natural key was not already present in the file
+    (a first-export addition) - the same value ``export_single_row`` reports
+    as ``RowExportResult.is_addition``.
+    """
+    file_existed = out_path.exists()
     row_key_folded = _record_key_folded(record["fields"], key_fields) if key_fields else None
     records: list[dict] = []
-    if out_path.exists():
+    if file_existed:
         with suppress(OSError, ValueError):
             loaded = json.loads(out_path.read_text(encoding="utf-8"))
             if isinstance(loaded, list):
@@ -671,7 +689,7 @@ def export_single_row(instance, *, content_root: Path) -> RowExportResult:
         if key_fields
         else set()
     )
-    is_addition = not out_path.exists() or row_key_folded not in existing_folded
+    is_addition = not file_existed or row_key_folded not in existing_folded
     replaced = False
     for i, existing in enumerate(records):
         if (
@@ -685,9 +703,9 @@ def export_single_row(instance, *, content_root: Path) -> RowExportResult:
             break
     if not replaced:
         records.append(record)
-    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
     out_path.write_text(json.dumps(records, indent=2) + "\n", encoding="utf-8")
-    return RowExportResult([out_path], is_addition, model_label, key_display)
+    return is_addition
 
 
 def _apply_addition_gate(

--- a/src/core_management/content_export.py
+++ b/src/core_management/content_export.py
@@ -19,6 +19,7 @@ standalone). All Django imports are deferred.
 
 from __future__ import annotations
 
+from contextlib import suppress
 from dataclasses import dataclass, field
 import json
 import logging
@@ -279,6 +280,23 @@ EXPORT_FILTERS: dict[str, dict[str, object]] = {
 }
 
 
+def _markdown_entry_path(root: Path, spec: dict, fields: dict) -> Path:
+    """Return the file a prose-domain record renders to (#3018).
+
+    Shared by ``_write_markdown_entries`` (whole-domain export) and
+    ``export_single_row`` (row-level export) so the slug/nesting rule can
+    never drift between the two callers.
+    """
+    domain_dir = root / spec["domain"]
+    out_dir = domain_dir
+    subdir_key = spec.get("subdir_from")
+    if subdir_key:
+        value = fields.get(subdir_key)
+        if isinstance(value, list) and value:
+            out_dir = domain_dir / content_slug(str(value[-1]))
+    return out_dir / f"{content_slug(fields['name'])}.md"
+
+
 def _write_markdown_entries(
     root: Path, spec: dict, serialized: str, *, allow_additions: bool = False
 ) -> tuple[list[Path], list[str]]:
@@ -308,17 +326,11 @@ def _write_markdown_entries(
     withheld: list[str] = []
     for record in json.loads(serialized):
         fields = record["fields"]
-        out_dir = domain_dir
-        subdir_key = spec.get("subdir_from")
-        if subdir_key:
-            value = fields.get(subdir_key)
-            if isinstance(value, list) and value:
-                out_dir = domain_dir / content_slug(str(value[-1]))
-        out_path = out_dir / f"{content_slug(fields['name'])}.md"
+        out_path = _markdown_entry_path(root, spec, fields)
         if gate_on and not out_path.exists():
             withheld.append(str(fields.get("name", out_path.stem)))
             continue
-        out_dir.mkdir(parents=True, exist_ok=True)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
         out_path.write_text(render_entry_markdown(fields, spec), encoding="utf-8")
         written.append(out_path)
     return written, withheld
@@ -534,6 +546,105 @@ def _write_one_model(
     out_path.write_text(json.dumps(records, indent=2) + "\n", encoding="utf-8")
     result.written.append(out_path)
     result.total_records += len(records)
+
+
+@dataclass
+class RowExportResult:
+    """Outcome of a single-row export (#3018)."""
+
+    paths: list[Path]
+    is_addition: bool
+    model_label: str
+    natural_key: str
+    refused: str | None = None
+
+
+def export_single_row(instance, *, content_root: Path) -> RowExportResult:
+    """Write ONE row's corpus form into the lore checkout working tree.
+
+    Reuses the corpus exporter's serializer and natural-key identity so a
+    row-level export can never disagree with a full export about a record's
+    shape. JSON domains re-emit the model's file with the exporter's canonical
+    formatting after replacing or appending the one record - a file predating
+    canonical formatting shows a one-time whole-file reformat in the diff
+    preview, which is the accepted trade against byte-surgery (#3018 spec).
+    Addition-vs-update is decided with the ADR-0191 record keys; the CALLER
+    enforces the explicit new-row acknowledgment - this function only reports.
+    """
+    from django.core import serializers  # noqa: PLC0415
+
+    model = type(instance)
+    model_name = model.__name__.lower()
+    model_label = f"{domain_of(model)}.{model_name}"
+    if model_label not in CONTENT_MODELS and model_label not in MARKDOWN_EXPORT_DOMAINS:
+        return RowExportResult(
+            [],
+            False,
+            model_label,
+            "",
+            refused=(f"{model.__name__} is not a content model; the content repo does not own it."),
+        )
+    predicate = EXPORT_FILTERS.get(model_label)
+    if predicate is not None and not model.objects.filter(pk=instance.pk, **predicate).exists():
+        return RowExportResult(
+            [],
+            False,
+            model_label,
+            "",
+            refused=(
+                f"This {model.__name__} row is excluded from export (player-owned rows "
+                "stay out of the corpus)."
+            ),
+        )
+    data = serializers.serialize(
+        "json",
+        model.objects.filter(pk=instance.pk),
+        indent=2,
+        use_natural_foreign_keys=True,
+        use_natural_primary_keys=True,
+    )
+    record = json.loads(data)[0]
+    key_fields = _natural_key_fields(model)
+    key_display = ", ".join(
+        str(v)
+        for v in ([record["fields"].get(f) for f in key_fields] if key_fields else [instance.pk])
+    )
+
+    spec = MARKDOWN_EXPORT_DOMAINS.get(model_label)
+    if spec is not None:
+        out_path = _markdown_entry_path(content_root, spec, record["fields"])
+        is_addition = not out_path.exists()
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(render_entry_markdown(record["fields"], spec), encoding="utf-8")
+        return RowExportResult([out_path], is_addition, model_label, key_display)
+
+    out_dir = content_root / "fixtures" / domain_of(model)
+    out_path = out_dir / f"{model_name}.json"
+    existing_keys = _existing_record_keys(out_path, key_fields) if key_fields is not None else None
+    row_key = _record_key(record["fields"], key_fields) if key_fields else None
+    is_addition = existing_keys is None or row_key not in existing_keys
+    records: list[dict] = []
+    if out_path.exists():
+        with suppress(OSError, ValueError):
+            loaded = json.loads(out_path.read_text(encoding="utf-8"))
+            if isinstance(loaded, list):
+                records = loaded
+    replaced = False
+    for i, existing in enumerate(records):
+        if (
+            key_fields
+            and isinstance(existing, dict)
+            and isinstance(existing.get("fields"), dict)
+            and _record_key(existing["fields"], key_fields) == row_key
+        ):
+            records[i] = record
+            replaced = True
+            break
+    if not replaced:
+        records.append(record)
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path.write_text(json.dumps(records, indent=2) + "\n", encoding="utf-8")
+    return RowExportResult([out_path], is_addition, model_label, key_display)
 
 
 def _apply_addition_gate(

--- a/src/core_management/content_export.py
+++ b/src/core_management/content_export.py
@@ -386,6 +386,32 @@ def _record_key(record_fields: dict, key_fields: list[str]) -> str:
     return json.dumps([record_fields.get(f) for f in key_fields], sort_keys=True)
 
 
+def _record_key_folded(record_fields: dict, key_fields: list[str]) -> str:
+    """Case-normalized ``_record_key``, matching the loader's iexact semantics (#2687).
+
+    Deliberately diverges from ``_record_key``'s exact-match identity, which
+    ``_apply_addition_gate`` (the corpus-wide export's addition gate) uses and
+    keeps using unchanged - that gate only ever compares two exports produced
+    by the same serializer settings on the same pass, so casing never drifts
+    between its two sides. ``export_single_row``'s JSON path is different: it
+    is a read-modify-write merge against a file that may already hold a row
+    under different casing (e.g. a name edited in admin), and the loader
+    resolves natural keys case-insensitively - so an exact-match comparison
+    there would append a second record instead of replacing the first, and the
+    next load would then treat both records as the same row (order-dependent
+    double-apply).
+    """
+
+    def fold(value: object) -> object:
+        if isinstance(value, str):
+            return value.casefold()
+        if isinstance(value, list):
+            return [fold(v) for v in value]
+        return value
+
+    return json.dumps([fold(record_fields.get(f)) for f in key_fields], sort_keys=True)
+
+
 def _existing_record_keys(out_path: Path, key_fields: list[str]) -> set[str] | None:
     """Return the natural keys already in the corpus file, or None if absent.
 
@@ -570,6 +596,11 @@ def export_single_row(instance, *, content_root: Path) -> RowExportResult:
     preview, which is the accepted trade against byte-surgery (#3018 spec).
     Addition-vs-update is decided with the ADR-0191 record keys; the CALLER
     enforces the explicit new-row acknowledgment - this function only reports.
+    The JSON merge below relies on every ``CONTENT_MODELS``/``MARKDOWN_EXPORT_DOMAINS``
+    row carrying ``NaturalKeyMixin`` (pinned by
+    ``test_content_models_all_have_natural_key``) - a model with no natural key
+    would make ``key_fields`` None and every export append a fresh record
+    instead of replacing one, which is why that invariant must hold.
     """
     from django.core import serializers  # noqa: PLC0415
 
@@ -620,22 +651,34 @@ def export_single_row(instance, *, content_root: Path) -> RowExportResult:
 
     out_dir = content_root / "fixtures" / domain_of(model)
     out_path = out_dir / f"{model_name}.json"
-    existing_keys = _existing_record_keys(out_path, key_fields) if key_fields is not None else None
-    row_key = _record_key(record["fields"], key_fields) if key_fields else None
-    is_addition = existing_keys is None or row_key not in existing_keys
+    # Case-folded comparison throughout (_record_key_folded, not _record_key):
+    # this is a read-modify-write merge against one file, and the loader
+    # matches natural keys case-insensitively (#2687) - see that helper's
+    # docstring for why this path must diverge from the corpus-wide gate.
+    row_key_folded = _record_key_folded(record["fields"], key_fields) if key_fields else None
     records: list[dict] = []
     if out_path.exists():
         with suppress(OSError, ValueError):
             loaded = json.loads(out_path.read_text(encoding="utf-8"))
             if isinstance(loaded, list):
                 records = loaded
+    existing_folded = (
+        {
+            _record_key_folded(r["fields"], key_fields)
+            for r in records
+            if isinstance(r, dict) and isinstance(r.get("fields"), dict)
+        }
+        if key_fields
+        else set()
+    )
+    is_addition = not out_path.exists() or row_key_folded not in existing_folded
     replaced = False
     for i, existing in enumerate(records):
         if (
             key_fields
             and isinstance(existing, dict)
             and isinstance(existing.get("fields"), dict)
-            and _record_key(existing["fields"], key_fields) == row_key
+            and _record_key_folded(existing["fields"], key_fields) == row_key_folded
         ):
             records[i] = record
             replaced = True

--- a/src/core_management/content_push.py
+++ b/src/core_management/content_push.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 import logging
 from pathlib import Path
+import re
 import subprocess
 
 from core_management.content_repo import resolve_content_root
@@ -34,6 +35,14 @@ _GIT_MAIN = "main"
 # traditions) live under content/, not fixtures/ - staging only fixtures/ left
 # them silently unpushed by the corpus push (pre-existing gap, #3018).
 _GIT_CONTENT_PATHSPECS = ("fixtures/", "content/")
+# Strips a userinfo/credential segment (user:token@ or token@) from a URL
+# before it ever reaches an error message - an https remote can carry one,
+# and a failed push/fetch embeds git's stderr verbatim, which can quote the
+# remote URL back in full (#3018 review). Canonical location: ``_run_git``
+# (below) is the one place a git failure message is built, so every caller
+# of it - including ``content_session.py``, which imports this - is scrubbed
+# for free rather than needing its own copy of this pattern.
+_URL_CREDENTIALS = re.compile(r"//[^/@]+@")
 
 
 class ContentPushError(Exception):
@@ -56,7 +65,11 @@ class PushResult:
 def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
     """Run a git command in ``repo`` and return the completed process.
 
-    Raises ``ContentPushError`` if git exits non-zero.
+    Raises ``ContentPushError`` if git exits non-zero. A failed push or fetch
+    can quote the remote URL back in its stderr, and an https remote can
+    carry a token-as-username credential - so the message is scrubbed with
+    ``_URL_CREDENTIALS`` before it ever reaches an exception a caller might
+    flash to an admin page (#3018 review).
     """
     result = subprocess.run(
         ["git", "-C", str(repo), *args],
@@ -66,8 +79,9 @@ def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
         timeout=120,
     )
     if result.returncode != 0:
+        safe_stderr = _URL_CREDENTIALS.sub("//", result.stderr.strip())
         raise ContentPushError(
-            f"git {' '.join(args)} failed (exit {result.returncode}):\n{result.stderr.strip()}"
+            f"git {' '.join(args)} failed (exit {result.returncode}):\n{safe_stderr}"
         )
     return result
 

--- a/src/core_management/content_push.py
+++ b/src/core_management/content_push.py
@@ -30,7 +30,10 @@ logger = logging.getLogger(__name__)
 _GIT_TRUE = "true"
 _GIT_ORIGIN = "origin"
 _GIT_MAIN = "main"
-_GIT_FIXTURES_PATHSPEC = "fixtures/"
+# The four markdown prose domains (codex entries, beginnings, starting areas,
+# traditions) live under content/, not fixtures/ - staging only fixtures/ left
+# them silently unpushed by the corpus push (pre-existing gap, #3018).
+_GIT_CONTENT_PATHSPECS = ("fixtures/", "content/")
 
 
 class ContentPushError(Exception):
@@ -159,9 +162,10 @@ def _push_with_rebase_retry(root: Path, result: PushResult) -> None:
 def push_content_to_repo(content_root: Path | None = None) -> PushResult:
     """Stage, commit, and push fixture changes in the lore repo.
 
-    Stages all changes under ``fixtures/``, commits with an auto-generated
-    message, and pushes to ``origin main``. If the push is rejected (remote
-    has newer commits), pulls with ``--rebase`` and retries once.
+    Stages all changes under ``fixtures/`` and ``content/``, commits with an
+    auto-generated message, and pushes to ``origin main``. If the push is
+    rejected (remote has newer commits), pulls with ``--rebase`` and retries
+    once.
 
     Returns a ``PushResult``. If there are no changes to commit, returns
     early with ``committed=False``.
@@ -181,12 +185,14 @@ def push_content_to_repo(content_root: Path | None = None) -> PushResult:
 
     result = PushResult()
 
-    # Stage all changes under fixtures/.
-    fixtures_dir = root / "fixtures"
-    if not fixtures_dir.is_dir():
+    # Stage all changes under fixtures/ and content/ - a pathspec for a
+    # directory that doesn't exist in this checkout makes `git add` fail
+    # outright, so only pass the ones actually present.
+    pathspecs = [p for p in _GIT_CONTENT_PATHSPECS if (root / p).is_dir()]
+    if not pathspecs:
         return result
 
-    _run_git(root, "add", "--all", "--", _GIT_FIXTURES_PATHSPEC)
+    _run_git(root, "add", "--all", "--", *pathspecs)
 
     result.files_staged = _staged_file_count(root)
     if result.files_staged == 0:

--- a/src/core_management/content_session.py
+++ b/src/core_management/content_session.py
@@ -1,0 +1,216 @@
+"""Row-level content export session: a single git branch as scratch space (#3018).
+
+This is additive beside ``content_push.py``'s ``push_content_to_repo``, which
+stays a main-only, whole-corpus flow. A content session lets staff export one
+row at a time from the admin, review each row's diff, and later bundle the
+accumulated commits into a single pull request for review - the branch *is*
+the session state. There is no separate database table tracking which rows
+are "in" a pending export; ``git log`` and ``git diff`` against
+``origin/main`` are the source of truth, queried fresh on every call.
+
+All git plumbing reuses ``content_push._run_git``/``ContentPushError`` so
+error formatting matches the rest of the export pipeline. The one HTTP call
+this module makes - opening the session's pull request - goes through the
+shared ``github_rest`` client.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+import re
+import subprocess
+
+from core_management.content_push import ContentPushError, _run_git
+from core_management.github_rest import GitHubRestError, github_request
+
+SESSION_BRANCH = "content-export-session"
+
+_GIT_ORIGIN = "origin"
+_GIT_MAIN = "main"
+
+_HTTPS_REMOTE = re.compile(r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$")
+_SSH_REMOTE = re.compile(r"^git@github\.com:(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$")
+
+
+@dataclass
+class SessionState:
+    """Snapshot of the session branch's state, relative to ``origin/main``."""
+
+    branch: str
+    on_session: bool
+    commits: list[str]
+    diff_stat: str
+    dirty: list[str]
+
+
+def _git_ok(repo: Path, *args: str) -> bool:
+    """Run a git command in ``repo``, returning True on exit 0 without raising."""
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    return result.returncode == 0
+
+
+def _current_branch(repo: Path) -> str:
+    """Return the current branch name (or empty string for detached HEAD)."""
+    return _run_git(repo, "branch", "--show-current").stdout.strip()
+
+
+def _short_status_lines(repo: Path) -> list[str]:
+    """Return non-empty ``git status --short`` lines."""
+    result = _run_git(repo, "status", "--short")
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def _to_relative(repo: Path, paths: list[Path]) -> list[str]:
+    """Return ``paths`` as strings relative to ``repo``."""
+    rels: list[str] = []
+    for path in paths:
+        candidate = Path(path)
+        if candidate.is_absolute():
+            rels.append(str(candidate.relative_to(repo)))
+        else:
+            rels.append(str(candidate))
+    return rels
+
+
+def ensure_session_branch(content_root: Path) -> None:
+    """Ensure the checkout is on ``SESSION_BRANCH``, fresh off ``origin/main`` if merged.
+
+    Fetches origin first. If the working tree is dirty on a branch other than
+    the session branch, raises ``ContentPushError`` without touching anything
+    else - the session flow never stashes work. If the session branch already
+    exists and is fully merged into ``origin/main`` (its PR landed), the stale
+    branch is deleted and recreated fresh; otherwise the existing branch (with
+    its unmerged commits) is reused.
+    """
+    _run_git(content_root, "fetch", _GIT_ORIGIN)
+
+    branch = _current_branch(content_root)
+    dirty = _short_status_lines(content_root)
+    if dirty and branch != SESSION_BRANCH:
+        raise ContentPushError(
+            f"working tree has uncommitted changes on '{branch}' - commit or "
+            "clean them first; the session flow never stashes work."
+        )
+
+    branch_exists = _git_ok(
+        content_root, "show-ref", "--verify", "--quiet", f"refs/heads/{SESSION_BRANCH}"
+    )
+    if branch_exists:
+        merged = _git_ok(
+            content_root,
+            "merge-base",
+            "--is-ancestor",
+            SESSION_BRANCH,
+            f"{_GIT_ORIGIN}/{_GIT_MAIN}",
+        )
+        if merged:
+            if branch == SESSION_BRANCH:
+                _run_git(content_root, "checkout", "--detach", f"{_GIT_ORIGIN}/{_GIT_MAIN}")
+            _run_git(content_root, "branch", "-D", SESSION_BRANCH)
+            branch_exists = False
+
+    if branch_exists:
+        if branch != SESSION_BRANCH:
+            _run_git(content_root, "switch", SESSION_BRANCH)
+    else:
+        _run_git(content_root, "switch", "-c", SESSION_BRANCH, f"{_GIT_ORIGIN}/{_GIT_MAIN}")
+
+
+def commit_row_export(content_root: Path, paths: list[Path], message: str) -> str:
+    """Stage exactly ``paths`` and commit them; return the short commit sha.
+
+    Any other dirty file in the working tree is left uncommitted.
+    """
+    rels = _to_relative(content_root, paths)
+    _run_git(content_root, "add", "--", *rels)
+    _run_git(content_root, "commit", "-m", message)
+    return _run_git(content_root, "rev-parse", "--short", "HEAD").stdout.strip()
+
+
+def discard_row_export(content_root: Path, paths: list[Path]) -> None:
+    """Discard uncommitted changes to ``paths`` - restore tracked, delete new."""
+    for path, rel in zip(paths, _to_relative(content_root, paths), strict=True):
+        if _git_ok(content_root, "ls-files", "--error-unmatch", "--", rel):
+            _run_git(content_root, "checkout", "--", rel)
+        else:
+            Path(path).unlink(missing_ok=True)
+
+
+def _session_commits(content_root: Path) -> list[str]:
+    """Return one-line ``sha subject`` entries for commits on the session branch not on main."""
+    result = _run_git(content_root, "log", "--oneline", f"{_GIT_ORIGIN}/{_GIT_MAIN}..HEAD")
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def session_state(content_root: Path) -> SessionState:
+    """Return the current session branch's state relative to ``origin/main``."""
+    branch = _current_branch(content_root)
+    diff_stat = _run_git(
+        content_root, "diff", f"{_GIT_ORIGIN}/{_GIT_MAIN}...HEAD", "--stat"
+    ).stdout.strip()
+    return SessionState(
+        branch=branch,
+        on_session=branch == SESSION_BRANCH,
+        commits=_session_commits(content_root),
+        diff_stat=diff_stat,
+        dirty=_short_status_lines(content_root),
+    )
+
+
+def row_diff(content_root: Path, paths: list[Path]) -> str:
+    """Return the uncommitted diff (working tree vs HEAD) for ``paths``."""
+    rels = _to_relative(content_root, paths)
+    return _run_git(content_root, "diff", "--", *rels).stdout
+
+
+def session_diff(content_root: Path) -> str:
+    """Return the full session diff, ``origin/main...HEAD``."""
+    return _run_git(content_root, "diff", f"{_GIT_ORIGIN}/{_GIT_MAIN}...HEAD").stdout
+
+
+def _remote_slug(content_root: Path) -> tuple[str, str]:
+    """Return ``(owner, repo)`` parsed from the origin remote URL.
+
+    Handles both ``https://github.com/O/R(.git)`` and ``git@github.com:O/R(.git)``.
+    Raises ``ContentPushError`` for anything else.
+    """
+    url = _run_git(content_root, "remote", "get-url", _GIT_ORIGIN).stdout.strip()
+    for pattern in (_HTTPS_REMOTE, _SSH_REMOTE):
+        match = pattern.match(url)
+        if match:
+            return match.group("owner"), match.group("repo")
+    raise ContentPushError(f"origin remote URL is not a GitHub URL this session flow parses: {url}")
+
+
+def open_session_pr(content_root: Path, *, title: str, body: str) -> str:
+    """Push the session branch and open (or reuse) its pull request; return the html_url.
+
+    Reuses an already-open PR for the session branch instead of filing a
+    duplicate on repeated calls.
+    """
+    owner, repo = _remote_slug(content_root)
+    slug = f"{owner}/{repo}"
+    _run_git(content_root, "push", "-u", _GIT_ORIGIN, SESSION_BRANCH)
+    try:
+        existing = github_request(
+            "GET", f"/repos/{slug}/pulls?head={owner}:{SESSION_BRANCH}&state=open"
+        )
+        if existing:
+            return existing[0]["html_url"]
+        created = github_request(
+            "POST",
+            f"/repos/{slug}/pulls",
+            payload={"title": title, "body": body, "head": SESSION_BRANCH, "base": _GIT_MAIN},
+        )
+    except GitHubRestError as exc:
+        raise ContentPushError(f"could not open the session pull request: {exc}") from exc
+    if not isinstance(created, dict):
+        raise ContentPushError("GitHub returned an unexpected response shape for the new PR.")
+    return created["html_url"]

--- a/src/core_management/content_session.py
+++ b/src/core_management/content_session.py
@@ -31,6 +31,9 @@ _GIT_MAIN = "main"
 
 _HTTPS_REMOTE = re.compile(r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$")
 _SSH_REMOTE = re.compile(r"^git@github\.com:(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$")
+# Strips a userinfo/credential segment (user:token@ or token@) from a URL
+# before it ever reaches an error message - an https remote can carry one.
+_URL_CREDENTIALS = re.compile(r"//[^/@]+@")
 
 
 @dataclass
@@ -79,25 +82,33 @@ def _to_relative(repo: Path, paths: list[Path]) -> list[str]:
     return rels
 
 
+def _dirty_refusal_message(branch: str) -> str:
+    """Return the standard refusal text for a dirty tree on ``branch``."""
+    return (
+        f"working tree has uncommitted changes on '{branch}' - commit or "
+        "clean them first; the session flow never stashes work."
+    )
+
+
 def ensure_session_branch(content_root: Path) -> None:
     """Ensure the checkout is on ``SESSION_BRANCH``, fresh off ``origin/main`` if merged.
 
-    Fetches origin first. If the working tree is dirty on a branch other than
-    the session branch, raises ``ContentPushError`` without touching anything
-    else - the session flow never stashes work. If the session branch already
-    exists and is fully merged into ``origin/main`` (its PR landed), the stale
-    branch is deleted and recreated fresh; otherwise the existing branch (with
-    its unmerged commits) is reused.
+    Fetches origin first. If the working tree is dirty, raises
+    ``ContentPushError`` without touching anything else - the session flow
+    never stashes work. This applies on any branch, including the session
+    branch itself: a dirty session branch that turns out to be merged would
+    otherwise have its uncommitted changes silently discarded by the
+    detach-and-delete recreate below. If the session branch already exists
+    and is fully merged into ``origin/main`` (its PR landed), the stale
+    branch is deleted and recreated fresh; otherwise the existing branch
+    (with its unmerged commits) is reused.
     """
     _run_git(content_root, "fetch", _GIT_ORIGIN)
 
     branch = _current_branch(content_root)
     dirty = _short_status_lines(content_root)
     if dirty and branch != SESSION_BRANCH:
-        raise ContentPushError(
-            f"working tree has uncommitted changes on '{branch}' - commit or "
-            "clean them first; the session flow never stashes work."
-        )
+        raise ContentPushError(_dirty_refusal_message(branch))
 
     branch_exists = _git_ok(
         content_root, "show-ref", "--verify", "--quiet", f"refs/heads/{SESSION_BRANCH}"
@@ -112,6 +123,8 @@ def ensure_session_branch(content_root: Path) -> None:
         )
         if merged:
             if branch == SESSION_BRANCH:
+                if dirty:
+                    raise ContentPushError(_dirty_refusal_message(branch))
                 _run_git(content_root, "checkout", "--detach", f"{_GIT_ORIGIN}/{_GIT_MAIN}")
             _run_git(content_root, "branch", "-D", SESSION_BRANCH)
             branch_exists = False
@@ -136,11 +149,11 @@ def commit_row_export(content_root: Path, paths: list[Path], message: str) -> st
 
 def discard_row_export(content_root: Path, paths: list[Path]) -> None:
     """Discard uncommitted changes to ``paths`` - restore tracked, delete new."""
-    for path, rel in zip(paths, _to_relative(content_root, paths), strict=True):
+    for rel in _to_relative(content_root, paths):
         if _git_ok(content_root, "ls-files", "--error-unmatch", "--", rel):
             _run_git(content_root, "checkout", "--", rel)
         else:
-            Path(path).unlink(missing_ok=True)
+            (content_root / rel).unlink(missing_ok=True)
 
 
 def _session_commits(content_root: Path) -> list[str]:
@@ -186,7 +199,10 @@ def _remote_slug(content_root: Path) -> tuple[str, str]:
         match = pattern.match(url)
         if match:
             return match.group("owner"), match.group("repo")
-    raise ContentPushError(f"origin remote URL is not a GitHub URL this session flow parses: {url}")
+    safe_url = _URL_CREDENTIALS.sub("//", url)
+    raise ContentPushError(
+        f"origin remote URL is not a GitHub URL this session flow parses: {safe_url}"
+    )
 
 
 def open_session_pr(content_root: Path, *, title: str, body: str) -> str:

--- a/src/core_management/content_session.py
+++ b/src/core_management/content_session.py
@@ -177,10 +177,49 @@ def session_state(content_root: Path) -> SessionState:
     )
 
 
+def _no_index_diff(content_root: Path, rel: str) -> str:
+    """Return a full-file addition diff for one untracked path (#3018).
+
+    Plain ``git diff`` only compares tracked content, so a brand-new export
+    (the common row-export case: a row's first commit into the corpus) is
+    invisible to it - the working tree file exists but the diff renders
+    empty. ``git diff --no-index`` against ``/dev/null`` shows the whole file
+    as an addition instead, without touching the index. Exit 1 is the normal
+    "a difference exists" result for ``--no-index``; only other nonzero
+    exits are a real git failure.
+    """
+    result = subprocess.run(
+        ["git", "-C", str(content_root), "diff", "--no-index", "--", "/dev/null", rel],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode not in (0, 1):
+        raise ContentPushError(
+            f"git diff --no-index failed (exit {result.returncode}):\n{result.stderr.strip()}"
+        )
+    return result.stdout
+
+
 def row_diff(content_root: Path, paths: list[Path]) -> str:
-    """Return the uncommitted diff (working tree vs HEAD) for ``paths``."""
+    """Return the uncommitted diff (working tree vs HEAD) for ``paths``.
+
+    Tracked paths go through plain ``git diff``; untracked ones (a row's
+    first-ever export, before it has any commit) go through
+    ``_no_index_diff`` instead - see that helper's docstring for why plain
+    ``git diff`` cannot show them.
+    """
     rels = _to_relative(content_root, paths)
-    return _run_git(content_root, "diff", "--", *rels).stdout
+    tracked = [
+        rel for rel in rels if _git_ok(content_root, "ls-files", "--error-unmatch", "--", rel)
+    ]
+    untracked = [rel for rel in rels if rel not in tracked]
+    parts: list[str] = []
+    if tracked:
+        parts.append(_run_git(content_root, "diff", "--", *tracked).stdout)
+    parts.extend(_no_index_diff(content_root, rel) for rel in untracked)
+    return "".join(parts)
 
 
 def session_diff(content_root: Path) -> str:

--- a/src/core_management/content_session.py
+++ b/src/core_management/content_session.py
@@ -83,31 +83,56 @@ def _to_relative(repo: Path, paths: list[Path]) -> list[str]:
 
 
 def _dirty_refusal_message(branch: str) -> str:
-    """Return the standard refusal text for a dirty tree on ``branch``."""
+    """Return the standard refusal text for a dirty tree on a non-session ``branch``."""
     return (
         f"working tree has uncommitted changes on '{branch}' - commit or "
         "clean them first; the session flow never stashes work."
     )
 
 
+def _pending_export_refusal_message() -> str:
+    """Return the refusal text for a dirty tree already on the session branch.
+
+    A dirty tree here always means a prior row's export is still
+    uncommitted/undiscarded (#3018 review) - there is no other legitimate
+    way for the session branch to be dirty, since nothing but
+    ``content_export_row`` ever writes to it outside a commit.
+    """
+    return (
+        "The content checkout has uncommitted changes from a pending export. "
+        "Confirm or discard it before exporting another row."
+    )
+
+
 def ensure_session_branch(content_root: Path) -> None:
     """Ensure the checkout is on ``SESSION_BRANCH``, fresh off ``origin/main`` if merged.
 
-    Fetches origin first. If the working tree is dirty, raises
-    ``ContentPushError`` without touching anything else - the session flow
-    never stashes work. This applies on any branch, including the session
-    branch itself: a dirty session branch that turns out to be merged would
-    otherwise have its uncommitted changes silently discarded by the
-    detach-and-delete recreate below. If the session branch already exists
-    and is fully merged into ``origin/main`` (its PR landed), the stale
-    branch is deleted and recreated fresh; otherwise the existing branch
-    (with its unmerged commits) is reused.
+    Fetches origin first, then refuses ANY dirty working tree - including
+    when already on the session branch. This function's only caller is the
+    row-export POST (``content_export_row``), which requires the tree to be
+    clean by definition: enforcing that here (against git state, the only
+    truth that holds across browsers/operators) is what guarantees the
+    flow's core invariant, at most one pending row export at a time. Without
+    this, exporting a second row while a first is still uncommitted would
+    merge both rows' writes into one file, and the second row's diff/commit/
+    discard would silently carry the first row's pending changes along with
+    it (#3018 review - live-reproduced: two same-model exports collapsed
+    into one commit under the second row's message).
+
+    This also protects the merged-branch recreate below: a dirty session
+    branch that turns out to be merged would otherwise have its uncommitted
+    changes silently discarded by the detach-and-delete. If the session
+    branch already exists and is fully merged into ``origin/main`` (its PR
+    landed), the stale branch is deleted and recreated fresh; otherwise the
+    existing branch (with its unmerged commits) is reused.
     """
     _run_git(content_root, "fetch", _GIT_ORIGIN)
 
     branch = _current_branch(content_root)
     dirty = _short_status_lines(content_root)
-    if dirty and branch != SESSION_BRANCH:
+    if dirty:
+        if branch == SESSION_BRANCH:
+            raise ContentPushError(_pending_export_refusal_message())
         raise ContentPushError(_dirty_refusal_message(branch))
 
     branch_exists = _git_ok(
@@ -123,8 +148,6 @@ def ensure_session_branch(content_root: Path) -> None:
         )
         if merged:
             if branch == SESSION_BRANCH:
-                if dirty:
-                    raise ContentPushError(_dirty_refusal_message(branch))
                 _run_git(content_root, "checkout", "--detach", f"{_GIT_ORIGIN}/{_GIT_MAIN}")
             _run_git(content_root, "branch", "-D", SESSION_BRANCH)
             branch_exists = False

--- a/src/core_management/content_session.py
+++ b/src/core_management/content_session.py
@@ -17,10 +17,12 @@ shared ``github_rest`` client.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import json
 from pathlib import Path
 import re
 import subprocess
 
+from core_management.content_export import _record_key_folded
 from core_management.content_push import ContentPushError, _run_git
 from core_management.github_rest import GitHubRestError, github_request
 
@@ -95,8 +97,13 @@ def _pending_export_refusal_message() -> str:
 
     A dirty tree here always means a prior row's export is still
     uncommitted/undiscarded (#3018 review) - there is no other legitimate
-    way for the session branch to be dirty, since nothing but
-    ``content_export_row`` ever writes to it outside a commit.
+    way for the session branch to *become* dirty, since nothing but
+    ``content_export_row`` ever writes to it outside a commit. Getting back
+    out of it does not have to mean confirming or discarding that specific
+    row, though - ``discard_all_pending`` (wired to the content session
+    page's "Discard all pending changes" button, #3018 review) wipes
+    whatever is dirty in one step, for a browser that can no longer reach the
+    pending row's own diff page or simply does not want to review it.
     """
     return (
         "The content checkout has uncommitted changes from a pending export. "
@@ -157,6 +164,42 @@ def ensure_session_branch(content_root: Path) -> None:
             _run_git(content_root, "switch", SESSION_BRANCH)
     else:
         _run_git(content_root, "switch", "-c", SESSION_BRANCH, f"{_GIT_ORIGIN}/{_GIT_MAIN}")
+
+
+#: The only two directories the row-export flow ever writes to - the sole
+#: pathspecs ``discard_all_pending`` is ever allowed to touch, so it can never
+#: become a bare ``git clean`` that sweeps an unrelated untracked file.
+_DISCARD_PATHSPECS = ("fixtures/", "content/")
+
+
+def discard_all_pending(content_root: Path) -> None:
+    """Discard every uncommitted change under ``fixtures/`` and ``content/`` (#3018 review).
+
+    The strand-recovery counterpart to a stuck pending row export: an
+    operator who cannot or does not want to confirm it (a crashed browser
+    mid-review, or simply changing their mind about a row) needs a way back
+    to a clean working tree without hand-running git. Scoped to
+    ``_DISCARD_PATHSPECS`` ONLY, always via explicit ``--`` pathspecs - never
+    a bare ``git clean``, which would happily sweep an unrelated untracked
+    file the operator left in the checkout for some other reason.
+
+    ``git checkout -- <pathspec>`` errors outright if the pathspec matches no
+    tracked file at all - exactly the common case for a row's first-ever
+    export, which by definition never committed anything under that
+    directory - so each pathspec is checked with ``git ls-files`` first and
+    only passed to ``checkout`` when something tracked actually needs
+    restoring. ``git clean -fd`` carries no such restriction and always runs
+    for both, since an untracked leftover (the addition case) is exactly what
+    it exists to remove.
+    """
+    to_restore = [
+        pathspec
+        for pathspec in _DISCARD_PATHSPECS
+        if _run_git(content_root, "ls-files", "--", pathspec).stdout.strip()
+    ]
+    if to_restore:
+        _run_git(content_root, "checkout", "--", *to_restore)
+    _run_git(content_root, "clean", "-fd", "--", *_DISCARD_PATHSPECS)
 
 
 def commit_row_export(content_root: Path, paths: list[Path], message: str) -> str:
@@ -243,6 +286,87 @@ def row_diff(content_root: Path, paths: list[Path]) -> str:
         parts.append(_run_git(content_root, "diff", "--", *tracked).stdout)
     parts.extend(_no_index_diff(content_root, rel) for rel in untracked)
     return "".join(parts)
+
+
+def _json_row_present_at_head(
+    content_root: Path, rel: str, key_fields: list[str], record_fields: dict
+) -> bool:
+    """True only if ``rel``'s ``HEAD`` copy is valid JSON containing this row's key.
+
+    Split out of ``row_is_addition_at_head`` (ruff PLR0911) - every failure
+    mode along the way (a failed ``git show``, unparseable content, an
+    unexpected shape) returns ``False`` here, which that caller reads as
+    "not affirmatively found" and therefore an addition (fail closed).
+    """
+    result = subprocess.run(
+        ["git", "-C", str(content_root), "show", f"HEAD:{rel}"],
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+    if result.returncode != 0:
+        return False
+    try:
+        head_records = json.loads(result.stdout)
+    except ValueError:
+        return False
+    if not isinstance(head_records, list):
+        return False
+    row_key = _record_key_folded(record_fields, key_fields)
+    head_keys = {
+        _record_key_folded(entry["fields"], key_fields)
+        for entry in head_records
+        if isinstance(entry, dict) and isinstance(entry.get("fields"), dict)
+    }
+    return row_key in head_keys
+
+
+def row_is_addition_at_head(
+    content_root: Path,
+    paths: list[Path],
+    key_fields: list[str] | None,
+    record_fields: dict,
+) -> bool:
+    """Return whether a pending row export is an addition, straight from git HEAD.
+
+    Fixes a spec hole (#3018 review): the row-export request-session record
+    only ever answers for the browser that ran the export, so a second
+    browser opening the same diff URL directly (or a fresh session after the
+    first cleared) saw a default of ``False`` and could confirm a genuine
+    addition with no new-row checkbox at all. Git state, not the request
+    session, is the only truth that holds across browsers and operators - the
+    same principle ``ensure_session_branch`` already applies to "is a row
+    pending."
+
+    A path not tracked at ``HEAD`` at all is unconditionally an addition - a
+    file git has never seen cannot already contain this row (covers both the
+    markdown case, one file per row, and a JSON fixture file's first-ever
+    write). A tracked JSON fixture file can still be missing this particular
+    row - ``export_single_row`` merges into a file that may hold other rows -
+    so its ``HEAD`` copy is parsed and the row's folded natural key (the same
+    case-insensitive comparison ``export_single_row`` itself uses) is looked
+    up inside it directly.
+
+    Fails closed on every uncertain case: no usable natural key, a ``git
+    show`` failure, or content that doesn't parse as the expected JSON
+    fixture shape all return ``True`` (addition) rather than ``False`` - the
+    new-row checkbox is only ever skipped when the row is affirmatively
+    found at ``HEAD``, never because this couldn't tell.
+    """
+    for path in paths:
+        rel = _to_relative(content_root, [path])[0]
+        if not _git_ok(content_root, "ls-files", "--error-unmatch", "--", rel):
+            return True
+        if not rel.endswith(".json"):
+            # A tracked markdown file is one row's whole identity - being
+            # tracked at HEAD already proves the row is known there.
+            continue
+        if key_fields is None or not _json_row_present_at_head(
+            content_root, rel, key_fields, record_fields
+        ):
+            return True
+    return False
 
 
 def session_diff(content_root: Path) -> str:

--- a/src/core_management/content_session.py
+++ b/src/core_management/content_session.py
@@ -23,7 +23,11 @@ import re
 import subprocess
 
 from core_management.content_export import _record_key_folded
-from core_management.content_push import ContentPushError, _run_git
+from core_management.content_push import (
+    _URL_CREDENTIALS,
+    ContentPushError,
+    _run_git,
+)
 from core_management.github_rest import GitHubRestError, github_request
 
 SESSION_BRANCH = "content-export-session"
@@ -33,9 +37,10 @@ _GIT_MAIN = "main"
 
 _HTTPS_REMOTE = re.compile(r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$")
 _SSH_REMOTE = re.compile(r"^git@github\.com:(?P<owner>[^/]+)/(?P<repo>[^/]+?)(?:\.git)?/?$")
-# Strips a userinfo/credential segment (user:token@ or token@) from a URL
-# before it ever reaches an error message - an https remote can carry one.
-_URL_CREDENTIALS = re.compile(r"//[^/@]+@")
+# ``_URL_CREDENTIALS`` (imported above) lives in ``content_push.py`` now -
+# ``_run_git`` is defined there, and it is the one place a git failure
+# message is actually built, so the scrub belongs where the risk originates
+# rather than duplicated here (#3018 review).
 
 
 @dataclass

--- a/src/core_management/github_rest.py
+++ b/src/core_management/github_rest.py
@@ -24,7 +24,17 @@ _METHOD_POST = "POST"
 
 
 class GitHubRestError(Exception):
-    """A GitHub REST call failed. Message carries the status code only, never the body."""
+    """A GitHub REST call failed. Message carries the status code only, never the body.
+
+    ``status_code`` is None for a transport-level failure (could not reach GitHub at
+    all) and set for any other failure (unexpected status, non-JSON body) - callers
+    that need to tell those apart (to reproduce a pre-existing message, say) can
+    branch on it without parsing the message text.
+    """
+
+    def __init__(self, message: str, *, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
 
 
 def _auth_token() -> str:
@@ -37,14 +47,23 @@ def _auth_token() -> str:
     return settings.GITHUB_ISSUE_TOKEN
 
 
-def github_request(method: str, path: str, *, payload: dict | None = None) -> dict | list:
+def github_request(
+    method: str,
+    path: str,
+    *,
+    payload: dict | None = None,
+    expected_status: int | None = None,
+) -> dict | list:
     """One authenticated call to api.github.com; raises GitHubRestError.
 
     Token from settings.GITHUB_ISSUE_TOKEN (falls back to GH_TOKEN in settings);
     headers Bearer + application/vnd.github+json + X-GitHub-Api-Version
-    2022-11-28; timeout 10s; non-2xx raises with the status code ONLY (the
-    body may echo a private repo name and error text travels into admin
-    flashes).
+    2022-11-28; timeout 10s. By default any 2xx status is a success; pass
+    ``expected_status`` to require an exact status code instead (GitHub's
+    issue-creation endpoint, for instance, only ever succeeds with 201).
+    Non-success and a non-JSON success body both raise with the status code
+    ONLY (the body may echo a private repo name and error text travels into
+    admin flashes).
     """
     token = _auth_token()
     if not token:
@@ -66,6 +85,19 @@ def github_request(method: str, path: str, *, payload: dict | None = None) -> di
             raise GitHubRestError(f"Unsupported GitHub REST method: {method}")
     except requests.RequestException as exc:
         raise GitHubRestError("Could not reach GitHub.") from exc
-    if not (200 <= response.status_code < 300):
-        raise GitHubRestError(f"GitHub REST call failed (HTTP {response.status_code}).")
-    return response.json()
+    if expected_status is not None:
+        succeeded = response.status_code == expected_status
+    else:
+        succeeded = 200 <= response.status_code < 300
+    if not succeeded:
+        raise GitHubRestError(
+            f"GitHub REST call failed (HTTP {response.status_code}).",
+            status_code=response.status_code,
+        )
+    try:
+        return response.json()
+    except ValueError as exc:
+        raise GitHubRestError(
+            f"GitHub returned a non-JSON response (HTTP {response.status_code}).",
+            status_code=response.status_code,
+        ) from exc

--- a/src/core_management/github_rest.py
+++ b/src/core_management/github_rest.py
@@ -1,0 +1,71 @@
+"""Shared authenticated client for the GitHub REST API (#3018).
+
+One HTTP client, not two: both ``content_session.py`` (opening the row-export
+session's pull request) and ``world/player_submissions/github_issues.py``
+(staff-filed bug/error issues) route their calls through ``github_request``
+here rather than each hand-rolling ``requests`` calls with their own auth
+headers.
+
+Error messages never carry the response body - only the HTTP status code.
+GitHub error bodies can echo back request details (including a private repo
+name), and callers surface these messages verbatim in admin flashes and API
+error responses.
+"""
+
+from __future__ import annotations
+
+from django.conf import settings
+import requests
+
+_GITHUB_API = "https://api.github.com"
+_REQUEST_TIMEOUT = 10
+_METHOD_GET = "GET"
+_METHOD_POST = "POST"
+
+
+class GitHubRestError(Exception):
+    """A GitHub REST call failed. Message carries the status code only, never the body."""
+
+
+def _auth_token() -> str:
+    """Return the configured GitHub token, or empty string if unset.
+
+    settings.GITHUB_ISSUE_TOKEN already falls back to the GH_TOKEN env var at
+    settings-load time (see server/conf/settings.py), so no separate lookup
+    is needed here.
+    """
+    return settings.GITHUB_ISSUE_TOKEN
+
+
+def github_request(method: str, path: str, *, payload: dict | None = None) -> dict | list:
+    """One authenticated call to api.github.com; raises GitHubRestError.
+
+    Token from settings.GITHUB_ISSUE_TOKEN (falls back to GH_TOKEN in settings);
+    headers Bearer + application/vnd.github+json + X-GitHub-Api-Version
+    2022-11-28; timeout 10s; non-2xx raises with the status code ONLY (the
+    body may echo a private repo name and error text travels into admin
+    flashes).
+    """
+    token = _auth_token()
+    if not token:
+        raise GitHubRestError(
+            "GitHub is not configured on this server (set GITHUB_ISSUE_TOKEN or GH_TOKEN)."
+        )
+    headers = {
+        "Authorization": f"Bearer {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    url = f"{_GITHUB_API}{path}"
+    try:
+        if method == _METHOD_GET:
+            response = requests.get(url, headers=headers, timeout=_REQUEST_TIMEOUT)
+        elif method == _METHOD_POST:
+            response = requests.post(url, json=payload, headers=headers, timeout=_REQUEST_TIMEOUT)
+        else:
+            raise GitHubRestError(f"Unsupported GitHub REST method: {method}")
+    except requests.RequestException as exc:
+        raise GitHubRestError("Could not reach GitHub.") from exc
+    if not (200 <= response.status_code < 300):
+        raise GitHubRestError(f"GitHub REST call failed (HTTP {response.status_code}).")
+    return response.json()

--- a/src/core_management/tests/_git_fixtures.py
+++ b/src/core_management/tests/_git_fixtures.py
@@ -1,0 +1,35 @@
+"""Shared tmp-bare-origin + clone git fixture helpers for content-session tests (#3018).
+
+Used by both the library-level session tests (``test_content_session.py``)
+and the admin row-export view tests
+(``web.admin.tests.test_content_row_export_views``), so the two suites can
+never drift on what a "content repo checkout" fixture looks like. Never the
+network, never the real lore checkout - a throwaway bare "origin" plus a
+configured clone, both in a tmp dir the caller owns and cleans up.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+
+
+def run_git(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run a git command in ``repo``, raising on failure."""
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=True
+    )
+
+
+def init_origin_and_clone(origin: Path, clone: Path) -> None:
+    """Bare origin + a configured clone, seeded with one commit on main and pushed."""
+    subprocess.run(
+        ["git", "init", "--bare", "-b", "main", str(origin)], capture_output=True, check=True
+    )
+    subprocess.run(["git", "clone", str(origin), str(clone)], capture_output=True, check=True)
+    run_git(clone, "config", "user.email", "test@example.com")
+    run_git(clone, "config", "user.name", "Test")
+    (clone / "README.md").write_text("# test repo\n", encoding="utf-8")
+    run_git(clone, "add", ".")
+    run_git(clone, "commit", "-m", "initial")
+    run_git(clone, "push", "-u", "origin", "main")

--- a/src/core_management/tests/test_content_push.py
+++ b/src/core_management/tests/test_content_push.py
@@ -147,6 +147,23 @@ class ContentPushTests(TestCase):
         assert "notes.md" not in show.stdout
         assert "fixtures/" in show.stdout
 
+    def test_push_stages_content_dir_too(self) -> None:
+        """A modified file under content/ is staged and committed alongside fixtures/."""
+        self._write_fixture()
+        content_dir = self.root / "content" / "codex_entries"
+        content_dir.mkdir(parents=True, exist_ok=True)
+        prose_path = content_dir / "entry.md"
+        prose_path.write_text("# Entry\n\nSome prose.\n", encoding="utf-8")
+        result = push_content_to_repo(self.root)
+        assert result.committed
+        show = subprocess.run(
+            ["git", "-C", str(self.root), "show", "--stat", "--name-only", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert "content/codex_entries/entry.md" in show.stdout
+
     def test_push_commit_message_includes_file_count(self) -> None:
         """The auto-generated commit message mentions the file count."""
         self._write_fixture()

--- a/src/core_management/tests/test_content_push.py
+++ b/src/core_management/tests/test_content_push.py
@@ -12,6 +12,7 @@ from django.test import TestCase
 
 from core_management.content_push import (
     ContentPushError,
+    _run_git,
     push_content_to_repo,
 )
 
@@ -163,6 +164,33 @@ class ContentPushTests(TestCase):
             check=True,
         )
         assert "content/codex_entries/entry.md" in show.stdout
+
+    def test_run_git_failure_scrubs_credentials_from_remote_url(self) -> None:
+        """A failed git command never leaks a token-as-username remote URL (#3018 review).
+
+        ``_run_git`` embeds git's stderr verbatim into ``ContentPushError``,
+        and a failed push/fetch can quote a credential-bearing remote URL
+        back in full. Modern git already redacts userinfo from its own
+        "unable to access" messages for the common network-failure case, so
+        this drives ``_run_git`` directly against a stubbed subprocess result
+        carrying a credentialed URL in stderr - the scenario the scrub
+        actually exists to catch regardless of which git failure mode
+        produces it.
+        """
+        token = "ghp_supersecrettoken123"  # noqa: S105 - test fixture value, not a real secret
+        stderr = f"fatal: repository 'https://{token}@github.com/acme/lore.git/' not found"
+        fake_result = subprocess.CompletedProcess(
+            args=["git", "fetch", "origin"], returncode=128, stdout="", stderr=stderr
+        )
+
+        with (
+            mock.patch("core_management.content_push.subprocess.run", return_value=fake_result),
+            self.assertRaises(ContentPushError) as ctx,
+        ):
+            _run_git(self.root, "fetch", "origin")
+
+        assert token not in str(ctx.exception)
+        assert "github.com/acme/lore.git" in str(ctx.exception)
 
     def test_push_commit_message_includes_file_count(self) -> None:
         """The auto-generated commit message mentions the file count."""

--- a/src/core_management/tests/test_content_session.py
+++ b/src/core_management/tests/test_content_session.py
@@ -116,7 +116,8 @@ class ContentSessionTests(TestCase):
 
         with self.assertRaises(ContentPushError) as ctx:
             ensure_session_branch(self.root)
-        assert "uncommitted changes" in str(ctx.exception)
+        assert "pending export" in str(ctx.exception)
+        assert "Confirm or discard it" in str(ctx.exception)
 
         branch = _run(self.root, "branch", "--show-current").stdout.strip()
         assert branch == SESSION_BRANCH

--- a/src/core_management/tests/test_content_session.py
+++ b/src/core_management/tests/test_content_session.py
@@ -22,27 +22,10 @@ from core_management.content_session import (
     session_state,
 )
 from core_management.github_rest import GitHubRestError, github_request
-
-
-def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
-    """Run a git command in ``repo``, raising on failure."""
-    return subprocess.run(
-        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=True
-    )
-
-
-def _init_origin_and_clone(origin: Path, clone: Path) -> None:
-    """Bare origin + a configured clone, seeded with one commit on main and pushed."""
-    subprocess.run(
-        ["git", "init", "--bare", "-b", "main", str(origin)], capture_output=True, check=True
-    )
-    subprocess.run(["git", "clone", str(origin), str(clone)], capture_output=True, check=True)
-    _run(clone, "config", "user.email", "test@example.com")
-    _run(clone, "config", "user.name", "Test")
-    (clone / "README.md").write_text("# test repo\n", encoding="utf-8")
-    _run(clone, "add", ".")
-    _run(clone, "commit", "-m", "initial")
-    _run(clone, "push", "-u", "origin", "main")
+from core_management.tests._git_fixtures import (
+    init_origin_and_clone as _init_origin_and_clone,
+    run_git as _run,
+)
 
 
 class ContentSessionTests(TestCase):
@@ -191,6 +174,24 @@ class ContentSessionTests(TestCase):
 
         s_diff = session_diff(self.root)
         assert "diffme.json" in s_diff
+
+    def test_row_diff_shows_untracked_addition(self) -> None:
+        """A brand-new, never-committed export shows as a full-file addition (#3018).
+
+        Plain ``git diff`` only compares tracked content and renders empty
+        for an untracked path - the common case for a row's first-ever
+        export, since nothing has been committed for it yet.
+        """
+        ensure_session_branch(self.root)
+        path = self._write_row("untracked.json", '{"a": 1}\n')
+
+        diff = row_diff(self.root, [path])
+
+        assert "untracked.json" in diff
+        assert "new file mode" in diff
+        assert '+{"a": 1}' in diff
+        status = _run(self.root, "status", "--short").stdout
+        assert "?? content/" in status
 
     def test_open_session_pr_posts_and_returns_url(self) -> None:
         # origin stays the local bare fixture repo (the push must succeed for

--- a/src/core_management/tests/test_content_session.py
+++ b/src/core_management/tests/test_content_session.py
@@ -14,10 +14,12 @@ from core_management.content_session import (
     SESSION_BRANCH,
     _remote_slug,
     commit_row_export,
+    discard_all_pending,
     discard_row_export,
     ensure_session_branch,
     open_session_pr,
     row_diff,
+    row_is_addition_at_head,
     session_diff,
     session_state,
 )
@@ -163,6 +165,44 @@ class ContentSessionTests(TestCase):
         status = _run(self.root, "status", "--short").stdout
         assert status.strip() == ""
 
+    def test_discard_all_pending_restores_tracked_and_removes_untracked(self) -> None:
+        ensure_session_branch(self.root)
+        tracked = self._write_row("tracked.json")
+        commit_row_export(self.root, [tracked], "seed tracked")
+        tracked.write_text('{"a": 2}\n', encoding="utf-8")
+        new_file = self._write_row("brand_new.json")
+
+        discard_all_pending(self.root)
+
+        assert tracked.read_text(encoding="utf-8") == '{"a": 1}\n'
+        assert not new_file.exists()
+        status = _run(self.root, "status", "--short").stdout
+        assert status.strip() == ""
+
+    def test_discard_all_pending_handles_missing_fixtures_directory(self) -> None:
+        """One of the two pathspecs having zero tracked entries must not fail the call.
+
+        ``git checkout -- fixtures/ content/`` errors outright if EITHER
+        pathspec matches no tracked file - the common case here, since this
+        checkout never wrote anything under ``fixtures/`` at all.
+        """
+        ensure_session_branch(self.root)
+        assert not (self.root / "fixtures").exists()
+        self._write_row("untracked.json")
+
+        discard_all_pending(self.root)
+
+        status = _run(self.root, "status", "--short").stdout
+        assert status.strip() == ""
+
+    def test_discard_all_pending_is_noop_on_clean_tree(self) -> None:
+        ensure_session_branch(self.root)
+
+        discard_all_pending(self.root)
+
+        status = _run(self.root, "status", "--short").stdout
+        assert status.strip() == ""
+
     def test_row_and_session_diff_render(self) -> None:
         ensure_session_branch(self.root)
         path = self._write_row("diffme.json")
@@ -193,6 +233,47 @@ class ContentSessionTests(TestCase):
         assert '+{"a": 1}' in diff
         status = _run(self.root, "status", "--short").stdout
         assert "?? content/" in status
+
+    def test_row_is_addition_at_head_untracked_path_is_addition(self) -> None:
+        ensure_session_branch(self.root)
+        path = self._write_row("brand_new.json", '[{"model": "m", "fields": {"name": "A"}}]\n')
+
+        assert row_is_addition_at_head(self.root, [path], ["name"], {"name": "A"}) is True
+
+    def test_row_is_addition_at_head_json_key_present_is_not_addition(self) -> None:
+        ensure_session_branch(self.root)
+        path = self._write_row("known.json", '[{"model": "m", "fields": {"name": "A"}}]\n')
+        commit_row_export(self.root, [path], "seed known row")
+
+        assert row_is_addition_at_head(self.root, [path], ["name"], {"name": "A"}) is False
+
+    def test_row_is_addition_at_head_json_key_absent_is_addition(self) -> None:
+        ensure_session_branch(self.root)
+        path = self._write_row("known2.json", '[{"model": "m", "fields": {"name": "A"}}]\n')
+        commit_row_export(self.root, [path], "seed known2 row")
+
+        assert row_is_addition_at_head(self.root, [path], ["name"], {"name": "B"}) is True
+
+    def test_row_is_addition_at_head_folds_case(self) -> None:
+        ensure_session_branch(self.root)
+        path = self._write_row("cased.json", '[{"model": "m", "fields": {"name": "Alpha"}}]\n')
+        commit_row_export(self.root, [path], "seed cased row")
+
+        assert row_is_addition_at_head(self.root, [path], ["name"], {"name": "alpha"}) is False
+
+    def test_row_is_addition_at_head_no_key_fields_fails_closed(self) -> None:
+        ensure_session_branch(self.root)
+        path = self._write_row("nokey.json", '[{"model": "m", "fields": {"name": "A"}}]\n')
+        commit_row_export(self.root, [path], "seed nokey row")
+
+        assert row_is_addition_at_head(self.root, [path], None, {"name": "A"}) is True
+
+    def test_row_is_addition_at_head_unparseable_json_fails_closed(self) -> None:
+        ensure_session_branch(self.root)
+        path = self._write_row("bad.json", "not json\n")
+        commit_row_export(self.root, [path], "seed bad row")
+
+        assert row_is_addition_at_head(self.root, [path], ["name"], {"name": "A"}) is True
 
     def test_open_session_pr_posts_and_returns_url(self) -> None:
         # origin stays the local bare fixture repo (the push must succeed for

--- a/src/core_management/tests/test_content_session.py
+++ b/src/core_management/tests/test_content_session.py
@@ -21,6 +21,7 @@ from core_management.content_session import (
     session_diff,
     session_state,
 )
+from core_management.github_rest import GitHubRestError, github_request
 
 
 def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
@@ -105,6 +106,40 @@ class ContentSessionTests(TestCase):
         assert branch == SESSION_BRANCH
         log = _run(self.root, "log", "--oneline", "origin/main..HEAD").stdout
         assert log.strip() == ""
+
+    def test_ensure_refuses_dirty_tree_on_merged_session_branch(self) -> None:
+        """A dirty working tree must refuse even when the merged-recreate path would fire.
+
+        Without this check, ensure_session_branch would detach off the session
+        branch and force-delete it out from under uncommitted local changes.
+        """
+        ensure_session_branch(self.root)
+        path = self._write_row()
+        commit_row_export(self.root, [path], "row export")
+        _run(self.root, "push", "-u", "origin", SESSION_BRANCH)
+
+        merger = Path(self.tmp.name) / "merger2"
+        subprocess.run(
+            ["git", "clone", str(self.origin), str(merger)], capture_output=True, check=True
+        )
+        _run(merger, "config", "user.email", "test@example.com")
+        _run(merger, "config", "user.name", "Test")
+        _run(merger, "fetch", "origin", SESSION_BRANCH)
+        _run(merger, "merge", "--ff-only", f"origin/{SESSION_BRANCH}")
+        _run(merger, "push", "origin", "main")
+
+        # Still on SESSION_BRANCH locally, now with an uncommitted change.
+        (self.root / "dirty2.txt").write_text("uncommitted", encoding="utf-8")
+
+        with self.assertRaises(ContentPushError) as ctx:
+            ensure_session_branch(self.root)
+        assert "uncommitted changes" in str(ctx.exception)
+
+        branch = _run(self.root, "branch", "--show-current").stdout.strip()
+        assert branch == SESSION_BRANCH
+        # Nothing was deleted or detached - the session commit is still HEAD.
+        log = _run(self.root, "log", "--oneline", "-1").stdout
+        assert "row export" in log
 
     def test_ensure_refuses_dirty_foreign_branch(self) -> None:
         (self.root / "dirty.txt").write_text("uncommitted", encoding="utf-8")
@@ -221,6 +256,21 @@ class ContentSessionTests(TestCase):
         _run(self.root, "remote", "set-url", "origin", "git@github.com:acme/lore")
         assert _remote_slug(self.root) == ("acme", "lore")
 
+    def test_remote_slug_failure_message_strips_embedded_credentials(self) -> None:
+        token = "ghp_supersecrettoken123"  # noqa: S105 - test fixture value, not a real secret
+        _run(
+            self.root,
+            "remote",
+            "set-url",
+            "origin",
+            f"https://{token}@github.com/acme/lore.git",
+        )
+
+        with self.assertRaises(ContentPushError) as ctx:
+            _remote_slug(self.root)
+
+        assert token not in str(ctx.exception)
+
     def test_session_state_reports_branch_commits_and_dirty(self) -> None:
         ensure_session_branch(self.root)
         path = self._write_row("state.json")
@@ -234,3 +284,17 @@ class ContentSessionTests(TestCase):
         assert any("state commit" in line for line in state.commits)
         assert "state.json" in state.diff_stat
         assert any("untracked.json" in line for line in state.dirty)
+
+    def test_github_request_wraps_non_json_success_body(self) -> None:
+        """A 2xx response with a non-JSON body raises GitHubRestError, not a bare ValueError."""
+        with (
+            self.settings(GITHUB_ISSUE_TOKEN="tok"),
+            mock.patch("core_management.github_rest.requests.get") as mock_get,
+        ):
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.json.side_effect = ValueError("not json")
+
+            with self.assertRaises(GitHubRestError) as ctx:
+                github_request("GET", "/repos/acme/lore/pulls")
+
+        assert "200" in str(ctx.exception)

--- a/src/core_management/tests/test_content_session.py
+++ b/src/core_management/tests/test_content_session.py
@@ -1,0 +1,236 @@
+"""Tests for the row-level content export session (#3018)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import subprocess
+import tempfile
+from unittest import mock
+
+from django.test import TestCase
+
+from core_management.content_push import ContentPushError
+from core_management.content_session import (
+    SESSION_BRANCH,
+    _remote_slug,
+    commit_row_export,
+    discard_row_export,
+    ensure_session_branch,
+    open_session_pr,
+    row_diff,
+    session_diff,
+    session_state,
+)
+
+
+def _run(repo: Path, *args: str) -> subprocess.CompletedProcess[str]:
+    """Run a git command in ``repo``, raising on failure."""
+    return subprocess.run(
+        ["git", "-C", str(repo), *args], capture_output=True, text=True, check=True
+    )
+
+
+def _init_origin_and_clone(origin: Path, clone: Path) -> None:
+    """Bare origin + a configured clone, seeded with one commit on main and pushed."""
+    subprocess.run(
+        ["git", "init", "--bare", "-b", "main", str(origin)], capture_output=True, check=True
+    )
+    subprocess.run(["git", "clone", str(origin), str(clone)], capture_output=True, check=True)
+    _run(clone, "config", "user.email", "test@example.com")
+    _run(clone, "config", "user.name", "Test")
+    (clone / "README.md").write_text("# test repo\n", encoding="utf-8")
+    _run(clone, "add", ".")
+    _run(clone, "commit", "-m", "initial")
+    _run(clone, "push", "-u", "origin", "main")
+
+
+class ContentSessionTests(TestCase):
+    """Tests for the branch-as-session git flow."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        base = Path(self.tmp.name)
+        self.origin = base / "origin.git"
+        self.root = base / "clone"
+        _init_origin_and_clone(self.origin, self.root)
+
+    def _write_row(self, name: str = "row.json", content: str = '{"a": 1}\n') -> Path:
+        """Write a dummy content row and return its absolute path."""
+        path = self.root / "content" / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def test_ensure_creates_branch_from_origin_main(self) -> None:
+        ensure_session_branch(self.root)
+        branch = _run(self.root, "branch", "--show-current").stdout.strip()
+        assert branch == SESSION_BRANCH
+
+    def test_ensure_reuses_unmerged_branch(self) -> None:
+        ensure_session_branch(self.root)
+        path = self._write_row()
+        commit_row_export(self.root, [path], "row export")
+        log_before = _run(self.root, "log", "--oneline", "-1").stdout
+
+        ensure_session_branch(self.root)
+
+        branch = _run(self.root, "branch", "--show-current").stdout.strip()
+        log_after = _run(self.root, "log", "--oneline", "-1").stdout
+        assert branch == SESSION_BRANCH
+        assert log_before == log_after
+        assert "row export" in log_after
+
+    def test_ensure_recreates_after_merge(self) -> None:
+        ensure_session_branch(self.root)
+        path = self._write_row()
+        commit_row_export(self.root, [path], "row export")
+        _run(self.root, "push", "-u", "origin", SESSION_BRANCH)
+
+        # Simulate the session PR merging: a second clone fast-forwards
+        # origin/main to the session branch's tip and pushes it.
+        merger = Path(self.tmp.name) / "merger"
+        subprocess.run(
+            ["git", "clone", str(self.origin), str(merger)], capture_output=True, check=True
+        )
+        _run(merger, "config", "user.email", "test@example.com")
+        _run(merger, "config", "user.name", "Test")
+        _run(merger, "fetch", "origin", SESSION_BRANCH)
+        _run(merger, "merge", "--ff-only", f"origin/{SESSION_BRANCH}")
+        _run(merger, "push", "origin", "main")
+
+        ensure_session_branch(self.root)
+
+        branch = _run(self.root, "branch", "--show-current").stdout.strip()
+        assert branch == SESSION_BRANCH
+        log = _run(self.root, "log", "--oneline", "origin/main..HEAD").stdout
+        assert log.strip() == ""
+
+    def test_ensure_refuses_dirty_foreign_branch(self) -> None:
+        (self.root / "dirty.txt").write_text("uncommitted", encoding="utf-8")
+
+        with self.assertRaises(ContentPushError) as ctx:
+            ensure_session_branch(self.root)
+        assert "uncommitted changes" in str(ctx.exception)
+
+        branch = _run(self.root, "branch", "--show-current").stdout.strip()
+        assert branch == "main"
+        status = _run(self.root, "status", "--short").stdout
+        assert "dirty.txt" in status
+
+    def test_commit_row_export_commits_named_paths_only(self) -> None:
+        ensure_session_branch(self.root)
+        target = self._write_row("target.json")
+        self._write_row("other.json")
+
+        sha = commit_row_export(self.root, [target], "export target")
+
+        assert sha
+        status = _run(self.root, "status", "--short").stdout
+        assert "other.json" in status
+        assert "target.json" not in status
+
+    def test_discard_restores_tracked_and_removes_new(self) -> None:
+        ensure_session_branch(self.root)
+        tracked = self._write_row("tracked.json")
+        commit_row_export(self.root, [tracked], "seed tracked")
+        tracked.write_text('{"a": 2}\n', encoding="utf-8")
+        new_file = self._write_row("new.json")
+
+        discard_row_export(self.root, [tracked, new_file])
+
+        assert tracked.read_text(encoding="utf-8") == '{"a": 1}\n'
+        assert not new_file.exists()
+        status = _run(self.root, "status", "--short").stdout
+        assert status.strip() == ""
+
+    def test_row_and_session_diff_render(self) -> None:
+        ensure_session_branch(self.root)
+        path = self._write_row("diffme.json")
+        commit_row_export(self.root, [path], "seed diffme")
+        path.write_text('{"a": 2}\n', encoding="utf-8")
+
+        diff = row_diff(self.root, [path])
+        assert diff.strip()
+        assert "diffme.json" in diff
+
+        s_diff = session_diff(self.root)
+        assert "diffme.json" in s_diff
+
+    def test_open_session_pr_posts_and_returns_url(self) -> None:
+        # origin stays the local bare fixture repo (the push must succeed for
+        # real); only the derived owner/repo slug is mocked, so the REST call
+        # shape can be asserted without an actual GitHub-shaped remote URL.
+        ensure_session_branch(self.root)
+        path = self._write_row("pr.json")
+        commit_row_export(self.root, [path], "pr row")
+
+        with (
+            self.settings(GITHUB_ISSUE_TOKEN="tok"),
+            mock.patch(
+                "core_management.content_session._remote_slug", return_value=("acme", "lore")
+            ),
+            mock.patch("core_management.github_rest.requests.get") as mock_get,
+            mock.patch("core_management.github_rest.requests.post") as mock_post,
+        ):
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.json.return_value = []
+            mock_post.return_value.status_code = 201
+            mock_post.return_value.json.return_value = {
+                "html_url": "https://github.com/acme/lore/pull/9"
+            }
+            url = open_session_pr(self.root, title="t", body="b")
+
+        assert url == "https://github.com/acme/lore/pull/9"
+        get_url = mock_get.call_args.args[0]
+        assert "head=acme:content-export-session" in get_url
+        assert "state=open" in get_url
+        post_payload = mock_post.call_args.kwargs["json"]
+        assert post_payload["head"] == SESSION_BRANCH
+        assert post_payload["base"] == "main"
+        # The session branch was pushed to origin before the REST calls.
+        log = _run(self.origin, "log", "--oneline", "-1", SESSION_BRANCH).stdout
+        assert "pr row" in log
+
+    def test_open_session_pr_reuses_open_pr(self) -> None:
+        ensure_session_branch(self.root)
+        path = self._write_row("pr2.json")
+        commit_row_export(self.root, [path], "pr row 2")
+
+        with (
+            self.settings(GITHUB_ISSUE_TOKEN="tok"),
+            mock.patch(
+                "core_management.content_session._remote_slug", return_value=("acme", "lore")
+            ),
+            mock.patch("core_management.github_rest.requests.get") as mock_get,
+            mock.patch("core_management.github_rest.requests.post") as mock_post,
+        ):
+            mock_get.return_value.status_code = 200
+            mock_get.return_value.json.return_value = [
+                {"html_url": "https://github.com/acme/lore/pull/3"}
+            ]
+            url = open_session_pr(self.root, title="t", body="b")
+
+        assert url == "https://github.com/acme/lore/pull/3"
+        mock_post.assert_not_called()
+
+    def test_remote_slug_parses_both_url_forms(self) -> None:
+        _run(self.root, "remote", "set-url", "origin", "https://github.com/acme/lore.git")
+        assert _remote_slug(self.root) == ("acme", "lore")
+
+        _run(self.root, "remote", "set-url", "origin", "git@github.com:acme/lore")
+        assert _remote_slug(self.root) == ("acme", "lore")
+
+    def test_session_state_reports_branch_commits_and_dirty(self) -> None:
+        ensure_session_branch(self.root)
+        path = self._write_row("state.json")
+        commit_row_export(self.root, [path], "state commit")
+        self._write_row("untracked.json")
+
+        state = session_state(self.root)
+
+        assert state.branch == SESSION_BRANCH
+        assert state.on_session is True
+        assert any("state commit" in line for line in state.commits)
+        assert "state.json" in state.diff_stat
+        assert any("untracked.json" in line for line in state.dirty)

--- a/src/core_management/tests/test_export_single_row.py
+++ b/src/core_management/tests/test_export_single_row.py
@@ -1,0 +1,158 @@
+"""Tests for the row-level content export seam (#3018)."""
+
+from datetime import date
+import json
+from pathlib import Path
+import tempfile
+
+from django.test import TestCase
+
+from core_management.content_export import export_single_row
+from core_management.content_fixtures import content_slug
+
+
+class RowExportTests(TestCase):
+    """export_single_row: JSON domains, markdown domains, and refusal paths."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def test_json_update_replaces_exactly_one_record(self) -> None:
+        """Exporting an edited row rewrites its record and leaves its sibling alone."""
+        from core_management.content_export import export_to_content_repo
+        from world.magic.factories import EffectTypeFactory
+
+        effect_a = EffectTypeFactory(name="Row Export A", description="Original A")
+        EffectTypeFactory(name="Row Export B", description="Original B")
+
+        # Seed the corpus file with both rows (no gate: the file doesn't exist yet).
+        seed_result = export_to_content_repo(self.root)
+        assert seed_result.errors == []
+
+        effect_a.description = "Updated A"
+        effect_a.save()
+
+        result = export_single_row(effect_a, content_root=self.root)
+
+        assert result.refused is None
+        assert result.is_addition is False
+        assert result.model_label == "magic.effecttype"
+
+        path = self.root / "fixtures" / "magic" / "effecttype.json"
+        assert result.paths == [path]
+        records = json.loads(path.read_text(encoding="utf-8"))
+        by_name = {r["fields"]["name"]: r["fields"]["description"] for r in records}
+        assert by_name["Row Export A"] == "Updated A"
+        assert by_name["Row Export B"] == "Original B"
+        assert len(records) == 2
+
+    def test_json_addition_appends(self) -> None:
+        """A row whose natural key isn't in the file yet is appended, not withheld."""
+        from world.magic.factories import EffectTypeFactory
+
+        effect_a = EffectTypeFactory(name="Append A")
+        first = export_single_row(effect_a, content_root=self.root)
+        assert first.is_addition is True
+
+        effect_c = EffectTypeFactory(name="Append C")
+        result = export_single_row(effect_c, content_root=self.root)
+
+        assert result.refused is None
+        assert result.is_addition is True
+
+        path = self.root / "fixtures" / "magic" / "effecttype.json"
+        records = json.loads(path.read_text(encoding="utf-8"))
+        names = {r["fields"]["name"] for r in records}
+        assert names == {"Append A", "Append C"}
+
+    def test_json_no_corpus_file_is_addition(self) -> None:
+        """No fixture file for the model yet: written as a fresh one-record file."""
+        from world.magic.factories import EffectTypeFactory
+
+        effect = EffectTypeFactory(name="Solo Effect")
+        result = export_single_row(effect, content_root=self.root)
+
+        path = self.root / "fixtures" / "magic" / "effecttype.json"
+        assert result.refused is None
+        assert result.is_addition is True
+        assert result.paths == [path]
+        records = json.loads(path.read_text(encoding="utf-8"))
+        assert len(records) == 1
+        assert records[0]["fields"]["name"] == "Solo Effect"
+
+    def test_markdown_row_writes_one_file(self) -> None:
+        """A CodexEntry writes exactly one markdown file with its credit intact."""
+        from world.codex.factories import (
+            CodexCategoryFactory,
+            CodexEntryFactory,
+            CodexSubjectFactory,
+        )
+        from world.contributors.factories import ContentContributorFactory
+
+        category = CodexCategoryFactory(name="Row Export Category")
+        subject = CodexSubjectFactory(category=category, name="Row Export Subject")
+        entry = CodexEntryFactory(
+            subject=subject, name="Row Export Entry", lore_content="Some authored lore."
+        )
+        contributor = ContentContributorFactory(name="Row Export Writer")
+        entry.written_by = contributor
+        entry.written_on = date(2026, 1, 1)
+        entry.save()
+
+        result = export_single_row(entry, content_root=self.root)
+
+        expected_path = (
+            self.root
+            / "content/codex_entries"
+            / content_slug("Row Export Subject")
+            / f"{content_slug('Row Export Entry')}.md"
+        )
+        assert result.refused is None
+        assert result.model_label == "codex.codexentry"
+        assert result.paths == [expected_path]
+        assert result.is_addition is True
+        assert expected_path.exists()
+
+        text = expected_path.read_text(encoding="utf-8")
+        assert "Row Export Writer" in text
+        assert "Some authored lore." in text
+
+        # Exporting again finds the file already present -> not an addition.
+        second = export_single_row(entry, content_root=self.root)
+        assert second.is_addition is False
+        assert list(self.root.glob("content/codex_entries/**/*.md")) == [expected_path]
+
+    def test_export_filter_refusal(self) -> None:
+        """A player-owned CheckType row is excluded from export and writes nothing."""
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.seeds_checks import ensure_character_magic_check_type
+        from world.skills.factories import SkillFactory
+        from world.traits.factories import TraitFactory
+        from world.traits.models import TraitType
+
+        sheet = CharacterSheetFactory()
+        stat = TraitFactory(name="row_export_willpower", trait_type=TraitType.STAT)
+        skill = SkillFactory(trait__name="row_export_ritualism")
+        synthesized = ensure_character_magic_check_type(sheet, stat=stat, skill=skill)
+
+        result = export_single_row(synthesized, content_root=self.root)
+
+        assert result.refused is not None
+        assert result.paths == []
+        path = self.root / "fixtures" / "checks" / "checktype.json"
+        assert not path.exists()
+
+    def test_non_content_model_refusal(self) -> None:
+        """A model outside CONTENT_MODELS/MARKDOWN_EXPORT_DOMAINS refuses, writes nothing."""
+        from world.character_sheets.factories import CharacterSheetFactory
+
+        sheet = CharacterSheetFactory()
+
+        result = export_single_row(sheet, content_root=self.root)
+
+        assert result.refused is not None
+        assert result.paths == []
+        assert result.model_label == "character_sheets.charactersheet"
+        assert not (self.root / "fixtures" / "character_sheets" / "charactersheet.json").exists()

--- a/src/core_management/tests/test_export_single_row.py
+++ b/src/core_management/tests/test_export_single_row.py
@@ -82,6 +82,78 @@ class RowExportTests(TestCase):
         assert len(records) == 1
         assert records[0]["fields"]["name"] == "Solo Effect"
 
+    def test_json_casing_only_rename_replaces_not_appends(self) -> None:
+        """A case-only natural-key rename still matches the loader's iexact identity (#2687).
+
+        The corpus file already holds "Performance"; the DB row's name is now
+        "PERFORMANCE" with an edited description. An exact-match comparison
+        would treat these as two different rows and append a second record,
+        which the (case-insensitive) loader would then collapse back into one
+        on the next load - an order-dependent double-apply. The merge must
+        instead recognize the row and replace in place.
+        """
+        from world.magic.factories import EffectTypeFactory
+
+        effect = EffectTypeFactory(name="Performance", description="Original")
+        first = export_single_row(effect, content_root=self.root)
+        assert first.is_addition is True
+
+        effect.name = "PERFORMANCE"
+        effect.description = "Updated"
+        effect.save()
+
+        result = export_single_row(effect, content_root=self.root)
+
+        assert result.is_addition is False
+        path = self.root / "fixtures" / "magic" / "effecttype.json"
+        records = json.loads(path.read_text(encoding="utf-8"))
+        assert len(records) == 1
+        assert records[0]["fields"]["name"] == "PERFORMANCE"
+        assert records[0]["fields"]["description"] == "Updated"
+
+    def test_json_fk_list_key_component_casing_rename_replaces_not_appends(self) -> None:
+        """A case-only rename on an FK the natural key nests as a list also merges (#2687).
+
+        ``checks.checktypetrait``'s natural key is ``[check_type, trait]``, and
+        ``check_type`` itself serializes as a natural-key list (not a scalar) -
+        exercising the recursive fold over a nested list, not just a bare string
+        field.
+        """
+        from decimal import Decimal
+
+        from world.checks.factories import (
+            CheckCategoryFactory,
+            CheckTypeFactory,
+            CheckTypeTraitFactory,
+        )
+        from world.traits.factories import TraitFactory
+        from world.traits.models import TraitType
+
+        category = CheckCategoryFactory(name="Row Export Case Category")
+        check_type = CheckTypeFactory(name="performance", category=category)
+        trait = TraitFactory(name="row_export_case_trait", trait_type=TraitType.OTHER)
+        link = CheckTypeTraitFactory(check_type=check_type, trait=trait, weight=Decimal("1.00"))
+
+        first = export_single_row(link, content_root=self.root)
+        assert first.is_addition is True
+
+        # Case-only rename of the FK target's name - the link row itself is
+        # untouched, but the nested natural-key list it serializes now carries
+        # different casing at that inner element.
+        check_type.name = "PERFORMANCE"
+        check_type.save()
+        link.weight = Decimal("2.00")
+        link.save()
+
+        result = export_single_row(link, content_root=self.root)
+
+        assert result.is_addition is False
+        path = self.root / "fixtures" / "checks" / "checktypetrait.json"
+        records = json.loads(path.read_text(encoding="utf-8"))
+        assert len(records) == 1
+        assert records[0]["fields"]["check_type"][0] == "PERFORMANCE"
+        assert records[0]["fields"]["weight"] == "2.00"
+
     def test_markdown_row_writes_one_file(self) -> None:
         """A CodexEntry writes exactly one markdown file with its credit intact."""
         from world.codex.factories import (

--- a/src/web/admin/CLAUDE.md
+++ b/src/web/admin/CLAUDE.md
@@ -117,6 +117,81 @@ If an agent is asked about any of these topics, this is the system:
 - "content inventory / what's seeded"
 - "Game Setup button at the top of Django admin"
 
+### Row export and content session (#3018)
+
+**Purpose:** a row-level counterpart to the whole-corpus export above. A
+superuser editing one record in any change form can send that single row's
+corpus form to the lore checkout, review its diff, and commit it - without
+running a full export/push over every content model. Rows accumulate on one
+shared branch until the operator opens a pull request for the batch, instead
+of every single row needing its own PR.
+
+- **The button** - `templates/admin/change_form.html` (site-wide override of
+  Django's stock change form, extending it the same way
+  `change_list.html` extends its own stock template - see that file's
+  docstring precedent) adds an `object-tools-items` entry: a small POST form
+  to `admin_content_export_row` carrying the row's `<domain>.<model_name>`
+  label and pk as hidden fields. It only renders for a superuser, on a
+  change form (not add), for a model the new
+  `web/admin/templatetags/content_export_tags.py` filters
+  (`content_exportable`, `content_model_label`) recognize as corpus-owned -
+  registered in `core_management.content_export.CONTENT_MODELS` or
+  `core_management.content_fixtures.MARKDOWN_EXPORT_DOMAINS`.
+- **Write + diff confirm** - `content_row_export_views.py`:
+  `content_export_row` (POST from the button) ensures the session branch
+  (below) and writes the row via
+  `core_management.content_export.export_single_row`, then redirects to
+  `content_export_row_diff` (GET), which renders the working-tree diff
+  behind a sha256 digest of that diff text.
+  `content_export_row_confirm` (POST, `action=confirm|discard`) re-checks
+  the posted digest against a freshly recomputed one before doing anything -
+  a mismatch means the tree changed since the diff page rendered and is
+  refused unconditionally, the same idiom as the load-conflict resolve
+  page. An addition (the row's natural key is not yet in the corpus) also
+  requires an explicit "new_row" checkbox, mirroring the corpus-wide
+  export's addition gate (ADR-0191) at row scope.
+- **One session branch, one pending export at a time** -
+  `core_management.content_session` (`ensure_session_branch`,
+  `commit_row_export`, `discard_row_export`) keeps every exported-but-not-
+  yet-PR'd row as its own small commit on a fixed branch,
+  `content-export-session`, created fresh off `origin/main` (or reused if
+  its prior pull request has not merged yet). Git state, not a database
+  table, is the source of truth: `ensure_session_branch` refuses to start a
+  new row export while the working tree is already dirty, which is how at
+  most one pending export exists at a time across browsers and operators.
+- **The session page and its pull request** - `content_session_views.py`:
+  `content_session` (GET, `admin_content_session`) shows the branch's
+  commit list and full diff against `origin/main`, naming the currently
+  pending row (if any) with a link straight to its diff page.
+  `content_session_pr` (POST, `admin_content_session_pr`) pushes the branch
+  and opens (or reuses) its pull request via
+  `core_management.content_session.open_session_pr`, one REST call through
+  the shared `core_management.github_rest.github_request` client
+  (`settings.GITHUB_ISSUE_TOKEN`, falling back to the `GH_TOKEN` env var;
+  no token configured is refused with a plain message). The target
+  owner/repo is parsed from the checkout's own `origin` remote URL - the
+  lore repo is never named anywhere in this code.
+- The corpus-wide push (`content_push_run` above) now stages `content/` as
+  well as `fixtures/` when committing, so the markdown prose domains travel
+  with the same pipeline as the flat JSON fixtures.
+- URLs: `_content_export_row/` (POST write), `_content_export_row_diff/`
+  (GET diff), `_content_export_row_confirm/` (POST commit/discard),
+  `_content_session/` (GET session page), `_content_session_pr/` (POST open
+  pull request).
+- Tests: `tests/test_content_row_export_views.py`,
+  `tests/test_content_session_views.py`,
+  `tests/test_change_form_export_button.py`.
+- Deliberate no-ADR: the decisions here were recorded in the approved #3018
+  spec, and ADR-0191/ADR-0201 already carry the addition-gate and credited-
+  row-freeze rationale this flow reuses.
+
+**When Asked About**
+
+If an agent is asked about any of these topics, this is the system:
+- "export one row from the admin"
+- "the Export to content repo button on a change form"
+- "content session / session branch / one PR per session"
+
 ## Game Tuning & Game Ops Dashboards (#1221)
 
 **Purpose:** Two superuser-only, admin-hosted HTMX dashboards linked from the Game Setup
@@ -226,6 +301,16 @@ Defined in `services.py` as `HARDCODED_EXCLUDED_APPS` (canonical location, impor
 - `_content_export_run/` - POST: writes flat fixtures + grid bundles to the content repo (superuser)
 - `_content_push/` - "Push content to lore repo" preview page (superuser; PR #2425), git status/diff-stat
 - `_content_push_run/` - POST: commits + pushes the content-repo working tree (superuser)
+- `_content_export_row/` - POST: writes one row's corpus form to the session branch, then
+  redirects to its diff page (superuser; #3018)
+- `_content_export_row_diff/` - GET: one pending row export's diff behind a digest
+  (superuser; `?model=&pk=`; #3018)
+- `_content_export_row_confirm/` - POST: commits or discards one pending row export
+  after the digest re-checks out (superuser; #3018)
+- `_content_session/` - GET: the content session page - commit list, full diff, open-PR
+  form (superuser; #3018)
+- `_content_session_pr/` - POST: pushes the session branch and opens (or reuses) its
+  pull request (superuser; #3018)
 - `_game_setup/` - "Game Setup" hub: wayfinding + per-cluster content inventory (superuser; #1333)
 - `_tuning/` - Game Tuning dashboard skeleton (superuser; #1221); `_tuning/checks/`,
   `_tuning/consequences/`, `_tuning/conditions/`, `_tuning/simulation/` - the four HTMX panel fragments

--- a/src/web/admin/CLAUDE.md
+++ b/src/web/admin/CLAUDE.md
@@ -149,7 +149,14 @@ of every single row needing its own PR.
   refused unconditionally, the same idiom as the load-conflict resolve
   page. An addition (the row's natural key is not yet in the corpus) also
   requires an explicit "new_row" checkbox, mirroring the corpus-wide
-  export's addition gate (ADR-0191) at row scope.
+  export's addition gate (ADR-0191) at row scope. Addition-ness is derived
+  straight from git `HEAD` at both diff-render and confirm time
+  (`content_session.row_is_addition_at_head`, fail-closed on any git/parse
+  trouble), not read out of the request session - a session record only
+  ever answered for the browser that ran the export, so a second browser
+  hitting either URL directly used to see a default of "not an addition"
+  and could commit a genuine addition with no checkbox at all (#3018
+  review).
 - **One session branch, one pending export at a time** -
   `core_management.content_session` (`ensure_session_branch`,
   `commit_row_export`, `discard_row_export`) keeps every exported-but-not-

--- a/src/web/admin/content_export_views.py
+++ b/src/web/admin/content_export_views.py
@@ -8,6 +8,8 @@ here) is located via the ``CONTENT_REPO_PATH`` environment variable. Drives
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from django.contrib import messages
 from django.contrib.admin.views.decorators import staff_member_required
 from django.core.exceptions import PermissionDenied
@@ -119,6 +121,43 @@ def _grid_preview_context() -> dict:
     }
 
 
+def _refuse_if_on_session_branch(
+    request: HttpRequest, content_root: Path | None
+) -> HttpResponse | None:
+    """Refuse a corpus export while the checkout is on the row-export session branch.
+
+    A corpus-wide export writes to the checkout's actual working tree, same
+    as a row export does - running it while the checkout is still on the
+    row-export session branch would mix a whole-corpus pass into that
+    branch's small, per-row commits (#3018 review). The row-export flow
+    never touches main, so this can only ever misfire the other direction.
+    Split out of ``content_export_run`` (ruff C901) to keep that view's own
+    branching under the complexity ceiling.
+
+    A ``ContentPushError`` here means the checkout isn't a usable git repo at
+    all (or the branch lookup otherwise failed) - that can never be the
+    session branch, so this guard stays silent and lets the export attempt
+    proceed to its own, more specific error handling.
+    """
+    from core_management.content_push import ContentPushError  # noqa: PLC0415
+    from core_management.content_session import SESSION_BRANCH, _current_branch  # noqa: PLC0415
+
+    if content_root is None:
+        return None
+    try:
+        on_session_branch = _current_branch(content_root) == SESSION_BRANCH
+    except ContentPushError:
+        return None
+    if not on_session_branch:
+        return None
+    messages.error(
+        request,
+        "The content checkout is on the row-export session branch. Finish "
+        "or discard the session before running a corpus export.",
+    )
+    return HttpResponseRedirect(reverse("admin_game_setup"))
+
+
 @staff_member_required
 @require_POST
 def content_export_run(request: HttpRequest) -> HttpResponse:
@@ -130,7 +169,13 @@ def content_export_run(request: HttpRequest) -> HttpResponse:
         ContentExportError,
         export_to_content_repo,
     )
+    from core_management.content_repo import resolve_content_root  # noqa: PLC0415
     from core_management.grid_export import export_grid_bundles  # noqa: PLC0415
+
+    content_root = resolve_content_root()
+    bail = _refuse_if_on_session_branch(request, content_root)
+    if bail is not None:
+        return bail
 
     # Off by default: the export withholds rows the corpus does not already have,
     # so a database seeded with sample content cannot launder them in as lore

--- a/src/web/admin/content_row_export_views.py
+++ b/src/web/admin/content_row_export_views.py
@@ -379,9 +379,7 @@ def _run_confirmed_action(
 
     _clear_pending_export(request)
     messages.success(request, f"Committed {model.__name__} [{natural_key}] as {sha}.")
-    # Redirects to the Game Setup hub for now - Task 4 adds the session page
-    # (admin_content_session) and this line moves there once it lands.
-    return HttpResponseRedirect(reverse("admin_game_setup"))
+    return HttpResponseRedirect(reverse("admin_content_session"))
 
 
 @staff_member_required

--- a/src/web/admin/content_row_export_views.py
+++ b/src/web/admin/content_row_export_views.py
@@ -1,0 +1,357 @@
+"""Superuser-only row-level content export surface (#3018).
+
+Mirrors ``content_conflict_views.py``'s idiom (``@staff_member_required``
+plus an explicit ``is_superuser`` check, ``resolve_content_root()`` for the
+private content-repo path, digest-guarded confirm) but drives the opposite
+direction: instead of pulling the repo's version of a credited row back into
+the database, this writes ONE database row's corpus form out to the lore
+checkout's working tree (``core_management.content_export.export_single_row``)
+on the fixed session branch (``core_management.content_session``), shows its
+git diff, and either commits it as one small export commit or discards it.
+
+Three views, one round trip: ``content_export_row`` (POST from the change
+form) writes the row and redirects to ``content_export_row_diff`` (GET),
+which renders the diff plus a digest of it; ``content_export_row_confirm``
+(POST) re-checks that digest before doing anything; a stale digest (the
+working tree changed between the GET and this POST) is refused the same way
+a stale conflict-resolve digest is. An addition (the row's natural key isn't
+in the corpus yet) requires an explicit "new_row" checkbox acknowledgment,
+mirroring the corpus-wide export's addition gate (ADR-0191) at row scope.
+
+``export_single_row`` is deliberately never called twice for the same
+pending export - a second call would flip its own ``is_addition`` reading
+(the row would already be in the file it just wrote). So the diff and
+confirm views never re-export; they recompute the same output path(s)
+``export_single_row`` would have used via a small read-only helper below,
+and carry the one thing genuinely lost between requests - whether this
+export was an addition - in the request session, keyed by (model, pk).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from pathlib import Path
+from urllib.parse import urlencode
+
+from django.contrib import messages
+from django.contrib.admin.views.decorators import staff_member_required
+from django.core.exceptions import PermissionDenied
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.shortcuts import render
+from django.urls import reverse
+from django.views.decorators.http import require_GET, require_POST
+
+_CONTENT_ROOT_UNSET_MSG = (
+    "CONTENT_REPO_PATH is not set. Add it to src/.env pointing at your "
+    "local checkout of the private content repository."
+)
+
+# The two values the diff page's ``action`` hidden field can carry.
+_ACTION_CONFIRM = "confirm"
+_ACTION_DISCARD = "discard"
+
+
+def _diff_url(model_label: str, pk: object) -> str:
+    """Build the row-export diff URL for one ``(model_label, pk)`` pair."""
+    query = urlencode({"model": model_label, "pk": pk})
+    return f"{reverse('admin_content_export_row_diff')}?{query}"
+
+
+def _change_url(model: type, pk: object) -> str:
+    """Build this model's admin change-form URL for ``pk``.
+
+    ``admin:arxii_<model_name>_change`` may look hardcodable, but every
+    first-party model's real Django ``app_label`` is ``arxii`` post-collapse
+    (#2906) - reading it off ``model._meta`` rather than assuming the string
+    keeps this correct if that ever changes again.
+    """
+    app_label = model._meta.app_label  # noqa: SLF001
+    model_name = model._meta.model_name  # noqa: SLF001
+    return reverse(f"admin:{app_label}_{model_name}_change", args=[pk])
+
+
+def _changelist_url(model: type) -> str:
+    """Build this model's admin changelist URL - the fallback when ``pk`` is gone."""
+    app_label = model._meta.app_label  # noqa: SLF001
+    model_name = model._meta.model_name  # noqa: SLF001
+    return reverse(f"admin:{app_label}_{model_name}_changelist")
+
+
+def _addition_session_key(model_label: str, pk: object) -> str:
+    """Session key carrying one pending export's addition state across requests."""
+    return f"content_export_row:{model_label}:{pk}:is_addition"
+
+
+def _row_export_preview(instance, content_root: Path) -> tuple[list[Path], str]:
+    """Recompute ``export_single_row``'s output path(s) and natural-key display.
+
+    Read-only: mirrors that function's path/key derivation exactly (same
+    serializer call, same natural-key fields, same markdown-vs-JSON path
+    formula) but never writes anything. The diff and confirm views need to
+    know where the pending export landed without re-running the write that
+    would flip its own addition bookkeeping a second time (see module
+    docstring).
+    """
+    from django.core import serializers  # noqa: PLC0415
+
+    from core.app_domains import domain_of  # noqa: PLC0415
+    from core_management.content_export import (  # noqa: PLC0415
+        _markdown_entry_path,
+        _natural_key_fields,
+    )
+    from core_management.content_fixtures import MARKDOWN_EXPORT_DOMAINS  # noqa: PLC0415
+
+    model = type(instance)
+    model_name = model.__name__.lower()
+    model_label = f"{domain_of(model)}.{model_name}"
+    data = serializers.serialize(
+        "json",
+        model.objects.filter(pk=instance.pk),
+        use_natural_foreign_keys=True,
+        use_natural_primary_keys=True,
+    )
+    records = json.loads(data)
+    if not records:
+        return [], ""
+    fields = records[0]["fields"]
+    key_fields = _natural_key_fields(model)
+    key_display = ", ".join(
+        str(v) for v in ([fields.get(f) for f in key_fields] if key_fields else [instance.pk])
+    )
+
+    spec = MARKDOWN_EXPORT_DOMAINS.get(model_label)
+    if spec is not None:
+        return [_markdown_entry_path(content_root, spec, fields)], key_display
+
+    out_path = content_root / "fixtures" / domain_of(model) / f"{model_name}.json"
+    return [out_path], key_display
+
+
+def _resolve_model_and_instance(model_label: str, pk: str):
+    """Resolve ``(model, instance)`` for a posted/queried ``(model, pk)`` pair.
+
+    Returns ``(model, instance)`` where either half may be ``None`` - pair
+    with ``_bail_on_missing_target`` to turn either gap into a flash +
+    redirect (a missing model has nowhere sensible to go but the Game Setup
+    hub; a missing instance can still fall back to that model's changelist).
+    """
+    from core.app_domains import resolve_model_by_name  # noqa: PLC0415
+
+    try:
+        model = resolve_model_by_name(model_label)
+    except LookupError:
+        return None, None
+    instance = model.objects.filter(pk=pk).first()
+    return model, instance
+
+
+def _bail_on_missing_target(
+    request: HttpRequest, model: type | None, instance: object | None, model_label: str, pk: str
+) -> HttpResponse | None:
+    """Return a flash-and-redirect response for an unresolved model/instance, else ``None``.
+
+    Shared by all three views so ``content_export_row_confirm`` (which also
+    branches on digest and on/off commit outcomes) doesn't pile up enough
+    ``return`` statements to trip the complexity linter.
+    """
+    if model is None:
+        messages.error(request, f"{model_label} is not a recognized model.")
+        return HttpResponseRedirect(reverse("admin_game_setup"))
+    if instance is None:
+        messages.error(request, f"{model.__name__} [{pk}] no longer exists.")
+        return HttpResponseRedirect(_changelist_url(model))
+    return None
+
+
+@staff_member_required
+@require_POST
+def content_export_row(request: HttpRequest) -> HttpResponse:
+    """Write one database row's corpus form into the session branch's working tree.
+
+    Ensures the session branch first (creating or reusing it - see
+    ``content_session.ensure_session_branch``), then exports exactly this
+    row. A refusal (the model isn't corpus-owned, or this row is filtered
+    out by ``EXPORT_FILTERS``) flashes and sends the operator back to the
+    change form without touching git at all. Success redirects to the diff
+    page for review before anything is committed.
+    """
+    if not request.user.is_superuser:
+        raise PermissionDenied
+
+    from core_management.content_export import export_single_row  # noqa: PLC0415
+    from core_management.content_push import ContentPushError  # noqa: PLC0415
+    from core_management.content_repo import resolve_content_root  # noqa: PLC0415
+    from core_management.content_session import ensure_session_branch  # noqa: PLC0415
+
+    content_root = resolve_content_root()
+    if content_root is None:
+        messages.error(request, _CONTENT_ROOT_UNSET_MSG)
+        return HttpResponseRedirect(reverse("admin_game_setup"))
+
+    model_label = request.POST.get("model", "")
+    pk = request.POST.get("pk", "")
+    model, instance = _resolve_model_and_instance(model_label, pk)
+    bail = _bail_on_missing_target(request, model, instance, model_label, pk)
+    if bail is not None:
+        return bail
+
+    try:
+        ensure_session_branch(content_root)
+    except ContentPushError as exc:
+        messages.error(request, str(exc))
+        return HttpResponseRedirect(_change_url(model, pk))
+
+    result = export_single_row(instance, content_root=content_root)
+    if result.refused is not None:
+        messages.error(request, result.refused)
+        return HttpResponseRedirect(_change_url(model, pk))
+
+    request.session[_addition_session_key(result.model_label, pk)] = result.is_addition
+    return HttpResponseRedirect(_diff_url(result.model_label, pk))
+
+
+@staff_member_required
+@require_GET
+def content_export_row_diff(request: HttpRequest) -> HttpResponse:
+    """Show one pending row export's git diff behind a digest the confirm POST checks."""
+    if not request.user.is_superuser:
+        raise PermissionDenied
+
+    from core_management.content_repo import resolve_content_root  # noqa: PLC0415
+    from core_management.content_session import row_diff  # noqa: PLC0415
+
+    content_root = resolve_content_root()
+    if content_root is None:
+        messages.error(request, _CONTENT_ROOT_UNSET_MSG)
+        return HttpResponseRedirect(reverse("admin_game_setup"))
+
+    model_label = request.GET.get("model", "")
+    pk = request.GET.get("pk", "")
+    model, instance = _resolve_model_and_instance(model_label, pk)
+    bail = _bail_on_missing_target(request, model, instance, model_label, pk)
+    if bail is not None:
+        return bail
+
+    paths, natural_key = _row_export_preview(instance, content_root)
+    diff_text = row_diff(content_root, paths)
+    if not diff_text.strip():
+        messages.info(
+            request, f"Nothing to review for {model.__name__} [{natural_key}] - export it first."
+        )
+        return HttpResponseRedirect(_change_url(model, pk))
+
+    is_addition = request.session.get(_addition_session_key(model_label, pk), False)
+    digest = hashlib.sha256(diff_text.encode("utf-8")).hexdigest()
+
+    context = {
+        "title": f"Export {model.__name__}: {natural_key}",
+        "model_label": model_label,
+        "pk": pk,
+        "natural_key": natural_key,
+        "diff_text": diff_text,
+        "is_addition": is_addition,
+        "digest": digest,
+        "confirm_url": reverse("admin_content_export_row_confirm"),
+        "change_url": _change_url(model, pk),
+    }
+    return render(request, "admin/content_row_export_diff.html", context)
+
+
+def _run_confirmed_action(
+    request: HttpRequest,
+    content_root: Path,
+    instance: object,
+    natural_key: str,
+    paths: list[Path],
+) -> HttpResponse:
+    """Apply ``action=confirm|discard`` once the digest has already checked out.
+
+    Split out of ``content_export_row_confirm`` (ruff PLR0911) so that view's
+    own preamble (superuser gate, content-root check, model/instance
+    resolution, digest check) stays separate from this branch's several
+    possible outcomes.
+    """
+    from core_management.content_push import ContentPushError  # noqa: PLC0415
+    from core_management.content_session import (  # noqa: PLC0415
+        commit_row_export,
+        discard_row_export,
+    )
+
+    model = type(instance)
+    pk = instance.pk
+    model_label = request.POST.get("model", "")
+    diff_url = _diff_url(model_label, pk)
+    session_key = _addition_session_key(model_label, pk)
+    action = request.POST.get("action", "")
+
+    if action == _ACTION_DISCARD:
+        discard_row_export(content_root, paths)
+        request.session.pop(session_key, None)
+        messages.info(request, f"Discarded the pending export of {model.__name__} [{natural_key}].")
+        return HttpResponseRedirect(_change_url(model, pk))
+
+    if action != _ACTION_CONFIRM:
+        messages.error(request, "Unknown export action.")
+        return HttpResponseRedirect(diff_url)
+
+    is_addition = request.session.get(session_key, False)
+    if is_addition and not request.POST.get("new_row"):
+        messages.error(
+            request, "Check the new-row box to confirm this export adds a row to the corpus."
+        )
+        return HttpResponseRedirect(diff_url)
+
+    try:
+        sha = commit_row_export(content_root, paths, f"Export {model.__name__} [{natural_key}]")
+    except ContentPushError as exc:
+        messages.error(request, str(exc))
+        return HttpResponseRedirect(diff_url)
+
+    request.session.pop(session_key, None)
+    messages.success(request, f"Committed {model.__name__} [{natural_key}] as {sha}.")
+    # Redirects to the Game Setup hub for now - Task 4 adds the session page
+    # (admin_content_session) and this line moves there once it lands.
+    return HttpResponseRedirect(reverse("admin_game_setup"))
+
+
+@staff_member_required
+@require_POST
+def content_export_row_confirm(request: HttpRequest) -> HttpResponse:
+    """Commit or discard one pending row export, after a matching digest.
+
+    A digest mismatch means the working tree changed since the diff page was
+    rendered - refused unconditionally, same as ``content_conflict_resolve``.
+    An addition (a row not yet in the corpus) also needs the ``new_row``
+    checkbox checked; anything else is refused back to the diff page rather
+    than silently committed.
+    """
+    if not request.user.is_superuser:
+        raise PermissionDenied
+
+    from core_management.content_repo import resolve_content_root  # noqa: PLC0415
+    from core_management.content_session import row_diff  # noqa: PLC0415
+
+    content_root = resolve_content_root()
+    if content_root is None:
+        messages.error(request, _CONTENT_ROOT_UNSET_MSG)
+        return HttpResponseRedirect(reverse("admin_game_setup"))
+
+    model_label = request.POST.get("model", "")
+    pk = request.POST.get("pk", "")
+    model, instance = _resolve_model_and_instance(model_label, pk)
+    bail = _bail_on_missing_target(request, model, instance, model_label, pk)
+    if bail is not None:
+        return bail
+
+    paths, natural_key = _row_export_preview(instance, content_root)
+    diff_text = row_diff(content_root, paths)
+    digest = hashlib.sha256(diff_text.encode("utf-8")).hexdigest()
+
+    if request.POST.get("digest", "") != digest:
+        messages.error(
+            request, "The working tree changed since you reviewed this diff. Review it again."
+        )
+        return HttpResponseRedirect(_diff_url(model_label, pk))
+
+    return _run_confirmed_action(request, content_root, instance, natural_key, paths)

--- a/src/web/admin/content_row_export_views.py
+++ b/src/web/admin/content_row_export_views.py
@@ -27,14 +27,20 @@ confirm views never re-export; they recompute the same output path(s)
 At most one pending row export can exist at a time - enforced not here but
 one layer down, by ``content_session.ensure_session_branch`` refusing any
 dirty working tree (git state is the only truth that holds across browsers/
-operators; request-session bookkeeping is not). This module still keeps one
-piece of state in the request session - ``is_addition`` and the identity of
-the currently pending row, since neither survives a re-derivation without
-re-exporting (which would flip ``is_addition`` itself). When
+operators; request-session bookkeeping is not). Addition-ness is derived the
+same way, straight from git at both diff-render and confirm time
+(``_derive_is_addition``, delegating to ``content_session
+.row_is_addition_at_head``) - fixed after review (#3018) found the original
+design read it out of the request session instead, which only ever answered
+for the browser that ran the export: a second browser opening the same diff
+URL directly saw a default of "not an addition" and could commit a genuine
+addition with no new-row checkbox at all. This module still keeps one piece
+of state in the request session - the identity of the currently pending row
+(model, pk, natural key) - purely as a courtesy: when
 ``ensure_session_branch`` refuses a second export because a first is still
-pending, that session record is what lets the flash name the pending row and
-the redirect send the operator straight to its diff page instead of a dead
-end.
+pending, that record is what lets the flash name the pending row and the
+redirect send the operator straight to its diff page instead of a dead end.
+It is never consulted for anything that gates a commit.
 """
 
 from __future__ import annotations
@@ -99,12 +105,16 @@ def _set_pending_export(request: HttpRequest, model_label: str, pk: object, resu
     there is never a need to remember more than one, and a stray leftover
     key from an abandoned export session can never linger under this
     invariant.
+
+    Carries only the identity needed to name the pending row in a flash
+    message (see the module docstring) - no ``is_addition``, which is
+    derived fresh from git on every diff render and confirm instead (#3018
+    review).
     """
     request.session[_PENDING_EXPORT_SESSION_KEY] = {
         "model_label": model_label,
         "pk": pk,
         "natural_key": result.natural_key,
-        "is_addition": result.is_addition,
     }
 
 
@@ -118,19 +128,20 @@ def _clear_pending_export(request: HttpRequest) -> None:
     request.session.pop(_PENDING_EXPORT_SESSION_KEY, None)
 
 
-def _is_pending_addition(request: HttpRequest, model_label: str, pk: object) -> bool:
-    """True when the session's pending-export record is this row and it's an addition.
+def _derive_is_addition(content_root: Path, model: type, paths: list[Path], fields: dict) -> bool:
+    """Return whether this pending row export is an addition, derived from git HEAD.
 
-    Defaults to ``False`` (never spuriously shows the new-row checkbox) when
-    the session record is missing or names a different row - e.g. a direct
-    hit on a stale diff URL after another operator's export replaced this
-    session's pending record.
+    Replaces the old request-session lookup (see the module docstring's
+    #3018-review note) - delegates the actual git plumbing to
+    ``content_session.row_is_addition_at_head``, which fails closed on any
+    git/parse trouble so uncertainty here can never suppress the new-row
+    checkbox.
     """
-    pending = _pending_export(request)
-    if pending is None:
-        return False
-    same_row = pending["model_label"] == model_label and str(pending["pk"]) == str(pk)
-    return same_row and bool(pending["is_addition"])
+    from core_management.content_export import _natural_key_fields  # noqa: PLC0415
+    from core_management.content_session import row_is_addition_at_head  # noqa: PLC0415
+
+    key_fields = _natural_key_fields(model)
+    return row_is_addition_at_head(content_root, paths, key_fields, fields)
 
 
 def _pending_export_display_name(model_label: str) -> str:
@@ -148,15 +159,17 @@ def _pending_export_display_name(model_label: str) -> str:
         return model_label
 
 
-def _row_export_preview(instance, content_root: Path) -> tuple[list[Path], str]:
-    """Recompute ``export_single_row``'s output path(s) and natural-key display.
+def _row_export_preview(instance, content_root: Path) -> tuple[list[Path], str, dict]:
+    """Recompute ``export_single_row``'s output path(s), key display, and fields.
 
     Read-only: mirrors that function's path/key derivation exactly (same
     serializer call, same natural-key fields, same markdown-vs-JSON path
     formula) but never writes anything. The diff and confirm views need to
     know where the pending export landed without re-running the write that
     would flip its own addition bookkeeping a second time (see module
-    docstring).
+    docstring). The returned ``fields`` dict is this row's serialized field
+    values - needed by ``_derive_is_addition`` to check the row's own
+    natural key against what git's ``HEAD`` copy of the file actually holds.
     """
     from django.core import serializers  # noqa: PLC0415
 
@@ -178,7 +191,7 @@ def _row_export_preview(instance, content_root: Path) -> tuple[list[Path], str]:
     )
     records = json.loads(data)
     if not records:
-        return [], ""
+        return [], "", {}
     fields = records[0]["fields"]
     key_fields = _natural_key_fields(model)
     key_display = ", ".join(
@@ -187,10 +200,10 @@ def _row_export_preview(instance, content_root: Path) -> tuple[list[Path], str]:
 
     spec = MARKDOWN_EXPORT_DOMAINS.get(model_label)
     if spec is not None:
-        return [_markdown_entry_path(content_root, spec, fields)], key_display
+        return [_markdown_entry_path(content_root, spec, fields)], key_display, fields
 
     out_path = content_root / "fixtures" / domain_of(model) / f"{model_name}.json"
-    return [out_path], key_display
+    return [out_path], key_display, fields
 
 
 def _resolve_model_and_instance(model_label: str, pk: str):
@@ -303,7 +316,7 @@ def content_export_row_diff(request: HttpRequest) -> HttpResponse:
     if bail is not None:
         return bail
 
-    paths, natural_key = _row_export_preview(instance, content_root)
+    paths, natural_key, fields = _row_export_preview(instance, content_root)
     diff_text = row_diff(content_root, paths)
     if not diff_text.strip():
         messages.info(
@@ -311,7 +324,7 @@ def content_export_row_diff(request: HttpRequest) -> HttpResponse:
         )
         return HttpResponseRedirect(_change_url(model, pk))
 
-    is_addition = _is_pending_addition(request, model_label, pk)
+    is_addition = _derive_is_addition(content_root, model, paths, fields)
     digest = hashlib.sha256(diff_text.encode("utf-8")).hexdigest()
 
     context = {
@@ -332,15 +345,16 @@ def _run_confirmed_action(
     request: HttpRequest,
     content_root: Path,
     instance: object,
-    natural_key: str,
-    paths: list[Path],
+    preview: tuple[list[Path], str, dict],
 ) -> HttpResponse:
     """Apply ``action=confirm|discard`` once the digest has already checked out.
 
     Split out of ``content_export_row_confirm`` (ruff PLR0911) so that view's
     own preamble (superuser gate, content-root check, model/instance
     resolution, digest check) stays separate from this branch's several
-    possible outcomes.
+    possible outcomes. ``preview`` is ``_row_export_preview``'s
+    ``(paths, natural_key, fields)`` result, passed through as one value to
+    stay under the argument-count ceiling (ruff PLR0913).
     """
     from core_management.content_push import ContentPushError  # noqa: PLC0415
     from core_management.content_session import (  # noqa: PLC0415
@@ -348,6 +362,7 @@ def _run_confirmed_action(
         discard_row_export,
     )
 
+    paths, natural_key, fields = preview
     model = type(instance)
     pk = instance.pk
     model_label = request.POST.get("model", "")
@@ -364,7 +379,10 @@ def _run_confirmed_action(
         messages.error(request, "Unknown export action.")
         return HttpResponseRedirect(diff_url)
 
-    is_addition = _is_pending_addition(request, model_label, pk)
+    # Derived straight from git HEAD, not the request session (#3018 review) -
+    # only computed here, not for the discard branch above, since discard
+    # never needs to know.
+    is_addition = _derive_is_addition(content_root, model, paths, fields)
     if is_addition and not request.POST.get("new_row"):
         messages.error(
             request, "Check the new-row box to confirm this export adds a row to the corpus."
@@ -411,7 +429,7 @@ def content_export_row_confirm(request: HttpRequest) -> HttpResponse:
     if bail is not None:
         return bail
 
-    paths, natural_key = _row_export_preview(instance, content_root)
+    paths, natural_key, fields = _row_export_preview(instance, content_root)
     diff_text = row_diff(content_root, paths)
     digest = hashlib.sha256(diff_text.encode("utf-8")).hexdigest()
 
@@ -421,4 +439,4 @@ def content_export_row_confirm(request: HttpRequest) -> HttpResponse:
         )
         return HttpResponseRedirect(_diff_url(model_label, pk))
 
-    return _run_confirmed_action(request, content_root, instance, natural_key, paths)
+    return _run_confirmed_action(request, content_root, instance, (paths, natural_key, fields))

--- a/src/web/admin/content_row_export_views.py
+++ b/src/web/admin/content_row_export_views.py
@@ -22,9 +22,19 @@ mirroring the corpus-wide export's addition gate (ADR-0191) at row scope.
 pending export - a second call would flip its own ``is_addition`` reading
 (the row would already be in the file it just wrote). So the diff and
 confirm views never re-export; they recompute the same output path(s)
-``export_single_row`` would have used via a small read-only helper below,
-and carry the one thing genuinely lost between requests - whether this
-export was an addition - in the request session, keyed by (model, pk).
+``export_single_row`` would have used via a small read-only helper below.
+
+At most one pending row export can exist at a time - enforced not here but
+one layer down, by ``content_session.ensure_session_branch`` refusing any
+dirty working tree (git state is the only truth that holds across browsers/
+operators; request-session bookkeeping is not). This module still keeps one
+piece of state in the request session - ``is_addition`` and the identity of
+the currently pending row, since neither survives a re-derivation without
+re-exporting (which would flip ``is_addition`` itself). When
+``ensure_session_branch`` refuses a second export because a first is still
+pending, that session record is what lets the flash name the pending row and
+the redirect send the operator straight to its diff page instead of a dead
+end.
 """
 
 from __future__ import annotations
@@ -78,9 +88,64 @@ def _changelist_url(model: type) -> str:
     return reverse(f"admin:{app_label}_{model_name}_changelist")
 
 
-def _addition_session_key(model_label: str, pk: object) -> str:
-    """Session key carrying one pending export's addition state across requests."""
-    return f"content_export_row:{model_label}:{pk}:is_addition"
+_PENDING_EXPORT_SESSION_KEY = "content_export_row:pending"
+
+
+def _set_pending_export(request: HttpRequest, model_label: str, pk: object, result) -> None:
+    """Record the just-written pending export as the session's single pending record.
+
+    A single key, not one keyed by ``(model_label, pk)``: at most one pending
+    export can exist at a time (enforced by ``ensure_session_branch``), so
+    there is never a need to remember more than one, and a stray leftover
+    key from an abandoned export session can never linger under this
+    invariant.
+    """
+    request.session[_PENDING_EXPORT_SESSION_KEY] = {
+        "model_label": model_label,
+        "pk": pk,
+        "natural_key": result.natural_key,
+        "is_addition": result.is_addition,
+    }
+
+
+def _pending_export(request: HttpRequest) -> dict | None:
+    """Return the session's pending-export record, or ``None`` if there isn't one."""
+    return request.session.get(_PENDING_EXPORT_SESSION_KEY)
+
+
+def _clear_pending_export(request: HttpRequest) -> None:
+    """Forget the session's pending-export record (after a confirm or discard)."""
+    request.session.pop(_PENDING_EXPORT_SESSION_KEY, None)
+
+
+def _is_pending_addition(request: HttpRequest, model_label: str, pk: object) -> bool:
+    """True when the session's pending-export record is this row and it's an addition.
+
+    Defaults to ``False`` (never spuriously shows the new-row checkbox) when
+    the session record is missing or names a different row - e.g. a direct
+    hit on a stale diff URL after another operator's export replaced this
+    session's pending record.
+    """
+    pending = _pending_export(request)
+    if pending is None:
+        return False
+    same_row = pending["model_label"] == model_label and str(pending["pk"]) == str(pk)
+    return same_row and bool(pending["is_addition"])
+
+
+def _pending_export_display_name(model_label: str) -> str:
+    """Return the pending export's model class name, falling back to its label.
+
+    Only used for a flash message, so an unresolvable label (a very stale
+    session surviving a model rename) degrades to showing the raw label
+    rather than raising out of an error-handling path.
+    """
+    from core.app_domains import resolve_model_by_name  # noqa: PLC0415
+
+    try:
+        return resolve_model_by_name(model_label).__name__
+    except LookupError:
+        return model_label
 
 
 def _row_export_preview(instance, content_root: Path) -> tuple[list[Path], str]:
@@ -199,15 +264,20 @@ def content_export_row(request: HttpRequest) -> HttpResponse:
     try:
         ensure_session_branch(content_root)
     except ContentPushError as exc:
-        messages.error(request, str(exc))
-        return HttpResponseRedirect(_change_url(model, pk))
+        pending = _pending_export(request)
+        if pending is None:
+            messages.error(request, str(exc))
+            return HttpResponseRedirect(_change_url(model, pk))
+        pending_name = _pending_export_display_name(pending["model_label"])
+        messages.error(request, f"{exc} Pending: {pending_name} [{pending['natural_key']}].")
+        return HttpResponseRedirect(_diff_url(pending["model_label"], pending["pk"]))
 
     result = export_single_row(instance, content_root=content_root)
     if result.refused is not None:
         messages.error(request, result.refused)
         return HttpResponseRedirect(_change_url(model, pk))
 
-    request.session[_addition_session_key(result.model_label, pk)] = result.is_addition
+    _set_pending_export(request, result.model_label, pk, result)
     return HttpResponseRedirect(_diff_url(result.model_label, pk))
 
 
@@ -241,7 +311,7 @@ def content_export_row_diff(request: HttpRequest) -> HttpResponse:
         )
         return HttpResponseRedirect(_change_url(model, pk))
 
-    is_addition = request.session.get(_addition_session_key(model_label, pk), False)
+    is_addition = _is_pending_addition(request, model_label, pk)
     digest = hashlib.sha256(diff_text.encode("utf-8")).hexdigest()
 
     context = {
@@ -282,12 +352,11 @@ def _run_confirmed_action(
     pk = instance.pk
     model_label = request.POST.get("model", "")
     diff_url = _diff_url(model_label, pk)
-    session_key = _addition_session_key(model_label, pk)
     action = request.POST.get("action", "")
 
     if action == _ACTION_DISCARD:
         discard_row_export(content_root, paths)
-        request.session.pop(session_key, None)
+        _clear_pending_export(request)
         messages.info(request, f"Discarded the pending export of {model.__name__} [{natural_key}].")
         return HttpResponseRedirect(_change_url(model, pk))
 
@@ -295,7 +364,7 @@ def _run_confirmed_action(
         messages.error(request, "Unknown export action.")
         return HttpResponseRedirect(diff_url)
 
-    is_addition = request.session.get(session_key, False)
+    is_addition = _is_pending_addition(request, model_label, pk)
     if is_addition and not request.POST.get("new_row"):
         messages.error(
             request, "Check the new-row box to confirm this export adds a row to the corpus."
@@ -308,7 +377,7 @@ def _run_confirmed_action(
         messages.error(request, str(exc))
         return HttpResponseRedirect(diff_url)
 
-    request.session.pop(session_key, None)
+    _clear_pending_export(request)
     messages.success(request, f"Committed {model.__name__} [{natural_key}] as {sha}.")
     # Redirects to the Game Setup hub for now - Task 4 adds the session page
     # (admin_content_session) and this line moves there once it lands.

--- a/src/web/admin/content_session_views.py
+++ b/src/web/admin/content_session_views.py
@@ -1,0 +1,104 @@
+"""Superuser-only content session page + one-pull-request-per-session flow (#3018).
+
+The session branch (``core_management.content_session.SESSION_BRANCH``) is the
+scratch space every row export (``content_row_export_views.py``) commits into,
+one small commit per row. This module is the operator's view onto that
+accumulated state - the branch name, the commit list, the full diff against
+``origin/main`` - and the one action that turns it into review: pushing the
+branch and opening (or reusing) its pull request.
+
+Two views: ``content_session`` (GET) renders the page; ``content_session_pr``
+(POST) reads the posted title/body, calls ``core_management.content_session
+.open_session_pr``, and redirects back to the session page with a flash
+either way. ``open_session_pr``, ``session_diff`` and ``session_state`` are
+imported at module scope (not the local-import idiom the sibling row-export
+views use) so a test can mock ``open_session_pr`` directly at this module's
+import site without needing a real GitHub-shaped remote.
+"""
+
+from __future__ import annotations
+
+from django.contrib import messages
+from django.contrib.admin.views.decorators import staff_member_required
+from django.core.exceptions import PermissionDenied
+from django.http import HttpRequest, HttpResponse, HttpResponseRedirect
+from django.shortcuts import render
+from django.urls import reverse
+from django.utils import timezone
+from django.views.decorators.http import require_GET, require_POST
+
+from core_management.content_push import ContentPushError
+from core_management.content_session import open_session_pr, session_diff, session_state
+
+_CONTENT_ROOT_UNSET_MSG = (
+    "CONTENT_REPO_PATH is not set. Add it to src/.env pointing at your "
+    "local checkout of the private content repository."
+)
+
+_DEFAULT_PR_BODY = "Authored in the Arx II admin; exported row by row with per-row diffs reviewed."
+
+
+@staff_member_required
+@require_GET
+def content_session(request: HttpRequest) -> HttpResponse:
+    """Show the session branch's commits, diff, and the open-pull-request form.
+
+    When the checkout isn't currently on the session branch (no export has
+    started one yet, or its pull request already merged and the branch was
+    recycled), the diff is left empty rather than computed - the template
+    renders a plain "no session yet" state instead of an empty diff block.
+    """
+    if not request.user.is_superuser:
+        raise PermissionDenied
+
+    from core_management.content_repo import resolve_content_root  # noqa: PLC0415
+
+    content_root = resolve_content_root()
+    if content_root is None:
+        messages.error(request, _CONTENT_ROOT_UNSET_MSG)
+        return HttpResponseRedirect(reverse("admin_game_setup"))
+
+    state = session_state(content_root)
+    diff_text = session_diff(content_root) if state.on_session else ""
+
+    context = {
+        "title": "Content session",
+        "state": state,
+        "diff_text": diff_text,
+        "pr_title": f"Content session {timezone.now().date().isoformat()}",
+        "pr_body": _DEFAULT_PR_BODY,
+        "pr_url": reverse("admin_content_session_pr"),
+    }
+    return render(request, "admin/content_session.html", context)
+
+
+@staff_member_required
+@require_POST
+def content_session_pr(request: HttpRequest) -> HttpResponse:
+    """Push the session branch and open (or reuse) its pull request.
+
+    Always redirects back to the session page - success flashes the pull
+    request's URL, and a ``ContentPushError`` from the push/API call flashes
+    as an error instead of raising.
+    """
+    if not request.user.is_superuser:
+        raise PermissionDenied
+
+    from core_management.content_repo import resolve_content_root  # noqa: PLC0415
+
+    content_root = resolve_content_root()
+    if content_root is None:
+        messages.error(request, _CONTENT_ROOT_UNSET_MSG)
+        return HttpResponseRedirect(reverse("admin_game_setup"))
+
+    title = request.POST.get("title", "")
+    body = request.POST.get("body", "")
+
+    try:
+        url = open_session_pr(content_root, title=title, body=body)
+    except ContentPushError as exc:
+        messages.error(request, str(exc))
+        return HttpResponseRedirect(reverse("admin_content_session"))
+
+    messages.success(request, f"Opened the session pull request: {url}")
+    return HttpResponseRedirect(reverse("admin_content_session"))

--- a/src/web/admin/content_session_views.py
+++ b/src/web/admin/content_session_views.py
@@ -9,11 +9,19 @@ branch and opening (or reusing) its pull request.
 
 Two views: ``content_session`` (GET) renders the page; ``content_session_pr``
 (POST) reads the posted title/body, calls ``core_management.content_session
-.open_session_pr``, and redirects back to the session page with a flash
-either way. ``open_session_pr``, ``session_diff`` and ``session_state`` are
+.open_session_pr``, and redirects back to the session page with a flash on
+success. ``open_session_pr``, ``session_diff`` and ``session_state`` are
 imported at module scope (not the local-import idiom the sibling row-export
 views use) so a test can mock ``open_session_pr`` directly at this module's
 import site without needing a real GitHub-shaped remote.
+
+A dirty working tree (``SessionState.dirty``) always means a row export is
+sitting uncommitted, pending confirm or discard (see
+``content_session.ensure_session_branch``'s docstring) - the page renders
+those ``git status --short`` lines verbatim so the operator can see which
+files, and when the *same browser session* holds the row-export module's
+pending-export record (#3018 review), names that row with a link straight to
+its diff page instead of leaving the operator to go hunting for it.
 """
 
 from __future__ import annotations
@@ -28,7 +36,17 @@ from django.utils import timezone
 from django.views.decorators.http import require_GET, require_POST
 
 from core_management.content_push import ContentPushError
-from core_management.content_session import open_session_pr, session_diff, session_state
+from core_management.content_session import (
+    SessionState,
+    open_session_pr,
+    session_diff,
+    session_state,
+)
+from web.admin.content_row_export_views import (
+    _diff_url,
+    _pending_export,
+    _pending_export_display_name,
+)
 
 _CONTENT_ROOT_UNSET_MSG = (
     "CONTENT_REPO_PATH is not set. Add it to src/.env pointing at your "
@@ -36,6 +54,50 @@ _CONTENT_ROOT_UNSET_MSG = (
 )
 
 _DEFAULT_PR_BODY = "Authored in the Arx II admin; exported row by row with per-row diffs reviewed."
+
+
+def _default_pr_title() -> str:
+    """Return the PR form's default title, dated for today."""
+    return f"Content session {timezone.now().date().isoformat()}"
+
+
+def _pending_row_display(request: HttpRequest, state: SessionState) -> dict | None:
+    """Return the pending row's display info, or ``None`` if there isn't one to show.
+
+    Only shown when the tree is actually dirty - a stale pending-export
+    session record with a clean tree (the row was already confirmed or
+    discarded from another tab) has nothing left to point at.
+    """
+    if not state.dirty:
+        return None
+    pending = _pending_export(request)
+    if pending is None:
+        return None
+    return {
+        "model_name": _pending_export_display_name(pending["model_label"]),
+        "natural_key": pending["natural_key"],
+        "diff_url": _diff_url(pending["model_label"], pending["pk"]),
+    }
+
+
+def _session_context(
+    request: HttpRequest, state: SessionState, pr_title: str, pr_body: str
+) -> dict:
+    """Build the ``content_session.html`` template context shared by both views.
+
+    ``diff_text`` is deliberately not set here - both callers overwrite it
+    right after, since computing it needs ``content_root`` too and the two
+    callers already have it in scope.
+    """
+    return {
+        "title": "Content session",
+        "state": state,
+        "dirty_text": "\n".join(state.dirty),
+        "pending_row": _pending_row_display(request, state),
+        "pr_title": pr_title,
+        "pr_body": pr_body,
+        "pr_url": reverse("admin_content_session_pr"),
+    }
 
 
 @staff_member_required
@@ -59,16 +121,8 @@ def content_session(request: HttpRequest) -> HttpResponse:
         return HttpResponseRedirect(reverse("admin_game_setup"))
 
     state = session_state(content_root)
-    diff_text = session_diff(content_root) if state.on_session else ""
-
-    context = {
-        "title": "Content session",
-        "state": state,
-        "diff_text": diff_text,
-        "pr_title": f"Content session {timezone.now().date().isoformat()}",
-        "pr_body": _DEFAULT_PR_BODY,
-        "pr_url": reverse("admin_content_session_pr"),
-    }
+    context = _session_context(request, state, _default_pr_title(), _DEFAULT_PR_BODY)
+    context["diff_text"] = session_diff(content_root) if state.on_session else ""
     return render(request, "admin/content_session.html", context)
 
 
@@ -77,9 +131,11 @@ def content_session(request: HttpRequest) -> HttpResponse:
 def content_session_pr(request: HttpRequest) -> HttpResponse:
     """Push the session branch and open (or reuse) its pull request.
 
-    Always redirects back to the session page - success flashes the pull
-    request's URL, and a ``ContentPushError`` from the push/API call flashes
-    as an error instead of raising.
+    Success redirects back to the session page with a flash naming the pull
+    request's URL. A ``ContentPushError`` from the push/API call instead
+    renders the session page directly (not a redirect) with the posted
+    title/body still in the form - a redirect would lose them, since the GET
+    view always recomputes the dated default (#3018 review).
     """
     if not request.user.is_superuser:
         raise PermissionDenied
@@ -98,7 +154,10 @@ def content_session_pr(request: HttpRequest) -> HttpResponse:
         url = open_session_pr(content_root, title=title, body=body)
     except ContentPushError as exc:
         messages.error(request, str(exc))
-        return HttpResponseRedirect(reverse("admin_content_session"))
+        state = session_state(content_root)
+        context = _session_context(request, state, title, body)
+        context["diff_text"] = session_diff(content_root) if state.on_session else ""
+        return render(request, "admin/content_session.html", context)
 
     messages.success(request, f"Opened the session pull request: {url}")
     return HttpResponseRedirect(reverse("admin_content_session"))

--- a/src/web/admin/content_session_views.py
+++ b/src/web/admin/content_session_views.py
@@ -7,21 +7,29 @@ accumulated state - the branch name, the commit list, the full diff against
 ``origin/main`` - and the one action that turns it into review: pushing the
 branch and opening (or reusing) its pull request.
 
-Two views: ``content_session`` (GET) renders the page; ``content_session_pr``
+Three views: ``content_session`` (GET) renders the page; ``content_session_pr``
 (POST) reads the posted title/body, calls ``core_management.content_session
 .open_session_pr``, and redirects back to the session page with a flash on
-success. ``open_session_pr``, ``session_diff`` and ``session_state`` are
-imported at module scope (not the local-import idiom the sibling row-export
-views use) so a test can mock ``open_session_pr`` directly at this module's
-import site without needing a real GitHub-shaped remote.
+success; ``content_session_discard`` (POST) is the strand-recovery escape
+hatch - it wipes every uncommitted change under ``fixtures/`` and ``content/``
+via ``content_session.discard_all_pending``, gated on a checkbox because it
+has no per-file review. ``open_session_pr``, ``session_diff`` and
+``session_state`` are imported at module scope (not the local-import idiom
+the sibling row-export views use) so a test can mock ``open_session_pr``
+directly at this module's import site without needing a real GitHub-shaped
+remote.
 
-A dirty working tree (``SessionState.dirty``) always means a row export is
+A dirty working tree (``SessionState.dirty``) usually means a row export is
 sitting uncommitted, pending confirm or discard (see
-``content_session.ensure_session_branch``'s docstring) - the page renders
-those ``git status --short`` lines verbatim so the operator can see which
-files, and when the *same browser session* holds the row-export module's
-pending-export record (#3018 review), names that row with a link straight to
-its diff page instead of leaving the operator to go hunting for it.
+``content_session.ensure_session_branch``'s docstring), but that is not the
+*only* way it can be dirty - a crashed browser mid-review, or an operator who
+wants out of a pending row without walking through its own diff page, both
+leave the same dirty tree with nothing left to point the pending-export
+record at. The page renders those ``git status --short`` lines verbatim, and
+when the *same browser session* holds the row-export module's pending-export
+record (#3018 review), names that row with a link straight to its diff page;
+either way, "Discard all pending changes" is always available as the general
+recovery, not conditioned on that record existing.
 """
 
 from __future__ import annotations
@@ -38,11 +46,13 @@ from django.views.decorators.http import require_GET, require_POST
 from core_management.content_push import ContentPushError
 from core_management.content_session import (
     SessionState,
+    discard_all_pending,
     open_session_pr,
     session_diff,
     session_state,
 )
 from web.admin.content_row_export_views import (
+    _clear_pending_export,
     _diff_url,
     _pending_export,
     _pending_export_display_name,
@@ -97,6 +107,7 @@ def _session_context(
         "pr_title": pr_title,
         "pr_body": pr_body,
         "pr_url": reverse("admin_content_session_pr"),
+        "discard_all_url": reverse("admin_content_session_discard"),
     }
 
 
@@ -160,4 +171,36 @@ def content_session_pr(request: HttpRequest) -> HttpResponse:
         return render(request, "admin/content_session.html", context)
 
     messages.success(request, f"Opened the session pull request: {url}")
+    return HttpResponseRedirect(reverse("admin_content_session"))
+
+
+@staff_member_required
+@require_POST
+def content_session_discard(request: HttpRequest) -> HttpResponse:
+    """Discard every uncommitted change on the session branch. Strand recovery (#3018 review).
+
+    Requires the ``discard_confirm`` checkbox - the same "you must
+    deliberately opt in" idiom the load-conflict resolve page uses for its
+    typed natural key, since ``content_session.discard_all_pending`` throws
+    away uncommitted work with no per-file review and no undo. Also clears
+    this browser's own pending-export record, if it holds one, since
+    whatever it was pointing at just got wiped.
+    """
+    if not request.user.is_superuser:
+        raise PermissionDenied
+
+    from core_management.content_repo import resolve_content_root  # noqa: PLC0415
+
+    content_root = resolve_content_root()
+    if content_root is None:
+        messages.error(request, _CONTENT_ROOT_UNSET_MSG)
+        return HttpResponseRedirect(reverse("admin_game_setup"))
+
+    if not request.POST.get("discard_confirm"):
+        messages.error(request, "Check the confirmation box to discard all pending changes.")
+        return HttpResponseRedirect(reverse("admin_content_session"))
+
+    discard_all_pending(content_root)
+    _clear_pending_export(request)
+    messages.success(request, "Discarded all pending changes on the content session branch.")
     return HttpResponseRedirect(reverse("admin_content_session"))

--- a/src/web/admin/templatetags/content_export_tags.py
+++ b/src/web/admin/templatetags/content_export_tags.py
@@ -1,0 +1,43 @@
+"""Template filters for the change-form "Export to content repo" button (#3018).
+
+``web/templates/admin/change_form.html`` needs to know two things about the
+object currently on screen: whether its model is corpus-owned at all
+(``content_exportable``) and, if so, the ``<domain>.<model_name>`` label the
+row-export POST view (``admin_content_export_row``) expects in its hidden
+``model`` field (``content_model_label``). Both filters compute the same
+label the same way ``content_row_export_views._resolve_model_and_instance``
+resolves it back from, via ``core.app_domains.resolve_model_by_name``.
+"""
+
+from __future__ import annotations
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def content_exportable(obj) -> bool:
+    """True when this admin object's model is corpus-owned (#3018).
+
+    ``obj`` is always either ``None`` or a Django model instance here (the
+    caller is always ``change_form.html``'s ``original`` context variable),
+    so ``obj.pk`` is safe once the ``None`` case is ruled out by the
+    short-circuiting ``or`` below.
+    """
+    if obj is None or not obj.pk:
+        return False
+    from core.app_domains import domain_of  # noqa: PLC0415
+    from core_management.content_export import CONTENT_MODELS  # noqa: PLC0415
+    from core_management.content_fixtures import MARKDOWN_EXPORT_DOMAINS  # noqa: PLC0415
+
+    label = f"{domain_of(type(obj))}.{type(obj).__name__.lower()}"
+    return label in CONTENT_MODELS or label in MARKDOWN_EXPORT_DOMAINS
+
+
+@register.filter
+def content_model_label(obj) -> str:
+    """Return this admin object's ``<domain>.<model_name>`` row-export label (#3018)."""
+    from core.app_domains import domain_of  # noqa: PLC0415
+
+    return f"{domain_of(type(obj))}.{type(obj).__name__.lower()}"

--- a/src/web/admin/tests/test_change_form_export_button.py
+++ b/src/web/admin/tests/test_change_form_export_button.py
@@ -1,0 +1,67 @@
+"""Tests for the change-form "Export to content repo" button (#3018).
+
+The button is a small ``{% block object-tools-items %}`` override in
+``web/templates/admin/change_form.html`` (mirroring the pin button in
+``change_list.html``'s override of the same block) that posts to
+``admin_content_export_row`` with the row's ``<domain>.<model_name>`` label
+and pk. It is gated three ways: the object must exist (a change form, not an
+add form), the model must be corpus-owned (``content_export_tags
+.content_exportable``), and the viewer must be a superuser.
+"""
+
+from django.contrib.auth.models import Group, Permission
+from django.test import TestCase
+from django.urls import reverse
+from evennia.accounts.models import AccountDB
+
+from world.magic.factories import EffectTypeFactory
+
+
+class TestChangeFormExportButton(TestCase):
+    """The button's presence/absence across model, permission, and add/change cases."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.super = AccountDB.objects.create_superuser("rootadmin", "root@example.com", "pw-123456")
+        cls.staff = AccountDB.objects.create_user("staffer", "s@example.com", "pw-123456")
+        cls.staff.is_staff = True
+        cls.staff.user_permissions.set(Permission.objects.all())
+        cls.staff.save()
+
+    def test_content_model_change_form_has_the_button_for_a_superuser(self) -> None:
+        effect = EffectTypeFactory(name="Export Button Effect")
+        self.client.force_login(self.super)
+
+        resp = self.client.get(reverse("admin:arxii_effecttype_change", args=[effect.pk]))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Export to content repo")
+        self.assertContains(resp, reverse("admin_content_export_row"))
+        self.assertContains(resp, 'value="magic.effecttype"')
+        self.assertContains(resp, f'value="{effect.pk}"')
+
+    def test_non_content_model_change_form_has_no_button(self) -> None:
+        group = Group.objects.create(name="Export Button Control Group")
+        self.client.force_login(self.super)
+
+        resp = self.client.get(reverse("admin:auth_group_change", args=[group.pk]))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotContains(resp, "Export to content repo")
+
+    def test_non_superuser_staff_does_not_see_the_button(self) -> None:
+        effect = EffectTypeFactory(name="Export Button Staff View Effect")
+        self.client.force_login(self.staff)
+
+        resp = self.client.get(reverse("admin:arxii_effecttype_change", args=[effect.pk]))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotContains(resp, "Export to content repo")
+
+    def test_add_form_has_no_button(self) -> None:
+        self.client.force_login(self.super)
+
+        resp = self.client.get(reverse("admin:arxii_effecttype_add"))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotContains(resp, "Export to content repo")

--- a/src/web/admin/tests/test_content_export_views.py
+++ b/src/web/admin/tests/test_content_export_views.py
@@ -15,6 +15,7 @@ from django.test import TestCase
 from django.urls import reverse
 from evennia.accounts.models import AccountDB
 
+from core_management.tests._git_fixtures import init_origin_and_clone, run_git
 from world.magic.models import EffectType
 
 
@@ -94,3 +95,37 @@ class TestContentExportConfigured(TestCase):
         messages = [str(m) for m in resp.wsgi_request._messages]
         self.assertTrue(any("Content export" in m for m in messages))
         self.assertTrue(any("Grid export" in m for m in messages))
+
+
+class TestContentExportRunRefusesOnSessionBranch(TestCase):
+    """The corpus export must refuse to run on the row-export session branch (#3018 review)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.super = AccountDB.objects.create_superuser("rootadmin", "root@example.com", "pw-123456")
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        base = Path(self.tmp.name)
+        self.origin = base / "origin.git"
+        self.root = base / "clone"
+        init_origin_and_clone(self.origin, self.root)
+        self.client.force_login(self.super)
+
+    def test_run_on_session_branch_refuses_and_redirects(self) -> None:
+        from core_management.content_session import SESSION_BRANCH, ensure_session_branch
+
+        with mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)}):
+            ensure_session_branch(self.root)
+            resp = self.client.post(reverse("admin_content_export_run"))
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, reverse("admin_game_setup"))
+        messages = [str(m) for m in resp.wsgi_request._messages]
+        self.assertTrue(any("row-export session branch" in m for m in messages))
+        branch = run_git(self.root, "branch", "--show-current").stdout.strip()
+        self.assertEqual(branch, SESSION_BRANCH)
+        # Nothing was exported - the branch check runs before any writing.
+        exported_path = self.root / "fixtures" / "magic" / "effecttype.json"
+        self.assertFalse(exported_path.exists())

--- a/src/web/admin/tests/test_content_row_export_views.py
+++ b/src/web/admin/tests/test_content_row_export_views.py
@@ -296,7 +296,7 @@ class TestContentRowExportViewsConfigured(TestCase):
             )
 
         self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp.url, reverse("admin_game_setup"))
+        self.assertEqual(resp.url, reverse("admin_content_session"))
         msgs = [str(m) for m in resp.wsgi_request._messages]
         self.assertTrue(any("Row Commit Flash" in m for m in msgs))
         log = run_git(self.root, "log", "--oneline", "-1").stdout

--- a/src/web/admin/tests/test_content_row_export_views.py
+++ b/src/web/admin/tests/test_content_row_export_views.py
@@ -441,3 +441,53 @@ class TestContentRowExportViewsConfigured(TestCase):
         self.assertTrue(any("excluded from export" in m for m in msgs))
         status = run_git(self.root, "status", "--short").stdout
         self.assertEqual(status.strip(), "")
+
+    def test_markdown_domain_row_exports_diffs_and_confirms(self) -> None:
+        """A markdown-domain row (CodexEntry) round-trips through export/diff/confirm.
+
+        Every other test in this module drives a flat-JSON model
+        (``magic.effecttype``). This covers the other export shape - one
+        markdown file per row, under ``content/`` rather than ``fixtures/``
+        - through the exact same three views.
+        """
+        from core_management.content_fixtures import content_slug
+        from world.codex.factories import CodexEntryFactory
+
+        entry = CodexEntryFactory(
+            name="Row Markdown Entry",
+            summary="A short summary.",
+            lore_content="Some in-character lore text.",
+            mechanics_content="Some out-of-character mechanics text.",
+        )
+
+        export_resp = self._export("codex.codexentry", entry.pk)
+        self.assertEqual(export_resp.status_code, 302)
+
+        diff_resp = self._diff("codex.codexentry", entry.pk)
+        self.assertEqual(diff_resp.status_code, 200)
+        self.assertTrue(diff_resp.context["diff_text"].strip())
+        self.assertContains(diff_resp, "Some in-character lore text.")
+
+        with self._env():
+            confirm_resp = self.client.post(
+                reverse("admin_content_export_row_confirm"),
+                {
+                    "model": "codex.codexentry",
+                    "pk": entry.pk,
+                    "digest": diff_resp.context["digest"],
+                    "action": "confirm",
+                    "new_row": "1",
+                },
+            )
+        self.assertEqual(confirm_resp.status_code, 302)
+        self.assertEqual(confirm_resp.url, reverse("admin_content_session"))
+
+        entry_dir = self.root / "content" / "codex_entries"
+        expected_name = f"{content_slug(entry.name)}.md"
+        matches = list(entry_dir.rglob(expected_name))
+        self.assertEqual(len(matches), 1)
+        body = matches[0].read_text(encoding="utf-8")
+        self.assertIn("Some in-character lore text.", body)
+        self.assertIn("Some out-of-character mechanics text.", body)
+        log = run_git(self.root, "log", "--oneline", "-1").stdout
+        self.assertIn("Export CodexEntry", log)

--- a/src/web/admin/tests/test_content_row_export_views.py
+++ b/src/web/admin/tests/test_content_row_export_views.py
@@ -1,0 +1,269 @@
+"""Tests for the row-export button/diff/confirm/discard surface (#3018).
+
+Mirrors ``test_content_conflict_views.py``'s structure: a superuser-only
+gate on every view, plus a real tmp content root standing in for a checkout.
+Unlike the conflict tests, the content root here has to be a real clone of a
+real bare "origin" (not just a lone repo with ``origin`` pointed at
+``/dev/null``, the ``test_content_push_views.py`` idiom) - the row-export
+flow's first step is ``ensure_session_branch``, which fetches origin and can
+create the session branch off ``origin/main``, so origin has to actually
+exist. ``core_management.tests._git_fixtures`` provides that pair; Task 2's
+``test_content_session.py`` uses the exact same helper.
+"""
+
+from pathlib import Path
+import tempfile
+from unittest import mock
+
+from django.test import TestCase
+from django.urls import reverse
+from evennia.accounts.models import AccountDB
+
+from core_management.tests._git_fixtures import init_origin_and_clone, run_git
+from world.magic.factories import EffectTypeFactory
+
+
+class TestContentRowExportViewsGate(TestCase):
+    """Superuser gate on all three views - no content root needed to fail this early."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.super = AccountDB.objects.create_superuser("rootadmin", "root@example.com", "pw-123456")
+        cls.staff = AccountDB.objects.create_user("staffer", "s@example.com", "pw-123456")
+        cls.staff.is_staff = True
+        cls.staff.save()
+
+    def test_all_three_views_require_superuser(self) -> None:
+        self.client.force_login(self.staff)
+
+        resp = self.client.post(
+            reverse("admin_content_export_row"), {"model": "magic.effecttype", "pk": "1"}
+        )
+        self.assertEqual(resp.status_code, 403)
+
+        resp = self.client.get(
+            reverse("admin_content_export_row_diff"), {"model": "magic.effecttype", "pk": "1"}
+        )
+        self.assertEqual(resp.status_code, 403)
+
+        resp = self.client.post(
+            reverse("admin_content_export_row_confirm"), {"model": "magic.effecttype", "pk": "1"}
+        )
+        self.assertEqual(resp.status_code, 403)
+
+
+class TestContentRowExportViewsConfigured(TestCase):
+    """A tmp clone of a tmp bare origin, standing in for a content-repo checkout."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.super = AccountDB.objects.create_superuser("rootadmin", "root@example.com", "pw-123456")
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        base = Path(self.tmp.name)
+        self.origin = base / "origin.git"
+        self.root = base / "clone"
+        init_origin_and_clone(self.origin, self.root)
+        self.client.force_login(self.super)
+
+    def _env(self):
+        return mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)})
+
+    def _export(self, model_label: str, pk: object):
+        with self._env():
+            return self.client.post(
+                reverse("admin_content_export_row"), {"model": model_label, "pk": pk}
+            )
+
+    def _diff(self, model_label: str, pk: object):
+        with self._env():
+            return self.client.get(
+                reverse("admin_content_export_row_diff"), {"model": model_label, "pk": pk}
+            )
+
+    def test_export_row_writes_working_tree_and_redirects_to_diff(self) -> None:
+        effect = EffectTypeFactory(name="Row View Export")
+
+        resp = self._export("magic.effecttype", effect.pk)
+
+        self.assertEqual(resp.status_code, 302)
+        diff_url = reverse("admin_content_export_row_diff")
+        expected = f"{diff_url}?model=magic.effecttype&pk={effect.pk}"
+        self.assertEqual(resp.url, expected)
+
+        path = self.root / "fixtures" / "magic" / "effecttype.json"
+        self.assertTrue(path.exists())
+        self.assertIn("Row View Export", path.read_text(encoding="utf-8"))
+        status = run_git(self.root, "status", "--short").stdout
+        self.assertIn("fixtures/", status)
+        branch = run_git(self.root, "branch", "--show-current").stdout.strip()
+        self.assertEqual(branch, "content-export-session")
+
+    def test_diff_page_shows_git_diff_and_addition_checkbox_only_for_additions(self) -> None:
+        from core_management.content_export import export_to_content_repo
+
+        seeded = EffectTypeFactory(name="Row Diff Seeded", description="Original")
+        with self._env():
+            export_to_content_repo(self.root)
+        run_git(self.root, "add", ".")
+        run_git(self.root, "commit", "-m", "seed corpus")
+        run_git(self.root, "push", "-u", "origin", "main")
+
+        seeded.description = "Updated"
+        seeded.save()
+
+        self._export("magic.effecttype", seeded.pk)
+        update_resp = self._diff("magic.effecttype", seeded.pk)
+
+        self.assertEqual(update_resp.status_code, 200)
+        self.assertFalse(update_resp.context["is_addition"])
+        self.assertNotContains(update_resp, 'name="new_row"')
+        self.assertContains(update_resp, "Original")
+        self.assertContains(update_resp, "Updated")
+
+        # Confirm (commit) the update before starting a second pending export -
+        # the session flow never has two uncommitted row exports at once.
+        with self._env():
+            self.client.post(
+                reverse("admin_content_export_row_confirm"),
+                {
+                    "model": "magic.effecttype",
+                    "pk": seeded.pk,
+                    "digest": update_resp.context["digest"],
+                    "action": "confirm",
+                },
+            )
+
+        added = EffectTypeFactory(name="Row Diff Added")
+        self._export("magic.effecttype", added.pk)
+        add_resp = self._diff("magic.effecttype", added.pk)
+
+        self.assertEqual(add_resp.status_code, 200)
+        self.assertTrue(add_resp.context["is_addition"])
+        self.assertContains(add_resp, 'name="new_row"')
+
+    def test_confirm_refuses_stale_digest(self) -> None:
+        effect = EffectTypeFactory(name="Row Stale Digest")
+        self._export("magic.effecttype", effect.pk)
+        diff_resp = self._diff("magic.effecttype", effect.pk)
+        stale_digest = diff_resp.context["digest"]
+
+        # Mutate the written file after the GET, so the diff the operator
+        # reviewed is no longer current.
+        path = self.root / "fixtures" / "magic" / "effecttype.json"
+        path.write_text(path.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+
+        with self._env():
+            resp = self.client.post(
+                reverse("admin_content_export_row_confirm"),
+                {
+                    "model": "magic.effecttype",
+                    "pk": effect.pk,
+                    "digest": stale_digest,
+                    "action": "confirm",
+                    "new_row": "1",
+                },
+            )
+
+        self.assertEqual(resp.status_code, 302)
+        msgs = [str(m) for m in resp.wsgi_request._messages]
+        self.assertTrue(any("changed since you reviewed" in m for m in msgs))
+        log = run_git(self.root, "log", "--oneline", "-5").stdout
+        self.assertNotIn("Export EffectType", log)
+
+    def test_confirm_addition_without_checkbox_refuses(self) -> None:
+        effect = EffectTypeFactory(name="Row No Checkbox")
+        self._export("magic.effecttype", effect.pk)
+        diff_resp = self._diff("magic.effecttype", effect.pk)
+        digest = diff_resp.context["digest"]
+        self.assertTrue(diff_resp.context["is_addition"])
+
+        with self._env():
+            resp = self.client.post(
+                reverse("admin_content_export_row_confirm"),
+                {
+                    "model": "magic.effecttype",
+                    "pk": effect.pk,
+                    "digest": digest,
+                    "action": "confirm",
+                },
+            )
+
+        self.assertEqual(resp.status_code, 302)
+        msgs = [str(m) for m in resp.wsgi_request._messages]
+        self.assertTrue(any("new-row box" in m for m in msgs))
+        log = run_git(self.root, "log", "--oneline", "-5").stdout
+        self.assertNotIn("Export EffectType", log)
+
+    def test_confirm_commits_and_flashes(self) -> None:
+        effect = EffectTypeFactory(name="Row Commit Flash")
+        self._export("magic.effecttype", effect.pk)
+        diff_resp = self._diff("magic.effecttype", effect.pk)
+        digest = diff_resp.context["digest"]
+
+        with self._env():
+            resp = self.client.post(
+                reverse("admin_content_export_row_confirm"),
+                {
+                    "model": "magic.effecttype",
+                    "pk": effect.pk,
+                    "digest": digest,
+                    "action": "confirm",
+                    "new_row": "1",
+                },
+            )
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, reverse("admin_game_setup"))
+        msgs = [str(m) for m in resp.wsgi_request._messages]
+        self.assertTrue(any("Row Commit Flash" in m for m in msgs))
+        log = run_git(self.root, "log", "--oneline", "-1").stdout
+        self.assertIn("Export EffectType", log)
+        status = run_git(self.root, "status", "--short").stdout
+        self.assertEqual(status.strip(), "")
+
+    def test_discard_restores_tree(self) -> None:
+        effect = EffectTypeFactory(name="Row Discard")
+        self._export("magic.effecttype", effect.pk)
+        diff_resp = self._diff("magic.effecttype", effect.pk)
+        digest = diff_resp.context["digest"]
+
+        with self._env():
+            resp = self.client.post(
+                reverse("admin_content_export_row_confirm"),
+                {
+                    "model": "magic.effecttype",
+                    "pk": effect.pk,
+                    "digest": digest,
+                    "action": "discard",
+                },
+            )
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, reverse("admin:arxii_effecttype_change", args=[effect.pk]))
+        path = self.root / "fixtures" / "magic" / "effecttype.json"
+        self.assertFalse(path.exists())
+        status = run_git(self.root, "status", "--short").stdout
+        self.assertEqual(status.strip(), "")
+
+    def test_refused_export_flashes_and_never_touches_git(self) -> None:
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.seeds_checks import ensure_character_magic_check_type
+        from world.skills.factories import SkillFactory
+        from world.traits.factories import TraitFactory
+        from world.traits.models import TraitType
+
+        sheet = CharacterSheetFactory()
+        stat = TraitFactory(name="row_view_willpower", trait_type=TraitType.STAT)
+        skill = SkillFactory(trait__name="row_view_ritualism")
+        synthesized = ensure_character_magic_check_type(sheet, stat=stat, skill=skill)
+
+        resp = self._export("checks.checktype", synthesized.pk)
+
+        self.assertEqual(resp.status_code, 302)
+        msgs = [str(m) for m in resp.wsgi_request._messages]
+        self.assertTrue(any("excluded from export" in m for m in msgs))
+        status = run_git(self.root, "status", "--short").stdout
+        self.assertEqual(status.strip(), "")

--- a/src/web/admin/tests/test_content_row_export_views.py
+++ b/src/web/admin/tests/test_content_row_export_views.py
@@ -101,6 +101,84 @@ class TestContentRowExportViewsConfigured(TestCase):
         branch = run_git(self.root, "branch", "--show-current").stdout.strip()
         self.assertEqual(branch, "content-export-session")
 
+    def test_export_refuses_while_same_model_pending(self) -> None:
+        """Exporting row B while row A (same model) is still pending is refused.
+
+        ``ensure_session_branch``'s dirty-tree check now fires even on the
+        session branch itself (#3018 review), so B is never written at all -
+        the operator is redirected to A's diff page instead, with a flash
+        naming A as the pending export.
+        """
+        first = EffectTypeFactory(name="Row Pending A")
+        second = EffectTypeFactory(name="Row Pending B")
+
+        first_resp = self._export("magic.effecttype", first.pk)
+        self.assertEqual(first_resp.status_code, 302)
+
+        second_resp = self._export("magic.effecttype", second.pk)
+
+        self.assertEqual(second_resp.status_code, 302)
+        diff_url = reverse("admin_content_export_row_diff")
+        expected = f"{diff_url}?model=magic.effecttype&pk={first.pk}"
+        self.assertEqual(second_resp.url, expected)
+        msgs = [str(m) for m in second_resp.wsgi_request._messages]
+        self.assertTrue(any("Pending:" in m for m in msgs))
+        self.assertTrue(any("Pending: EffectType [Row Pending A]" in m for m in msgs))
+
+        path = self.root / "fixtures" / "magic" / "effecttype.json"
+        content = path.read_text(encoding="utf-8")
+        self.assertIn("Row Pending A", content)
+        self.assertNotIn("Row Pending B", content)
+
+    def test_export_succeeds_after_confirming_pending(self) -> None:
+        """Once A is confirmed (committed), exporting B proceeds normally."""
+        first = EffectTypeFactory(name="Row Sequence A")
+        second = EffectTypeFactory(name="Row Sequence B")
+
+        self._export("magic.effecttype", first.pk)
+        diff_resp = self._diff("magic.effecttype", first.pk)
+        with self._env():
+            self.client.post(
+                reverse("admin_content_export_row_confirm"),
+                {
+                    "model": "magic.effecttype",
+                    "pk": first.pk,
+                    "digest": diff_resp.context["digest"],
+                    "action": "confirm",
+                    "new_row": "1",
+                },
+            )
+
+        second_resp = self._export("magic.effecttype", second.pk)
+
+        self.assertEqual(second_resp.status_code, 302)
+        diff_url = reverse("admin_content_export_row_diff")
+        expected = f"{diff_url}?model=magic.effecttype&pk={second.pk}"
+        self.assertEqual(second_resp.url, expected)
+        path = self.root / "fixtures" / "magic" / "effecttype.json"
+        self.assertIn("Row Sequence B", path.read_text(encoding="utf-8"))
+
+    def test_export_refuses_while_cross_model_pending(self) -> None:
+        """A pending export on a different model also refuses the next export."""
+        from world.traits.factories import TraitFactory
+        from world.traits.models import TraitType
+
+        pending_effect = EffectTypeFactory(name="Row Cross Pending")
+        other_trait = TraitFactory(name="row_cross_pending_trait", trait_type=TraitType.OTHER)
+
+        self._export("magic.effecttype", pending_effect.pk)
+
+        resp = self._export("traits.trait", other_trait.pk)
+
+        self.assertEqual(resp.status_code, 302)
+        diff_url = reverse("admin_content_export_row_diff")
+        expected = f"{diff_url}?model=magic.effecttype&pk={pending_effect.pk}"
+        self.assertEqual(resp.url, expected)
+        msgs = [str(m) for m in resp.wsgi_request._messages]
+        self.assertTrue(any("Pending: EffectType [Row Cross Pending]" in m for m in msgs))
+        trait_path = self.root / "fixtures" / "traits" / "trait.json"
+        self.assertFalse(trait_path.exists())
+
     def test_diff_page_shows_git_diff_and_addition_checkbox_only_for_additions(self) -> None:
         from core_management.content_export import export_to_content_repo
 
@@ -124,7 +202,9 @@ class TestContentRowExportViewsConfigured(TestCase):
         self.assertContains(update_resp, "Updated")
 
         # Confirm (commit) the update before starting a second pending export -
-        # the session flow never has two uncommitted row exports at once.
+        # ensure_session_branch refuses a dirty tree even on the session
+        # branch itself, so the flow enforces at most one uncommitted row
+        # export at a time (see test_export_refuses_while_another_pending*).
         with self._env():
             self.client.post(
                 reverse("admin_content_export_row_confirm"),

--- a/src/web/admin/tests/test_content_row_export_views.py
+++ b/src/web/admin/tests/test_content_row_export_views.py
@@ -328,6 +328,100 @@ class TestContentRowExportViewsConfigured(TestCase):
         status = run_git(self.root, "status", "--short").stdout
         self.assertEqual(status.strip(), "")
 
+    def test_second_browser_diff_shows_addition_checkbox_and_enforces_it(self) -> None:
+        """A second browser's request session never ran the export (#3018 review).
+
+        The original design read ``is_addition`` out of the exporting browser's
+        request session, which defaulted to ``False`` for anyone else - so a
+        second superuser hitting this diff URL directly could confirm a
+        genuine addition with no new-row checkbox at all. It must now be
+        derived straight from git, so a fresh client (standing in for a
+        second browser/operator, never touching ``self.client``'s session)
+        sees the same checkbox and enforcement as the browser that exported.
+        """
+        from django.test import Client
+
+        added = EffectTypeFactory(name="Row Second Browser Addition")
+        self._export("magic.effecttype", added.pk)
+
+        second = Client()
+        second.force_login(self.super)
+
+        with self._env():
+            diff_resp = second.get(
+                reverse("admin_content_export_row_diff"),
+                {"model": "magic.effecttype", "pk": added.pk},
+            )
+        self.assertEqual(diff_resp.status_code, 200)
+        self.assertTrue(diff_resp.context["is_addition"])
+        self.assertContains(diff_resp, 'name="new_row"')
+        digest = diff_resp.context["digest"]
+
+        with self._env():
+            refused = second.post(
+                reverse("admin_content_export_row_confirm"),
+                {
+                    "model": "magic.effecttype",
+                    "pk": added.pk,
+                    "digest": digest,
+                    "action": "confirm",
+                },
+            )
+        self.assertEqual(refused.status_code, 302)
+        msgs = [str(m) for m in refused.wsgi_request._messages]
+        self.assertTrue(any("new-row box" in m for m in msgs))
+        log = run_git(self.root, "log", "--oneline", "-5").stdout
+        self.assertNotIn("Export EffectType", log)
+
+        with self._env():
+            committed = second.post(
+                reverse("admin_content_export_row_confirm"),
+                {
+                    "model": "magic.effecttype",
+                    "pk": added.pk,
+                    "digest": digest,
+                    "action": "confirm",
+                    "new_row": "1",
+                },
+            )
+        self.assertEqual(committed.status_code, 302)
+        self.assertEqual(committed.url, reverse("admin_content_session"))
+        log = run_git(self.root, "log", "--oneline", "-1").stdout
+        self.assertIn("Export EffectType", log)
+
+    def test_second_browser_diff_update_row_stays_not_addition(self) -> None:
+        """An update row derives ``is_addition = False`` for a fresh session too.
+
+        The fail-closed fix must not over-fire on the far more common case -
+        editing a row the corpus already has - or every ordinary update would
+        start spuriously demanding the new-row checkbox.
+        """
+        from django.test import Client
+
+        from core_management.content_export import export_to_content_repo
+
+        seeded = EffectTypeFactory(name="Row Second Browser Update", description="Original")
+        with self._env():
+            export_to_content_repo(self.root)
+        run_git(self.root, "add", ".")
+        run_git(self.root, "commit", "-m", "seed corpus")
+        run_git(self.root, "push", "-u", "origin", "main")
+
+        seeded.description = "Updated"
+        seeded.save()
+        self._export("magic.effecttype", seeded.pk)
+
+        second = Client()
+        second.force_login(self.super)
+        with self._env():
+            diff_resp = second.get(
+                reverse("admin_content_export_row_diff"),
+                {"model": "magic.effecttype", "pk": seeded.pk},
+            )
+        self.assertEqual(diff_resp.status_code, 200)
+        self.assertFalse(diff_resp.context["is_addition"])
+        self.assertNotContains(diff_resp, 'name="new_row"')
+
     def test_refused_export_flashes_and_never_touches_git(self) -> None:
         from world.character_sheets.factories import CharacterSheetFactory
         from world.magic.seeds_checks import ensure_character_magic_check_type

--- a/src/web/admin/tests/test_content_session_views.py
+++ b/src/web/admin/tests/test_content_session_views.py
@@ -22,6 +22,7 @@ from evennia.accounts.models import AccountDB
 from core_management.content_push import ContentPushError
 from core_management.content_session import commit_row_export, ensure_session_branch
 from core_management.tests._git_fixtures import init_origin_and_clone
+from web.admin.content_row_export_views import _PENDING_EXPORT_SESSION_KEY
 
 
 class TestContentSessionViewsGate(TestCase):
@@ -93,6 +94,49 @@ class TestContentSessionViewsConfigured(TestCase):
         self.assertContains(resp, "state.json")
         self.assertContains(resp, "Open pull request")
 
+    def test_dirty_session_renders_status_lines_and_names_pending_row(self) -> None:
+        """An uncommitted export shows its ``git status`` lines and, when this
+        browser session holds the row-export module's pending-export record,
+        names the row with a link to its diff page (#3018 review)."""
+        ensure_session_branch(self.root)
+        self._write_row("pending.json")  # written but never committed - stays dirty
+
+        session = self.client.session
+        session[_PENDING_EXPORT_SESSION_KEY] = {
+            "model_label": "magic.effecttype",
+            "pk": "42",
+            "natural_key": "Test Pending Row",
+            "is_addition": True,
+        }
+        session.save()
+
+        with self._env():
+            resp = self.client.get(reverse("admin_content_session"))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.context["state"].dirty)
+        self.assertContains(resp, "?? content/")
+        self.assertContains(resp, "Pending export:")
+        self.assertContains(resp, "EffectType")
+        self.assertContains(resp, "Test Pending Row")
+        diff_url = reverse("admin_content_export_row_diff")
+        expected_link = f"{diff_url}?model=magic.effecttype&amp;pk=42"
+        self.assertContains(resp, expected_link)
+
+    def test_dirty_session_without_matching_pending_record_omits_named_row(self) -> None:
+        """A dirty tree with no pending-export record in *this* session still
+        shows the status lines, but never fabricates a named row for it."""
+        ensure_session_branch(self.root)
+        self._write_row("orphaned.json")
+
+        with self._env():
+            resp = self.client.get(reverse("admin_content_session"))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.context["state"].dirty)
+        self.assertContains(resp, "?? content/")
+        self.assertNotContains(resp, "Pending export:")
+
     def test_pr_post_calls_open_session_pr_with_posted_title_and_body(self) -> None:
         ensure_session_branch(self.root)
         path = self._write_row("pr.json")
@@ -119,7 +163,10 @@ class TestContentSessionViewsConfigured(TestCase):
         msgs = [str(m) for m in resp.wsgi_request._messages]
         self.assertTrue(any("https://github.com/acme/lore/pull/9" in m for m in msgs))
 
-    def test_pr_post_flashes_content_push_error(self) -> None:
+    def test_pr_post_flashes_content_push_error_and_keeps_typed_title_and_body(self) -> None:
+        """A ``ContentPushError`` renders the page in place (no redirect), so the
+        operator's typed title/body survive instead of being lost to the GET
+        view's recomputed dated default (#3018 review)."""
         ensure_session_branch(self.root)
         path = self._write_row("err.json")
         commit_row_export(self.root, [path], "err export")
@@ -133,10 +180,11 @@ class TestContentSessionViewsConfigured(TestCase):
         ):
             resp = self.client.post(
                 reverse("admin_content_session_pr"),
-                {"title": "t", "body": "b"},
+                {"title": "My typed title", "body": "My typed body"},
             )
 
-        self.assertEqual(resp.status_code, 302)
-        self.assertEqual(resp.url, reverse("admin_content_session"))
+        self.assertEqual(resp.status_code, 200)
         msgs = [str(m) for m in resp.wsgi_request._messages]
         self.assertTrue(any("could not open the session pull request" in m for m in msgs))
+        self.assertContains(resp, "My typed title")
+        self.assertContains(resp, "My typed body")

--- a/src/web/admin/tests/test_content_session_views.py
+++ b/src/web/admin/tests/test_content_session_views.py
@@ -44,6 +44,9 @@ class TestContentSessionViewsGate(TestCase):
         resp = self.client.post(reverse("admin_content_session_pr"), {"title": "t", "body": "b"})
         self.assertEqual(resp.status_code, 403)
 
+        resp = self.client.post(reverse("admin_content_session_discard"))
+        self.assertEqual(resp.status_code, 403)
+
 
 class TestContentSessionViewsConfigured(TestCase):
     """A tmp clone of a tmp bare origin, standing in for a content-repo checkout."""
@@ -188,3 +191,45 @@ class TestContentSessionViewsConfigured(TestCase):
         self.assertTrue(any("could not open the session pull request" in m for m in msgs))
         self.assertContains(resp, "My typed title")
         self.assertContains(resp, "My typed body")
+
+    def test_discard_all_without_checkbox_refuses_and_leaves_tree_dirty(self) -> None:
+        ensure_session_branch(self.root)
+        self._write_row("keepme.json")
+
+        with self._env():
+            resp = self.client.post(reverse("admin_content_session_discard"), {})
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, reverse("admin_content_session"))
+        msgs = [str(m) for m in resp.wsgi_request._messages]
+        self.assertTrue(any("Check the confirmation box" in m for m in msgs))
+        self.assertTrue((self.root / "content" / "keepme.json").exists())
+
+    def test_discard_all_with_checkbox_cleans_working_tree(self) -> None:
+        """Discard-all restores tracked edits and removes untracked additions."""
+        ensure_session_branch(self.root)
+        tracked = self._write_row("tracked.json")
+        commit_row_export(self.root, [tracked], "seed tracked")
+        tracked.write_text('{"a": 2}\n', encoding="utf-8")
+        self._write_row("brand_new.json")
+
+        session = self.client.session
+        session[_PENDING_EXPORT_SESSION_KEY] = {
+            "model_label": "magic.effecttype",
+            "pk": "42",
+            "natural_key": "Discard Me",
+        }
+        session.save()
+
+        with self._env():
+            resp = self.client.post(
+                reverse("admin_content_session_discard"), {"discard_confirm": "1"}
+            )
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, reverse("admin_content_session"))
+        msgs = [str(m) for m in resp.wsgi_request._messages]
+        self.assertTrue(any("Discarded all pending changes" in m for m in msgs))
+        self.assertEqual(tracked.read_text(encoding="utf-8"), '{"a": 1}\n')
+        self.assertFalse((self.root / "content" / "brand_new.json").exists())
+        self.assertNotIn(_PENDING_EXPORT_SESSION_KEY, self.client.session)

--- a/src/web/admin/tests/test_content_session_views.py
+++ b/src/web/admin/tests/test_content_session_views.py
@@ -1,0 +1,142 @@
+"""Tests for the content session page + one-pull-request-per-session flow (#3018).
+
+Mirrors ``test_content_row_export_views.py``'s structure: a superuser-only
+gate on both views, plus a real tmp clone of a real bare "origin" (never the
+network, never the real lore checkout) - ``session_state``/``session_diff``
+run real git commands against it, so the fixture has to be an actual
+checkout with a real ``origin/main``. ``open_session_pr`` itself is mocked
+at this test module's import site of the view module
+(``web.admin.content_session_views.open_session_pr``) rather than exercised
+for real, since it pushes to origin and calls the GitHub REST API - both
+already covered directly by ``core_management.tests.test_content_session``.
+"""
+
+from pathlib import Path
+import tempfile
+from unittest import mock
+
+from django.test import TestCase
+from django.urls import reverse
+from evennia.accounts.models import AccountDB
+
+from core_management.content_push import ContentPushError
+from core_management.content_session import commit_row_export, ensure_session_branch
+from core_management.tests._git_fixtures import init_origin_and_clone
+
+
+class TestContentSessionViewsGate(TestCase):
+    """Superuser gate on both views - no content root needed to fail this early."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.super = AccountDB.objects.create_superuser("rootadmin", "root@example.com", "pw-123456")
+        cls.staff = AccountDB.objects.create_user("staffer", "s@example.com", "pw-123456")
+        cls.staff.is_staff = True
+        cls.staff.save()
+
+    def test_both_views_require_superuser(self) -> None:
+        self.client.force_login(self.staff)
+
+        resp = self.client.get(reverse("admin_content_session"))
+        self.assertEqual(resp.status_code, 403)
+
+        resp = self.client.post(reverse("admin_content_session_pr"), {"title": "t", "body": "b"})
+        self.assertEqual(resp.status_code, 403)
+
+
+class TestContentSessionViewsConfigured(TestCase):
+    """A tmp clone of a tmp bare origin, standing in for a content-repo checkout."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.super = AccountDB.objects.create_superuser("rootadmin", "root@example.com", "pw-123456")
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        base = Path(self.tmp.name)
+        self.origin = base / "origin.git"
+        self.root = base / "clone"
+        init_origin_and_clone(self.origin, self.root)
+        self.client.force_login(self.super)
+
+    def _env(self):
+        return mock.patch.dict("os.environ", {"CONTENT_REPO_PATH": str(self.root)})
+
+    def _write_row(self, name: str = "row.json", content: str = '{"a": 1}\n') -> Path:
+        path = self.root / "content" / name
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return path
+
+    def test_empty_session_renders_no_session_state(self) -> None:
+        with self._env():
+            resp = self.client.get(reverse("admin_content_session"))
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.content.decode()
+        self.assertFalse(resp.context["state"].on_session)
+        self.assertIn("No content session is open yet", body)
+        self.assertNotContains(resp, "Open pull request")
+
+    def test_session_page_renders_commits_and_diff(self) -> None:
+        ensure_session_branch(self.root)
+        path = self._write_row("state.json")
+        commit_row_export(self.root, [path], "state export")
+
+        with self._env():
+            resp = self.client.get(reverse("admin_content_session"))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertTrue(resp.context["state"].on_session)
+        self.assertContains(resp, "state export")
+        self.assertContains(resp, "state.json")
+        self.assertContains(resp, "Open pull request")
+
+    def test_pr_post_calls_open_session_pr_with_posted_title_and_body(self) -> None:
+        ensure_session_branch(self.root)
+        path = self._write_row("pr.json")
+        commit_row_export(self.root, [path], "pr export")
+
+        with (
+            self._env(),
+            mock.patch(
+                "web.admin.content_session_views.open_session_pr",
+                return_value="https://github.com/acme/lore/pull/9",
+            ) as mock_open_pr,
+        ):
+            resp = self.client.post(
+                reverse("admin_content_session_pr"),
+                {"title": "My session title", "body": "My session body"},
+            )
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, reverse("admin_content_session"))
+        mock_open_pr.assert_called_once()
+        _, kwargs = mock_open_pr.call_args
+        self.assertEqual(kwargs["title"], "My session title")
+        self.assertEqual(kwargs["body"], "My session body")
+        msgs = [str(m) for m in resp.wsgi_request._messages]
+        self.assertTrue(any("https://github.com/acme/lore/pull/9" in m for m in msgs))
+
+    def test_pr_post_flashes_content_push_error(self) -> None:
+        ensure_session_branch(self.root)
+        path = self._write_row("err.json")
+        commit_row_export(self.root, [path], "err export")
+
+        with (
+            self._env(),
+            mock.patch(
+                "web.admin.content_session_views.open_session_pr",
+                side_effect=ContentPushError("could not open the session pull request: boom"),
+            ),
+        ):
+            resp = self.client.post(
+                reverse("admin_content_session_pr"),
+                {"title": "t", "body": "b"},
+            )
+
+        self.assertEqual(resp.status_code, 302)
+        self.assertEqual(resp.url, reverse("admin_content_session"))
+        msgs = [str(m) for m in resp.wsgi_request._messages]
+        self.assertTrue(any("could not open the session pull request" in m for m in msgs))

--- a/src/web/admin/urls.py
+++ b/src/web/admin/urls.py
@@ -16,7 +16,11 @@ from web.admin.content_row_export_views import (
     content_export_row_confirm,
     content_export_row_diff,
 )
-from web.admin.content_session_views import content_session, content_session_pr
+from web.admin.content_session_views import (
+    content_session,
+    content_session_discard,
+    content_session_pr,
+)
 from web.admin.game_setup_views import game_setup
 from web.admin.seed_views import seed_confirm, seed_run
 from web.admin.sphinx_views import sphinx_audit
@@ -87,6 +91,11 @@ urlpatterns = [
     ),
     path("_content_session/", content_session, name="admin_content_session"),
     path("_content_session_pr/", content_session_pr, name="admin_content_session_pr"),
+    path(
+        "_content_session_discard/",
+        content_session_discard,
+        name="admin_content_session_discard",
+    ),
     path(
         "_content_export/",
         content_export_preview,

--- a/src/web/admin/urls.py
+++ b/src/web/admin/urls.py
@@ -16,6 +16,7 @@ from web.admin.content_row_export_views import (
     content_export_row_confirm,
     content_export_row_diff,
 )
+from web.admin.content_session_views import content_session, content_session_pr
 from web.admin.game_setup_views import game_setup
 from web.admin.seed_views import seed_confirm, seed_run
 from web.admin.sphinx_views import sphinx_audit
@@ -84,6 +85,8 @@ urlpatterns = [
         content_export_row_confirm,
         name="admin_content_export_row_confirm",
     ),
+    path("_content_session/", content_session, name="admin_content_session"),
+    path("_content_session_pr/", content_session_pr, name="admin_content_session_pr"),
     path(
         "_content_export/",
         content_export_preview,

--- a/src/web/admin/urls.py
+++ b/src/web/admin/urls.py
@@ -11,6 +11,11 @@ from web.admin.content_conflict_views import (
 from web.admin.content_export_views import content_export_preview, content_export_run
 from web.admin.content_load_views import content_load_confirm, content_load_run
 from web.admin.content_push_views import content_push_preview, content_push_run
+from web.admin.content_row_export_views import (
+    content_export_row,
+    content_export_row_confirm,
+    content_export_row_diff,
+)
 from web.admin.game_setup_views import game_setup
 from web.admin.seed_views import seed_confirm, seed_run
 from web.admin.sphinx_views import sphinx_audit
@@ -63,6 +68,21 @@ urlpatterns = [
         "_content_conflict_resolve/",
         content_conflict_resolve,
         name="admin_content_conflict_resolve",
+    ),
+    path(
+        "_content_export_row/",
+        content_export_row,
+        name="admin_content_export_row",
+    ),
+    path(
+        "_content_export_row_diff/",
+        content_export_row_diff,
+        name="admin_content_export_row_diff",
+    ),
+    path(
+        "_content_export_row_confirm/",
+        content_export_row_confirm,
+        name="admin_content_export_row_confirm",
     ),
     path(
         "_content_export/",

--- a/src/web/templates/admin/change_form.html
+++ b/src/web/templates/admin/change_form.html
@@ -4,7 +4,8 @@
 {% block object-tools-items %}
     {% if original and request.user.is_superuser and original|content_exportable %}
     <li>
-        <form method="post" action="{% url 'admin_content_export_row' %}" class="content-export-row-form">
+        <form method="post" action="{% url 'admin_content_export_row' %}"
+              class="content-export-row-form">
             {% csrf_token %}
             <input type="hidden" name="model" value="{{ original|content_model_label }}">
             <input type="hidden" name="pk" value="{{ original.pk }}">

--- a/src/web/templates/admin/change_form.html
+++ b/src/web/templates/admin/change_form.html
@@ -1,7 +1,18 @@
 {% extends "admin/change_form.html" %}
-{% load i18n content_export_tags %}
+{% load i18n admin_modify content_export_tags %}
 
-{% block object-tools-items %}
+{# Override the OUTER object-tools block, not the nested object-tools-items #}
+{# block, and reproduce Django's stock structure verbatim (see #}
+{# .venv/lib/python3.13/site-packages/django/contrib/admin/templates/admin/ #}
+{# change_form.html). SonarCloud's fragment parser analyzes each overridden #}
+{# block in isolation, so a bare <li> inside object-tools-items looked like #}
+{# it was outside any <ul> even though it renders inside the stock <ul #}
+{# class="object-tools"> at runtime (Web:ItemTagNotWithinContainerTagCheck). #}
+{# Owning the <ul> ourselves keeps the fragment self-contained for analysis #}
+{# while keeping the add-form/popup exclusion Django's own gate provides. #}
+{% block object-tools %}
+{% if change and not is_popup %}
+  <ul class="object-tools">
     {% if original and request.user.is_superuser and original|content_exportable %}
     <li>
         <form method="post" action="{% url 'admin_content_export_row' %}"
@@ -13,5 +24,7 @@
         </form>
     </li>
     {% endif %}
-    {{ block.super }}
+    {% change_form_object_tools %}
+  </ul>
+{% endif %}
 {% endblock %}

--- a/src/web/templates/admin/change_form.html
+++ b/src/web/templates/admin/change_form.html
@@ -1,0 +1,16 @@
+{% extends "admin/change_form.html" %}
+{% load i18n content_export_tags %}
+
+{% block object-tools-items %}
+    {% if original and request.user.is_superuser and original|content_exportable %}
+    <li>
+        <form method="post" action="{% url 'admin_content_export_row' %}" class="content-export-row-form">
+            {% csrf_token %}
+            <input type="hidden" name="model" value="{{ original|content_model_label }}">
+            <input type="hidden" name="pk" value="{{ original.pk }}">
+            <button type="submit" class="content-export-row-btn">Export to content repo</button>
+        </form>
+    </li>
+    {% endif %}
+    {{ block.super }}
+{% endblock %}

--- a/src/web/templates/admin/content_row_export_diff.html
+++ b/src/web/templates/admin/content_row_export_diff.html
@@ -1,0 +1,68 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}{{ title }} | {% translate 'Site administration' %}{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+    &rsaquo; <a href="{% url 'admin_game_setup' %}">Game Setup</a>
+    &rsaquo; {{ title }}
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+
+    <div class="module" style="padding: 15px; margin-bottom: 20px;">
+        <h2 style="margin-top: 0;">{{ title }}</h2>
+        <p>Natural key: <code>{{ natural_key }}</code></p>
+        {% if is_addition %}
+        <p>
+            This row is not yet in the content repo. Committing this export
+            adds a new row to the corpus rather than updating an existing one.
+        </p>
+        {% endif %}
+    </div>
+
+    <div class="module" style="padding: 15px; margin-bottom: 20px;">
+        <pre>{{ diff_text }}</pre>
+    </div>
+
+    <div class="module" style="padding: 15px;">
+        <form method="post" action="{{ confirm_url }}">
+            {% csrf_token %}
+            <input type="hidden" name="model" value="{{ model_label }}">
+            <input type="hidden" name="pk" value="{{ pk }}">
+            <input type="hidden" name="digest" value="{{ digest }}">
+            <input type="hidden" name="action" value="confirm">
+            {% if is_addition %}
+            <p>
+                <label for="new_row">
+                    <input type="checkbox" id="new_row" name="new_row" value="1">
+                    This adds a new row to the content repo.
+                </label>
+            </p>
+            {% endif %}
+            <div class="submit-row" style="padding: 12px;">
+                <input type="submit" value="Commit export" class="default"
+                       style="padding: 10px 20px;">
+            </div>
+        </form>
+        <form method="post" action="{{ confirm_url }}">
+            {% csrf_token %}
+            <input type="hidden" name="model" value="{{ model_label }}">
+            <input type="hidden" name="pk" value="{{ pk }}">
+            <input type="hidden" name="digest" value="{{ digest }}">
+            <input type="hidden" name="action" value="discard">
+            <div class="submit-row" style="padding: 12px;">
+                <input type="submit" value="Discard this export" style="padding: 10px 20px;">
+                <a href="{{ change_url }}" style="padding: 10px 20px; margin-left: 10px;">
+                    Back without discarding
+                </a>
+            </div>
+        </form>
+    </div>
+
+</div>
+{% endblock %}

--- a/src/web/templates/admin/content_session.html
+++ b/src/web/templates/admin/content_session.html
@@ -50,7 +50,13 @@
         <p>
             The working tree has uncommitted changes - a pending row export
             still needs to be confirmed or discarded.
+            {% if pending_row %}
+            Pending export: {{ pending_row.model_name }}
+            [<code>{{ pending_row.natural_key }}</code>] -
+            <a href="{{ pending_row.diff_url }}">review it</a>.
+            {% endif %}
         </p>
+        <pre>{{ dirty_text }}</pre>
     </div>
     {% endif %}
 

--- a/src/web/templates/admin/content_session.html
+++ b/src/web/templates/admin/content_session.html
@@ -1,0 +1,84 @@
+{% extends "admin/base_site.html" %}
+{% load i18n %}
+
+{% block title %}{{ title }} | {% translate 'Site administration' %}{% endblock %}
+
+{% block breadcrumbs %}
+<div class="breadcrumbs">
+    <a href="{% url 'admin:index' %}">{% translate 'Home' %}</a>
+    &rsaquo; <a href="{% url 'admin_game_setup' %}">Game Setup</a>
+    &rsaquo; {{ title }}
+</div>
+{% endblock %}
+
+{% block content %}
+<div id="content-main">
+
+    <div class="module" style="padding: 15px; margin-bottom: 20px;">
+        <h2 style="margin-top: 0;">Content session</h2>
+        <p>Branch: <code>{{ state.branch }}</code></p>
+        {% if not state.on_session %}
+        <p>
+            No content session is open yet. Exporting a row from any content
+            model's change form starts one.
+        </p>
+        {% endif %}
+    </div>
+
+    {% if state.on_session %}
+    <div class="module" style="padding: 15px; margin-bottom: 20px;">
+        <h3 style="margin-top: 0;">Commits</h3>
+        {% if state.commits %}
+        <ul>
+            {% for commit in state.commits %}
+            <li><code>{{ commit }}</code></li>
+            {% endfor %}
+        </ul>
+        {% else %}
+        <p>No commits on this session branch yet.</p>
+        {% endif %}
+    </div>
+
+    <div class="module" style="padding: 15px; margin-bottom: 20px;">
+        <h3 style="margin-top: 0;">Diff</h3>
+        <p>{{ state.diff_stat }}</p>
+        <pre>{{ diff_text }}</pre>
+    </div>
+
+    {% if state.dirty %}
+    <div class="module" style="padding: 15px; margin-bottom: 20px;">
+        <p>
+            The working tree has uncommitted changes - a pending row export
+            still needs to be confirmed or discarded.
+        </p>
+    </div>
+    {% endif %}
+
+    <div class="module" style="padding: 15px;">
+        <h3 style="margin-top: 0;">Open the session pull request</h3>
+        <p>
+            Pushes the session branch and opens its pull request, reusing an
+            already-open one instead of filing a duplicate.
+        </p>
+        <form method="post" action="{{ pr_url }}">
+            {% csrf_token %}
+            <p>
+                <label for="pr_title">Title</label><br>
+                <input type="text" id="pr_title" name="title" value="{{ pr_title }}"
+                       style="width: 100%;">
+            </p>
+            <p>
+                <label for="pr_body">Body</label><br>
+                <textarea id="pr_body" name="body" rows="4"
+                          style="width: 100%;">{{ pr_body }}</textarea>
+            </p>
+            <div class="submit-row" style="padding: 12px;">
+                <input type="submit" value="Open pull request" class="default"
+                       style="padding: 10px 20px;">
+            </div>
+        </form>
+    </div>
+    {% endif %}
+
+</div>
+{% endblock %}

--- a/src/web/templates/admin/content_session.html
+++ b/src/web/templates/admin/content_session.html
@@ -57,6 +57,19 @@
             {% endif %}
         </p>
         <pre>{{ dirty_text }}</pre>
+        <form method="post" action="{{ discard_all_url }}">
+            {% csrf_token %}
+            <p>
+                <label for="discard_confirm">
+                    <input type="checkbox" id="discard_confirm" name="discard_confirm">
+                    Discard ALL pending changes shown above - this cannot be undone.
+                </label>
+            </p>
+            <div class="submit-row" style="padding: 12px;">
+                <input type="submit" value="Discard all pending changes"
+                       class="deletelink" style="padding: 10px 20px;">
+            </div>
+        </form>
     </div>
     {% endif %}
 

--- a/src/web/templates/admin/game_setup.html
+++ b/src/web/templates/admin/game_setup.html
@@ -42,6 +42,10 @@
         lists credited rows a load left untouched because the repo's
         incoming values differ - resolve one at a time with a typed
         confirmation.
+        <br>
+        <a href="{% url 'admin_content_session' %}">Content session</a>
+        reviews the accumulated row-export commits on the session branch and
+        opens one pull request for the whole session.
       {% else %}
         set <code>CONTENT_REPO_PATH</code> in <code>src/.env</code> to enable
         this step. Until then, the

--- a/src/world/player_submissions/github_issues.py
+++ b/src/world/player_submissions/github_issues.py
@@ -16,12 +16,13 @@ from typing import TYPE_CHECKING
 
 from django.conf import settings
 
-# Not called directly here anymore (create_github_issue delegates to
-# github_rest.github_request), but kept as a module attribute: existing tests
-# patch world.player_submissions.github_issues.requests.post, and patching an
-# attribute on this shared requests module also redirects github_rest's own
+# requests.post itself is no longer called from here (create_github_issue
+# delegates to github_rest.github_request) - kept for requests.codes.created
+# below, and as a module attribute existing tests patch directly:
+# world.player_submissions.github_issues.requests.post. Patching an attribute
+# on this shared requests module also redirects github_rest's own
 # requests.post call, since both modules hold the same module object.
-import requests  # noqa: F401
+import requests
 
 from core_management.github_rest import GitHubRestError, github_request
 
@@ -134,9 +135,13 @@ def create_github_issue(*, title: str, body: str, labels: list[str]) -> tuple[in
             "POST",
             f"/repos/{repo}/issues",
             payload={"title": title, "body": body, "labels": labels},
+            expected_status=requests.codes.created,
         )
     except GitHubRestError as exc:
-        msg = f"Could not file the GitHub issue ({exc})."
+        if exc.status_code is None:
+            msg = "Could not reach GitHub to file the issue. Please try again."
+        else:
+            msg = f"GitHub rejected the issue (HTTP {exc.status_code})."
         raise GitHubIssueError(msg) from exc
     if not isinstance(data, dict):
         msg = "GitHub returned an unexpected response shape while filing the issue."

--- a/src/world/player_submissions/github_issues.py
+++ b/src/world/player_submissions/github_issues.py
@@ -15,15 +15,21 @@ import re
 from typing import TYPE_CHECKING
 
 from django.conf import settings
-import requests
+
+# Not called directly here anymore (create_github_issue delegates to
+# github_rest.github_request), but kept as a module attribute: existing tests
+# patch world.player_submissions.github_issues.requests.post, and patching an
+# attribute on this shared requests module also redirects github_rest's own
+# requests.post call, since both modules hold the same module object.
+import requests  # noqa: F401
+
+from core_management.github_rest import GitHubRestError, github_request
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
     from world.player_submissions.models import BugReport, SystemErrorReport
 
-_GITHUB_API = "https://api.github.com"
-_REQUEST_TIMEOUT = 10
 _REDACTED = "[redacted]"
 
 
@@ -124,23 +130,17 @@ def create_github_issue(*, title: str, body: str, labels: list[str]) -> tuple[in
         msg = "GitHub issue filing is not configured on this server."
         raise GitHubIssueError(msg)
     try:
-        response = requests.post(
-            f"{_GITHUB_API}/repos/{repo}/issues",
-            json={"title": title, "body": body, "labels": labels},
-            headers={
-                "Authorization": f"Bearer {token}",
-                "Accept": "application/vnd.github+json",
-                "X-GitHub-Api-Version": "2022-11-28",
-            },
-            timeout=_REQUEST_TIMEOUT,
+        data = github_request(
+            "POST",
+            f"/repos/{repo}/issues",
+            payload={"title": title, "body": body, "labels": labels},
         )
-    except requests.RequestException as exc:
-        msg = "Could not reach GitHub to file the issue. Please try again."
+    except GitHubRestError as exc:
+        msg = f"Could not file the GitHub issue ({exc})."
         raise GitHubIssueError(msg) from exc
-    if response.status_code != requests.codes.created:
-        msg = f"GitHub rejected the issue (HTTP {response.status_code})."
+    if not isinstance(data, dict):
+        msg = "GitHub returned an unexpected response shape while filing the issue."
         raise GitHubIssueError(msg)
-    data = response.json()
     return data["number"], data["html_url"]
 
 


### PR DESCRIPTION
Closes #3018

## Summary

Row-level content export from admin with a session-branch, one-PR-per-session flow. An Export to content repo button on every content model's change form writes exactly that row into the lore checkout (reusing the corpus serializer, natural-key identity with loader-matching case folding, and the ADR-0191 addition keys), shows its git diff behind a digest-guarded confirm (additions need an explicit per-row checkbox, derived fail-closed from git HEAD, never from the browser session), commits per export on the fixed content-export-session branch (at most one pending export at a time, enforced at the git layer), and a session page opens one REST PR per session (owner/repo derived from the checkout's remote at runtime; token GITHUB_ISSUE_TOKEN/GH_TOKEN; no gh subprocess; error messages carry status codes only and git errors scrub embedded credentials). Includes strand recovery (scoped discard-all with confirm checkbox), a guard refusing the corpus export while the checkout sits on the session branch, and the pre-existing corpus-push gap fix: content/ markdown domains are now staged alongside fixtures/. No models, no migrations. Deliberate no-ADR: decisions live in the approved #3018 spec plus ADR-0191/0201.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #3018 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main at pickup (8ee4750a2, includes #3022/#3023); branch already up to date at PR time; no migrations on this branch.

<!-- last-addressed-comment: 0 -->