### PR TITLE
Stat-triggered achievements can be earned by untenured/staff characters, silently consuming the first-ever Discovery slot

### DIFF
--- a/AGENT_GLOSSARY_MAP.md
+++ b/AGENT_GLOSSARY_MAP.md
@@ -406,6 +406,13 @@ source (alternate-self shapeshift, covenant role, character creation). Handled b
 `announce_access_change` in `achievements/discovery.py`; callers never branch on source.
 _Avoid_: ability grant, capability notification, technique change.
 
+**Eligible earner**:
+A character sheet currently piloted by a regular player, holding a current, non-staff RosterTenure.
+Only eligible earners can earn a CharacterAchievement, claim a first-ever Discovery, receive
+rewards, or fire the stories reactivity hook. Enforced by the single `can_earn_achievements`
+predicate inside `grant_achievement`, so every caller inherits it (#3024, ADR-0202).
+_Avoid_: ceremony eligible (the narrower pre-#3024 term), tenured sheet (staff tenures are still ineligible).
+
 ## Public-event vectors
 
 **Scene**:

--- a/docs/adr/0202-achievement-earning-gated-at-grant-chokepoint.md
+++ b/docs/adr/0202-achievement-earning-gated-at-grant-chokepoint.md
@@ -1,0 +1,20 @@
+# ADR-0202: Achievement earning is gated at the grant_achievement chokepoint, not per-caller
+
+Achievement earning is gated on "current, non-staff RosterTenure" inside `grant_achievement`
+itself, not in callers. Context: #2899 gated only `announce_access_change`; four other callers
+(stat thresholds, worship favor, crossing/combo/signature ceremony beats, aura thresholds) stayed
+ungated, letting a GM-piloted or mid-CG sheet silently consume a first-ever Discovery slot, and
+the ceremony beat could fire the gamewide announcement, irreversibly spoiling an NPC: an NPC or
+non-player-piloted character earning a discovery robs players of getting it, robs the surprise,
+and spoils the NPC's own capabilities, and a spoiler cannot be taken back (#3024 ruling by
+TehomCD, 2026-08-06). Decision: enforce at the single production write path for
+CharacterAchievement/Discovery so current and future callers inherit the invariant; stat tracking
+continues for ineligible sheets (a GM-authored roster character is built to player norms, so
+grant-on-first-eligible-increment once a player takes tenure is acceptable, while a true NPC may
+carry stats or levels unavailable to players for years and never gains tenure, so the gate holds
+permanently for it). Rejected: per-caller gating (has to be re-remembered per new caller; the four
+ungated callers are the proof) and freezing/resetting stats at tenure start (loses world-state
+for no player-visible gain).
+
+> Status: accepted · Source: #3024, TehomCD's ruling 2026-08-06 · Related: ADR-0061 (access-change
+> fires one shared surface), #2899 (the narrower pre-#3024 ceremony-only gate)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -145,6 +145,7 @@ treat those names as hints to confirm, not gospel.
 - [0060 — Reactive defenses are mutation-only DAMAGE_PRE_APPLY flow handlers with a shared anima-cost pattern](0060-reactive-defenses-are-mutation-only-flow-handlers.md)
 - [0118 — Declared guardian reactions roll the caster's cast check outside `use_technique`](0118-guardian-reaction-seam.md) (extends ADR-0060/0096)
 - [0061 — Access-change fires one shared surface; discoverability is a shared abstract base](0061-access-change-fires-one-surface-discoverable-is-shared-base.md)
+- [0202 - Achievement earning is gated at the grant_achievement chokepoint, not per-caller](0202-achievement-earning-gated-at-grant-chokepoint.md) (#3024; extends ADR-0061, #2899)
 - [0069 — Succor is a RoundContext capability; location shelter is a hard gate, not arithmetic resistance](0069-succor-roundcontext-capability.md)
 - [0070 — NPC ontology: Functionary, Standing, and Story NPCs as class-1..4](0070-npc-ontology-functionary-standing-story.md)
 - [0073 — Environmental vulnerabilities are ConditionDamageOverTime rows riding the peril pipeline](0073-environmental-vulnerabilities-are-dot-rows-riding-the-peril-pipeline.md)

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2638,18 +2638,23 @@ gains a discoverable content item for the first time.
 - **Handlers:** `character_sheet.stats` (`StatHandler`) — `get(stat_def) -> int`,
   `increment(stat_def, n) -> int` (atomic F() expression; checks requirement thresholds after increment)
 - **Key Services (`world/achievements/services.py`):** `grant_achievement(achievement,
-  sheets) -> list[CharacterAchievement]`, `apply_achievement_rewards(sheet, achievement)`,
+  sheets) -> list[CharacterAchievement]` (drops any sheet that fails
+  `can_earn_achievements`, returning `[]` and creating no Discovery if none remain),
+  `can_earn_achievements(character_sheet) -> bool` (current, non-staff `RosterTenure`; #3024,
+  ADR-0202), `apply_achievement_rewards(sheet, achievement)`,
   `get_stat(sheet, stat_def) -> int`, `increment_stat(sheet, stat_def, n) -> int`
 - **Access-change + discovery surface (`world/achievements/discovery.py` — ADR-0061):**
   - `announce_access_change(character_sheet, *, gained, lost, source)` — sends an ABILITY
     `NarrativeMessage` to the character listing what techniques/capabilities changed, then for
     each gained item with a non-null `discovery_achievement` FK fires `grant_achievement` and
     `announce_achievement`. Source-agnostic: callers never branch on covenant vs. form vs. CG.
-    Gated by two eligibility checks before the per-item loop (#2899): (1) a live, non-staff
-    `RosterTenure` (`_ceremony_eligible`); (2) content reachable through a CG catalog table is
-    excluded regardless of route (`_cg_catalog_exclusions`). Both gates apply only to callers of
-    this function — other ceremony-firing paths (e.g. `execute_ceremony_beat`) sit outside it;
-    see `world/achievements/CLAUDE.md`.
+    Gated by two eligibility checks before the per-item loop: (1) the same `can_earn_achievements`
+    predicate `grant_achievement` enforces globally (#3024, ADR-0202), checked again here only to
+    skip the ceremony (not the plain gained/lost message) early; (2) content reachable through a
+    CG catalog table is excluded regardless of route (`_cg_catalog_exclusions`, #2899). Gate (2)
+    remains local to this function by design; gate (1) is inherited by every `grant_achievement`
+    caller, including paths outside this function such as `execute_ceremony_beat`; see
+    `world/achievements/CLAUDE.md`.
   - `announce_achievement(earners, *, is_first, first_body, personal_body, category)` —
     gamewide to all active player sheets when `is_first` (first-ever Discovery); otherwise
     personal to the earner list.

--- a/src/integration_tests/test_magic_story_pipeline.py
+++ b/src/integration_tests/test_magic_story_pipeline.py
@@ -87,6 +87,7 @@ from world.magic.seeds_resonance import first_authored_resonance
 from world.magic.services.resonance_environment import evaluate_resonance_environment
 from world.magic.services.techniques import use_technique
 from world.magic.tests._cache_isolation import ResonanceCacheIsolationMixin
+from world.roster.factories import grant_test_tenure
 from world.traits.models import CheckOutcome
 
 
@@ -201,6 +202,7 @@ class MagicStoryPipelineTests(ResonanceCacheIsolationMixin, EvenniaTestCase):
         # Build an Abyssal-aura caster.  CharacterSheetFactory creates an
         # ObjectDB character + CharacterSheet + PRIMARY Persona in one shot.
         self.sheet = CharacterSheetFactory()
+        grant_test_tenure(self.sheet)  # achievement eligibility gate (#3024)
         self.caster = self.sheet.character  # ObjectDB
 
         # CharacterAura: abyssal=100 so caster_alignment=1.0 against any room.
@@ -1313,6 +1315,7 @@ class MagicStoryPipelineTests(ResonanceCacheIsolationMixin, EvenniaTestCase):
         # No StoryProgress — story routing is not required for the Discovery assertion.
         # ------------------------------------------------------------------
         second_sheet = CharacterSheetFactory()
+        grant_test_tenure(second_sheet)  # achievement eligibility gate (#3024)
         second_caster = second_sheet.character
 
         CharacterAuraFactory(

--- a/src/world/achievements/AGENT_GLOSSARY.md
+++ b/src/world/achievements/AGENT_GLOSSARY.md
@@ -27,3 +27,7 @@ _Avoid_: discoverable mixin (it is a base class, not a mixin), achievement holde
 **Access change**:
 The event of a character gaining or losing access to techniques or capabilities, regardless of source (alternate-self shapeshift, covenant role engagement/disengagement, character creation). A single surface — `announce_access_change` in `achievements/discovery.py` — handles notification and fires any first-ever Discovery ceremony; callers never branch on the source.
 _Avoid_: ability change, capability notification, technique grant (too narrow)
+
+**Eligible earner**:
+A character sheet currently piloted by a regular player, i.e. holding a current, non-staff RosterTenure. Only eligible earners can earn a CharacterAchievement, claim a first-ever Discovery, receive rewards, or fire the stories reactivity hook. The single predicate is `can_earn_achievements` in `achievements/services.py`, enforced inside `grant_achievement` so every caller inherits it (#3024, ADR-0202).
+_Avoid_: ceremony eligible (the narrower pre-#3024 term), tenured sheet (staff tenures are still ineligible)

--- a/src/world/achievements/CLAUDE.md
+++ b/src/world/achievements/CLAUDE.md
@@ -150,27 +150,21 @@ Called whenever any mechanism changes what techniques/capabilities a character c
 - **Never branches on source** — covenant, form shapeshift, and CG gift/technique grant are all identical.
 - `source` is an `AccessChangeSource` TextChoices value (drives the lead-in text label).
 - **Two eligibility gates run before the per-item loop, both source-agnostic:** (1) the receiving
-  character must have a current, non-staff `RosterTenure` (`_ceremony_eligible`) — a mid-CG,
-  GM-created-and-untenured, or staff-piloted sheet never fires the ceremony, though the plain
-  gained/lost message above still sends; (2) content reachable through a CG catalog table never
-  fires the ceremony regardless of route (`_cg_catalog_exclusions` — covers `CodexEntry` via
-  Beginnings/Tradition/Path/Distinction/Species/Resonance grants, and `Technique` via
-  `PathGiftGrant`/`TraditionGiftGrant`). See #2899.
-- **Scope: these two gates only apply to callers of `announce_access_change` itself** — the six
-  callers listed above. Several other discovery-ceremony-firing paths call `grant_achievement`/
-  `announce_achievement` directly instead, bypassing this function (and both gates) entirely:
-  `world/combat/combo_discovery.py` (ComboDefinition) and `world/magic/services/signature.py`
-  (SignatureMotifBonus) — both via the shared `execute_ceremony_beat` helper
-  (`world/magic/crossing/ceremony.py`) — plus `world/magic/crossing/handlers.py` and
-  `world/magic/services/crossing.py` (crossing variants/options, also via `execute_ceremony_beat`),
-  and `world/magic/services/aura.py` (aura threshold crossings, calling `grant_achievement`
-  directly, not via `execute_ceremony_beat`). `execute_ceremony_beat` is a separate,
-  ungated ceremony-firing path outside `announce_access_change`'s scope.
-- A related gap: `character_sheet.stats.increment` (`StatHandler`) checks achievement stat
-  requirements and can grant an achievement independent of `announce_access_change` entirely —
-  so an untenured/staff character can still earn a stat-triggered achievement (including
-  consuming the first-ever Discovery slot) through that path. Neither gate above covers it;
-  tracked as #3024.
+  character must have a current, non-staff `RosterTenure`, which is now the shared
+  `can_earn_achievements` predicate in `achievements/services.py`, enforced globally inside
+  `grant_achievement` itself, not a local check here. `announce_access_change` additionally skips
+  its own ceremony for an ineligible sheet before the per-item loop, so the plain gained/lost
+  message above still sends even when the ceremony is skipped; (2) content reachable through a CG
+  catalog table never fires the ceremony regardless of route (`_cg_catalog_exclusions`, covering
+  `CodexEntry` via Beginnings/Tradition/Path/Distinction/Species/Resonance grants, and `Technique`
+  via `PathGiftGrant`/`TraditionGiftGrant`). See #2899.
+- Every `grant_achievement` caller (the stat-threshold path, worship favor, `execute_ceremony_beat`
+  for crossing/combo/signature ceremony beats, and aura thresholds) now inherits the eligibility
+  invariant at the chokepoint, not just the six `announce_access_change` callers listed below.
+  `execute_ceremony_beat`'s `is_first` derives from the `grant_achievement` results, so an
+  ineligible sheet can never trigger the gamewide first-ever announcement (#3024, ADR-0202). The
+  CG-catalog exclusion gate (2) above remains `announce_access_change`-local by design, since it is
+  about content reachability, not earner eligibility.
 
 Current callers:
 - `world/forms/services.py` — assume / revert alternate self
@@ -193,7 +187,10 @@ Sends one `NarrativeMessage`:
   using `first_body` (which must NOT name the discoverer).
 - `is_first=False` → **personal** to the `earners` list, using `personal_body`.
 
-Also used directly by `world/covenants/discovery.py::_notify` (sub-role discovery ceremony).
+`world/covenants/discovery.py` is now a backwards-compatible re-export shim around
+`world.magic.crossing.ceremony.execute_crossing_ceremonies` (ADR-0094); it has no `_notify`
+function. `announce_achievement`'s direct callers are `announce_access_change` (in its per-item
+loop above) and `execute_ceremony_beat` (`world/magic/crossing/ceremony.py`).
 
 ## Key Rules
 
@@ -207,3 +204,5 @@ Also used directly by `world/covenants/discovery.py::_notify` (sub-role discover
 - Character ownership queries use RosterTenure chain, NOT db_account
 - **`announce_access_change` is source-agnostic** — never add a source branch inside it;
   place source-specific pre/post logic in the caller instead
+- **Only eligible earners (current, non-staff tenure, `can_earn_achievements`) can earn
+  achievements**, enforced inside `grant_achievement`, never per-caller

--- a/src/world/achievements/discovery.py
+++ b/src/world/achievements/discovery.py
@@ -14,7 +14,7 @@ identical regardless of source — never branch on covenant (spec Decision 11).
 """
 
 from world.achievements.constants import AccessChangeSource
-from world.achievements.services import grant_achievement
+from world.achievements.services import can_earn_achievements, grant_achievement
 
 
 def announce_achievement(
@@ -73,7 +73,8 @@ def announce_access_change(character_sheet, *, gained, lost, source):
             category=NarrativeCategory.ABILITY,
             sender_account=None,
         )
-    if not _ceremony_eligible(character_sheet):
+    # Same current-tenure, non-staff gate as the grant_achievement chokepoint (#3024).
+    if not can_earn_achievements(character_sheet):
         return
 
     excluded_ids = _cg_catalog_exclusions(gained)
@@ -104,23 +105,6 @@ def announce_access_change(character_sheet, *, gained, lost, source):
             personal_body=f"You have manifested {name}.",
             category=NarrativeCategory.ABILITY,
         )
-
-
-def _ceremony_eligible(character_sheet):
-    """Whether ``character_sheet`` can trigger the discovery/achievement ceremony.
-
-    Requires a current, non-staff RosterTenure. A sheet mid-character-creation (no
-    RosterEntry yet), a GM-created sheet sitting untenured on the Available roster,
-    or one piloted by a staff account never fires the ceremony — the plain
-    gained/lost narrative message above this check is unaffected (#2899).
-    """
-    from core_management.permissions import is_staff_observer  # noqa: PLC0415
-
-    roster_entry = character_sheet.roster_entry_or_none
-    tenure = roster_entry.current_tenure if roster_entry is not None else None
-    if tenure is None:
-        return False
-    return not is_staff_observer(tenure.player_data.account)
 
 
 def _cg_catalog_exclusions(gained):

--- a/src/world/achievements/services.py
+++ b/src/world/achievements/services.py
@@ -48,6 +48,27 @@ def increment_stat(character_sheet: CharacterSheet, stat: StatDefinition, amount
     return character_sheet.stats.increment(stat, amount)
 
 
+def can_earn_achievements(character_sheet: CharacterSheet) -> bool:
+    """Whether ``character_sheet`` may earn achievements at all (#3024).
+
+    Requires a current, non-staff RosterTenure: the character must be piloted
+    by a regular player right now. A sheet mid-character-creation (no
+    RosterEntry yet), a GM-created sheet sitting untenured on the Available
+    roster, a true NPC, or a staff-piloted sheet never earns a
+    CharacterAchievement, never claims a first-ever Discovery, never receives
+    rewards, and never fires the stories reactivity hook. Enforced inside
+    ``grant_achievement`` so every caller inherits it (extends the #2899
+    ceremony rule; see ADR-0202).
+    """
+    from core_management.permissions import is_staff_observer  # noqa: PLC0415
+
+    roster_entry = character_sheet.roster_entry_or_none
+    tenure = roster_entry.current_tenure if roster_entry is not None else None
+    if tenure is None:
+        return False
+    return not is_staff_observer(tenure.player_data.account)
+
+
 def grant_achievement(
     achievement: Achievement, character_sheets: list[CharacterSheet]
 ) -> list[CharacterAchievement]:
@@ -60,7 +81,14 @@ def grant_achievement(
     After commit, notifies the stories reactivity service so any active
     stories with ACHIEVEMENT_HELD beats for this achievement are
     re-evaluated (and flip SUCCESS when the requirement is met).
+
+    Ineligible sheets (see ``can_earn_achievements``) are dropped; if none
+    remain, returns ``[]`` and no Discovery is created.
     """
+    character_sheets = [s for s in character_sheets if can_earn_achievements(s)]
+    if not character_sheets:
+        return []
+
     from world.stories.services.reactivity import on_achievement_earned  # noqa: PLC0415
 
     with transaction.atomic():
@@ -97,6 +125,9 @@ def _check_achievements(character_sheet: CharacterSheet, stat: StatDefinition) -
     Find active, unearned achievements with requirements on the given stat
     and grant any whose requirements are fully met.
     """
+    if not can_earn_achievements(character_sheet):
+        return
+
     earned_ids = CharacterAchievement.objects.filter(character_sheet=character_sheet).values_list(
         "achievement_id", flat=True
     )

--- a/src/world/achievements/tests/test_reward_application.py
+++ b/src/world/achievements/tests/test_reward_application.py
@@ -24,11 +24,13 @@ from world.distinctions.types import DistinctionOrigin
 from world.mechanics.factories import ModifierCategoryFactory, ModifierTargetFactory
 from world.mechanics.models import CharacterModifier
 from world.mechanics.services import get_modifier_total
+from world.roster.factories import grant_test_tenure
 
 
 class RewardApplicationTests(TestCase):
     def setUp(self) -> None:
         self.sheet = CharacterSheetFactory()
+        grant_test_tenure(self.sheet)
         self.achievement = AchievementFactory(name="Sample Rewarding Achievement")
         self.allure = ModifierTargetFactory(
             name="allure", category=ModifierCategoryFactory(name="roll_modifier")
@@ -84,6 +86,7 @@ class DistinctionRewardApplicationTests(TestCase):
 
     def setUp(self) -> None:
         self.sheet = CharacterSheetFactory()
+        grant_test_tenure(self.sheet)
         self.achievement = AchievementFactory(name="Sample Distinction Achievement")
         self.distinction = DistinctionFactory(name="Silver Tongue", max_rank=5)
 

--- a/src/world/achievements/tests/test_services.py
+++ b/src/world/achievements/tests/test_services.py
@@ -11,6 +11,7 @@ from world.achievements.factories import (
 from world.achievements.models import CharacterAchievement, Discovery, StatTracker
 from world.achievements.services import get_stat, grant_achievement, increment_stat
 from world.character_sheets.factories import CharacterSheetFactory
+from world.roster.factories import grant_test_tenure
 
 
 class GetStatTest(TestCase):
@@ -34,6 +35,7 @@ class IncrementStatTest(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         cls.sheet = CharacterSheetFactory()
+        grant_test_tenure(cls.sheet)
         cls.new_stat = StatDefinitionFactory(key="new_stat", name="New Stat")
         cls.combat_stat = StatDefinitionFactory(key="combat_wins", name="Combat Wins")
         cls.quest_stat = StatDefinitionFactory(key="quests", name="Quests")
@@ -142,7 +144,9 @@ class GrantAchievementTest(TestCase):
     def setUpTestData(cls) -> None:
         cls.achievement = AchievementFactory()
         cls.sheet1 = CharacterSheetFactory()
+        grant_test_tenure(cls.sheet1)
         cls.sheet2 = CharacterSheetFactory()
+        grant_test_tenure(cls.sheet2)
 
     def test_single_grant_creates_discovery(self) -> None:
         results = grant_achievement(self.achievement, [self.sheet1])
@@ -202,6 +206,7 @@ class GrantAchievementStoryReactivityTest(TestCase):
         from world.stories.models import BeatCompletion
 
         sheet = CharacterSheetFactory()
+        grant_test_tenure(sheet)
         story = StoryFactory(scope=StoryScope.CHARACTER, character_sheet=sheet)
         episode = EpisodeFactory(chapter=ChapterFactory(story=story))
         StoryProgressFactory(
@@ -243,6 +248,7 @@ class GrantAchievementStoryReactivityTest(TestCase):
         from world.stories.models import BeatCompletion
 
         sheet = CharacterSheetFactory()
+        grant_test_tenure(sheet)
         story = StoryFactory(scope=StoryScope.CHARACTER, character_sheet=sheet)
         episode = EpisodeFactory(chapter=ChapterFactory(story=story))
         StoryProgressFactory(
@@ -263,3 +269,72 @@ class GrantAchievementStoryReactivityTest(TestCase):
         grant_achievement(achievement, [sheet])
         count_after_second = BeatCompletion.objects.count()
         self.assertEqual(count_after_first, count_after_second)
+
+
+class AchievementEligibilityGateTest(TestCase):
+    """#3024: only sheets piloted by a regular player may earn achievements."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.stat = StatDefinitionFactory(key="gate_stat", name="Gate Stat")
+        cls.achievement = AchievementFactory(name="Gate Test", slug="gate-test")
+        AchievementStatRequirementFactory(achievement=cls.achievement, stat=cls.stat, threshold=3)
+
+    def test_untenured_sheet_stat_increment_never_grants(self) -> None:
+        sheet = CharacterSheetFactory()
+        for _ in range(5):
+            increment_stat(sheet, self.stat)
+        self.assertEqual(get_stat(sheet, self.stat), 5)  # tracking continues
+        self.assertFalse(CharacterAchievement.objects.filter(character_sheet=sheet).exists())
+        self.assertFalse(Discovery.objects.filter(achievement=self.achievement).exists())
+
+    def test_staff_piloted_sheet_never_grants(self) -> None:
+        from evennia_extensions.factories import AccountFactory
+        from world.roster.factories import (
+            PlayerDataFactory,
+            RosterEntryFactory,
+            RosterTenureFactory,
+        )
+
+        sheet = CharacterSheetFactory()
+        RosterTenureFactory(
+            roster_entry=RosterEntryFactory(character_sheet=sheet),
+            player_data=PlayerDataFactory(account=AccountFactory(is_staff=True)),
+            end_date=None,
+        )
+        for _ in range(5):
+            increment_stat(sheet, self.stat)
+        self.assertFalse(CharacterAchievement.objects.filter(character_sheet=sheet).exists())
+
+    def test_grant_filters_mixed_co_discoverer_list(self) -> None:
+        from world.roster.factories import grant_test_tenure
+
+        eligible = CharacterSheetFactory()
+        grant_test_tenure(eligible)
+        ineligible = CharacterSheetFactory()
+        results = grant_achievement(self.achievement, [eligible, ineligible])
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].character_sheet, eligible)
+        self.assertIsNotNone(results[0].discovery_id)
+        self.assertFalse(CharacterAchievement.objects.filter(character_sheet=ineligible).exists())
+
+    def test_all_ineligible_grant_is_a_noop(self) -> None:
+        sheet = CharacterSheetFactory()
+        results = grant_achievement(self.achievement, [sheet])
+        self.assertEqual(results, [])
+        self.assertFalse(Discovery.objects.filter(achievement=self.achievement).exists())
+
+    def test_npc_then_tenured_earns_on_next_increment(self) -> None:
+        from world.roster.factories import grant_test_tenure
+
+        sheet = CharacterSheetFactory()
+        for _ in range(5):
+            increment_stat(sheet, self.stat)  # accrues past threshold, no grant
+        self.assertFalse(CharacterAchievement.objects.filter(character_sheet=sheet).exists())
+        grant_test_tenure(sheet)
+        increment_stat(sheet, self.stat)
+        self.assertTrue(
+            CharacterAchievement.objects.filter(
+                character_sheet=sheet, achievement=self.achievement
+            ).exists()
+        )

--- a/src/world/combat/tests/test_combo_discovery.py
+++ b/src/world/combat/tests/test_combo_discovery.py
@@ -11,6 +11,7 @@ from world.combat.constants import ComboLearningMethod
 from world.combat.factories import ComboDefinitionFactory, ComboSlotFactory
 from world.combat.models import ComboLearning
 from world.magic.factories import EffectTypeFactory, ResonanceFactory
+from world.roster.factories import grant_test_tenure
 
 
 class FireComboDiscoveryTests(TestCase):
@@ -89,6 +90,7 @@ class FireComboDiscoveryTests(TestCase):
         effect_type = EffectTypeFactory()
         ComboSlotFactory(combo=combo, required_action_type=effect_type)
         sheet = CharacterSheetFactory()
+        grant_test_tenure(sheet)
 
         fire_combo_discovery(combo=combo, participant_sheets=[sheet])
 

--- a/src/world/combat/tests/test_combo_journey.py
+++ b/src/world/combat/tests/test_combo_journey.py
@@ -42,6 +42,7 @@ from world.magic.factories import (
     TechniqueFactory,
 )
 from world.mechanics.factories import CharacterEngagementFactory
+from world.roster.factories import grant_test_tenure
 from world.scenes.constants import RoundStatus
 from world.vitals.models import CharacterVitals
 
@@ -108,6 +109,8 @@ class ComboJourneyTests(TestCase):
     def _setup_pc(self, *, effect: object, speed_rank: int) -> None:
         """Create a PC participant with a technique matching the given effect type."""
         sheet = CharacterSheetFactory()
+        # Achievement eligibility requires a live, non-staff RosterTenure (#3024).
+        grant_test_tenure(sheet)
         role = CovenantRoleFactory(speed_rank=speed_rank)
         participant = CombatParticipantFactory(
             encounter=self.encounter,

--- a/src/world/magic/tests/integration/test_deed_resonance_aura_drift_e2e.py
+++ b/src/world/magic/tests/integration/test_deed_resonance_aura_drift_e2e.py
@@ -34,11 +34,13 @@ from world.missions.factories import (
 )
 from world.missions.services.cron import apply_mission_reward_batch
 from world.missions.services.rewards import apply_deed_rewards, emit_terminal_rewards
+from world.roster.factories import grant_test_tenure
 
 
 class DeedResonanceAuraDriftE2ETest(TestCase):
     def test_full_deed_to_achievement_pipeline(self):
         sheet = CharacterSheetFactory()
+        grant_test_tenure(sheet)
         CharacterAuraFactory(character=sheet)
         abyssal = AffinityFactory(name="Abyssal")
         cruelty = ResonanceFactory(name="Cruelty", affinity=abyssal)

--- a/src/world/magic/tests/integration/test_gift_specialization_e2e.py
+++ b/src/world/magic/tests/integration/test_gift_specialization_e2e.py
@@ -47,7 +47,7 @@ from world.magic.specialization.services import (
     provision_latent_gift_thread,
     resolve_specialized_variant,
 )
-from world.roster.factories import RosterEntryFactory
+from world.roster.factories import RosterEntryFactory, grant_test_tenure
 from world.scenes.cast_services import request_technique_cast
 from world.scenes.tests.cast_test_helpers import CastScenarioMixin
 
@@ -67,6 +67,8 @@ class GiftSpecializationE2ETest(TestCase):
         # Codex unlock is keyed on RosterEntry; ensure one exists so the full
         # discovery beat (achievement + codex) can be asserted end-to-end.
         RosterEntryFactory(character_sheet=cls.sheet)
+        # Achievement eligibility requires a live, non-staff RosterTenure (#3024).
+        grant_test_tenure(cls.sheet)
         cls.gift = GiftFactory()
         cls.resonance = ResonanceFactory()
         cls.gift.resonances.add(cls.resonance)

--- a/src/world/magic/tests/integration/test_species_gift_e2e.py
+++ b/src/world/magic/tests/integration/test_species_gift_e2e.py
@@ -64,7 +64,7 @@ from world.magic.services import spend_resonance_for_imbuing, spend_resonance_fo
 from world.magic.specialization.models import TechniqueVariant
 from world.magic.specialization.services import resolve_specialized_variant
 from world.magic.types import PullActionContext
-from world.roster.factories import RosterEntryFactory
+from world.roster.factories import RosterEntryFactory, grant_test_tenure
 from world.species.factories import SpeciesFactory, SpeciesGiftGrantFactory
 
 
@@ -139,6 +139,8 @@ class _SpeciesGiftJourneyBase(TestCase):
         # Codex unlock is keyed on RosterEntry; ensure one so the discovery beat
         # (achievement + codex) can be asserted end-to-end.
         RosterEntryFactory(character_sheet=sheet)
+        # Achievement eligibility requires a live, non-staff RosterTenure (#3024).
+        grant_test_tenure(sheet)
         draft = CharacterDraftFactory(
             selected_tradition=self.tradition,
             draft_data={

--- a/src/world/magic/tests/test_aura_recompute.py
+++ b/src/world/magic/tests/test_aura_recompute.py
@@ -8,6 +8,7 @@ from world.character_sheets.factories import CharacterSheetFactory
 from world.magic.factories import AffinityFactory, CharacterAuraFactory, ResonanceFactory
 from world.magic.models import CharacterAura, CharacterResonance
 from world.magic.services.aura import recompute_aura
+from world.roster.factories import grant_test_tenure
 
 
 class RecomputeAuraTests(TestCase):
@@ -124,6 +125,7 @@ class FireAuraThresholdCrossingsTests(TestCase):
     @classmethod
     def setUpTestData(cls):
         cls.sheet = CharacterSheetFactory()
+        grant_test_tenure(cls.sheet)
         CharacterAuraFactory(character=cls.sheet)
         cls.abyssal = AffinityFactory(name="Abyssal")
         cls.abyssal_resonance = ResonanceFactory(affinity=cls.abyssal)

--- a/src/world/magic/tests/test_crossing_ceremony.py
+++ b/src/world/magic/tests/test_crossing_ceremony.py
@@ -192,3 +192,31 @@ class BackwardsCompatibilityTests(TestCase):
         from world.covenants.discovery import fire_variant_discoveries
 
         self.assertIs(fire_variant_discoveries, execute_crossing_ceremonies)
+
+
+class ExecuteCeremonyBeatEligibilityTests(TestCase):
+    """execute_ceremony_beat respects the achievement-eligibility gate (#3024)."""
+
+    def test_ineligible_sheet_gets_no_grant_and_no_gamewide_message(self) -> None:
+        from world.achievements.factories import AchievementFactory
+        from world.achievements.models import CharacterAchievement, Discovery
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.crossing.ceremony import CeremonyNarrative, execute_ceremony_beat
+
+        sheet = CharacterSheetFactory()  # no tenure: ineligible
+        achievement = AchievementFactory(name="Beat Gate", slug="beat-gate")
+        execute_ceremony_beat(
+            sheet=sheet,
+            narrative=CeremonyNarrative(first_body="A first.", personal_body="You did it."),
+            achievement=achievement,
+        )
+        self.assertFalse(CharacterAchievement.objects.filter(character_sheet=sheet).exists())
+        self.assertFalse(Discovery.objects.filter(achievement=achievement).exists())
+        # is_first derives from grant results, so the message must be personal,
+        # not gamewide: exactly the one delivery, to the sheet itself.
+        from world.narrative.models import NarrativeMessageDelivery
+
+        self.assertTrue(
+            NarrativeMessageDelivery.objects.filter(recipient_character_sheet=sheet).exists()
+        )
+        self.assertEqual(NarrativeMessageDelivery.objects.count(), 1)

--- a/src/world/magic/tests/test_gift_variant_discovery.py
+++ b/src/world/magic/tests/test_gift_variant_discovery.py
@@ -15,12 +15,14 @@ from world.magic.factories import (
     ThreadFactory,
 )
 from world.magic.specialization.models import TechniqueVariant
+from world.roster.factories import grant_test_tenure
 
 
 class GiftVariantDiscoveryTests(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         cls.sheet = CharacterSheetFactory()
+        grant_test_tenure(cls.sheet)
         cls.gift = GiftFactory()
         cls.resonance = ResonanceFactory()
         cls.gift.resonances.add(cls.resonance)

--- a/src/world/roster/factories.py
+++ b/src/world/roster/factories.py
@@ -13,6 +13,7 @@ from evennia_extensions.factories import (  # noqa: F401  (CharacterFactory re-e
 )
 from evennia_extensions.models import Artist, PlayerData
 from world.character_sheets.factories import CharacterSheetFactory
+from world.character_sheets.models import CharacterSheet
 from world.roster.models import (
     Family,
     GameInvite,
@@ -264,3 +265,15 @@ class GameInviteFactory(factory_django.DjangoModelFactory):
     token = factory.Sequence(lambda n: f"test-token-{n:048d}")
     message = factory.Faker("sentence")
     status = InviteStatus.PENDING
+
+
+def grant_test_tenure(character_sheet: CharacterSheet) -> RosterTenure:
+    """Give ``character_sheet`` a live, non-staff tenure (achievement-eligible, #3024).
+
+    Reuses the sheet's existing RosterEntry when one exists (a second would
+    violate the OneToOne); otherwise creates one.
+    """
+    entry = character_sheet.roster_entry_or_none
+    if entry is None:
+        entry = RosterEntryFactory(character_sheet=character_sheet)
+    return RosterTenureFactory(roster_entry=entry, end_date=None)

--- a/src/world/worship/tests/test_services.py
+++ b/src/world/worship/tests/test_services.py
@@ -6,6 +6,7 @@ from django.utils.text import slugify
 from world.achievements.models import Achievement, CharacterAchievement
 from world.character_sheets.factories import CharacterSheetFactory
 from world.character_sheets.models import Gender
+from world.roster.factories import grant_test_tenure
 from world.worship.constants import (
     GODS_FAVORITE_CHOSEN,
     GODS_FAVORITE_PRINCE,
@@ -71,17 +72,21 @@ class GodsFavoriteTests(TestCase):
 
     def test_first_worshipper_becomes_favorite_with_gender_variant(self) -> None:
         sheet = CharacterSheetFactory(gender=self.female)
+        grant_test_tenure(sheet)
         bump_devotion(sheet, self.being, 10)
         self.assertIn(GODS_FAVORITE_PRINCESS, self._earned(sheet))
 
     def test_nonbinary_or_unset_gender_gets_chosen(self) -> None:
         sheet = CharacterSheetFactory(gender=None)
+        grant_test_tenure(sheet)
         bump_devotion(sheet, self.being, 5)
         self.assertIn(GODS_FAVORITE_CHOSEN, self._earned(sheet))
 
     def test_tie_grants_and_leapfrog_grants_while_prior_holder_keeps(self) -> None:
         first = CharacterSheetFactory(gender=self.male)
         second = CharacterSheetFactory(gender=self.female)
+        grant_test_tenure(first)
+        grant_test_tenure(second)
         bump_devotion(first, self.being, 10)
         self.assertIn(GODS_FAVORITE_PRINCE, self._earned(first))
         # Tie at 10 grants to the second character too.
@@ -95,6 +100,8 @@ class GodsFavoriteTests(TestCase):
     def test_trailing_worshipper_gets_nothing(self) -> None:
         leader = CharacterSheetFactory(gender=self.male)
         trailer = CharacterSheetFactory(gender=self.female)
+        grant_test_tenure(leader)
+        grant_test_tenure(trailer)
         bump_devotion(leader, self.being, 50)
         bump_devotion(trailer, self.being, 10)
         self.assertEqual(self._earned(trailer), set())
@@ -105,6 +112,11 @@ class GodsFavoriteTests(TestCase):
         standing = bump_devotion(sheet, self.being, 10)
         self.assertEqual(standing.favor, 10)
         self.assertEqual(self._earned(sheet), set())
+
+    def test_untenured_top_favor_never_earns_gods_favorite(self) -> None:
+        sheet = CharacterSheetFactory(gender=self.female)
+        bump_devotion(sheet, self.being, 10)
+        self.assertFalse(CharacterAchievement.objects.filter(character_sheet=sheet).exists())
 
 
 class EstablishPatronageTests(TestCase):


### PR DESCRIPTION
Closes #3024

## Summary

Gates all achievement earning on a current, non-staff RosterTenure at the grant_achievement chokepoint (new public predicate can_earn_achievements, promoted from #2899's private _ceremony_eligible). Closes the #3024 gap where the stat-threshold path, worship favor, crossing/combo/signature ceremony beats, and aura thresholds could all grant achievements (and silently consume the irreversible first-ever Discovery slot, or in the ceremony-beat case fire the gamewide announcement) for GM-created NPCs, mid-CG sheets, or staff-piloted characters. Stat tracking continues for ineligible sheets; only earning is gated (ratified: true NPCs never gain tenure so the gate holds permanently; GM-authored roster characters are built to player norms). No model changes or migrations. Six test files remediated with tenure fixtures via the new grant_test_tenure helper; new gate tests cover the stat path, mixed co-discoverer lists, worship, and an ineligible ceremony beat (proven personal-only, non-vacuously). Docs updated in tandem (achievements CLAUDE.md, glossary, INDEX, ADR-0202). Dev-DB audit: 0 ineligible-held CharacterAchievement rows. Note: the pre-existing unrestricted Django ModelAdmin on CharacterAchievement/Discovery is a superuser-only manual bypass outside this gate's scope (equivalent trust already has raw DB access); noted here so the spec ledger's 'no bypass write paths' claim is read as 'no gameplay-reachable paths'.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #3024 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch already up to date with origin/main; no conflicts, no migrations in branch.

<!-- last-addressed-comment: 0 -->