### PR TITLE
An empty gift resonance set means 'unrestricted' at the gate but 'none available' to all four selectors, so authored gifts are granted with no thread

### DIFF
--- a/docs/adr/0203-a-granted-gift-always-gets-a-thread.md
+++ b/docs/adr/0203-a-granted-gift-always-gets-a-thread.md
@@ -1,0 +1,28 @@
+# ADR-0203: A granted gift always gets a thread — resonance resolves inside the grant primitive
+
+Context: #2967/#2968 gave `Gift.resonances` a legitimate empty-set meaning ("unrestricted" at
+the weave gate), but the four call sites that granted a gift (`grant_path_magic`,
+`provision_species_gifts`, CG's `_finalize_gift_and_techniques`, `charge_and_learn`'s implicit
+gift acquisition) each read that same empty set as "no resonance available" and silently skipped
+provisioning the gift's latent GIFT thread — #2971 named this "an empty gift resonance set means
+unrest": a character could hold a `CharacterGift` and its techniques with no GIFT thread for any
+downstream reader (cast resolution, dramatic-moment grants, crossing ceremonies) to find a
+resonance on. Decision: move resonance resolution *inside* the shared primitive,
+`grant_gift_to_character` — `_resolve_grant_resonance` (`world/magic/specialization/services.py`)
+tries, in order, the caller's explicit pick (when the supported set is empty or contains it), an
+existing GIFT thread already covering the gift (lineage-aware, via `gift_threads_for` — makes a
+re-grant a true no-op), the supported set's claimed-or-first member, the character's own earliest
+GIFT thread's resonance, their highest-`lifetime_earned` claimed resonance, and finally their
+anima-ritual resonance; if none of those resolves, it raises `GiftResonanceUnresolvable` loudly
+*before* the `CharacterGift` row is minted, so a partially-granted gift (link with no thread) —
+the exact corrupted state this ADR eliminates — can never be created. Every grant call site now
+goes through this one resolver, so a new caller inherits the "always a thread" contract for free
+instead of needing to remember its own resonance-availability check. CG additionally writes the
+same resolved pick onto the character's anima ritual (`RitualCheckConfig.resonance`) at finalize,
+since the anima ritual is the character's magical identity and previously never recorded one from
+CG at all. Rejected: keep "`None` skips thread provisioning" and patch each of the four call sites
+individually to pick a fallback resonance — this is exactly the shape that produced the bug (a
+policy duplicated per caller drifts, and a fifth future call site would silently reintroduce it).
+
+> Status: accepted · Source: #2971 (spec references #2968) · Related: ADR-0052 (`Gift.resonances`
+> is the weave-time supported set, not the cast-time value), ADR-0055 (specialization engine)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -234,6 +234,7 @@ treat those names as hints to confirm, not gospel.
 - [0113 — A technique-driven entrance carries the cast: one check, not two](0113-entrance-carries-the-cast.md)
 - [0136 — Cantrips retired for authored CG catalogs; tradition-gated magic selection](0136-cantrips-retired-for-authored-cg-catalogs-tradition-gated-magic-selection.md) (extends ADR-0063, ADR-0055, ADR-0072; #2426)
 - [0137 — Golden Hares: deed-denominated Academy favor tokens](0137-golden-hares-deed-denominated-academy-favor-tokens.md) (extends ADR-0053; related ADR-0136; #2428/#2440/#2441/#2442)
+- [0203 — A granted gift always gets a thread: resonance resolves inside the grant primitive](0203-a-granted-gift-always-gets-a-thread.md) (#2971; extends ADR-0052, ADR-0055)
 
 ### Story & stakes
 - [0067 — Beat.risk is the stakes-wager declaration](0067-beat-risk-is-the-stakes-wager-declaration.md)

--- a/docs/systems/MODEL_MAP.md
+++ b/docs/systems/MODEL_MAP.md
@@ -364,6 +364,7 @@
 
 ### Service Functions
 - `apply_achievement_rewards(character_sheet: 'CharacterSheet', achievement: 'Achievement') -> 'None' - Apply an achievement's rewards to a character — title / bonus / prestige / distinction`
+- `can_earn_achievements(character_sheet: 'CharacterSheet') -> 'bool' - Whether ``character_sheet`` may earn achievements at all (#3024).`
 - `get_stat(character_sheet: 'CharacterSheet', stat: 'StatDefinition') -> 'int' - Return current value of a stat tracker, 0 if it doesn't exist.`
 - `grant_achievement(achievement: 'Achievement', character_sheets: 'list[CharacterSheet]') -> 'list[CharacterAchievement]' - Grant an achievement to one or more characters simultaneously.`
 - `increment_stat(character_sheet: 'CharacterSheet', stat: 'StatDefinition', amount: 'int' = 1) -> 'int' - Increment a stat tracker (create if needed) and check for achievements.`
@@ -3684,6 +3685,7 @@
   - technique_progress_weekly <- magic.TechniqueProgressWeekly
   - purse_drain_weeks <- currency.PurseDrainWeek
   - gm_reward_trackers <- gm.GMWeeklyRewardTracker
+  - goal_journals <- goals.GoalJournal
   - journal_xp_trackers <- journals.WeeklyJournalXP
   - relationships <- relationships.CharacterRelationship
 
@@ -3905,6 +3907,7 @@
 **Foreign Keys:**
   - character -> character_sheets.CharacterSheet [FK]
   - domain -> mechanics.ModifierTarget [FK] (nullable)
+  - game_week -> game_clock.GameWeek [FK] (nullable)
 
 ### GoalRevision
 **Foreign Keys:**
@@ -3916,7 +3919,7 @@
 - `get_goal_bonus(character: 'CharacterSheet', domain: 'ModifierTarget') -> int - Get the goal bonus for a specific domain, applying percentage modifiers.`
 - `get_goal_bonuses_breakdown(character: 'CharacterSheet') -> dict[str, world.goals.types.GoalBonusBreakdown] - Get breakdown of all goal bonuses for a character.`
 - `get_total_goal_points(character: 'CharacterSheet') -> int - Get the total goal points available for a character to distribute.`
-- `log_goal_progress(*, character: 'CharacterSheet', domain: 'ModifierTarget | None', title: str, content: str, is_public: bool = False) -> 'GoalJournal' - Create a goal-progress journal entry (records 1 XP on the row).`
+- `log_goal_progress(*, character: 'CharacterSheet', domain: 'ModifierTarget | None', title: str, content: str, is_public: bool = False) -> 'GoalJournal' - Create a goal-progress journal entry and grant weekly-capped XP.`
 - `set_character_goals(*, character: 'CharacterSheet', goals: list['GoalInputData']) -> list[world.goals.models.CharacterGoal] - Replace a character's goal allocations, enforcing the weekly revision limit.`
 
 
@@ -5772,7 +5775,7 @@
 - `imbue_ready_threads(character_sheet: 'CharacterSheet') -> 'list[Thread]' - Return threads that have matching CharacterResonance balance > 0 and level < cap.`
 - `near_xp_lock_threads(character_sheet: 'CharacterSheet', within: 'int' = 100) -> 'list[ThreadXPLockProspect]' - Return threads whose dev_points are within `within` of the next XP-locked boundary.`
 - `preview_resonance_pull(character_sheet: 'CharacterSheet', resonance: 'ResonanceModel', tier: 'int', threads: 'list[Thread]', *, combat_encounter: 'CombatEncounter | None' = None, scene_id: 'int | None' = None, excluded_kinds: 'frozenset[str] | None' = None, target: 'ObjectDB | None' = None) -> 'PullPreviewResult' - Read-only preview of a resonance pull (Spec A §5.6).`
-- `provision_player_anima_ritual(account: 'AccountDB', character_sheet: 'CharacterSheet', roster_entry: 'RosterEntry', *, ritual_name: 'str', stat: 'Trait | None' = None, skill: 'Skill | None' = None) -> 'Ritual | None' - Create a SCENE_ACTION Ritual + sidecar + CharacterRitualKnowledge for a player.`
+- `provision_player_anima_ritual(account: 'AccountDB', character_sheet: 'CharacterSheet', roster_entry: 'RosterEntry', *, ritual_name: 'str', stat: 'Trait | None' = None, skill: 'Skill | None' = None, resonance: 'Resonance | None' = None) -> 'Ritual | None' - Create a SCENE_ACTION Ritual + sidecar + CharacterRitualKnowledge for a player.`
 - `recompute_max_health_with_threads(character_sheet: 'CharacterSheet') -> 'int' - Recompute max_health folding in thread-derived VITAL_BONUS addends.`
 - `reconcile_ritual_knowledge(roster_entry: 'RosterEntry') -> None - Ensure CharacterRitualKnowledge rows exist for all granted rituals.`
 - `resolve_and_consume_ritual_components(*, ritual: 'Ritual', components: 'list[ItemInstance]', performer_sheet: 'CharacterSheet', resonance_context: 'Resonance | None' = None) -> 'None' - Validate and atomically consume ``ritual``'s components from ``components``.`

--- a/docs/systems/magic.md
+++ b/docs/systems/magic.md
@@ -1465,13 +1465,29 @@ ceremony-direct testing. (`world/covenants/discovery.py` re-exports it as
 - `TargetKind.GIFT` + `Thread.target_gift` FK (PROTECT) — a thread anchored to a Gift.
   One active GIFT thread per `(owner, gift)` for now (multi-resonance chooser is a deferred
   needs-design follow-up).
-- **Latent provisioning at CG** — `provision_latent_gift_thread(sheet, gift, *, resonance)`
-  (`world/magic/specialization/services.py`) creates the level-0 GIFT thread at
-  character-creation finalization, idempotent on `(owner, gift)` and write-once on resonance.
-  Wires from `finalize_magic_data` after `CharacterGift` creation, reading the chosen
-  `selected_gift_resonance_id` from `draft.draft_data` (frontend picker is built #1620;
-  the `GiftStage` funnel writes the key, #2426 Task 10; `compute_magic_errors` requires it.
-  Legacy/absent draft data falls back to `gift.resonances.first()`).
+- **Grant-time resonance resolution (#2971, ADR-0203)** — `grant_gift_to_character(sheet,
+  gift, *, resonance=None)` (`world/magic/specialization/services.py`) is the shared
+  gift-acquisition primitive every grant call site uses: CG's `_finalize_gift_and_techniques`
+  (reading `selected_gift_resonance_id` from `draft.draft_data` — frontend picker built #1620,
+  the `GiftStage` funnel writes the key, #2426 Task 10; `compute_magic_errors` requires it and,
+  as of #2971, also rejects a stale pick pointing at a deleted `Resonance`), the path-crossing
+  grant (`grant_path_magic`), species-gift provisioning (`provision_species_gifts`), and
+  `charge_and_learn`'s implicit gift acquisition. It mints the `CharacterGift` link and
+  **always** provisions the gift's latent level-0 GIFT thread — resonance is resolved by
+  `_resolve_grant_resonance` *before* the `CharacterGift` row is minted, so a raise leaves no
+  partial state (a `CharacterGift` with no thread — the exact corrupted state #2971 eliminates —
+  can never be created). Resolution order: the caller's explicit pick (when the gift's
+  supported set is empty or contains it) → an existing active GIFT thread already covering the
+  gift (lineage-aware, via `gift_threads_for` — makes a re-grant a true no-op) → the supported
+  set's claimed-or-first member → the character's own earliest GIFT thread's resonance → their
+  highest-`lifetime_earned` claimed resonance → the anima-ritual resonance. Raises
+  `GiftResonanceUnresolvable` when none of those resolves — an empty `Gift.resonances` (the
+  "unrestricted" weave-gate meaning, ADR-0052/#2967) no longer means "skip provisioning the
+  thread"; a fresh CG character with nothing else resolved is exactly the case CG guards
+  against by also always supplying a `selected_gift_resonance_id`.
+  `provision_latent_gift_thread(sheet, gift, *, resonance)` is the idempotent level-0 GIFT
+  thread writer `grant_gift_to_character` calls once resonance is resolved (write-once on
+  resonance) — no grant call site invokes it directly anymore.
 - **Weaving commits resonance** — `weave_thread(target_kind=GIFT)` commits/chooses a
   resonance onto the existing latent thread rather than creating a new one (validates the
   resonance is in the gift's supported set, else raises `UnsupportedGiftResonanceError`,
@@ -1492,6 +1508,15 @@ Proven end-to-end by `world/magic/tests/integration/test_gift_specialization_e2e
 CG provisioning → base resolve at level 0 → `gift_resonances_for` reads the thread's
 resonance → advance past `unlock_thread_level=3` → variant resolve (name/intensity/control
 deltas) → discovery beat fires (achievement + codex).
+
+**The anima ritual records the same CG pick too (#2971).** `_finalize_anima_ritual`
+(`world.character_creation.services`) resolves `selected_gift_resonance_id` the same way
+`_finalize_gift_and_techniques` does and passes it to `provision_player_anima_ritual(...,
+resonance=...)`, which writes it onto the created `RitualCheckConfig.resonance` — the anima
+ritual IS the character's magical identity, so CG now populates it there instead of leaving it
+`None` until a post-CG edit. `world.magic.services.gain.anima_ritual_resonance(sheet)` — one of
+`_resolve_grant_resonance`'s own fallback rungs above — resolves for every freshly finalized
+character as a result, instead of always returning `None` at CG time.
 
 ### Path-crossing grant — (Gift × Path) → base technique set (grants.py, services/path_magic.py — #1579)
 
@@ -1521,8 +1546,12 @@ natural key `(species, gift)`) is the through-model that links a species to one 
 `Gift`s with an optional `drawback_condition` FK to `conditions.ConditionTemplate`.
 `provision_species_gifts(sheet, *, resonance=None)` (`world/species/services.py`) is called
 from `finalize_magic_data` after the Major-gift block; it mints the MINOR `CharacterGift`
-(via the shared `grant_gift_to_character` primitive) and applies any drawback idempotently. The
-gift's GIFT thread carries a tier-0 `ThreadPullEffect` with `effect_kind=RESISTANCE` that nets
+(via the shared `grant_gift_to_character` primitive) and applies any drawback idempotently.
+`resonance=None` (the common case — species gifts have no CG-picker field of their own) lets
+`_resolve_grant_resonance` (#2971, ADR-0203) anchor the Minor Gift's thread to the character's
+Major-gift thread resonance, since that thread already exists by the time species gifts
+provision — never "no thread provisioned" the way an empty `Gift.resonances` set used to mean.
+The gift's GIFT thread carries a tier-0 `ThreadPullEffect` with `effect_kind=RESISTANCE` that nets
 against the drawback vulnerability at the combat-damage seam. `gift_thread_resistance(character,
 damage_type) -> int` (services/threads.py) returns the aggregate resistance (passive +
 active paid-pull snapshots). See ADR-0050, ADR-0071. E2E:

--- a/src/world/character_creation/CLAUDE.md
+++ b/src/world/character_creation/CLAUDE.md
@@ -104,9 +104,15 @@ for the five-branch validation gate this data must satisfy before submission.
   since `compute_magic_errors` requires the key on any draft that reaches submission.
 - The resonance is read from `draft.draft_data["selected_gift_resonance_id"]`
   (required by `compute_magic_errors`) and resolved to a `Resonance` row; `None`
-  when unset or invalid — `grant_gift_to_character` skips thread provisioning in
-  that case (no fallback-to-first-supported-resonance; that fallback only existed
-  in the old CG-creates-a-new-technique path).
+  when unset or invalid. As of #2971, `None` no longer skips thread provisioning —
+  `grant_gift_to_character` always runs it through the shared grant-time resolver
+  (`_resolve_grant_resonance`: an existing thread already on this gift → the
+  gift's supported-set policy → the character's own main-resonance fallbacks) and
+  ALWAYS provisions the latent GIFT thread. If nothing resolves at all (a fresh CG
+  character with no claimed resonance, no thread, and no anima ritual — the common
+  case here, since anima rituals are set up post-CG), it raises
+  `GiftResonanceUnresolvable` and `finalize_magic_data` fails loudly rather than
+  minting a character holding a gift with no thread to cast from.
 - `draft.draft_data["selected_technique_ids"]` names the chosen catalog
   `Technique`s (drawn from the gift's pool ∪ the tradition's signature set); each
   gets a `CharacterTechnique.objects.get_or_create` link. `announce_access_change`

--- a/src/world/character_creation/CLAUDE.md
+++ b/src/world/character_creation/CLAUDE.md
@@ -103,16 +103,27 @@ for the five-branch validation gate this data must satisfy before submission.
   draft has no `selected_gift_id` — only legacy/test-only draft_data reaches this,
   since `compute_magic_errors` requires the key on any draft that reaches submission.
 - The resonance is read from `draft.draft_data["selected_gift_resonance_id"]`
-  (required by `compute_magic_errors`) and resolved to a `Resonance` row; `None`
-  when unset or invalid. As of #2971, `None` no longer skips thread provisioning —
+  (required by `compute_magic_errors`, which as of #2971 also rejects a stale pick —
+  a pk pointing at a since-deleted `Resonance` — with the same "Select a gift
+  resonance" error as an unset one) and resolved to a `Resonance` row; `None` when
+  unset or invalid. As of #2971, `None` no longer skips thread provisioning —
   `grant_gift_to_character` always runs it through the shared grant-time resolver
   (`_resolve_grant_resonance`: an existing thread already on this gift → the
   gift's supported-set policy → the character's own main-resonance fallbacks) and
   ALWAYS provisions the latent GIFT thread. If nothing resolves at all (a fresh CG
   character with no claimed resonance, no thread, and no anima ritual — the common
-  case here, since anima rituals are set up post-CG), it raises
+  case here, since the gift/technique link (Step 1) runs before the anima ritual is
+  provisioned (Step 6) in `finalize_magic_data`'s ordering), it raises
   `GiftResonanceUnresolvable` and `finalize_magic_data` fails loudly rather than
   minting a character holding a gift with no thread to cast from.
+- **The anima ritual now carries the CG pick too (#2971 Task 3).** The anima ritual
+  IS the character's magical identity, so `_finalize_anima_ritual` resolves the same
+  `selected_gift_resonance_id` (the identical pattern `finalize_magic_data` uses for
+  the gift thread) and passes it to `provision_player_anima_ritual(...,
+  resonance=...)`, which writes it onto the created `RitualCheckConfig.resonance`.
+  `world.magic.services.gain.anima_ritual_resonance(sheet)` — one of the grant-time
+  resolver's own fallback rungs above — now resolves for every freshly finalized
+  character instead of always returning `None` at CG time.
 - `draft.draft_data["selected_technique_ids"]` names the chosen catalog
   `Technique`s (drawn from the gift's pool ∪ the tradition's signature set); each
   gets a `CharacterTechnique.objects.get_or_create` link. `announce_access_change`

--- a/src/world/character_creation/services.py
+++ b/src/world/character_creation/services.py
@@ -1524,6 +1524,13 @@ def _finalize_anima_ritual(draft: CharacterDraft, sheet: CharacterSheet) -> None
     highest-CG-skill defaults. Both are customisable post-CG.
     CharacterRitualKnowledge is created so the ritual gate in the scene action
     menu is satisfied.
+
+    The CG-picked gift resonance (``selected_gift_resonance_id``, resolved the
+    same way ``finalize_magic_data`` resolves it for the gift thread) is also
+    passed through: the anima ritual IS the character's magical identity, so
+    it carries the same resonance as the gift the ritual was built to recover
+    (#2971).
+
     Guard: if the sheet has no RosterEntry yet (e.g. in isolated unit tests that
     call finalize_magic_data directly), skip — the CharacterRitualKnowledge cannot
     be created without a roster_entry FK. finalize_character always creates the
@@ -1555,6 +1562,13 @@ def _finalize_anima_ritual(draft: CharacterDraft, sheet: CharacterSheet) -> None
 
         skill = Skill.objects.filter(pk=skill_id).first()
 
+    resonance = None
+    resonance_id = draft.draft_data.get("selected_gift_resonance_id")
+    if resonance_id:
+        from world.magic.models import Resonance  # noqa: PLC0415
+
+        resonance = Resonance.objects.filter(pk=resonance_id).first()
+
     provision_player_anima_ritual(
         account=draft.account,
         character_sheet=sheet,
@@ -1562,6 +1576,7 @@ def _finalize_anima_ritual(draft: CharacterDraft, sheet: CharacterSheet) -> None
         ritual_name=ritual_name,
         stat=stat,
         skill=skill,
+        resonance=resonance,
     )
 
 

--- a/src/world/character_creation/services.py
+++ b/src/world/character_creation/services.py
@@ -1604,7 +1604,12 @@ def finalize_magic_data(draft: CharacterDraft, sheet: CharacterSheet) -> None:
     # 1b. Provision species Minor Gift(s) + latent GIFT thread + any drawback (#1580).
     #     Re-uses the player's CG-chosen resonance (same key as the Major-gift block)
     #     so the species gift thread anchors to the same resonance the player picked.
-    #     Falls back to each gift's first supported resonance when unset.
+    #     When unset, `provision_species_gifts` passes resonance=None through to
+    #     `grant_gift_to_character`, whose shared `_resolve_grant_resonance` ladder
+    #     resolves one (#2971) — the Major-gift thread already exists by this point,
+    #     so its "existing thread covering this gift" / "main resonance" rungs anchor
+    #     the species gift to the same resonance rather than the gift's first
+    #     supported member.
     from world.species.services import provision_species_gifts  # noqa: PLC0415
 
     _cg_resonance = None

--- a/src/world/character_creation/tests/test_add_to_roster_view.py
+++ b/src/world/character_creation/tests/test_add_to_roster_view.py
@@ -1,0 +1,40 @@
+"""Endpoint test for POST /api/character-creation/drafts/<pk>/add-to-roster/ (#2971).
+
+``CharacterDraftViewSet.add_to_roster`` catches ``CharacterCreationError`` and maps it
+to a 400; as of the #2971 final-review fix it also catches ``GiftResonanceUnresolvable``
+(``world.magic.exceptions``) the same way — a gift grant during finalize that can't
+resolve any resonance for its latent GIFT thread must not surface as an unhandled 500.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory
+from world.character_creation.factories import CharacterDraftFactory
+from world.magic.exceptions import GiftResonanceUnresolvable
+
+
+class AddToRosterViewGiftResonanceUnresolvableTests(APITestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.staff = AccountFactory(is_staff=True)
+
+    def _url(self, draft) -> str:
+        return f"/api/character-creation/drafts/{draft.pk}/add-to-roster/"
+
+    def test_unresolvable_gift_resonance_maps_to_400_not_500(self) -> None:
+        draft = CharacterDraftFactory(account=self.staff)
+        self.client.force_authenticate(user=self.staff)
+
+        with patch(
+            "world.character_creation.views.finalize_character",
+            side_effect=GiftResonanceUnresolvable,
+        ):
+            response = self.client.post(self._url(draft), {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.assertEqual(response.data["detail"], "Character creation failed.")

--- a/src/world/character_creation/tests/test_magic_stage.py
+++ b/src/world/character_creation/tests/test_magic_stage.py
@@ -142,6 +142,22 @@ class MagicStageValidationTest(TestCase):
         errors = compute_magic_errors(draft)
         assert errors == ["Select a gift resonance"]
 
+    def test_stale_gift_resonance_pk_fails(self):
+        """A pick pointing at a since-deleted Resonance must not pass (#2971) — it
+        cannot resolve at finalize, so it fails validation the same as no pick.
+
+        Uses a throwaway Resonance (not the shared ``cls.resonance``) — deleting a
+        model instance nulls its in-memory ``pk``, which would poison every later
+        test in this class if the shared fixture were deleted instead.
+        """
+        doomed_resonance = ResonanceFactory()
+        doomed_id = doomed_resonance.id
+        draft = self._draft(selected_gift_resonance_id=doomed_id)
+        doomed_resonance.delete()
+
+        errors = compute_magic_errors(draft)
+        assert errors == ["Select a gift resonance"]
+
     def test_no_anima_check_stat_fails(self):
         draft = self._draft(anima_check_stat_id=None)
         errors = compute_magic_errors(draft)

--- a/src/world/character_creation/tests/test_services.py
+++ b/src/world/character_creation/tests/test_services.py
@@ -1286,6 +1286,32 @@ class FinalizeGiftAndTechniquesTests(TestCase):
         assert config.stat == self.stat_trait
         assert config.skill == self.skill
 
+    def test_ritual_check_config_resonance_matches_cg_pick(self) -> None:
+        """The provisioned anima Ritual's check_config.resonance matches the CG-picked
+        gift resonance (#2971) — the anima ritual IS the character's magical identity."""
+        from world.character_creation.services import finalize_magic_data
+        from world.character_sheets.factories import CharacterSheetFactory
+        from world.magic.models.ritual_check_config import RitualCheckConfig
+        from world.magic.services.gain import anima_ritual_resonance
+        from world.roster.factories import RosterEntryFactory
+
+        sheet = CharacterSheetFactory()
+        RosterEntryFactory(character_sheet=sheet)
+        draft = self._create_draft(resonance=self.other_resonance)
+
+        finalize_magic_data(draft, sheet)
+
+        config = RitualCheckConfig.objects.get(ritual__author_account=draft.account)
+        assert config.resonance == self.other_resonance
+
+        # Task 1's public seam also resolves it now — mirrors the runtime path
+        # where get_character_anima_ritual queries author_account=character.db_account
+        # (db_account is set when the player puppets the finalized character, not
+        # at CG finalize time itself; test_character_cast_check.py does the same).
+        sheet.character.db_account = draft.account
+        sheet.character.save(update_fields=["db_account"])
+        assert anima_ritual_resonance(sheet) == self.other_resonance
+
     def test_ritual_name_honors_anima_ritual_name(self) -> None:
         """draft_data['anima_ritual_name'], when set, names the provisioned Ritual."""
         from world.character_creation.services import finalize_magic_data

--- a/src/world/character_creation/validators.py
+++ b/src/world/character_creation/validators.py
@@ -334,6 +334,7 @@ def compute_magic_errors(draft: CharacterDraft) -> list[str]:  # noqa: PLR0911
     5. Must have a valid anima_check_stat_id (a Trait with trait_type=STAT) and a
        valid anima_check_skill_id (an active Skill) — the character's Anima Check.
     """
+    from world.magic.models import Resonance  # noqa: PLC0415
     from world.magic.services.cg_catalog import (  # noqa: PLC0415
         get_gift_options,
         get_technique_options,
@@ -368,9 +369,12 @@ def compute_magic_errors(draft: CharacterDraft) -> list[str]:  # noqa: PLR0911
     if len(technique_ids) > picks:
         return [f"You may select at most {picks} techniques"]
 
-    # Resonance is required — anchors the latent GIFT thread (#1620)
+    # Resonance is required — anchors the latent GIFT thread (#1620). The pick
+    # must also still RESOLVE: a stale id (pointing at a since-deleted Resonance)
+    # is worthless to the grant-time resolver at finalize (#2971), so it fails
+    # validation here rather than raising GiftResonanceUnresolvable at submit.
     resonance_id = draft.draft_data.get("selected_gift_resonance_id")
-    if not resonance_id:
+    if not resonance_id or not Resonance.objects.filter(pk=resonance_id).exists():
         return ["Select a gift resonance"]
 
     stat_id = draft.draft_data.get("anima_check_stat_id")

--- a/src/world/character_creation/views.py
+++ b/src/world/character_creation/views.py
@@ -91,6 +91,7 @@ from world.classes.models import Path, PathAspect, PathStage
 from world.codex.models import BeginningsCodexGrant, PathCodexGrant
 from world.forms.models import FormTrait, FormTraitOption, SpeciesFormTrait
 from world.forms.services import get_cg_form_options
+from world.magic.exceptions import GiftResonanceUnresolvable
 from world.magic.models import (
     Gift,
     GlimpseTag,
@@ -706,7 +707,7 @@ class CharacterDraftViewSet(viewsets.ModelViewSet):
                     "message": "Character added to roster.",
                 }
             )
-        except CharacterCreationError:
+        except (CharacterCreationError, GiftResonanceUnresolvable):
             logger.exception("Character creation failed while adding to roster.")
             return Response(
                 {"detail": "Character creation failed."},

--- a/src/world/magic/CLAUDE.md
+++ b/src/world/magic/CLAUDE.md
@@ -206,8 +206,13 @@ technique-design step or a magical-research unlock — never on-demand) is a def
 - `AnimaRitualPerformance` - Historical record of ritual performances
 
 **Note:** During character creation, the magic stage uses the starter Gift/Technique
-catalog pick (see below). Anima rituals are set up post-CG. The player-authored `Ritual` row (SCENE_ACTION)
-carries check configuration via its `RitualCheckConfig` sidecar (stat, skill, resonance, check_type).
+catalog pick (see below). CG finalization also provisions the anima ritual itself —
+`_finalize_anima_ritual` (`world.character_creation.services`) calls
+`provision_player_anima_ritual` at finalize, not post-CG. The player-authored `Ritual` row
+(SCENE_ACTION) carries check configuration via its `RitualCheckConfig` sidecar (stat, skill,
+resonance, check_type); as of #2971, that `resonance` is also populated at CG time — resolved
+from the same `selected_gift_resonance_id` pick the gift-thread grant resolves (see "GIFT
+thread substrate" below) — since the anima ritual IS the character's magical identity.
 
 **Anima/severity budget per outcome tier (#1207):** `anima._budget_for_outcome` reads
 `AnimaRitualBudgetAward` (`world/magic/models/soulfray.py`) — a per-`CheckOutcome`-tier
@@ -844,10 +849,24 @@ also standalone-callable. (`world/covenants/discovery.py` re-exports it as
 **GIFT thread substrate:**
 - `TargetKind.GIFT` + `Thread.target_gift` FK (PROTECT) — a thread anchored to a Gift. One
   active GIFT thread per `(owner, gift)` for now (multi-resonance chooser deferred).
-- `provision_latent_gift_thread(sheet, gift, *, resonance)` — idempotent level-0 GIFT
-  thread at CG finalization (`finalize_magic_data`), write-once on resonance. The
-  resonance is chosen at the provisioning call (a frontend CG picker is deferred;
-  the E2E test passes `resonance=` directly).
+- `grant_gift_to_character(sheet, gift, *, resonance=None)`
+  (`world/magic/specialization/services.py`) — the shared gift-acquisition primitive
+  (path-crossing grant, species-gift provisioning, CG's gift-stage finalize, and
+  `charge_and_learn`'s implicit gift acquisition all call this, not
+  `provision_latent_gift_thread` directly). Mints (idempotently) the `CharacterGift` link
+  and **always** provisions the gift's latent level-0 GIFT thread — resonance is resolved by
+  `_resolve_grant_resonance` **before** the `CharacterGift` row is minted, so a raise leaves
+  no partial state. In order: the caller's explicit `resonance=` pick (when the gift's
+  supported set is empty or contains it); an existing active GIFT thread already covering
+  this gift, lineage-aware via `gift_threads_for` (makes a re-grant a true no-op); a
+  non-empty supported set's claimed-or-first member; the character's own earliest GIFT
+  thread's resonance (their "main" one); their highest-`lifetime_earned` claimed resonance;
+  the anima-ritual resonance. Raises `GiftResonanceUnresolvable` if nothing resolves — an
+  empty `Gift.resonances` (the "unrestricted" weave-gate meaning, ADR-0052/#2967) no longer
+  means "skip provisioning the thread" (#2971); see ADR-0203.
+- `provision_latent_gift_thread(sheet, gift, *, resonance)` — the idempotent level-0 GIFT
+  thread writer `grant_gift_to_character` calls once resonance is resolved; write-once on
+  resonance. Not called directly by any grant call site anymore.
 - `weave_thread(target_kind=GIFT)` — commits/chooses a resonance onto the existing latent
   thread rather than creating a new one (validates the resonance is in the gift's
   supported set, else `UnsupportedGiftResonanceError`, caught by `WeaveThreadAction`).
@@ -862,15 +881,20 @@ also standalone-callable. (`world/covenants/discovery.py` re-exports it as
 **GIFT anchor cap (#1580):** `compute_anchor_cap` now handles `TargetKind.GIFT`:
 `_current_path_stage(thread.owner) × ANCHOR_CAP_GIFT_PER_STAGE` (=10). GIFT threads are
 always in-action (`_ALWAYS_IN_ACTION_KINDS`; a species gift is intrinsic). The frontend CG
-resonance picker remains a needs-design follow-up. Proven end-to-end by
+resonance picker is built (`GiftStage`, #1620/#2426 Task 10 — writes
+`selected_gift_resonance_id`). Proven end-to-end by
 `world/magic/tests/integration/test_gift_specialization_e2e.py` (#1578) and
 `world/magic/tests/integration/test_species_gift_e2e.py` (#1580).
 - **Species gift provisioning** — `SpeciesGiftGrant` (`world/species/models.py`; natural key
   `(species, gift)`) is the through-model linking a species to MINOR Gifts with an optional
   `drawback_condition` FK. `provision_species_gifts(sheet, *, resonance=None)`
   (`world/species/services.py`) is called from `finalize_magic_data` after the Major-gift
-  block; mints the MINOR `CharacterGift`, calls `provision_latent_gift_thread`, applies any
-  drawback idempotently. See ADR-0071.
+  block; mints the MINOR `CharacterGift` via `grant_gift_to_character`, applies any
+  drawback idempotently. `resonance=None` (the common case — this call has no CG-picker
+  field of its own) lets the shared resolver anchor the Minor Gift's thread to the
+  character's Major-gift thread resonance, since that thread already exists by the time
+  species gifts provision (`finalize_magic_data`'s ordering runs the Major-gift block
+  first). See ADR-0071, ADR-0203.
 - **Gift-specific pull-effect lookup** — `get_pull_effects_for_thread(thread, **filters)`
   (`world/magic/services/pull_effects.py`): for `TargetKind.GIFT` threads, tries rows where
   `target_gift == thread.target_gift` first, falls back to `target_gift IS NULL`; all other

--- a/src/world/magic/exceptions.py
+++ b/src/world/magic/exceptions.py
@@ -435,6 +435,16 @@ class UnsupportedGiftResonanceError(MagicError):
     user_message = "That resonance is not supported by this gift."
 
 
+class GiftResonanceUnresolvable(MagicError):
+    """Raised when granting a gift (#2971) cannot resolve ANY resonance for its
+    latent GIFT thread — no explicit pick, no supported-set member, no existing
+    GIFT thread, no claimed resonance, and no anima-ritual resonance. A granted
+    gift must always get a thread; this is the fail-loud case where nothing was
+    available to weave it at."""
+
+    user_message = "You have no resonance to grant this gift a thread with yet."
+
+
 class TechniqueAuthoringNotPermitted(MagicError):
     user_message = "You are not permitted to author a technique at that tier."
 

--- a/src/world/magic/offer_handlers.py
+++ b/src/world/magic/offer_handlers.py
@@ -187,6 +187,7 @@ class CrossingOfferHandler:
             AudereMajoraOfferNotFoundError,
             AudereMajoraOfferStaleError,
             AudereMajoraPathError,
+            GiftResonanceUnresolvable,
             ProtagonismLockedError,
         )
         from world.magic.types import AlterationGateError  # noqa: PLC0415
@@ -228,6 +229,7 @@ class CrossingOfferHandler:
             AudereMajoraPathError,
             ProtagonismLockedError,
             AlterationGateError,
+            GiftResonanceUnresolvable,
         ) as exc:
             raise CommandError(str(exc)) from exc
 

--- a/src/world/magic/offer_handlers.py
+++ b/src/world/magic/offer_handlers.py
@@ -231,7 +231,15 @@ class CrossingOfferHandler:
             AlterationGateError,
             GiftResonanceUnresolvable,
         ) as exc:
-            raise CommandError(str(exc)) from exc
+            # str(exc) is empty for every one of these — they're all raised bare
+            # (no message args) at their raise sites — so the bare-str idiom
+            # silently discarded each exception's own curated ``user_message``
+            # and surfaced "" to the telnet player (#2971 final-review fix).
+            # Every exception in this tuple declares ``user_message`` (directly
+            # or via its base — MagicError/AudereOfferError/CorruptionError chains,
+            # or a direct class attribute on AlterationGateError), so plain
+            # attribute access is used rather than getattr.
+            raise CommandError(exc.user_message) from exc
 
         return (
             f"You cross into {result.chosen_path_name} "

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -2697,6 +2697,7 @@ class AudereMajoraRespondSerializer(serializers.Serializer):
         from world.magic.audere_majora import resolve_audere_majora_offer  # noqa: PLC0415
         from world.magic.exceptions import (  # noqa: PLC0415
             AudereMajoraOfferError,
+            GiftResonanceUnresolvable,
             ProtagonismLockedError,
         )
         from world.magic.types import AlterationGateError  # noqa: PLC0415
@@ -2714,6 +2715,8 @@ class AudereMajoraRespondSerializer(serializers.Serializer):
         except AlterationGateError as exc:
             raise serializers.ValidationError(exc.user_message) from exc
         except AudereMajoraOfferError as exc:
+            raise serializers.ValidationError(exc.user_message) from exc
+        except GiftResonanceUnresolvable as exc:
             raise serializers.ValidationError(exc.user_message) from exc
 
 

--- a/src/world/magic/services/anima.py
+++ b/src/world/magic/services/anima.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
     from evennia.objects.models import ObjectDB
 
     from world.character_sheets.models import CharacterSheet
+    from world.magic.models.affinity import Resonance
     from world.magic.models.rituals import Ritual
     from world.roster.models import RosterEntry
     from world.scenes.models import Scene
@@ -303,6 +304,7 @@ def provision_player_anima_ritual(  # noqa: PLR0913
     ritual_name: str,
     stat: Trait | None = None,
     skill: Skill | None = None,
+    resonance: Resonance | None = None,
 ) -> Ritual | None:
     """Create a SCENE_ACTION Ritual + sidecar + CharacterRitualKnowledge for a player.
 
@@ -326,6 +328,10 @@ def provision_player_anima_ritual(  # noqa: PLR0913
         stat: Explicit Anima Check stat; falls back to Willpower when None.
         skill: Explicit Anima Check skill; falls back to the character's
             highest-valued skill (or first active skill) when None.
+        resonance: The character's CG-picked gift resonance (#2971) — the anima
+            ritual IS the character's magical identity, so it is written onto the
+            created ``RitualCheckConfig``. ``None`` when unset (legacy/test-only
+            callers), which leaves ``RitualCheckConfig.resonance`` null as before.
     """
     from world.magic.constants import RitualExecutionKind  # noqa: PLC0415
     from world.magic.models import CharacterRitualKnowledge  # noqa: PLC0415
@@ -417,6 +423,7 @@ def provision_player_anima_ritual(  # noqa: PLR0913
         stat=stat_trait,
         skill=skill,
         check_type=check_type,
+        resonance=resonance,
     )
 
     # 5. Grant knowledge so the ritual appears in the scene action menu.

--- a/src/world/magic/services/gain.py
+++ b/src/world/magic/services/gain.py
@@ -841,13 +841,14 @@ def _resolve_moment_resonance(
     4. the character's anima-ritual resonance — their "main" one.
 
     Step 4 exists because step 2 can come up empty even for a technique-driven
-    entrance. ``grant_gift_to_character`` skips thread provisioning entirely
-    when no resonance was chosen at CG, and ``gift_resonances_for`` then falls
-    back to the gift's authored supported set — which is empty for every
-    authored gift, since an empty set means "unrestricted". A character can
-    therefore hold a gift, know its techniques, and have no gift thread to read
-    a resonance from. Their anima ritual is the one place a "main" resonance is
-    always recorded, so it is the last resort before granting nothing.
+    entrance — e.g. a gift-holder whose thread was provisioned at a resonance
+    that isn't among the candidates already tried. Their anima ritual is the
+    one place a "main" resonance is always recorded, so it is the last resort
+    before granting nothing. (As of #2971, ``grant_gift_to_character`` always
+    provisions a GIFT thread, so step 2 is no longer the common failure case
+    it once was — this fallback stays as a defense for sheets whose thread
+    predates that guarantee, or whose thread's resonance the character never
+    claimed.)
     """
     from world.magic.specialization.services import gift_resonances_for  # noqa: PLC0415
 
@@ -861,7 +862,7 @@ def _resolve_moment_resonance(
         candidates.extend(gift_resonances_for(character_sheet.character, technique.gift))
     if moment_type.resonance_id:
         candidates.append(moment_type.resonance)
-    main = _anima_ritual_resonance(character_sheet)
+    main = anima_ritual_resonance(character_sheet)
     if main is not None:
         candidates.append(main)
 
@@ -873,7 +874,7 @@ def _resolve_moment_resonance(
     return None
 
 
-def _anima_ritual_resonance(character_sheet: CharacterSheet) -> Resonance | None:
+def anima_ritual_resonance(character_sheet: CharacterSheet) -> Resonance | None:
     """The character's anima-ritual resonance — their 'main' one, if authored.
 
     The anima ritual is per-character and carries a ``RitualCheckConfig`` whose

--- a/src/world/magic/services/gift_acquisition.py
+++ b/src/world/magic/services/gift_acquisition.py
@@ -244,19 +244,6 @@ def get_technique_cap_for_gift(sheet: CharacterSheet, gift: Gift) -> int:
 # ---------------------------------------------------------------------------
 
 
-def _resolve_resonance_for(gift: Gift, claimed_ids: set[int]):
-    """Resonance for a newly-granted gift's latent thread.
-
-    Prefer a claimed resonance in the gift's supported set; otherwise
-    the gift's first supported resonance; None if the gift supports none.
-    Lifted from path_magic._grant_resonance_for.
-    """
-    supported = gift.cached_resonances
-    if not supported:
-        return None
-    return next((r for r in supported if r.pk in claimed_ids), supported[0])
-
-
 def magic_learning_ap_cost_surcharge_percent(learner: CharacterSheet) -> int:
     """Live AP surcharge percent for magic-learning activities (#2442).
 
@@ -362,7 +349,6 @@ def charge_and_learn(  # noqa: PLR0913 - shared core for two front doors; params
         TechniqueCapExceeded,
     )
     from world.magic.models import (  # noqa: PLC0415
-        CharacterResonance,
         CharacterTechnique,
         TechniqueProgress,
     )
@@ -414,13 +400,7 @@ def charge_and_learn(  # noqa: PLR0913 - shared core for two front doors; params
 
     # 4. Implicit gift acquisition (first technique).
     if not has_gift:
-        claimed_ids = set(
-            CharacterResonance.objects.filter(character_sheet=sheet).values_list(
-                "resonance_id", flat=True
-            )
-        )
-        resonance = _resolve_resonance_for(gift, claimed_ids)
-        grant_gift_to_character(sheet, gift, resonance=resonance)
+        grant_gift_to_character(sheet, gift)
 
     # 5. Check technique cap (after acquisition so the thread exists for depth).
     current_count = count_techniques_for_gift(sheet, cap_gift)

--- a/src/world/magic/services/path_magic.py
+++ b/src/world/magic/services/path_magic.py
@@ -24,22 +24,6 @@ from world.magic.types.path_magic import PathMagicGrantResult
 if TYPE_CHECKING:
     from world.character_sheets.models import CharacterSheet
     from world.classes.models import Path
-    from world.magic.models.affinity import Resonance
-    from world.magic.models.gifts import Gift
-
-
-def _grant_resonance_for(gift: Gift, claimed_ids: set[int]) -> Resonance | None:
-    """Resonance for a newly-granted gift's latent thread.
-
-    Prefer a resonance the character has already claimed (``claimed_ids``) that the
-    gift supports; otherwise the gift's first supported resonance; ``None`` if the
-    gift supports none (then the thread is not provisioned, mirroring CG). The
-    player commits their true choice later via the Rite of Weaving.
-    """
-    supported = gift.cached_resonances
-    if not supported:
-        return None
-    return next((r for r in supported if r.pk in claimed_ids), supported[0])
 
 
 @transaction.atomic
@@ -51,7 +35,6 @@ def grant_path_magic(sheet: CharacterSheet, path: Path) -> PathMagicGrantResult:
     ``PathGiftGrant`` rows is a no-op).
     """
     from world.magic.models import (  # noqa: PLC0415
-        CharacterResonance,
         CharacterTechnique,
         PathGiftGrant,
     )
@@ -60,19 +43,12 @@ def grant_path_magic(sheet: CharacterSheet, path: Path) -> PathMagicGrantResult:
     )
 
     grants = PathGiftGrant.objects.filter(path=path).select_related("gift")
-    # The character's claimed resonances, fetched once (not per granted gift).
-    claimed_ids = set(
-        CharacterResonance.objects.filter(character_sheet=sheet).values_list(
-            "resonance_id", flat=True
-        )
-    )
 
     granted_gifts: list = []
     granted_techniques: list = []
     for grant in grants:
         gift = grant.gift
-        resonance = _grant_resonance_for(gift, claimed_ids)
-        _, gift_created = grant_gift_to_character(sheet, gift, resonance=resonance)
+        _, gift_created = grant_gift_to_character(sheet, gift)
         if gift_created:
             granted_gifts.append(gift)
         for technique in grant.starter_techniques.all():

--- a/src/world/magic/services/threads.py
+++ b/src/world/magic/services/threads.py
@@ -423,8 +423,10 @@ def _weave_gift_thread(
     # 2026-08-04). Resonance comes from the thread the player weaves, not from
     # the gift; the set is only an optional narrowing. Every one of the 17
     # authored gifts carries an empty set, so the old reading locked all of
-    # them out of this path while character creation -- which calls
-    # ``provision_latent_gift_thread`` directly, ungated -- happily let them in.
+    # them out of this path. Character creation goes through
+    # ``grant_gift_to_character`` (#2971), which resolves a resonance via
+    # ``_resolve_grant_resonance`` and always provisions a thread — an empty
+    # supported set is UNRESTRICTED there too, not a skip.
     supported = gift.cached_resonances
     if supported and not any(r.pk == resonance.pk for r in supported):
         from world.magic.exceptions import UnsupportedGiftResonanceError  # noqa: PLC0415

--- a/src/world/magic/specialization/services.py
+++ b/src/world/magic/specialization/services.py
@@ -198,14 +198,17 @@ def grant_gift_to_character(
     provisioned — a granted gift with an empty supported set no longer silently
     skips thread provisioning, since that left characters holding a gift and its
     techniques with no GIFT thread to read a resonance from anywhere downstream
-    (cast resolution, dramatic-moment grants, ...). Raises
-    ``GiftResonanceUnresolvable`` when nothing resolves. Returns
-    ``(character_gift, created)``.
+    (cast resolution, dramatic-moment grants, ...). Resolution runs BEFORE the
+    ``CharacterGift`` row is minted, so a ``GiftResonanceUnresolvable`` raise leaves
+    no trace — a partially-granted gift (a ``CharacterGift`` with no thread) is the
+    exact corrupted state #2971 eliminates, and minting first would just move it to
+    the failure path. Raises ``GiftResonanceUnresolvable`` when nothing resolves.
+    Returns ``(character_gift, created)``.
     """
     from world.magic.models import CharacterGift  # noqa: PLC0415
 
-    character_gift, created = CharacterGift.objects.get_or_create(character=sheet, gift=gift)
     resolved = _resolve_grant_resonance(sheet, gift, preferred=resonance)
+    character_gift, created = CharacterGift.objects.get_or_create(character=sheet, gift=gift)
     provision_latent_gift_thread(sheet, gift, resonance=resolved)
     return character_gift, created
 

--- a/src/world/magic/specialization/services.py
+++ b/src/world/magic/specialization/services.py
@@ -110,8 +110,80 @@ def provision_additional_gift_thread(
     return provision_latent_gift_thread(sheet, gift, resonance=resonance)
 
 
+def _first_gift_thread_resonance(sheet: CharacterSheet) -> Resonance | None:
+    """The character's main resonance: their earliest active GIFT thread's (the CG pick)."""
+    threads = [
+        t
+        for t in sheet.character.threads.all()
+        if t.target_kind == TargetKind.GIFT and t.retired_at is None
+    ]
+    if not threads:
+        return None
+    return min(threads, key=lambda t: t.pk).resonance
+
+
+def _resolve_grant_resonance(
+    sheet: CharacterSheet, gift: Gift, *, preferred: Resonance | None = None
+) -> Resonance:
+    """Grant-time resonance policy (#2971). Empty supported set = unrestricted (#2968).
+
+    In order, taking the first that resolves:
+
+    1. ``preferred`` (the caller's explicit pick), when the gift's supported set is
+       empty OR contains it — an explicit pick outside a non-empty set is NOT used
+       verbatim; it falls through to the set policy below instead.
+    2. An existing active GIFT thread already covering ``gift`` (lineage-aware, via
+       ``gift_threads_for``) — its resonance, regardless of the supported-set shape.
+       Without this step, an unconditional re-grant (e.g. ``grant_path_magic`` looping
+       over ``PathGiftGrant`` rows for a gift the character already owns) could
+       resolve a DIFFERENT resonance from the set/claim policy below and mint a
+       second thread on the same gift; this makes a re-grant a true no-op.
+    3. A non-empty supported set: the member the character has already claimed, else
+       the set's first member.
+    4. An empty supported set with no thread on this gift yet: the character's
+       earliest active GIFT thread's resonance, on ANY gift (their "main" one).
+    5. The character's highest-``lifetime_earned`` claimed resonance.
+    6. The character's anima-ritual resonance.
+
+    Raises ``GiftResonanceUnresolvable`` when none of the above resolves anything.
+    """
+    from world.magic.exceptions import GiftResonanceUnresolvable  # noqa: PLC0415
+    from world.magic.models import CharacterResonance  # noqa: PLC0415
+
+    supported = gift.cached_resonances
+    if preferred is not None and (not supported or any(r.pk == preferred.pk for r in supported)):
+        return preferred
+    covering = gift_threads_for(sheet.character, gift)
+    if covering:
+        return min(covering, key=lambda t: t.pk).resonance
+    if supported:
+        claimed_ids = set(
+            CharacterResonance.objects.filter(character_sheet=sheet).values_list(
+                "resonance_id", flat=True
+            )
+        )
+        return next((r for r in supported if r.pk in claimed_ids), supported[0])
+    thread_resonance = _first_gift_thread_resonance(sheet)
+    if thread_resonance is not None:
+        return thread_resonance
+    claimed = (
+        CharacterResonance.objects.filter(character_sheet=sheet)
+        .select_related("resonance")
+        .order_by("-lifetime_earned", "resonance_id")
+        .first()
+    )
+    if claimed is not None:
+        return claimed.resonance
+    from world.magic.services.gain import anima_ritual_resonance  # noqa: PLC0415
+
+    main = anima_ritual_resonance(sheet)
+    if main is not None:
+        return main
+    raise GiftResonanceUnresolvable
+
+
 def grant_gift_to_character(
-    sheet: CharacterSheet, gift: Gift, *, resonance: Resonance | None
+    sheet: CharacterSheet, gift: Gift, *, resonance: Resonance | None = None
 ) -> tuple[CharacterGift, bool]:
     """Mint (idempotently) the CharacterGift link + the latent GIFT thread.
 
@@ -120,16 +192,21 @@ def grant_gift_to_character(
     path-crossing grant (#1579) and species-gift provisioning (#1580) so there is
     one place that does this, not a per-source copy.
 
-    ``resonance`` is the already-resolved resonance for the latent thread — each
-    caller applies its own resonance-selection policy; ``None`` skips thread
-    provisioning (e.g. a gift that supports no resonances). Returns
+    ``resonance`` is the caller's preferred resonance for the latent thread, if any;
+    ``None`` (the default) means "resolve one for me." Either way, the resonance is
+    run through ``_resolve_grant_resonance`` (#2971) and a thread is ALWAYS
+    provisioned — a granted gift with an empty supported set no longer silently
+    skips thread provisioning, since that left characters holding a gift and its
+    techniques with no GIFT thread to read a resonance from anywhere downstream
+    (cast resolution, dramatic-moment grants, ...). Raises
+    ``GiftResonanceUnresolvable`` when nothing resolves. Returns
     ``(character_gift, created)``.
     """
     from world.magic.models import CharacterGift  # noqa: PLC0415
 
     character_gift, created = CharacterGift.objects.get_or_create(character=sheet, gift=gift)
-    if resonance is not None:
-        provision_latent_gift_thread(sheet, gift, resonance=resonance)
+    resolved = _resolve_grant_resonance(sheet, gift, preferred=resonance)
+    provision_latent_gift_thread(sheet, gift, resonance=resolved)
     return character_gift, created
 
 

--- a/src/world/magic/specialization/services.py
+++ b/src/world/magic/specialization/services.py
@@ -155,7 +155,14 @@ def _resolve_grant_resonance(
         return preferred
     covering = gift_threads_for(sheet.character, gift)
     if covering:
-        return min(covering, key=lambda t: t.pk).resonance
+        # ``gift_threads_for`` sorts direct-hold-first (a thread whose
+        # ``target_gift`` is this exact gift beats an ancestor-gift thread) —
+        # take covering[0], not the lowest-pk thread, or a lower-pk ancestor
+        # thread could win over a direct hold and mint a second thread on the
+        # same gift (idempotency in ``provision_latent_gift_thread`` is keyed
+        # on the exact (owner, gift, resonance) triple, not "any covering
+        # thread").
+        return covering[0].resonance
     if supported:
         claimed_ids = set(
             CharacterResonance.objects.filter(character_sheet=sheet).values_list(

--- a/src/world/magic/tests/integration/test_gift_specialization_e2e.py
+++ b/src/world/magic/tests/integration/test_gift_specialization_e2e.py
@@ -145,6 +145,38 @@ class GiftSpecializationE2ETest(TestCase):
                 ).exists()
             )
 
+    def test_anima_ritual_resonance_resolves_once_cg_records_it(self) -> None:
+        """anima_ritual_resonance (Task 1's public seam, world.magic.services.gain)
+        now resolves once CG's anima-ritual provisioning carries the picked
+        resonance (#2971 Task 3) — the anima ritual IS the character's magical
+        identity, the same identity the latent GIFT thread above anchors to.
+        """
+        from evennia.accounts.models import AccountDB
+
+        from world.magic.services.anima import provision_player_anima_ritual
+        from world.magic.services.gain import anima_ritual_resonance
+        from world.skills.factories import SkillFactory
+        from world.traits.factories import StatTraitFactory
+
+        self.assertIsNone(anima_ritual_resonance(self.sheet))
+
+        account = AccountDB.objects.create(username=f"identity_ritual_{id(self)}")
+        provision_player_anima_ritual(
+            account=account,
+            character_sheet=self.sheet,
+            roster_entry=self.sheet.roster_entry,
+            ritual_name="Identity Ritual",
+            stat=StatTraitFactory(),
+            skill=SkillFactory(),
+            resonance=self.resonance,
+        )
+        # Mirrors the runtime path: get_character_anima_ritual queries
+        # author_account=character.db_account.
+        self.sheet.character.db_account = account
+        self.sheet.character.save(update_fields=["db_account"])
+
+        self.assertEqual(anima_ritual_resonance(self.sheet), self.resonance)
+
     def test_base_form_resolves_without_thread(self) -> None:
         # A character with the technique but no GIFT thread still resolves to parent.
         other_sheet = CharacterSheetFactory()

--- a/src/world/magic/tests/integration/test_path_crossing_grant_e2e.py
+++ b/src/world/magic/tests/integration/test_path_crossing_grant_e2e.py
@@ -14,6 +14,7 @@ from world.classes.models import PathStage
 from world.magic.audere_majora import resolve_audere_majora_offer
 from world.magic.constants import TargetKind
 from world.magic.factories import (
+    CharacterResonanceFactory,
     GiftFactory,
     ResonanceFactory,
     TechniqueFactory,
@@ -99,6 +100,36 @@ class PathCrossingGrantE2ETests(TestCase):
         # (base form at thread level 0 — usable, ready to specialize as the thread grows).
         resolved = resolve_specialized_variant(entity=self.warrior_attack, character=self.character)
         self.assertEqual(resolved.name, self.warrior_attack.name)
+
+    def test_grant_of_empty_resonance_gift_still_leaves_a_gift_thread(self) -> None:
+        """A gift with an EMPTY resonance set (the 17-of-18 normal case, #2971)
+
+        still gets a GIFT thread — previously the grant silently skipped thread
+        provisioning when the gift supported no resonances, leaving a character
+        holding a gift (and its techniques) with no thread to read a resonance
+        from anywhere downstream (cast resolution, dramatic-moment grants, ...).
+        The shared resolver's claimed-resonance fallback anchors the thread.
+        """
+        claimed_resonance = ResonanceFactory(name="Claimed_e2e")
+        CharacterResonanceFactory(character_sheet=self.sheet, resonance=claimed_resonance)
+
+        empty_gift = GiftFactory(name="Hollowform_e2e")  # no resonances added — empty set
+        quiet_path = PathFactory(name="Quiet Path_e2e", stage=PathStage.PUISSANT, is_active=True)
+        quiet_path.parent_paths.add(self.prospect_path)
+        PathGiftGrant.objects.create(path=quiet_path, gift=empty_gift)
+
+        from world.magic.services.path_magic import grant_path_magic
+
+        grant_path_magic(self.sheet, quiet_path)
+
+        self.assertTrue(
+            CharacterGift.objects.filter(character=self.sheet, gift=empty_gift).exists()
+        )
+        thread = Thread.objects.filter(
+            owner=self.sheet, target_kind=TargetKind.GIFT, target_gift=empty_gift
+        ).first()
+        self.assertIsNotNone(thread)
+        self.assertEqual(thread.resonance_id, claimed_resonance.pk)
 
     def test_grant_is_idempotent_on_recross(self) -> None:
         from world.magic.services.path_magic import grant_path_magic

--- a/src/world/magic/tests/integration/test_species_gift_e2e.py
+++ b/src/world/magic/tests/integration/test_species_gift_e2e.py
@@ -296,6 +296,44 @@ class SpeciesGiftSpineSQLiteTest(_SpeciesGiftJourneyBase):
         # Beat 6: non-regression.
         self._assert_non_regression(sheet)
 
+    def test_provision_species_gifts_bare_call_anchors_to_major_gift_thread(self) -> None:
+        """A species Minor Gift with an EMPTY resonance set (the 17-of-18 normal
+
+        case, #2971) provisioned with no explicit resonance anchors to the
+        already-existing Major-gift thread's resonance, via the shared resolver's
+        ANY-gift-thread fallback — not the CG's explicit pick (which this test
+        deliberately withholds). ``finalize_magic_data`` guarantees species
+        provisioning runs AFTER the Major-gift grant (services.py:1587 -> 1601),
+        so this is the realistic call shape.
+        """
+        from world.magic.specialization.services import provision_latent_gift_thread
+        from world.species.services import provision_species_gifts
+
+        isolated_species = SpeciesFactory(name="Isolated Species_e2e")
+        sheet = CharacterSheetFactory(species=isolated_species)
+
+        # Simulate the ordering guarantee: the character already has a GIFT thread
+        # on an unrelated Major gift, at a resonance the empty-set minor gift
+        # could not have chosen on its own.
+        other_resonance = ResonanceFactory(name="Other_e2e")
+        provision_latent_gift_thread(sheet, self.major_gift, resonance=other_resonance)
+
+        empty_gift = GiftFactory(name="Bare Nightform_e2e", kind=GiftKind.MINOR)
+        SpeciesGiftGrantFactory(species=isolated_species, gift=empty_gift, drawback_condition=None)
+
+        minted = provision_species_gifts(sheet)  # no explicit resonance
+        self.assertEqual(len(minted), 1)
+        self.assertEqual(minted[0].gift_id, empty_gift.id)
+
+        thread = Thread.objects.get(
+            owner=sheet, target_kind=TargetKind.GIFT, target_gift=empty_gift
+        )
+        self.assertEqual(
+            thread.resonance_id,
+            other_resonance.id,
+            "the minor gift's thread anchors to the major-gift thread's resonance",
+        )
+
 
 @tag("postgres")
 class SpeciesGiftFullJourneyPostgresTest(_SpeciesGiftJourneyBase):

--- a/src/world/magic/tests/test_audere_majora_api.py
+++ b/src/world/magic/tests/test_audere_majora_api.py
@@ -15,6 +15,8 @@ Covers:
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from rest_framework.test import APITestCase
 
 from world.classes.factories import PathFactory
@@ -22,7 +24,7 @@ from world.classes.models import PathStage
 from world.conditions.factories import ConditionStageFactory, ConditionTemplateFactory
 from world.magic.audere import SOULFRAY_CONDITION_NAME
 from world.magic.audere_majora import PendingAudereMajoraOffer
-from world.magic.exceptions import AudereMajoraOfferNotFoundError
+from world.magic.exceptions import AudereMajoraOfferNotFoundError, GiftResonanceUnresolvable
 from world.magic.factories import IntensityTierFactory, wire_audere_power_multipliers
 from world.magic.tests.majora_fixtures import build_crossing_world
 from world.progression.models import PathIntent
@@ -389,6 +391,34 @@ class AudereMajoraRespondViewTests(APITestCase):
         self.assertEqual(response.status_code, 400, response.content)
         # Offer row survives the ownership rejection
         self.assertTrue(PendingAudereMajoraOffer.objects.filter(pk=offer.pk).exists())
+
+    def test_respond_accept_unresolvable_gift_resonance_400(self) -> None:
+        """A ``GiftResonanceUnresolvable`` from ``resolve_audere_majora_offer`` (e.g. the
+        crossed-into path's gift grant can't resolve a resonance, #2971 final-review fix)
+        maps to 400 with its user_message — not an unhandled 500.
+        """
+        _character, _sheet, _threshold, _prospect, puissant_path, offer = self._build_my_offer(
+            20, "_unresolvable"
+        )
+
+        self.client.force_authenticate(user=self.my_account)
+        with patch(
+            "world.magic.audere_majora.resolve_audere_majora_offer",
+            side_effect=GiftResonanceUnresolvable,
+        ):
+            response = self.client.post(
+                _RESPOND_URL,
+                {
+                    "offer_id": offer.pk,
+                    "accept": True,
+                    "path_id": puissant_path.pk,
+                    "declaration_text": "I step beyond the threshold and claim my becoming.",
+                },
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, 400, response.content)
+        self.assertIn(GiftResonanceUnresolvable.user_message, str(response.data))
 
     def test_respond_unknown_offer_id_400(self) -> None:
         """An unknown offer_id returns 400 with 'No pending Crossing offer found.'."""

--- a/src/world/magic/tests/test_dramatic_moment.py
+++ b/src/world/magic/tests/test_dramatic_moment.py
@@ -156,12 +156,10 @@ class CreateDramaticMomentTagServiceTest(TestCase):
     def test_falls_back_to_the_anima_ritual_resonance(self):
         """With nothing else to go on, the moment grants their 'main' resonance.
 
-        A character can hold a gift, know its techniques, and still have NO gift
-        thread: ``grant_gift_to_character`` skips thread provisioning when no
-        resonance was chosen at CG, and ``gift_resonances_for`` then falls back
-        to the gift's supported set, which is empty for every authored gift
-        (empty means unrestricted). Without this fallback such a character earns
-        renown but never any resonance.
+        Exercises the fallback directly (no gift/technique candidate at all) —
+        the anima ritual resonance is always available as a last resort before
+        granting nothing, independent of whatever a gift's GIFT thread resolves
+        to (``grant_gift_to_character`` always provisions one as of #2971).
         """
         from world.magic.factories import RitualCheckConfigFactory
 

--- a/src/world/magic/tests/test_gift_acquisition_service.py
+++ b/src/world/magic/tests/test_gift_acquisition_service.py
@@ -263,6 +263,46 @@ class AcceptTechniqueOfferTest(TestCase):
         self.assertTrue(CharacterGift.objects.filter(character=self.sheet, gift=self.gift).exists())
 
     @patch("world.magic.services.gift_acquisition.enforce_advancement_gate")
+    def test_first_technique_from_empty_resonance_gift_leaves_a_gift_thread(self, mock_gate):
+        """Implicit gift acquisition (#2971) for a gift with an EMPTY resonance set
+
+        (the 17-of-18 normal case) still provisions a GIFT thread — previously this
+        silently minted a CharacterGift with no thread when the gift supported no
+        resonances, leaving nothing downstream (cast resolution, dramatic-moment
+        grants, ...) to read a resonance from.
+        """
+        mock_gate.return_value = None
+        from world.magic.constants import TargetKind
+        from world.magic.factories import CharacterResonanceFactory, TechniqueFactory
+        from world.magic.models import GiftUnlock, Thread
+
+        empty_gift = GiftFactory(kind=GiftKind.MINOR)  # no resonances added — empty set
+        technique = TechniqueFactory(gift=empty_gift)
+        empty_unlock = GiftUnlock.objects.create(gift=empty_gift, xp_cost=10)
+        # A resonance already claimed elsewhere — the resolver's claimed-resonance
+        # fallback anchors the new gift's thread to it.
+        CharacterResonanceFactory(character_sheet=self.sheet, resonance=self.resonance)
+
+        spend_xp_on_gift_unlock(self.sheet, empty_unlock)
+        offer = TechniqueTeachingOffer.objects.create(
+            teacher=self.teacher_tenure,
+            technique=technique,
+            pitch="empty resonance gift",
+            learn_ap_cost=5,
+            banked_ap=1,
+        )
+
+        from world.magic.services.gift_acquisition import accept_technique_offer
+
+        accept_technique_offer(self.sheet, offer)
+
+        thread = Thread.objects.filter(
+            owner=self.sheet, target_kind=TargetKind.GIFT, target_gift=empty_gift
+        ).first()
+        self.assertIsNotNone(thread)
+        self.assertEqual(thread.resonance_id, self.resonance.id)
+
+    @patch("world.magic.services.gift_acquisition.enforce_advancement_gate")
     def test_first_technique_without_unlock_raises(self, mock_gate):
         mock_gate.return_value = None
         offer = TechniqueTeachingOffer.objects.create(

--- a/src/world/magic/tests/test_grant_gift_to_character.py
+++ b/src/world/magic/tests/test_grant_gift_to_character.py
@@ -8,7 +8,8 @@ from django.test import TestCase
 
 from world.character_sheets.factories import CharacterSheetFactory
 from world.magic.constants import TargetKind
-from world.magic.factories import GiftFactory, ResonanceFactory
+from world.magic.exceptions import GiftResonanceUnresolvable
+from world.magic.factories import CharacterResonanceFactory, GiftFactory, ResonanceFactory
 from world.magic.models import CharacterGift, Thread
 from world.magic.specialization.services import grant_gift_to_character
 
@@ -38,8 +39,23 @@ class GrantGiftToCharacterTests(TestCase):
         self.assertFalse(created)
         self.assertEqual(CharacterGift.objects.filter(character=sheet, gift=self.gift).count(), 1)
 
-    def test_no_resonance_skips_thread(self):
+    def test_no_resonance_still_provisions_a_thread_when_one_resolves(self):
+        """#2971: ``resonance=None`` no longer skips thread provisioning — it
+        resolves a default instead. A fresh sheet with no claims, threads, or
+        anima ritual has nothing to resolve from, so grant a claimed resonance
+        first so the resolver has something to fall back to."""
         sheet = CharacterSheetFactory()
+        CharacterResonanceFactory(character_sheet=sheet, resonance=self.res, lifetime_earned=1)
+
         _, created = grant_gift_to_character(sheet, self.gift, resonance=None)
+
         self.assertTrue(created)
-        self.assertFalse(self._has_thread(sheet))
+        self.assertTrue(self._has_thread(sheet))
+
+    def test_no_resonance_and_nothing_to_resolve_raises(self):
+        """#2971: with nothing to resolve a resonance from, the grant raises
+        ``GiftResonanceUnresolvable`` rather than silently skipping the thread."""
+        sheet = CharacterSheetFactory()
+
+        with self.assertRaises(GiftResonanceUnresolvable):
+            grant_gift_to_character(sheet, self.gift, resonance=None)

--- a/src/world/magic/tests/test_grant_resonance_resolver.py
+++ b/src/world/magic/tests/test_grant_resonance_resolver.py
@@ -22,7 +22,7 @@ from world.magic.factories import (
     ResonanceFactory,
     RitualCheckConfigFactory,
 )
-from world.magic.models import Thread
+from world.magic.models import CharacterGift, Thread
 from world.magic.specialization.services import (
     _resolve_grant_resonance,
     grant_gift_to_character,
@@ -151,6 +151,12 @@ class GrantGiftToCharacterAlwaysProvisionsTests(TestCase):
         self.assertEqual(gift_threads[0].resonance, ritual_resonance)
 
     def test_unresolvable_grant_raises_and_mints_no_thread(self):
+        """Resolution runs BEFORE the ``CharacterGift`` row is minted (#2971
+        review fix), so an unresolvable grant leaves no trace at all — no
+        thread AND no CharacterGift. A CharacterGift with no thread is the
+        exact corrupted state #2971 exists to eliminate; committing the
+        CharacterGift first would just move that state to the failure path.
+        """
         sheet = CharacterSheetFactory()
         gift = GiftFactory()
 
@@ -162,6 +168,7 @@ class GrantGiftToCharacterAlwaysProvisionsTests(TestCase):
                 owner=sheet, target_kind=TargetKind.GIFT, target_gift=gift
             ).exists()
         )
+        self.assertFalse(CharacterGift.objects.filter(character=sheet, gift=gift).exists())
 
     def test_regrant_of_owned_gift_is_a_true_noop_using_gifts_own_thread(self):
         """An unconditional re-grant of an already-owned gift must not mint a

--- a/src/world/magic/tests/test_grant_resonance_resolver.py
+++ b/src/world/magic/tests/test_grant_resonance_resolver.py
@@ -1,0 +1,189 @@
+"""Tests for the grant-time resonance resolver (#2971).
+
+An authored gift can carry an empty ``resonances`` supported set (meaning
+"unrestricted" per #2968) — but a granted gift must ALWAYS get a GIFT thread,
+or downstream reads (cast resolution, dramatic-moment grants, ...) have
+nowhere to read a resonance from. ``_resolve_grant_resonance`` is the shared
+policy that fills in a resonance when none is explicitly chosen (or when the
+explicit choice doesn't fit a non-empty supported set); ``grant_gift_to_character``
+runs every grant through it and always provisions the thread, raising
+``GiftResonanceUnresolvable`` only when nothing resolves at all.
+"""
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.constants import TargetKind
+from world.magic.exceptions import GiftResonanceUnresolvable
+from world.magic.factories import (
+    AffinityFactory,
+    CharacterResonanceFactory,
+    GiftFactory,
+    ResonanceFactory,
+    RitualCheckConfigFactory,
+)
+from world.magic.models import Thread
+from world.magic.specialization.services import (
+    _resolve_grant_resonance,
+    grant_gift_to_character,
+    provision_latent_gift_thread,
+)
+
+
+class ResolveGrantResonanceTests(TestCase):
+    """Direct tests of ``_resolve_grant_resonance``'s fallback ladder."""
+
+    def test_empty_set_with_existing_gift_thread_uses_its_resonance(self):
+        sheet = CharacterSheetFactory()
+        gift = GiftFactory()
+        resonance = ResonanceFactory()
+        provision_latent_gift_thread(sheet, gift, resonance=resonance)
+
+        resolved = _resolve_grant_resonance(sheet, gift)
+
+        self.assertEqual(resolved, resonance)
+
+    def test_empty_set_no_threads_uses_highest_lifetime_earned_claim(self):
+        sheet = CharacterSheetFactory()
+        gift = GiftFactory()
+        low = ResonanceFactory()
+        high = ResonanceFactory()
+        CharacterResonanceFactory(character_sheet=sheet, resonance=low, lifetime_earned=5)
+        CharacterResonanceFactory(character_sheet=sheet, resonance=high, lifetime_earned=50)
+
+        resolved = _resolve_grant_resonance(sheet, gift)
+
+        self.assertEqual(resolved, high)
+
+    def test_empty_set_no_threads_no_claims_uses_anima_ritual_resonance(self):
+        sheet = CharacterSheetFactory()
+        gift = GiftFactory()
+        ritual_resonance = ResonanceFactory()
+        RitualCheckConfigFactory(
+            ritual__author_account=sheet.character.db_account,
+            resonance=ritual_resonance,
+        )
+
+        resolved = _resolve_grant_resonance(sheet, gift)
+
+        self.assertEqual(resolved, ritual_resonance)
+
+    def test_empty_set_with_nothing_at_all_raises(self):
+        sheet = CharacterSheetFactory()
+        gift = GiftFactory()
+
+        with self.assertRaises(GiftResonanceUnresolvable):
+            _resolve_grant_resonance(sheet, gift)
+
+    def test_non_empty_set_with_claimed_member_uses_claimed(self):
+        sheet = CharacterSheetFactory()
+        affinity = AffinityFactory()
+        first = ResonanceFactory(affinity=affinity, name="AAA_grr5")
+        claimed = ResonanceFactory(affinity=affinity, name="BBB_grr5")
+        gift = GiftFactory()
+        gift.resonances.add(first, claimed)
+        CharacterResonanceFactory(character_sheet=sheet, resonance=claimed, lifetime_earned=1)
+
+        resolved = _resolve_grant_resonance(sheet, gift)
+
+        self.assertEqual(resolved, claimed)
+
+    def test_non_empty_set_with_no_claim_uses_first_in_set(self):
+        sheet = CharacterSheetFactory()
+        affinity = AffinityFactory()
+        first = ResonanceFactory(affinity=affinity, name="AAA_grr6")
+        second = ResonanceFactory(affinity=affinity, name="BBB_grr6")
+        gift = GiftFactory()
+        gift.resonances.add(second, first)
+
+        resolved = _resolve_grant_resonance(sheet, gift)
+
+        self.assertEqual(resolved, first)
+
+    def test_preferred_excluded_by_non_empty_set_falls_through_to_set_policy(self):
+        sheet = CharacterSheetFactory()
+        affinity = AffinityFactory()
+        in_set = ResonanceFactory(affinity=affinity, name="AAA_grr7")
+        also_in_set = ResonanceFactory(affinity=affinity, name="BBB_grr7")
+        outside_set = ResonanceFactory()
+        gift = GiftFactory()
+        gift.resonances.add(in_set, also_in_set)
+        CharacterResonanceFactory(character_sheet=sheet, resonance=also_in_set, lifetime_earned=1)
+
+        resolved = _resolve_grant_resonance(sheet, gift, preferred=outside_set)
+
+        self.assertEqual(resolved, also_in_set)
+        self.assertNotEqual(resolved, outside_set)
+
+    def test_preferred_in_set_wins(self):
+        sheet = CharacterSheetFactory()
+        affinity = AffinityFactory()
+        first = ResonanceFactory(affinity=affinity, name="AAA_grr7b")
+        preferred = ResonanceFactory(affinity=affinity, name="BBB_grr7b")
+        gift = GiftFactory()
+        gift.resonances.add(first, preferred)
+
+        resolved = _resolve_grant_resonance(sheet, gift, preferred=preferred)
+
+        self.assertEqual(resolved, preferred)
+
+
+class GrantGiftToCharacterAlwaysProvisionsTests(TestCase):
+    """``grant_gift_to_character`` always provisions a thread (#2971)."""
+
+    def test_resonance_none_on_empty_set_gift_provisions_a_thread(self):
+        sheet = CharacterSheetFactory()
+        gift = GiftFactory()
+        ritual_resonance = ResonanceFactory()
+        RitualCheckConfigFactory(
+            ritual__author_account=sheet.character.db_account,
+            resonance=ritual_resonance,
+        )
+
+        grant_gift_to_character(sheet, gift)
+
+        gift_threads = [
+            t
+            for t in sheet.character.threads.all()
+            if t.target_kind == TargetKind.GIFT and t.target_gift_id == gift.pk
+        ]
+        self.assertEqual(len(gift_threads), 1)
+        self.assertEqual(gift_threads[0].resonance, ritual_resonance)
+
+    def test_unresolvable_grant_raises_and_mints_no_thread(self):
+        sheet = CharacterSheetFactory()
+        gift = GiftFactory()
+
+        with self.assertRaises(GiftResonanceUnresolvable):
+            grant_gift_to_character(sheet, gift)
+
+        self.assertFalse(
+            Thread.objects.filter(
+                owner=sheet, target_kind=TargetKind.GIFT, target_gift=gift
+            ).exists()
+        )
+
+    def test_regrant_of_owned_gift_is_a_true_noop_using_gifts_own_thread(self):
+        """An unconditional re-grant of an already-owned gift must not mint a
+        second thread at a different resonance (#2971 spec-review delta).
+
+        The earlier thread (lower pk) sits on a DIFFERENT gift; the resolver
+        must prefer the resonance of the thread already covering THIS gift,
+        not the earliest GIFT thread across the whole character.
+        """
+        sheet = CharacterSheetFactory()
+        other_gift = GiftFactory()
+        gift = GiftFactory()
+        earlier_resonance = ResonanceFactory()
+        own_resonance = ResonanceFactory()
+
+        grant_gift_to_character(sheet, other_gift, resonance=earlier_resonance)
+        grant_gift_to_character(sheet, gift, resonance=own_resonance)
+        thread_count_before = Thread.objects.filter(owner=sheet).count()
+
+        _character_gift, created = grant_gift_to_character(sheet, gift)
+
+        self.assertFalse(created)
+        self.assertEqual(Thread.objects.filter(owner=sheet).count(), thread_count_before)
+        own_thread = Thread.objects.get(owner=sheet, target_kind=TargetKind.GIFT, target_gift=gift)
+        self.assertEqual(own_thread.resonance, own_resonance)

--- a/src/world/magic/tests/test_grant_resonance_resolver.py
+++ b/src/world/magic/tests/test_grant_resonance_resolver.py
@@ -170,6 +170,41 @@ class GrantGiftToCharacterAlwaysProvisionsTests(TestCase):
         )
         self.assertFalse(CharacterGift.objects.filter(character=sheet, gift=gift).exists())
 
+    def test_regrant_prefers_direct_hold_over_lower_pk_ancestor_thread(self):
+        """Covering-thread step must prefer a DIRECT thread on the granted gift
+        over a lower-pk ancestor-gift thread (#2971 final-review fix).
+
+        ``gift_threads_for`` sorts direct-hold-first regardless of pk order;
+        the resolver must honor that ordering (``covering[0]``), not re-sort
+        by pk (``min(covering, key=lambda t: t.pk)``), or an older ancestor
+        thread wins and a bare re-grant of the child mints a second thread on
+        the same gift (idempotency in ``provision_latent_gift_thread`` is
+        keyed on the exact (owner, gift, resonance) triple).
+        """
+        sheet = CharacterSheetFactory()
+        parent_gift = GiftFactory()
+        child_gift = GiftFactory(parent=parent_gift)
+        ancestor_resonance = ResonanceFactory()
+        direct_resonance = ResonanceFactory()
+
+        # Ancestor-gift thread minted FIRST (lower pk).
+        grant_gift_to_character(sheet, parent_gift, resonance=ancestor_resonance)
+        # Direct thread on the child gift, minted SECOND (higher pk), at a
+        # different resonance.
+        grant_gift_to_character(sheet, child_gift, resonance=direct_resonance)
+        thread_count_before = Thread.objects.filter(owner=sheet).count()
+
+        resolved = _resolve_grant_resonance(sheet, child_gift)
+        _character_gift, created = grant_gift_to_character(sheet, child_gift)
+
+        self.assertEqual(resolved, direct_resonance)
+        self.assertFalse(created)
+        self.assertEqual(Thread.objects.filter(owner=sheet).count(), thread_count_before)
+        direct_thread = Thread.objects.get(
+            owner=sheet, target_kind=TargetKind.GIFT, target_gift=child_gift
+        )
+        self.assertEqual(direct_thread.resonance, direct_resonance)
+
     def test_regrant_of_owned_gift_is_a_true_noop_using_gifts_own_thread(self):
         """An unconditional re-grant of an already-owned gift must not mint a
         second thread at a different resonance (#2971 spec-review delta).

--- a/src/world/magic/tests/test_grant_resonance_resolver.py
+++ b/src/world/magic/tests/test_grant_resonance_resolver.py
@@ -170,38 +170,49 @@ class GrantGiftToCharacterAlwaysProvisionsTests(TestCase):
         )
         self.assertFalse(CharacterGift.objects.filter(character=sheet, gift=gift).exists())
 
-    def test_regrant_prefers_direct_hold_over_lower_pk_ancestor_thread(self):
+    def test_regrant_prefers_direct_hold_over_lower_pk_descendant_thread(self):
         """Covering-thread step must prefer a DIRECT thread on the granted gift
-        over a lower-pk ancestor-gift thread (#2971 final-review fix).
+        over a lower-pk thread on a DESCENDANT gift (#2971 final-review fix).
 
-        ``gift_threads_for`` sorts direct-hold-first regardless of pk order;
-        the resolver must honor that ordering (``covering[0]``), not re-sort
-        by pk (``min(covering, key=lambda t: t.pk)``), or an older ancestor
-        thread wins and a bare re-grant of the child mints a second thread on
-        the same gift (idempotency in ``provision_latent_gift_thread`` is
-        keyed on the exact (owner, gift, resonance) triple).
+        ``gift_threads_for(character, X)`` returns threads whose ``target_gift``
+        is ``X`` itself or a DESCENDANT of ``X`` (``X.pk`` must be in the
+        thread's own gift's ``lineage_ids``, which walks from that gift UPWARD
+        through its ancestors) — so querying for a CHILD gift never sees a
+        thread on its PARENT (the parent isn't a descendant of the child); the
+        ambiguous case is the reverse. A thread on the child gift DOES cover
+        the parent (the child's lineage includes the parent), so querying for
+        the PARENT while the character holds both a lower-pk thread on the
+        CHILD and a higher-pk DIRECT thread on the parent itself must resolve
+        the direct thread's resonance, not the child's — ``gift_threads_for``
+        sorts direct-hold-first regardless of pk order, and the resolver must
+        honor that ordering (``covering[0]``) rather than re-sorting by pk
+        (``min(covering, key=lambda t: t.pk)``), or the older child-gift thread
+        wins and a bare re-grant of the parent mints a second thread on it
+        (idempotency in ``provision_latent_gift_thread`` is keyed on the exact
+        (owner, gift, resonance) triple).
         """
         sheet = CharacterSheetFactory()
         parent_gift = GiftFactory()
         child_gift = GiftFactory(parent=parent_gift)
-        ancestor_resonance = ResonanceFactory()
+        descendant_resonance = ResonanceFactory()
         direct_resonance = ResonanceFactory()
 
-        # Ancestor-gift thread minted FIRST (lower pk).
-        grant_gift_to_character(sheet, parent_gift, resonance=ancestor_resonance)
-        # Direct thread on the child gift, minted SECOND (higher pk), at a
-        # different resonance.
-        grant_gift_to_character(sheet, child_gift, resonance=direct_resonance)
+        # Descendant (child-gift) thread minted FIRST (lower pk) — covers the
+        # parent via lineage, but is NOT a direct hold on it.
+        grant_gift_to_character(sheet, child_gift, resonance=descendant_resonance)
+        # Direct thread on the parent gift itself, minted SECOND (higher pk),
+        # at a different resonance.
+        grant_gift_to_character(sheet, parent_gift, resonance=direct_resonance)
         thread_count_before = Thread.objects.filter(owner=sheet).count()
 
-        resolved = _resolve_grant_resonance(sheet, child_gift)
-        _character_gift, created = grant_gift_to_character(sheet, child_gift)
+        resolved = _resolve_grant_resonance(sheet, parent_gift)
+        _character_gift, created = grant_gift_to_character(sheet, parent_gift)
 
         self.assertEqual(resolved, direct_resonance)
         self.assertFalse(created)
         self.assertEqual(Thread.objects.filter(owner=sheet).count(), thread_count_before)
         direct_thread = Thread.objects.get(
-            owner=sheet, target_kind=TargetKind.GIFT, target_gift=child_gift
+            owner=sheet, target_kind=TargetKind.GIFT, target_gift=parent_gift
         )
         self.assertEqual(direct_thread.resonance, direct_resonance)
 

--- a/src/world/magic/tests/test_offer_handlers.py
+++ b/src/world/magic/tests/test_offer_handlers.py
@@ -23,12 +23,15 @@ from commands.exceptions import CommandError
 from world.classes.factories import PathFactory
 from world.classes.models import PathStage
 from world.magic.entry_flourish import PendingEntryFlourishOffer
+from world.magic.exceptions import GiftResonanceUnresolvable
 from world.magic.factories import (
     CharacterResonanceFactory,
     ResonanceFactory,
     ensure_dramatic_entrance_content,
+    wire_audere_power_multipliers,
 )
 from world.magic.models.dramatic_moment import DramaticMomentSuggestion
+from world.magic.tests.majora_fixtures import build_crossing_world
 from world.magic.types.techniques import SoulfrayWarning
 from world.scenes.tests.cast_test_helpers import (
     CastScenarioMixin,
@@ -91,6 +94,34 @@ class TestResolvePathByName(TestCase):
         paths = _make_paths("Ironwood", "Ashfall")
         with self.assertRaises(CommandError):
             _resolve_path_by_name("", paths)
+
+
+class CrossingOfferHandlerAcceptTests(TestCase):
+    """``CrossingOfferHandler.accept`` error mapping (#2971 final-review fix).
+
+    A ``GiftResonanceUnresolvable`` from ``resolve_audere_majora_offer`` (e.g. the
+    crossed-into path's gift grant can't resolve a resonance) must map to the
+    handler's ``CommandError`` idiom, not propagate as an unhandled exception.
+    """
+
+    def test_accept_maps_unresolvable_gift_resonance_to_command_error(self) -> None:
+        from world.magic.offer_handlers import CrossingOfferHandler
+
+        wire_audere_power_multipliers()
+        character, _sheet, _threshold, _prospect, puissant_path, offer = build_crossing_world(
+            15, "_offer_handler_unresolvable"
+        )
+
+        with patch(
+            "world.magic.audere_majora.resolve_audere_majora_offer",
+            side_effect=GiftResonanceUnresolvable,
+        ):
+            with self.assertRaises(CommandError):
+                CrossingOfferHandler().accept(
+                    offer,
+                    character,
+                    f"path={puissant_path.name} declaration=I step beyond.",
+                )
 
 
 @override_settings(SEED_SAMPLE_CONTENT=True)

--- a/src/world/magic/tests/test_offer_handlers.py
+++ b/src/world/magic/tests/test_offer_handlers.py
@@ -101,7 +101,11 @@ class CrossingOfferHandlerAcceptTests(TestCase):
 
     A ``GiftResonanceUnresolvable`` from ``resolve_audere_majora_offer`` (e.g. the
     crossed-into path's gift grant can't resolve a resonance) must map to the
-    handler's ``CommandError`` idiom, not propagate as an unhandled exception.
+    handler's ``CommandError`` idiom, not propagate as an unhandled exception —
+    and the telnet player must see the exception's own ``user_message``, not a
+    blank string. Every exception in the handler's catch tuple is raised bare (no
+    message args) at its raise sites, so the old ``CommandError(str(exc))`` idiom
+    always produced ``""`` — the player-visible text was silently discarded.
     """
 
     def test_accept_maps_unresolvable_gift_resonance_to_command_error(self) -> None:
@@ -116,12 +120,15 @@ class CrossingOfferHandlerAcceptTests(TestCase):
             "world.magic.audere_majora.resolve_audere_majora_offer",
             side_effect=GiftResonanceUnresolvable,
         ):
-            with self.assertRaises(CommandError):
+            with self.assertRaises(CommandError) as ctx:
                 CrossingOfferHandler().accept(
                     offer,
                     character,
                     f"path={puissant_path.name} declaration=I step beyond.",
                 )
+
+        self.assertEqual(ctx.exception.msg, GiftResonanceUnresolvable.user_message)
+        self.assertTrue(ctx.exception.msg)
 
 
 @override_settings(SEED_SAMPLE_CONTENT=True)

--- a/src/world/scenes/tests/test_sunlight_exposure_e2e.py
+++ b/src/world/scenes/tests/test_sunlight_exposure_e2e.py
@@ -44,7 +44,7 @@ class SunlightExposureE2ETests(TestCase):
         from evennia import create_object
 
         from world.character_sheets.factories import CharacterSheetFactory
-        from world.magic.factories import GiftFactory
+        from world.magic.factories import GiftFactory, ResonanceFactory
         from world.species.factories import (
             SpeciesFactory,
             SpeciesGiftGrantFactory,
@@ -69,7 +69,13 @@ class SunlightExposureE2ETests(TestCase):
 
         sheet = CharacterSheetFactory(species=self.species)
         CharacterVitalsFactory(character_sheet=sheet, health=100, max_health=100)
-        provision_species_gifts(sheet)
+        # Real CG always resolves a gift resonance before this call — normally via
+        # the Major-gift thread that already exists by the time species-gift
+        # provisioning runs (see provision_species_gifts' docstring). This fixture
+        # skips CG entirely, so give it the same guarantee explicitly: a CG pick
+        # always resolves (#2971 — grant_gift_to_character now raises
+        # GiftResonanceUnresolvable instead of silently minting a threadless gift).
+        provision_species_gifts(sheet, resonance=ResonanceFactory())
         self.vampire = sheet.character
         self.vampire.db_location = self.room
         self.vampire.save(update_fields=["db_location"])

--- a/src/world/species/services.py
+++ b/src/world/species/services.py
@@ -270,7 +270,10 @@ def provision_species_gifts(sheet: CharacterSheet, *, resonance=None) -> list[Ch
     """Mint the species' Minor Gift(s) + latent GIFT thread + any drawback. Idempotent.
 
     ``resonance`` is the player's CG-chosen gift resonance (the same value the Major-gift
-    block resolves). When None, falls back to each gift's first supported resonance.
+    block resolves). When None, ``grant_gift_to_character`` resolves it via the shared
+    grant-time resolver (``_resolve_grant_resonance``) — for a Minor Gift this typically
+    anchors to the Major-gift thread's resonance, since that thread already exists by the
+    time this runs.
 
     Called from finalize_magic_data after the Major-gift block so the species
     gift thread anchors to the same resonance as the player's Major-gift thread.
@@ -285,8 +288,7 @@ def provision_species_gifts(sheet: CharacterSheet, *, resonance=None) -> list[Ch
     ).select_related("gift", "drawback_condition", "benefit_condition", "drawback_distinction")
     minted: list[CharacterGift] = []
     for grant in grants:
-        res = resonance or grant.gift.resonances.first()
-        cg, _ = grant_gift_to_character(sheet, grant.gift, resonance=res)
+        cg, _ = grant_gift_to_character(sheet, grant.gift, resonance=resonance)
         minted.append(cg)
         if grant.drawback_condition_id is not None:
             _apply_permanent_condition_once(sheet.character, grant.drawback_condition)


### PR DESCRIPTION
Closes #2971

## Summary

Every authored gift (17 of 18 carry an empty resonance set) was granted with NO latent GIFT thread — no cast-time resonance, no pulls, no variant specialization — because the four grant-time selectors still read an empty set as 'nothing to pick' after #2968 ruled it means 'unrestricted'. This PR moves resonance resolution inside grant_gift_to_character (one shared resolver: preferred pick → the gift's own covering thread, direct-hold-first → claimed-in-set/first-in-set → earliest GIFT thread → claimed → anima-ritual resonance → loud GiftResonanceUnresolvable), deletes the three divergent call-site selectors, makes the CG gift-stage validator require the resonance pick to actually resolve (closing the lore#39 stale-id hazard), and — per Tehom's ruling — records the CG pick on the anima ritual's RitualCheckConfig.resonance as the character's magical identity. GiftResonanceUnresolvable is handled at the three player-facing caller sites (Audere Majora web + telnet crossing, staff add-to-roster) instead of surfacing as a 500, and the telnet crossing handler now surfaces user_message for its whole exception tuple (previously blank for all six). Docs updated in tandem (systems/magic.md, magic + character_creation CLAUDE.md, MODEL_MAP regen) plus ADR-0203: a granted gift always gets a thread. Follow-up #3029 (needs-design) tracks the graduated cost curve for changing the anima-ritual resonance post-CG.

## Follow-ups filed

- #3029

## Notes

- Spec: reviewed & approved on #2971 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch based on main tip a0b0f7c05; sync-with-main reported up to date, no conflicts, no migrations on this branch.

<!-- last-addressed-comment: 0 -->