### PR TITLE
ModelAdmin credit-status filters, fieldset coverage, and workbench deep links

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -6693,6 +6693,15 @@ Admin-hosted, superuser-only HTMX dashboards for difficulty tuning/simulation an
   mentions pane, and reference search over the database plus opt-in staff-
   docs/Arx I file corpora. See the "Authoring Workbench" section in
   `src/web/admin/CLAUDE.md`.
+- **Stock-admin credit complement (#3020):** every registered credited-model admin
+  gets a `credit_status` changelist filter and linked column
+  (`world/contributors/admin.py`'s `CreditStatusListFilter`/`credit_status`),
+  attached uniformly by `web/admin/apps.py`'s `_attach_credit_admin_extras`, a
+  `web_admin.E001` system check (`web/admin/checks.py`'s
+  `check_credited_admin_fieldsets`) that catches a fieldset missing credit
+  coverage, and an "Open in Authoring Workbench" deep link on the change form
+  (`web/admin/templatetags/authoring_tags.py`, built from the shared
+  `web/admin/authoring/links.py`'s `workbench_editor_url`).
 - **Permissions:** every view superuser-only (`web.admin.tuning.views.superuser_required`,
   mirroring `game_setup_views.py`'s gate).
 - **Source:** `src/web/admin/tuning/`, `src/web/admin/content_load_views.py`,

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -6702,6 +6702,9 @@ Admin-hosted, superuser-only HTMX dashboards for difficulty tuning/simulation an
   coverage, and an "Open in Authoring Workbench" deep link on the change form
   (`web/admin/templatetags/authoring_tags.py`, built from the shared
   `web/admin/authoring/links.py`'s `workbench_editor_url`).
+- **Operator guide:** `docs/systems/content-authoring.md` - the end-to-end staff
+  walkthrough (load, find gaps, edit/credit, row export, session PR, conflict
+  resolution) across #3017-#3020.
 - **Permissions:** every view superuser-only (`web.admin.tuning.views.superuser_required`,
   mirroring `game_setup_views.py`'s gate).
 - **Source:** `src/web/admin/tuning/`, `src/web/admin/content_load_views.py`,

--- a/docs/systems/content-authoring.md
+++ b/docs/systems/content-authoring.md
@@ -1,0 +1,129 @@
+# Content Authoring Workflow (operator guide)
+
+How staff load the game's authored content into a database, find what still
+needs writing, edit and credit it, and save it back to the private content
+repo. This is the operator walkthrough; the implementation detail lives in
+`src/web/admin/CLAUDE.md` and the per-part specs on issues #3017-#3020.
+
+The mental model: **the database is your working copy, the content repo is
+the durable source of truth, and credit stamps are the lock between them.**
+
+## One-time setup
+
+1. Clone the private content repo somewhere on the machine.
+2. In `src/.env`, set `CONTENT_REPO_PATH` to that checkout. Every surface
+   below resolves the path through the same helper
+   (`core_management.content_repo.resolve_content_root()`); if it is unset,
+   loading/export surfaces hide themselves and show a setup hint instead of
+   erroring.
+3. If this machine will open session pull requests (see below), make a
+   GitHub token available: `GITHUB_ISSUE_TOKEN` in settings, or the
+   `GH_TOKEN` env var. Local commits work without it; only the open-PR
+   action needs it. The target repo is parsed from the checkout's own
+   `origin` remote, so the content repo is never named in this codebase.
+4. Optional, for reference search: place the Arx I dump as a sibling
+   `arx1/` directory next to the content root.
+
+First time in the Authoring Workbench, it will ask you to link your account
+to a contributor identity (pick an existing unlinked one or type a name).
+Credit stamps come from that link.
+
+## Loading content into a database
+
+Admin header, then **Game Setup**, then **Load private content repo**. The
+load is an upsert by natural key: existing rows update, missing rows are
+created, and rows the corpus does not know are left alone.
+
+One deliberate exception (#3017): a **credited row is frozen against
+loads**. If a row has `written_by` set and any of its values differ from
+what the corpus says, the load leaves the whole row untouched and it
+appears on the **Load conflicts** page instead. Resolving a conflict is
+one row at a time: read the field-by-field diff, then type the row's own
+natural key back to confirm replacing the database version with the corpus
+version. There is no bulk resolve on purpose; clearing a human's credited
+edit is always a deliberate, single-row act.
+
+## Finding what needs writing
+
+Two doors into the same backlog:
+
+- **The Authoring Workbench** (header link, superuser) is the writer's
+  door: one worst-first queue across every credited model - placeholder
+  text first, then unwritten, then unreviewed - with per-domain stats and
+  domain/status/text filters. You never need to know which model a piece
+  of prose lives in.
+- **The stock changelists** (#3020) are the browser's door: every
+  registered credited model's changelist carries a **credit status**
+  column and filter (`?credit=unwritten|written|reviewed`). When you are
+  already in a model doing mechanical work, flip the filter to "Unwritten"
+  and the prose debt is right there. The status cell links into the
+  workbench editor for that row, and every change form has an **Open in
+  Authoring Workbench** button. Credit fields are editable on every
+  credited admin; a system check (`web_admin.E001`) fails any admin whose
+  explicit fieldsets would hide them.
+
+## Editing, crediting, reviewing
+
+The workbench editor shows only the row's prose fields as textareas;
+mechanical fields cannot be submitted through it at all. Actions:
+
+- **Save** writes the prose.
+- **Save and credit me** additionally stamps `written_by`/`written_on`
+  from your linked contributor. From that moment the row is frozen against
+  loads (above) until the corpus catches up.
+- **Mark reviewed** stamps `reviewed_by`/`reviewed_on` and never touches
+  prose or authorship; writing and reviewing are separate acts.
+
+There is no stored status enum anywhere: unwritten / written / reviewed is
+always derived from those two links, so it can never drift.
+
+For mechanical edits, use the ordinary change form; the deep links run in
+both directions.
+
+## Saving back to the content repo
+
+From a change form's **Export to content repo** button (or the workbench's
+export handoff after crediting): the row's corpus form is written into the
+content checkout, you review the resulting diff, and confirming commits it
+onto the shared session branch (`content-export-session`). A row whose
+natural key is not in the corpus yet additionally requires the explicit
+new-row checkbox (the row-scoped form of the addition gate, ADR-0191).
+Only one row export can be pending confirmation at a time; git state, not
+a table, is the bookkeeping.
+
+Rows accumulate as small commits across a writing session. When you are
+done, the **Content session** page shows the branch's commits and its full
+diff against main, and one click pushes and opens (or reuses) the pull
+request for the whole batch. Merge that PR in the content repo and the
+loop closes: the corpus now matches the database, so the freeze on those
+rows dissolves naturally - the next load finds no difference.
+
+A few builder-domain models (ItemTemplate, NPCRole, BuildingKind,
+DecorationKind) carry credit but are database-only; the editor says so in
+place of the export handoff, and that is expected.
+
+## Bulk export and push
+
+Game Setup also carries the corpus-wide **Export to content repo** and
+**Push content to lore repo** buttons (all flat fixtures plus grid
+bundles, then commit and push, with the same addition gate as a checkbox).
+That is the maintainer bulk path; the expected day-to-day rhythm is the
+row-level one: load once, write all session, export as you credit, one PR
+per session.
+
+## Reference search while writing
+
+The workbench's reference panel searches the content database's prose by
+default. Two file corpora are opt-in per search: the staff docs inside the
+content repo (`design/`, `world_bibles/`) and the Arx I dump (`arx1/`
+sibling directory). Missing roots are silently omitted, so database search
+works with no content repo configured at all.
+
+## Where the deeper detail lives
+
+- `src/web/admin/CLAUDE.md` - the full admin-surface reference (load
+  conflicts, row export, session branch, workbench, stock-admin
+  complement).
+- ADR-0191 (export addition gate), ADR-0201 (credited-row load freeze),
+  ADR-0142 (content vs config in the dev seed).
+- Issues #3017-#3020 - the approved specs for each part of this program.

--- a/src/web/admin/CLAUDE.md
+++ b/src/web/admin/CLAUDE.md
@@ -164,8 +164,9 @@ of every single row needing its own PR.
   `ModelAdmin` (13 as of #3019 review, e.g. `missions.MissionTemplate`,
   `magic.PortalAnchorKind`), and building that URL for one used to raise
   `NoReverseMatch` and 500 the diff page. Every caller degrades `None` to
-  `_workbench_url` - an Authoring Workbench editor deep-link, which always
-  resolves regardless of the admin registry.
+  `web/admin/authoring/links.py:workbench_editor_url` - an Authoring
+  Workbench editor deep-link, which always resolves regardless of the admin
+  registry.
 - **One session branch, one pending export at a time** -
   `core_management.content_session` (`ensure_session_branch`,
   `commit_row_export`, `discard_row_export`) keeps every exported-but-not-
@@ -372,6 +373,37 @@ to `_authoring/` (`admin_authoring`).
   `test_authoring_reference.py`.
 - Deliberate no-ADR: the decisions here were recorded in the approved #3019
   spec, the same precedent #3018 set above.
+
+### Stock-admin complement (#3020)
+
+The stock changelists carry the same credit story the workbench queue tells:
+
+- **Credit-status filter + column, injected registry-wide** -
+  `world/contributors/admin.py` defines `CreditStatusListFilter`
+  (`?credit=unwritten|written|reviewed`, a three-way partition derived from
+  `written_by`/`reviewed_by` - never stored) and the `credit_status` cell,
+  which links each row into the workbench editor whenever the model has
+  prose fields. `web/admin/apps.py:_attach_credit_admin_extras` attaches
+  both to every `credited_content_models()` entry registered in
+  `admin.site` at ready() time (same window as `_patch_external_admins`);
+  no admin lists them by hand. Credited models without a registered admin
+  are skipped - the workbench is their surface.
+- **Fieldset coverage is enforced, not hoped for** - `web_admin.E001`
+  (`checks.py:check_credited_admin_fieldsets`) errors when a credited
+  model's admin declares explicit `fieldsets` without the four credit
+  fields (an explicit fieldsets otherwise silently hides them -
+  `ItemTemplateAdmin` shipped that way until #3020). Fix by appending
+  `CREDIT_FIELDSET`; nested side-by-side field tuples are flattened, so
+  that layout cannot evade the check.
+- **Change-form deep link** - `templatetags/authoring_tags.py:workbench_url`
+  + a superuser-only "Open in Authoring Workbench" object-tool `<li>` in
+  `change_form.html`, beside the #3018 export button, for credited models
+  with prose fields. All deep links share one URL builder:
+  `web/admin/authoring/links.py:workbench_editor_url` (promoted from
+  `content_row_export_views`).
+- Tests: `tests/test_credit_admin_extras.py`,
+  `tests/test_change_form_workbench_link.py`, `tests/test_authoring_links.py`,
+  plus the E001 class in `tests/test_admin_checks.py`.
 
 **When Asked About**
 

--- a/src/web/admin/apps.py
+++ b/src/web/admin/apps.py
@@ -24,6 +24,7 @@ class AdminConfig(AppConfig):
         from web.admin import checks  # noqa: F401, PLC0415
 
         _patch_external_admins()
+        _attach_credit_admin_extras()
 
 
 def _patch_external_admins():
@@ -64,3 +65,31 @@ def _patch_external_admins():
 
     # Django's built-in Group admin — Group.user points to User (AccountDB)
     GroupAdmin.autocomplete_fields = ("user",)
+
+
+def _attach_credit_admin_extras():
+    """Attach the credit-status filter + column to every registered credited admin (#3020).
+
+    Runs at ready() time, after admin autodiscovery (django.contrib.admin
+    precedes web.admin in INSTALLED_APPS), so the registry is complete -
+    the same window ``_patch_external_admins`` uses. Mutates the registered
+    ModelAdmin INSTANCES, so Django's own admin checks still validate the
+    result. Idempotent via the membership guards. Credited models with no
+    registered admin are skipped - the Authoring Workbench is their surface.
+    """
+    from django.contrib import admin  # noqa: PLC0415
+
+    from core.app_domains import credited_content_models  # noqa: PLC0415
+    from world.contributors.admin import (  # noqa: PLC0415
+        CreditStatusListFilter,
+        credit_status,
+    )
+
+    for model in credited_content_models():
+        instance = admin.site._registry.get(model)  # noqa: SLF001
+        if instance is None:
+            continue
+        if CreditStatusListFilter not in instance.list_filter:
+            instance.list_filter = [*instance.list_filter, CreditStatusListFilter]
+        if credit_status not in instance.list_display:
+            instance.list_display = [*instance.list_display, credit_status]

--- a/src/web/admin/authoring/links.py
+++ b/src/web/admin/authoring/links.py
@@ -1,0 +1,23 @@
+"""Workbench deep-link building, shared by every stock-admin surface (#3020).
+
+Promoted from ``content_row_export_views._workbench_url`` (#3018) so the
+credit-status changelist cell, the change-form object-tool link, and the
+row-export fallbacks all build the same URL the same way.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlencode
+
+from django.urls import reverse
+
+
+def workbench_editor_url(model_label: str, pk: object) -> str:
+    """Build the Authoring Workbench editor deep-link for one row.
+
+    Unlike a per-model admin change-form URL, this always resolves -
+    ``admin_authoring_editor`` is a fixed route, not one built off the admin
+    registry (#3019 review, Item 2).
+    """
+    query = urlencode({"model": model_label, "pk": pk})
+    return f"{reverse('admin_authoring_editor')}?{query}"

--- a/src/web/admin/checks.py
+++ b/src/web/admin/checks.py
@@ -19,6 +19,9 @@ EVENNIA_LARGE_TABLE_LABELS = {
     "scripts.ScriptDB",
 }
 
+#: The four columns CreditedContent adds - what CREDIT_FIELDSET shows.
+CREDIT_FIELD_NAMES = ("written_by", "written_on", "reviewed_by", "reviewed_on")
+
 # Arx-specific large tables. Staff add models here as the game grows.
 # Grouped by domain for readability.
 LARGE_TABLE_MODELS = {
@@ -158,3 +161,53 @@ def _find_large_table_fk_violations(model, admin_cls, exempt, protected):
             )
         )
     return violations
+
+
+@register()
+def check_credited_admin_fieldsets(app_configs, **kwargs):  # noqa: ARG001
+    """Fieldsets-declaring admins for credited models must include the credit fields.
+
+    An explicit ``fieldsets`` shows only what it names, so a credited model's
+    admin declaring one without the credit fields silently hides who wrote
+    the row (#3020 - ``ItemTemplateAdmin`` shipped that way). Emits
+    ``web_admin.E001`` per violating admin.
+    """
+    from core.app_domains import credited_content_models  # noqa: PLC0415
+
+    errors = []
+    credited = set(credited_content_models())
+    for model, admin_cls in admin.site._registry.items():  # noqa: SLF001
+        if model not in credited or not admin_cls.fieldsets:
+            continue
+        declared = _declared_fieldset_fields(admin_cls.fieldsets)
+        missing = [name for name in CREDIT_FIELD_NAMES if name not in declared]
+        if missing:
+            errors.append(
+                Error(
+                    f"{type(admin_cls).__name__} declares fieldsets for credited model "
+                    f"{model.__name__} without the credit fields: {', '.join(missing)}.",
+                    hint=(
+                        "Append CREDIT_FIELDSET from world.contributors.admin to the "
+                        "fieldsets declaration."
+                    ),
+                    id="web_admin.E001",
+                )
+            )
+    return errors
+
+
+def _declared_fieldset_fields(fieldsets):
+    """Flatten every field name a fieldsets declaration shows, one nested level deep.
+
+    A ``fields`` entry may itself be a tuple/list (Django's side-by-side
+    widget layout); flatten it so that layout cannot evade the check. No
+    current admin uses it - this is check hardening, not a live case.
+    """
+    declared: set[str] = set()
+    for _label, options in fieldsets:
+        for entry in options.get("fields", ()):
+            if isinstance(entry, (list, tuple)):
+                declared.update(entry)
+            else:
+                declared.add(entry)
+    return declared

--- a/src/web/admin/content_row_export_views.py
+++ b/src/web/admin/content_row_export_views.py
@@ -58,6 +58,8 @@ from django.shortcuts import render
 from django.urls import reverse
 from django.views.decorators.http import require_GET, require_POST
 
+from web.admin.authoring.links import workbench_editor_url
+
 _CONTENT_ROOT_UNSET_MSG = (
     "CONTENT_REPO_PATH is not set. Add it to src/.env pointing at your "
     "local checkout of the private content repository."
@@ -74,18 +76,6 @@ def _diff_url(model_label: str, pk: object) -> str:
     return f"{reverse('admin_content_export_row_diff')}?{query}"
 
 
-def _workbench_url(model_label: str, pk: object) -> str:
-    """Build the Authoring Workbench editor deep-link for this row.
-
-    Unlike ``_change_url``, this always resolves - ``admin_authoring_editor``
-    is a fixed route, not one built per-model off the admin registry - so
-    it's the fallback destination every ``_change_url`` call site degrades to
-    when a model has no registered ``ModelAdmin`` (#3019 review, Item 2).
-    """
-    query = urlencode({"model": model_label, "pk": pk})
-    return f"{reverse('admin_authoring_editor')}?{query}"
-
-
 def _change_url(model: type, pk: object) -> str | None:
     """Build this model's admin change-form URL for ``pk``, or ``None`` if it can't.
 
@@ -100,8 +90,8 @@ def _change_url(model: type, pk: object) -> str | None:
     ``magic.PortalAnchorKind``), and building this URL for one of them used
     to raise ``NoReverseMatch`` and 500 the diff page. Mirrors
     ``web.admin.authoring.views._admin_change_url``'s registry check. Every
-    caller here degrades to ``_workbench_url`` (a route that always exists)
-    instead of assuming this resolves.
+    caller here degrades to ``workbench_editor_url`` (a route that always
+    exists) instead of assuming this resolves.
     """
     if model not in admin.site._registry:  # noqa: SLF001
         return None
@@ -303,7 +293,9 @@ def content_export_row(request: HttpRequest) -> HttpResponse:
         pending = _pending_export(request)
         if pending is None:
             messages.error(request, str(exc))
-            return HttpResponseRedirect(_change_url(model, pk) or _workbench_url(model_label, pk))
+            return HttpResponseRedirect(
+                _change_url(model, pk) or workbench_editor_url(model_label, pk)
+            )
         pending_name = _pending_export_display_name(pending["model_label"])
         messages.error(request, f"{exc} Pending: {pending_name} [{pending['natural_key']}].")
         return HttpResponseRedirect(_diff_url(pending["model_label"], pending["pk"]))
@@ -311,7 +303,7 @@ def content_export_row(request: HttpRequest) -> HttpResponse:
     result = export_single_row(instance, content_root=content_root)
     if result.refused is not None:
         messages.error(request, result.refused)
-        return HttpResponseRedirect(_change_url(model, pk) or _workbench_url(model_label, pk))
+        return HttpResponseRedirect(_change_url(model, pk) or workbench_editor_url(model_label, pk))
 
     _set_pending_export(request, result.model_label, pk, result)
     return HttpResponseRedirect(_diff_url(result.model_label, pk))
@@ -345,7 +337,7 @@ def content_export_row_diff(request: HttpRequest) -> HttpResponse:
         messages.info(
             request, f"Nothing to review for {model.__name__} [{natural_key}] - export it first."
         )
-        return HttpResponseRedirect(_change_url(model, pk) or _workbench_url(model_label, pk))
+        return HttpResponseRedirect(_change_url(model, pk) or workbench_editor_url(model_label, pk))
 
     is_addition = _derive_is_addition(content_root, model, paths, fields)
     digest = hashlib.sha256(diff_text.encode("utf-8")).hexdigest()
@@ -360,7 +352,7 @@ def content_export_row_diff(request: HttpRequest) -> HttpResponse:
         "digest": digest,
         "confirm_url": reverse("admin_content_export_row_confirm"),
         "change_url": _change_url(model, pk),
-        "workbench_url": _workbench_url(model_label, pk),
+        "workbench_url": workbench_editor_url(model_label, pk),
     }
     return render(request, "admin/content_row_export_diff.html", context)
 
@@ -397,7 +389,7 @@ def _run_confirmed_action(
         discard_row_export(content_root, paths)
         _clear_pending_export(request)
         messages.info(request, f"Discarded the pending export of {model.__name__} [{natural_key}].")
-        return HttpResponseRedirect(_change_url(model, pk) or _workbench_url(model_label, pk))
+        return HttpResponseRedirect(_change_url(model, pk) or workbench_editor_url(model_label, pk))
 
     if action != _ACTION_CONFIRM:
         messages.error(request, "Unknown export action.")

--- a/src/web/admin/templatetags/authoring_tags.py
+++ b/src/web/admin/templatetags/authoring_tags.py
@@ -1,0 +1,29 @@
+"""Template filter for the change-form "Open in Authoring Workbench" link (#3020).
+
+``change_form.html`` needs one value: the workbench editor URL for the row on
+screen, or ``""`` when there is nothing to link (non-credited model, credited
+model with no prose fields, or an unsaved add-form object). Kept separate
+from ``content_export_tags`` - that module is the #3018 export button's and
+answers a different question (corpus-owned) than this one (prose-editable).
+"""
+
+from __future__ import annotations
+
+from django import template
+
+register = template.Library()
+
+
+@register.filter
+def workbench_url(obj) -> str:
+    """Return the workbench editor deep-link for this row, or ``""`` when it has none."""
+    if obj is None or not obj.pk:
+        return ""
+    from core.app_domains import credited_content_models, domain_of  # noqa: PLC0415
+    from core_management.prose_fields import prose_fields_for  # noqa: PLC0415
+    from web.admin.authoring.links import workbench_editor_url  # noqa: PLC0415
+
+    model = type(obj)
+    if model not in credited_content_models() or not prose_fields_for(model):
+        return ""
+    return workbench_editor_url(f"{domain_of(model)}.{model.__name__}", obj.pk)

--- a/src/web/admin/tests/test_admin_checks.py
+++ b/src/web/admin/tests/test_admin_checks.py
@@ -6,7 +6,9 @@ from django.test import TestCase
 from web.admin.checks import (
     _is_large_table,
     check_admin_fk_widgets,
+    check_credited_admin_fieldsets,
 )
+from world.magic.models import EffectType
 
 
 class IsLargeTableTest(TestCase):
@@ -108,3 +110,41 @@ class CheckAdminFkWidgetsTest(TestCase):
                     str(error),
                     f"Exempt field '{exempt_field}' appeared in error: {error}",
                 )
+
+
+class CreditedAdminFieldsetsCheckTests(TestCase):
+    """web_admin.E001: fieldsets-declaring credited admins must show the credit fields."""
+
+    def test_live_registry_is_clean(self) -> None:
+        # Permanently guards the ItemTemplateAdmin fix and the 7 admins that
+        # already carry CREDIT_FIELDSET.
+        self.assertEqual(check_credited_admin_fieldsets(None), [])
+
+    def _with_registered_fieldsets(self, fieldsets):
+        bad = admin.ModelAdmin(EffectType, admin.site)
+        bad.fieldsets = fieldsets
+        original = admin.site._registry[EffectType]
+        admin.site._registry[EffectType] = bad
+        try:
+            return check_credited_admin_fieldsets(None)
+        finally:
+            admin.site._registry[EffectType] = original
+
+    def test_missing_credit_fields_is_an_error(self) -> None:
+        errors = self._with_registered_fieldsets([(None, {"fields": ["name", "description"]})])
+
+        self.assertEqual([e.id for e in errors], ["web_admin.E001"])
+        self.assertIn("reviewed_on", errors[0].msg)
+
+    def test_nested_tuple_layout_cannot_evade_the_check(self) -> None:
+        errors = self._with_registered_fieldsets(
+            [
+                (None, {"fields": ["name"]}),
+                (
+                    "Credit",
+                    {"fields": [("written_by", "written_on"), ("reviewed_by", "reviewed_on")]},
+                ),
+            ]
+        )
+
+        self.assertEqual(errors, [])

--- a/src/web/admin/tests/test_authoring_links.py
+++ b/src/web/admin/tests/test_authoring_links.py
@@ -1,0 +1,16 @@
+"""Tests for the shared workbench deep-link builder (#3020)."""
+
+from django.test import TestCase
+from django.urls import reverse
+
+from web.admin.authoring.links import workbench_editor_url
+
+
+class WorkbenchEditorUrlTests(TestCase):
+    """One URL shape, shared by every stock-admin surface that links into the workbench."""
+
+    def test_builds_editor_url_with_model_and_pk_query(self) -> None:
+        url = workbench_editor_url("magic.EffectType", 7)
+
+        expected = f"{reverse('admin_authoring_editor')}?model=magic.EffectType&pk=7"
+        self.assertEqual(url, expected)

--- a/src/web/admin/tests/test_change_form_workbench_link.py
+++ b/src/web/admin/tests/test_change_form_workbench_link.py
@@ -1,0 +1,61 @@
+"""Tests for the change-form "Open in Authoring Workbench" link (#3020).
+
+Same gating shape as the #3018 export button beside it: change form (not
+add), credited model with prose fields, superuser only.
+"""
+
+from django.contrib.auth.models import Group, Permission
+from django.test import TestCase
+from django.urls import reverse
+from evennia.accounts.models import AccountDB
+
+from world.magic.factories import EffectTypeFactory
+
+
+class TestChangeFormWorkbenchLink(TestCase):
+    """Presence/absence of the workbench link across model, permission, and form cases."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.super = AccountDB.objects.create_superuser("rootadmin", "root@example.com", "pw-123456")
+        cls.staff = AccountDB.objects.create_user("staffer", "s@example.com", "pw-123456")
+        cls.staff.is_staff = True
+        cls.staff.user_permissions.set(Permission.objects.all())
+        cls.staff.save()
+
+    def test_credited_change_form_links_to_the_workbench_for_a_superuser(self) -> None:
+        effect = EffectTypeFactory(name="Workbench Link Effect")
+        self.client.force_login(self.super)
+
+        resp = self.client.get(reverse("admin:arxii_effecttype_change", args=[effect.pk]))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertContains(resp, "Open in Authoring Workbench")
+        self.assertContains(resp, reverse("admin_authoring_editor"))
+        self.assertContains(resp, "model=magic.EffectType")
+
+    def test_non_credited_change_form_has_no_link(self) -> None:
+        group = Group.objects.create(name="Workbench Link Control Group")
+        self.client.force_login(self.super)
+
+        resp = self.client.get(reverse("admin:auth_group_change", args=[group.pk]))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotContains(resp, "Open in Authoring Workbench")
+
+    def test_non_superuser_staff_does_not_see_the_link(self) -> None:
+        effect = EffectTypeFactory(name="Workbench Link Staff Effect")
+        self.client.force_login(self.staff)
+
+        resp = self.client.get(reverse("admin:arxii_effecttype_change", args=[effect.pk]))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotContains(resp, "Open in Authoring Workbench")
+
+    def test_add_form_has_no_link(self) -> None:
+        self.client.force_login(self.super)
+
+        resp = self.client.get(reverse("admin:arxii_effecttype_add"))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertNotContains(resp, "Open in Authoring Workbench")

--- a/src/web/admin/tests/test_credit_admin_extras.py
+++ b/src/web/admin/tests/test_credit_admin_extras.py
@@ -1,0 +1,89 @@
+"""Tests for the registry-wide credit-status filter/column injection (#3020).
+
+Uses ``magic.EffectType`` as the sample credited model (registered admin,
+factory, prose ``description`` field - same choice as
+``test_change_form_export_button.py``) and ``auth.Group`` as the non-credited
+control.
+"""
+
+from django.contrib import admin
+from django.contrib.auth.models import Group
+from django.test import TestCase
+from django.urls import reverse
+from evennia.accounts.models import AccountDB
+
+from web.admin.apps import _attach_credit_admin_extras
+from web.admin.authoring.links import workbench_editor_url
+from world.contributors.admin import CreditStatusListFilter, credit_status
+from world.contributors.factories import ContentContributorFactory
+from world.magic.factories import EffectTypeFactory
+from world.magic.models import EffectType
+
+
+class CreditAdminInjectionTests(TestCase):
+    """The ready()-time pass attaches the filter and column exactly once."""
+
+    def test_credited_admin_carries_filter_and_column(self) -> None:
+        instance = admin.site._registry[EffectType]
+
+        self.assertIn(CreditStatusListFilter, instance.list_filter)
+        self.assertIn(credit_status, instance.list_display)
+
+    def test_non_credited_admin_is_untouched(self) -> None:
+        instance = admin.site._registry[Group]
+
+        self.assertNotIn(CreditStatusListFilter, instance.list_filter)
+        self.assertNotIn(credit_status, instance.list_display)
+
+    def test_injection_pass_is_idempotent(self) -> None:
+        _attach_credit_admin_extras()
+        instance = admin.site._registry[EffectType]
+
+        self.assertEqual(list(instance.list_filter).count(CreditStatusListFilter), 1)
+        self.assertEqual(list(instance.list_display).count(credit_status), 1)
+
+
+class CreditStatusChangelistTests(TestCase):
+    """Filter partition and linked cell, proven through a real changelist GET."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.super = AccountDB.objects.create_superuser("rootadmin", "root@example.com", "pw-123456")
+        writer = ContentContributorFactory(name="Writer")
+        reviewer = ContentContributorFactory(name="Reviewer")
+        cls.unwritten = EffectTypeFactory(name="Credit Unwritten Effect")
+        cls.written = EffectTypeFactory(name="Credit Written Effect", written_by=writer)
+        cls.reviewed = EffectTypeFactory(
+            name="Credit Reviewed Effect", written_by=writer, reviewed_by=reviewer
+        )
+
+    def _changelist(self, query: str = ""):
+        self.client.force_login(self.super)
+        return self.client.get(reverse("admin:arxii_effecttype_changelist") + query)
+
+    def test_unwritten_lookup_shows_only_unwritten_rows(self) -> None:
+        resp = self._changelist("?credit=unwritten")
+
+        self.assertContains(resp, "Credit Unwritten Effect")
+        self.assertNotContains(resp, "Credit Written Effect")
+        self.assertNotContains(resp, "Credit Reviewed Effect")
+
+    def test_written_lookup_means_written_and_not_reviewed(self) -> None:
+        resp = self._changelist("?credit=written")
+
+        self.assertContains(resp, "Credit Written Effect")
+        self.assertNotContains(resp, "Credit Unwritten Effect")
+        self.assertNotContains(resp, "Credit Reviewed Effect")
+
+    def test_reviewed_lookup_shows_only_reviewed_rows(self) -> None:
+        resp = self._changelist("?credit=reviewed")
+
+        self.assertContains(resp, "Credit Reviewed Effect")
+        self.assertNotContains(resp, "Credit Unwritten Effect")
+        self.assertNotContains(resp, "Credit Written Effect")
+
+    def test_cell_links_into_the_workbench_editor(self) -> None:
+        resp = self._changelist()
+
+        url = workbench_editor_url("magic.EffectType", self.unwritten.pk)
+        self.assertContains(resp, url.replace("&", "&amp;"))

--- a/src/web/templates/admin/change_form.html
+++ b/src/web/templates/admin/change_form.html
@@ -1,5 +1,5 @@
 {% extends "admin/change_form.html" %}
-{% load i18n admin_modify content_export_tags %}
+{% load i18n admin_modify content_export_tags authoring_tags %}
 
 {# Override the OUTER object-tools block, not the nested object-tools-items #}
 {# block, and reproduce Django's stock structure verbatim (see #}
@@ -24,6 +24,11 @@
         </form>
     </li>
     {% endif %}
+    {% if original and request.user.is_superuser %}{% with wb=original|workbench_url %}{% if wb %}
+    <li>
+        <a href="{{ wb }}" class="workbench-open-link">Open in Authoring Workbench</a>
+    </li>
+    {% endif %}{% endwith %}{% endif %}
     {% change_form_object_tools %}
   </ul>
 {% endif %}

--- a/src/world/contributors/admin.py
+++ b/src/world/contributors/admin.py
@@ -1,4 +1,5 @@
 from django.contrib import admin
+from django.utils.html import format_html
 
 from world.contributors.models import ContentContributor
 
@@ -12,6 +13,73 @@ CREDIT_FIELDSET = (
         "classes": ("collapse",),
     },
 )
+
+
+#: Query-string values for CreditStatusListFilter's three states (also reused
+#: as credit_status's cell text below). Module-level constants, not bare
+#: string literals, per tools/lint_string_literal.py.
+_CREDIT_UNWRITTEN = "unwritten"
+_CREDIT_WRITTEN = "written"
+_CREDIT_REVIEWED = "reviewed"
+
+
+class CreditStatusListFilter(admin.SimpleListFilter):
+    """Three-way derived credit state for any CreditedContent changelist (#3020).
+
+    Derived from ``written_by``/``reviewed_by`` on every evaluation - no
+    stored enum, per ``CreditedContent``'s docstring. Distinct from
+    ``web.admin.constants.BacklogStatusFilter``, the workbench queue's
+    ``?status=`` vocabulary (placeholder/unwritten/unreviewed): this filter
+    partitions every row into exactly one of unwritten/written/reviewed.
+    Attached to every registered credited-model admin by
+    ``web.admin.apps._attach_credit_admin_extras``, never listed by hand.
+    """
+
+    title = "credit status"
+    parameter_name = "credit"
+
+    #: Django passes both hook arguments positionally, so the leading underscores
+    #: mark them unused without needing a suppression.
+    def lookups(self, _request, _model_admin):
+        return [
+            (_CREDIT_UNWRITTEN, "Unwritten"),
+            (_CREDIT_WRITTEN, "Written, unreviewed"),
+            (_CREDIT_REVIEWED, "Reviewed"),
+        ]
+
+    def queryset(self, _request, queryset):
+        if self.value() == _CREDIT_UNWRITTEN:
+            return queryset.filter(written_by__isnull=True)
+        if self.value() == _CREDIT_WRITTEN:
+            return queryset.filter(written_by__isnull=False, reviewed_by__isnull=True)
+        if self.value() == _CREDIT_REVIEWED:
+            return queryset.filter(reviewed_by__isnull=False)
+        return queryset
+
+
+@admin.display(description="Credit")
+def credit_status(obj):
+    """Changelist cell: the row's derived credit state, linked into the workbench.
+
+    Plain text for a credited model with no prose fields - a real path, not
+    defensive (the backlog applies the same guard, ``backlog.py``'s
+    ``if not prose_names``); the workbench editor has nothing to edit there.
+    """
+    from core.app_domains import domain_of  # noqa: PLC0415
+    from core_management.prose_fields import prose_fields_for  # noqa: PLC0415
+    from web.admin.authoring.links import workbench_editor_url  # noqa: PLC0415
+
+    if obj.reviewed_by_id is not None:
+        state = _CREDIT_REVIEWED
+    elif obj.written_by_id is not None:
+        state = _CREDIT_WRITTEN
+    else:
+        state = _CREDIT_UNWRITTEN
+    model = type(obj)
+    if not prose_fields_for(model):
+        return state
+    url = workbench_editor_url(f"{domain_of(model)}.{model.__name__}", obj.pk)
+    return format_html('<a href="{}">{}</a>', url, state)
 
 
 @admin.register(ContentContributor)

--- a/src/world/items/admin.py
+++ b/src/world/items/admin.py
@@ -2,6 +2,7 @@
 
 from django.contrib import admin
 
+from world.contributors.admin import CREDIT_FIELDSET
 from world.items.crafting.models import AccentArchetypeAllowance, AccentExclusion, ItemAccent
 from world.items.models import (
     AccentLevel,
@@ -270,6 +271,7 @@ class ItemTemplateAdmin(admin.ModelAdmin):
                 "classes": ["collapse"],
             },
         ),
+        CREDIT_FIELDSET,
     ]
     inlines = [
         TemplateSlotInline,


### PR DESCRIPTION
Closes #3020

## Summary

Surfaces derived credit status on the stock admin, closing out the admin-as-authoring-hub program (parts 1-3: #3017/#3018/#3019). A CreditStatusListFilter (?credit=unwritten|written|reviewed) and a linked credit-status column attach to all 71 registered credited-model admins in one ready()-time pass (no per-admin edits; future admins covered automatically). ItemTemplateAdmin - the census-confirmed single fieldsets gap - gains CREDIT_FIELDSET, and a new web_admin.E001 system check keeps every fieldsets-declaring credited admin honest, including nested side-by-side layouts. Changelist cells and a new change-form object-tool link deep-link into the Authoring Workbench via one shared URL builder (workbench_editor_url, promoted from content_row_export_views). No model changes, no migrations. Docs updated in tandem (web/admin/CLAUDE.md subsection + systems INDEX entry).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #3020 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch created from main tip a0b0f7c05 (#3028); sync-with-main reported up to date; no migrations on the branch, so no max_migration.txt exposure.

<!-- last-addressed-comment: 0 -->