### PR TITLE
Player-facing training trigger for check-based technique learning

### DIFF
--- a/docs/roadmap/character-progression.md
+++ b/docs/roadmap/character-progression.md
@@ -34,6 +34,20 @@ The central spine connecting every system in the game. Characters develop throug
   and deed. Personas present in the scene are recorded as `WITNESSED` via
   `grant_deed_knowledge` + `scene_witness_personas`. No deed is created when
   `threshold.risk == NONE` or the character has no primary persona.
+- **Technique training meters, check-based sessions, and their player-facing trigger
+  (#2711/#2727/#2739):** `TechniqueProgress` per-(character × technique) development
+  meters (mounted via a teaching offer or an Academy TRAIN offer, #2711) accrue
+  through checked training sessions — `resolve_training_check` (#2727) rolls
+  intellect + Arcane Theory against a tier/level/teacher-scaled difficulty and maps
+  the outcome to a dev-point multiplier (botch/failure 0×, partial 0.5×, success
+  1.0×, critical 1.5×; AP is always spent regardless of outcome). #2739 built the
+  missing production caller: `TrainTechniqueAction` is the shared `action.run()`
+  seam telnet (`train <technique>[=<ap>]` / bare `train` for the meter list) and
+  web (`GET`/`POST /api/magic/technique-progress/`) converge on, with a frontend
+  meter panel (`TechniqueProgressPanel`, mounted in the character sheet's Spellbook
+  tab) making the loop visible — progress bar/fraction, teacher-or-self-study,
+  weekly remaining, a Train button with an optional AP input. See
+  `docs/systems/magic.md`'s "Check-Based Training Session Trigger" section.
 - **Tests:** Extensive tests for traits, skills, kudos, character XP, path history, legend
 
 ## What's Needed for MVP

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2865,8 +2865,42 @@ register as additional kinds.
   dev points). Difficulty: `target_difficulty = (technique.tier × step)
   − (learner_level // divisor) − teacher_skill_bonus
   + (self_study_penalty if teacher is None)`. Four tuning knobs on
-  `GiftAcquisitionConfig`. No production caller yet — the player-facing
-  training trigger is a deferred follow-up.
+  `GiftAcquisitionConfig`.
+- **Player-facing training trigger (#2739):** the production caller #2727 shipped
+  without. `TrainTechniqueAction` (`actions/definitions/technique_training.py`, key
+  `"train_technique"`, REGISTRY, `category="magic"`) is the `action.run()` seam
+  telnet and web converge on — resolves the learner's `TechniqueProgress` meter for
+  a `technique_id` kwarg (no meter → clean failure naming the front doors that
+  create one: accepting a teaching offer or an Academy TRAIN offer), resolves a
+  co-present teacher (`progress.teacher_tenure`'s character sharing the learner's
+  room *at session time* — Decision 3a: never a location hard-block, silent
+  self-study fallback otherwise, true for both PC-teacher and Academy meters), and
+  calls `resolve_training_check`. `ap_to_invest` defaults to 1 (no base-session-cost
+  constant exists yet) and is rejected when non-positive; the action does not
+  pre-bound it further — the seam spends it in full and raises
+  `WeeklyTrainingCapExceeded`/`MagicError` (mapped to failure `ActionResult`s) or a
+  bare `ValueError` (mapped the same way) when the meter's technique arrived by
+  another route while the meter sat open (a staff grant, a `TechniqueGrant` item).
+  **Telnet:** `CmdTrain` (`commands/training.py`, key `"train"`) — `train <technique>
+  [=<ap>]` dispatches the action by resolved `technique_id`; bare `train` lists the
+  caller's `TechniqueProgress` meters (name, progress/total, teacher-or-dash) with no
+  dispatch. **Web:** `TechniqueProgressViewSet`
+  (`world/magic/views_technique_progress.py`, routed at
+  `/api/magic/technique-progress/`) — `GET` lists the scoped character's own meters
+  (`TechniqueProgressSerializer`: technique id/name, `points_accumulated`/
+  `total_required`, teacher name-or-null via `RosterTenure.display_name`, source
+  label, a batched-query `weekly_remaining`); `POST <technique_id>/train/` dispatches
+  the action, mapping a failure `ActionResult` to HTTP 400 with its message.
+  Character scoping mirrors `MotifStyleViewSet` (#2030): `X-Character-ID` header,
+  validated as owned, takes precedence over the active puppet. `<technique_id>` is
+  the `Technique` pk (matching the action's own kwarg), not the `TechniqueProgress`
+  row's pk — a technique with no meter yet surfaces the action's own "you aren't
+  training that" failure as a clean 400 rather than a router-level 404. **Frontend:**
+  `TechniqueProgressPanel` (`frontend/src/magic/components/`), mounted in
+  `SpellbookTab` below `MotifStylePanel`, own-view only — one card per meter (progress
+  bar/fraction, teacher-or-self-study, weekly remaining, an optional AP-to-invest
+  input, a Train button); the session outcome and any 400 message render inline per
+  row. See `frontend/src/magic/CLAUDE.md` for the wire-contract detail.
 - **SETTLE_OBLIGATION — the Academy Registrar (#2428 whole-branch fix):** closes the gap
   where `societies.obligation_services.settle_obligation` (Task 1) shipped with no live
   caller — an Unbound Prospect had no in-game way to ever pay off their Academy entrance

--- a/docs/systems/magic.md
+++ b/docs/systems/magic.md
@@ -1623,6 +1623,67 @@ automatically via `world.magic.services.tradition_membership.join_tradition` and
 the `CharacterDistinction` row (`ModifierSource.character_distinction` is `on_delete=CASCADE`),
 so the surcharge disappears the moment the drawback is shed, no separate cleanup needed.
 
+### Check-Based Training Session Trigger (#2739) [BUILT & WIRED]
+
+`resolve_training_check()` (`services/technique_training.py`, #2727) wraps
+`contribute_to_technique_progress` with a learning check — the learner rolls
+intellect + "Arcane Theory" against a difficulty derived from the technique's tier,
+the learner's level, and any teacher's skill bonus (self-study takes a flat
+penalty) — but shipped with no production caller: nothing dispatched it from telnet
+or the web. #2739 is that trigger, one seam for both surfaces:
+
+- **Action** — `TrainTechniqueAction` (`actions/definitions/technique_training.py`,
+  key `train_technique`, REGISTRY, `category="magic"`, `target_type=SELF`). Kwargs:
+  `technique_id` (the `Technique` pk — resolved against the learner's own open
+  `TechniqueProgress` meter; no meter is a clean failure naming the two front doors
+  that create one — accepting a teaching offer, or an Academy TRAIN offer, both
+  covered above), `ap_to_invest` (defaults to 1 — no base-session-cost constant
+  exists yet on `GiftAcquisitionConfig` or the seam itself; a supplied value ≤ 0 is
+  rejected). Resolves a co-present teacher: `progress.teacher_tenure` counts only
+  when that tenure's live character shares the learner's room *at session time* —
+  never a location hard-block (Decision 3a), true for both PC-teacher meters and
+  Academy TRAIN meters; a teacher out of the room silently drops to self-study
+  rates for that session. `resolve_training_check`'s own `WeeklyTrainingCapExceeded`
+  / `MagicError` raises map to failure `ActionResult`s; a bare `ValueError` from
+  `learn_technique` (reached on meter completion) — raised when the learner already
+  holds the `CharacterTechnique`, e.g. a stale meter left open after the technique
+  arrived by another route (a staff grant, a `TechniqueGrant` item) — maps to a
+  failure the same way rather than escaping as a traceback. On success, `data`
+  carries `{technique_id, outcome_name, points_before, points_after,
+  total_required, technique_acquired, self_study}`.
+- **Telnet** — `CmdTrain` (`commands/training.py`, key `train`). `train <technique>
+  [=<ap>]` resolves the technique by name and dispatches the action; bare `train`
+  lists the caller's open `TechniqueProgress` meters (name, progress/total,
+  teacher-or-dash) with no dispatch — a read path, not an action.
+- **Web** — `TechniqueProgressViewSet` (`world/magic/views_technique_progress.py`,
+  routed at `/api/magic/technique-progress/`). `list` returns the scoped
+  character's own meters via `TechniqueProgressSerializer` (technique id/name,
+  `points_accumulated`/`total_required`, teacher name-or-null via
+  `RosterTenure.display_name`, `source_label` from
+  `TechniqueProgress.get_source_display()`, and a batched-query
+  `weekly_remaining` — one `GameWeek` lookup + one config lookup + one query over
+  the listed meters' technique ids, never per-row). `POST
+  <technique_id>/train/` (`TrainTechniqueRequestSerializer`, body
+  `{ap_to_invest?}`) dispatches the action, mapping a failure `ActionResult` to
+  HTTP 400 with its message. `<technique_id>` is the `Technique` pk (matching the
+  action's own kwarg), not the `TechniqueProgress` row's pk, so a technique with
+  no meter surfaces the action's own "you aren't training that" failure as a clean
+  400 rather than a router-level 404. Character scoping mirrors
+  `MotifStyleViewSet` (#2030): an `X-Character-ID` header, validated as owned, takes
+  precedence over the caller's active puppet.
+- **Frontend** — `TechniqueProgressPanel` (`frontend/src/magic/components/`),
+  mounted in `SpellbookTab` below `MotifStylePanel`, own-view only. One card per
+  meter: a progress bar/fraction, a "Taught by `<name>`"/"Self-study" badge, weekly
+  remaining (when the server supplies it), an optional AP-to-invest number input,
+  and a Train button. The session outcome (or the server's 400 message) renders
+  inline per row; the mutation invalidates the meter query so the refetched
+  figures reflect the session immediately. See `frontend/src/magic/CLAUDE.md` for
+  the query/mutation wire contract.
+
+This closes the same "built but unreachable" gap the acquisition surface above
+closed for `spend_xp_on_gift_unlock`/`accept_technique_offer` — `resolve_training_check`
+now has exactly one production caller, shared by both client surfaces.
+
 ### Entry-Flourish Declaration (entry_flourish.py, models/endorsement.py — #1140)
 
 Poll-able offer created on a successful Entrance social action; the entrant picks one
@@ -2923,6 +2984,15 @@ the legacy ThreadType lookup no longer exists.
 | `/techniques/` | GET/POST/PATCH | Character techniques |
 | `/techniques/author/` | POST | Author a technique via `AuthorTechniqueAction`; 201/400/403 |
 | `/techniques/price/` | POST | Dry-run budget breakdown (read-only) |
+
+### Technique Progress / Training Session (#2739)
+
+| Endpoint | Method | Description |
+|----------|--------|-------------|
+| `/technique-progress/` | GET | The acting character's own `TechniqueProgress` meters (`X-Character-ID` header, mirrors `MotifStyleViewSet`'s scoping) — bare array, not paginated |
+| `/technique-progress/{technique_id}/train/` | POST | Runs one training session via `TrainTechniqueAction`; body `{ap_to_invest?}`. `{technique_id}` is the `Technique` pk, not the meter's own pk — a technique with no meter fails 400 with the action's own message, never a 404 |
+
+Telnet parity: `train <technique> [=<ap>]` / bare `train` for the meter list (`CmdTrain`).
 
 ### Mage Scars (renamed from Magical Scars — §7.2 display-only)
 

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -12537,6 +12537,72 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/magic/technique-progress/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description List the acting character's technique-progress meters; train one via POST.
+     *
+     *     ``list`` returns the scoped character's own ``TechniqueProgress`` rows —
+     *     another account's meters are never visible. ``POST <technique_id>/train/``
+     *     dispatches :class:`TrainTechniqueAction` (#2739 Task 1); the ``<id>`` path
+     *     segment is the ``Technique`` pk (matching the action's own ``technique_id``
+     *     kwarg), not the ``TechniqueProgress`` row's pk, so a technique with no
+     *     meter yet cleanly surfaces the action's own "you aren't training that"
+     *     failure as a 400 rather than a router-level 404.
+     *
+     *     Character scoping mirrors ``MotifStyleViewSet`` (#2030): an
+     *     ``X-Character-ID`` header, once validated as owned via
+     *     ``CharacterContextMixin``, takes precedence over the caller's active
+     *     puppet; no header falls back to the puppet (400 if none); a header
+     *     naming an unowned character 404s rather than silently falling back.
+     */
+    get: operations['magic_technique_progress_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/magic/technique-progress/{id}/train/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description List the acting character's technique-progress meters; train one via POST.
+     *
+     *     ``list`` returns the scoped character's own ``TechniqueProgress`` rows —
+     *     another account's meters are never visible. ``POST <technique_id>/train/``
+     *     dispatches :class:`TrainTechniqueAction` (#2739 Task 1); the ``<id>`` path
+     *     segment is the ``Technique`` pk (matching the action's own ``technique_id``
+     *     kwarg), not the ``TechniqueProgress`` row's pk, so a technique with no
+     *     meter yet cleanly surfaces the action's own "you aren't training that"
+     *     failure as a 400 rather than a router-level 404.
+     *
+     *     Character scoping mirrors ``MotifStyleViewSet`` (#2030): an
+     *     ``X-Character-ID`` header, once validated as owned via
+     *     ``CharacterContextMixin``, takes precedence over the caller's active
+     *     puppet; no header falls back to the puppet (400 if none); a header
+     *     naming an unowned character 404s rather than silently falling back.
+     */
+    post: operations['magic_technique_progress_train_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/magic/techniques/': {
     parameters: {
       query?: never;
@@ -56260,6 +56326,44 @@ export interface operations {
         content: {
           'application/json': components['schemas']['AcceptTechniqueOfferResponse'];
         };
+      };
+    };
+  };
+  magic_technique_progress_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No response body */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
+      };
+    };
+  };
+  magic_technique_progress_train_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        id: string;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      /** @description No response body */
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content?: never;
       };
     };
   };

--- a/frontend/src/magic/CLAUDE.md
+++ b/frontend/src/magic/CLAUDE.md
@@ -283,7 +283,12 @@ React Query hooks with a `magicKeys` query key factory.
 - `useTrainTechnique(characterSheetId)` — takes `{techniqueId, body?}`; calls
   `api.trainTechnique(characterSheetId, techniqueId, body)`; invalidates
   `techniqueProgress(characterSheetId)` on success so the refetched
-  progress/teacher/weekly-remaining figures reflect the session immediately
+  progress/teacher/weekly-remaining figures reflect the session immediately, plus
+  `['character-sheets', characterSheetId]` (unconditional, mirroring
+  `useBindMotifStyle`/`useUnbindMotifStyle`) — a completed session mints a
+  `CharacterTechnique`, which `SpellbookTab` renders from the sheet payload, not
+  from the meter list, so without this the new technique wouldn't appear until an
+  unrelated refetch
 
 **Note:** `previewPull` is NOT a hook — it's a plain `api.previewPull(body)` async function.
 Pull previews are user-driven and ephemeral; components should debounce calls manually.
@@ -312,7 +317,11 @@ Covers: `useSoulTetherDetail`, `usePendingSineatingOffers`, `usePendingStageAdva
 `usePatchThreadNarrative`, `useRetireThread`, `useImbueThread`, `useCrossXPLock`,
 `useAcceptTeachingOffer`, `useNextPathOptions`, `useMotifStyleBindings`/
 `useBindMotifStyle`/`useUnbindMotifStyle` (character-id threading into the api call +
-query key, #2030 review fix), and `magicKeys` shape assertions.
+query key, #2030 review fix), `useTrainTechnique` (character-id threading + the
+`createWrapperWithClient`/`invalidateSpy` idiom pinning that a completed session
+invalidates BOTH `techniqueProgress(characterSheetId)` and
+`['character-sheets', characterSheetId]`, #2739 review fix), and `magicKeys` shape
+assertions.
 
 The imbue tests call `__resetImbuingRitualIdCacheForTests()` in `beforeEach`.
 
@@ -572,10 +581,11 @@ than an empty card.
 
 ### `components/TechniqueProgressPanel.test.tsx` (#2739 Task 3)
 
-7 unit tests (mocks `../queries`, no msw — mirrors `MotifStylePanel.test.tsx`'s idiom).
+8 unit tests (mocks `../queries`, no msw — mirrors `MotifStylePanel.test.tsx`'s idiom).
 Covers: meter rows render name/fraction/teacher-or-self-study/weekly-remaining;
 `useTechniqueProgress`/`useTrainTechnique` are both called with `characterSheetId`; the
-empty state; the train mutation payload with and without an AP input value; the
+empty state; the train mutation payload with and without an AP input value; a
+non-integer AP input (e.g. `2.5`) is treated as unset rather than sent fractional; the
 success-outcome line after a train call resolves; the 400 `detail` message renders under
 the row that failed.
 

--- a/frontend/src/magic/CLAUDE.md
+++ b/frontend/src/magic/CLAUDE.md
@@ -221,6 +221,7 @@ React Query hooks with a `magicKeys` query key factory.
 - `magicKeys.pathIntent(characterId)` → `['magic', 'path-intent', characterId]`
 - `magicKeys.motifStyleBindings(characterId)` → `['magic', 'motif-styles', 'bindings', characterId]`
 - `magicKeys.styleCatalog()` → `['magic', 'motif-styles', 'catalog']`
+- `magicKeys.techniqueProgress(characterId)` → `['magic', 'technique-progress', characterId]`
 
 **Alteration read hooks:**
 
@@ -248,6 +249,9 @@ React Query hooks with a `magicKeys` query key factory.
   (`X-Character-ID` header); the given character's current Style bindings; disabled
   when `characterId ≤ 0`
 - `useStyleCatalog()` — GET `/api/items/styles/`; the Style catalog for the bind form's picker
+- `useTechniqueProgress(characterId)` — GET `/api/magic/technique-progress/`
+  (`X-Character-ID` header); the given character's in-progress training meters;
+  disabled when `characterId ≤ 0`
 
 **Mutation hooks:**
 
@@ -276,9 +280,27 @@ React Query hooks with a `magicKeys` query key factory.
   (`['character-sheets', characterSheetId]`, per `character_sheets/queries.ts`'
   `useCharacterSheetQuery`) — the sheet's `magic.motif.resonances[*].styles` mirrors
   the same bindings
+- `useTrainTechnique(characterSheetId)` — takes `{techniqueId, body?}`; calls
+  `api.trainTechnique(characterSheetId, techniqueId, body)`; invalidates
+  `techniqueProgress(characterSheetId)` on success so the refetched
+  progress/teacher/weekly-remaining figures reflect the session immediately
 
 **Note:** `previewPull` is NOT a hook — it's a plain `api.previewPull(body)` async function.
 Pull previews are user-driven and ephemeral; components should debounce calls manually.
+
+**Technique progress meters (#2739):**
+
+- `getTechniqueProgress(characterId)` — GET `/api/magic/technique-progress/`
+  (`X-Character-ID` header) → `TechniqueProgressMeter[]` (bare array — the
+  view's `list` returns `Response(serializer.data)` directly, no pagination
+  class). Wire contract: `TechniqueProgressViewSet`
+  (`src/world/magic/views_technique_progress.py`).
+- `trainTechnique(characterId, techniqueId, body?)` — POST
+  `/api/magic/technique-progress/{technique_id}/train/` (`X-Character-ID`
+  header), body `TrainTechniqueRequest` (`{ap_to_invest?}`) → `TrainTechniqueResult`.
+  `techniqueId` is the `Technique` pk (matching `TrainTechniqueAction`'s own
+  kwarg), not the `TechniqueProgress` row's pk. 400s (no meter, weekly cap hit,
+  can't afford the AP, stale meter) carry a `{detail}` string via `readErrorDetail`.
 
 ### `__tests__/queries.test.tsx`
 
@@ -527,6 +549,35 @@ until both selects have a value; "claim a resonance first" empty state (and no
 selects rendered); the bind and unbind mutations' 400 `detail` messages both render;
 `useMotifStyleBindings`/`useBindMotifStyle`/`useUnbindMotifStyle` are all called with
 `characterSheetId` (cross-character scoping, #2030 review fix).
+
+### `components/TechniqueProgressPanel.tsx` (#2739 Task 3)
+
+Card rendered in `SpellbookTab.tsx`, own-view only, below `MotifStylePanel` — the
+player-facing meter panel that makes the training-check loop (Task 1's
+`TrainTechniqueAction`, Task 2's web endpoints) visible in the game UI. Lists the
+character's `useTechniqueProgress(characterSheetId)` rows, one card per meter: technique
+name, a `Progress` bar + `points_accumulated`/`total_required` fraction, a "Taught by
+`teacher_name`" or "Self-study" badge, `weekly_remaining` (when non-null), an optional
+AP-to-invest number input, and a Train button. Submitting calls
+`useTrainTechnique(characterSheetId).mutate({ techniqueId, body })` — `body` is omitted
+(server default) when the AP input is blank. On success the session outcome renders
+inline (`data-testid="technique-progress-result-{techniqueId}"` — "you've learned X!"
+when `technique_acquired`, else `"{outcome_name}: {points_after}/{total_required}."`,
+mirroring `TrainTechniqueAction`'s own message); the query invalidation refetches the row
+so the bar/fraction/weekly-remaining stay live. On a 400 the server's `detail` message
+renders under the row that triggered it
+(`data-testid="technique-progress-error-{techniqueId}"`). Empty state is a single quiet
+line (`data-testid="technique-progress-empty"`, "Nothing in training right now.") rather
+than an empty card.
+
+### `components/TechniqueProgressPanel.test.tsx` (#2739 Task 3)
+
+7 unit tests (mocks `../queries`, no msw — mirrors `MotifStylePanel.test.tsx`'s idiom).
+Covers: meter rows render name/fraction/teacher-or-self-study/weekly-remaining;
+`useTechniqueProgress`/`useTrainTechnique` are both called with `characterSheetId`; the
+empty state; the train mutation payload with and without an AP input value; the
+success-outcome line after a train call resolves; the 400 `detail` message renders under
+the row that failed.
 
 ## Data Flow
 

--- a/frontend/src/magic/__tests__/queries.test.tsx
+++ b/frontend/src/magic/__tests__/queries.test.tsx
@@ -31,6 +31,7 @@ import {
   useMotifStyleBindings,
   useBindMotifStyle,
   useUnbindMotifStyle,
+  useTrainTechnique,
   magicKeys,
 } from '../queries';
 import { __resetImbuingRitualIdCacheForTests } from '../api';
@@ -64,6 +65,7 @@ vi.mock('../api', () => ({
   getMotifStyleBindings: vi.fn(),
   bindMotifStyle: vi.fn(),
   unbindMotifStyle: vi.fn(),
+  trainTechnique: vi.fn(),
 }));
 
 import * as api from '../api';
@@ -81,6 +83,24 @@ function createWrapper() {
   return function Wrapper({ children }: { children: ReactNode }) {
     return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
   };
+}
+
+/** Like createWrapper, but also returns the QueryClient so a test can spy on invalidateQueries. */
+function createWrapperWithClient() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  });
+
+  function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+  }
+
+  return { wrapper: Wrapper, client };
 }
 
 // ---------------------------------------------------------------------------
@@ -942,5 +962,63 @@ describe('useUnbindMotifStyle', () => {
     });
 
     expect(api.unbindMotifStyle).toHaveBeenCalledWith(11, { style_id: 1 });
+  });
+});
+
+describe('useTrainTechnique', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls trainTechnique with the character id (X-Character-ID scoping) and payload', async () => {
+    vi.mocked(api.trainTechnique).mockResolvedValue({
+      technique_id: 11,
+      outcome_name: 'Solid Progress',
+      points_before: 4,
+      points_after: 6,
+      total_required: 10,
+      technique_acquired: false,
+      self_study: false,
+    });
+
+    const { result } = renderHook(() => useTrainTechnique(10), { wrapper: createWrapper() });
+    await act(async () => {
+      await result.current.mutateAsync({ techniqueId: 11, body: { ap_to_invest: 3 } });
+    });
+
+    expect(api.trainTechnique).toHaveBeenCalledWith(10, 11, { ap_to_invest: 3 });
+  });
+
+  it('invalidates both techniqueProgress(characterSheetId) and the character-sheet query on success', async () => {
+    vi.mocked(api.trainTechnique).mockResolvedValue({
+      technique_id: 11,
+      outcome_name: 'Breakthrough',
+      points_before: 8,
+      points_after: 10,
+      total_required: 10,
+      technique_acquired: true,
+      self_study: true,
+    });
+
+    const { wrapper, client } = createWrapperWithClient();
+    const invalidateSpy = vi.spyOn(client, 'invalidateQueries');
+
+    const { result } = renderHook(() => useTrainTechnique(10), { wrapper });
+    await act(async () => {
+      await result.current.mutateAsync({ techniqueId: 11 });
+    });
+
+    // A completed session mints a CharacterTechnique, rendered by SpellbookTab from
+    // the character-sheet cache, not from the meter list — both keys must be
+    // invalidated regardless of whether this particular session completed the meter
+    // (unconditional, mirroring useBindMotifStyle/useUnbindMotifStyle's precedent).
+    await waitFor(() => {
+      expect(invalidateSpy).toHaveBeenCalledWith({
+        queryKey: ['magic', 'technique-progress', 10],
+      });
+    });
+    expect(invalidateSpy).toHaveBeenCalledWith({
+      queryKey: ['character-sheets', 10],
+    });
   });
 });

--- a/frontend/src/magic/api.ts
+++ b/frontend/src/magic/api.ts
@@ -66,10 +66,13 @@ import type {
   StageAdvanceRespondRequest,
   TechniqueCostBreakdown,
   TechniqueDesignRequest,
+  TechniqueProgressMeter,
   TetherBond,
   Thread,
   ThreadApplicability,
   ThreadHubSummary,
+  TrainTechniqueRequest,
+  TrainTechniqueResult,
   UnbindMotifStyleRequest,
   WeaveThreadRequest,
 } from './types';
@@ -105,6 +108,7 @@ const PATH_OPTIONS_URL = '/api/progression/path-options/';
 const MOTIF_STYLES_URL = '/api/magic/motif-styles';
 const ITEMS_STYLES_URL = '/api/items/styles';
 const CHARACTER_AURAS_URL = '/api/magic/character-auras';
+const TECHNIQUE_PROGRESS_URL = '/api/magic/technique-progress';
 
 // ---------------------------------------------------------------------------
 // Soul Tether reads
@@ -1176,4 +1180,52 @@ export async function unlinkGlimpseDistinction(
     await readErrorDetail(res, 'Failed to unlink distinction from the glimpse');
   }
   return res.json();
+}
+
+// ---------------------------------------------------------------------------
+// Technique progress meters, #2739
+//
+// Wire contract: TechniqueProgressViewSet (src/world/magic/views_technique_progress.py),
+// character scoping mirrors MotifStyleViewSet — X-Character-ID header, validated
+// as owned, takes precedence over the caller's active puppet.
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /api/magic/technique-progress/
+ *
+ * The training meters (in-progress technique acquisitions) for the character
+ * named by the `X-Character-ID` header. Bare array — the view's `list` returns
+ * `Response(serializer.data)` directly, no pagination class.
+ */
+export async function getTechniqueProgress(characterId: number): Promise<TechniqueProgressMeter[]> {
+  const res = await apiFetch(`${TECHNIQUE_PROGRESS_URL}/`, {
+    headers: { 'X-Character-ID': String(characterId) },
+  });
+  if (!res.ok) throw new Error('Failed to load technique training meters');
+  return res.json() as Promise<TechniqueProgressMeter[]>;
+}
+
+/**
+ * POST /api/magic/technique-progress/{technique_id}/train/
+ *
+ * Runs one training session against an in-progress meter for the character
+ * named by the `X-Character-ID` header. `technique_id` is the `Technique` pk
+ * (matching `TrainTechniqueAction`'s own kwarg), not the `TechniqueProgress`
+ * row's pk. 400s (no meter, weekly cap hit, can't afford the AP, meter stale)
+ * carry a `{detail}` string — surfaced via `readErrorDetail`.
+ */
+export async function trainTechnique(
+  characterId: number,
+  techniqueId: number,
+  body?: TrainTechniqueRequest
+): Promise<TrainTechniqueResult> {
+  const res = await apiFetch(`${TECHNIQUE_PROGRESS_URL}/${techniqueId}/train/`, {
+    method: 'POST',
+    headers: { ...jsonHeaders(), 'X-Character-ID': String(characterId) },
+    body: JSON.stringify(body ?? {}),
+  });
+  if (!res.ok) {
+    await readErrorDetail(res, 'Failed to train that technique');
+  }
+  return res.json() as Promise<TrainTechniqueResult>;
 }

--- a/frontend/src/magic/components/SpellbookTab.test.tsx
+++ b/frontend/src/magic/components/SpellbookTab.test.tsx
@@ -61,10 +61,11 @@ vi.mock('@/character_sheets/queries', () => ({
   useCharacterSheetQuery: vi.fn(),
 }));
 
-// MotifStylePanel (#2030) is mounted below the Motif card for the own view —
-// mock its hooks so this suite stays focused on SpellbookTab's own rendering
-// and never issues a real fetch. GlimpseEditorDialog's mutations (#2427) are
-// mocked here too, for the same reason.
+// MotifStylePanel (#2030) and TechniqueProgressPanel (#2739) are mounted below
+// the Motif card for the own view — mock their hooks so this suite stays
+// focused on SpellbookTab's own rendering and never issues a real fetch.
+// GlimpseEditorDialog's mutations (#2427) are mocked here too, for the same
+// reason.
 vi.mock('@/magic/queries', () => ({
   useMotifStyleBindings: vi.fn(),
   useStyleCatalog: vi.fn(),
@@ -74,6 +75,8 @@ vi.mock('@/magic/queries', () => ({
   useSetGlimpseTags: vi.fn(),
   useSetGlimpseProse: vi.fn(),
   useToggleGlimpseDistinction: vi.fn(),
+  useTechniqueProgress: vi.fn(),
+  useTrainTechnique: vi.fn(),
 }));
 
 // GlimpseEditorDialog reads the catalog via the character-creation module's
@@ -111,6 +114,16 @@ function mockMotifStyleQueries() {
     isError: false,
     error: null,
   } as unknown as ReturnType<typeof magicQueries.useUnbindMotifStyle>);
+  vi.mocked(magicQueries.useTechniqueProgress).mockReturnValue({
+    data: [],
+    isLoading: false,
+  } as unknown as ReturnType<typeof magicQueries.useTechniqueProgress>);
+  vi.mocked(magicQueries.useTrainTechnique).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+    isError: false,
+    error: null,
+  } as unknown as ReturnType<typeof magicQueries.useTrainTechnique>);
 }
 
 const glimpseTagCatalog: GlimpseTagOption[] = [

--- a/frontend/src/magic/components/SpellbookTab.tsx
+++ b/frontend/src/magic/components/SpellbookTab.tsx
@@ -27,6 +27,7 @@ import type { CharacterSheetAura, CharacterSheetTechnique } from '@/character_sh
 import type { TechniqueForm } from '@/magic/types';
 import { MotifStylePanel } from './MotifStylePanel';
 import { TechniqueEffectSummaryDisplay } from './TechniqueEffectSummary';
+import { TechniqueProgressPanel } from './TechniqueProgressPanel';
 import { GlimpseEditorDialog } from './glimpse/GlimpseEditorDialog';
 
 interface Props {
@@ -237,6 +238,8 @@ export function SpellbookTab({ characterId, isMyCharacter }: Props) {
       )}
 
       {isMyCharacter && magic && <MotifStylePanel characterSheetId={characterId} />}
+
+      {isMyCharacter && magic && <TechniqueProgressPanel characterSheetId={characterId} />}
 
       {magic?.aura && (
         <Card data-testid="spellbook-aura">

--- a/frontend/src/magic/components/TechniqueProgressPanel.test.tsx
+++ b/frontend/src/magic/components/TechniqueProgressPanel.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * TechniqueProgressPanel tests (#2739 Task 3) — player-facing training-meter list.
+ *
+ * Mirrors MotifStylePanel.test.tsx's mock-the-hook-module idiom (no msw).
+ */
+
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import { renderWithProviders } from '@/test/utils/renderWithProviders';
+import { TechniqueProgressPanel } from './TechniqueProgressPanel';
+import type { useTechniqueProgress, useTrainTechnique } from '../queries';
+
+vi.mock('../queries', () => ({
+  useTechniqueProgress: vi.fn(),
+  useTrainTechnique: vi.fn(),
+}));
+
+import * as magicQueries from '../queries';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockMeters = [
+  {
+    id: 1,
+    technique_id: 11,
+    technique_name: 'Cinderline Draw',
+    points_accumulated: 4,
+    total_required: 10,
+    teacher_name: 'Ariel',
+    source_label: 'Teaching Offer',
+    weekly_remaining: 30,
+  },
+  {
+    id: 2,
+    technique_id: 22,
+    technique_name: 'Hollow Step',
+    points_accumulated: 8,
+    total_required: 8,
+    teacher_name: null,
+    source_label: 'Academy Training',
+    weekly_remaining: null,
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setupMocks(options?: {
+  meters?: typeof mockMeters;
+  isLoading?: boolean;
+  trainOverrides?: { isPending?: boolean; isError?: boolean; error?: Error | null };
+}) {
+  const trainMutate = vi.fn();
+
+  vi.mocked(magicQueries.useTechniqueProgress).mockReturnValue({
+    data: options?.meters ?? mockMeters,
+    isLoading: options?.isLoading ?? false,
+  } as unknown as ReturnType<typeof useTechniqueProgress>);
+
+  vi.mocked(magicQueries.useTrainTechnique).mockReturnValue({
+    mutate: trainMutate,
+    isPending: options?.trainOverrides?.isPending ?? false,
+    isError: options?.trainOverrides?.isError ?? false,
+    error: options?.trainOverrides?.error ?? null,
+  } as unknown as ReturnType<typeof useTrainTechnique>);
+
+  return { trainMutate };
+}
+
+describe('TechniqueProgressPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders each meter with progress fraction, teacher, and weekly remaining', () => {
+    setupMocks({});
+    renderWithProviders(<TechniqueProgressPanel characterSheetId={10} />);
+
+    const rows = screen.getAllByTestId('technique-progress-row');
+    expect(rows).toHaveLength(2);
+    expect(rows[0]).toHaveTextContent('Cinderline Draw');
+    expect(rows[0]).toHaveTextContent('4/10');
+    expect(rows[0]).toHaveTextContent('Taught by Ariel');
+    expect(rows[0]).toHaveTextContent('30 AP left this week');
+
+    expect(rows[1]).toHaveTextContent('Hollow Step');
+    expect(rows[1]).toHaveTextContent('Self-study');
+  });
+
+  it('scopes the meter list and mutation to the viewed character', () => {
+    setupMocks({});
+    renderWithProviders(<TechniqueProgressPanel characterSheetId={10} />);
+
+    expect(magicQueries.useTechniqueProgress).toHaveBeenCalledWith(10);
+    expect(magicQueries.useTrainTechnique).toHaveBeenCalledWith(10);
+  });
+
+  it('shows a quiet empty state when there are no meters', () => {
+    setupMocks({ meters: [] });
+    renderWithProviders(<TechniqueProgressPanel characterSheetId={10} />);
+
+    expect(screen.getByTestId('technique-progress-empty')).toBeInTheDocument();
+    expect(screen.queryByTestId('technique-progress-row')).not.toBeInTheDocument();
+  });
+
+  it('fires the train mutation with no body when the AP input is left blank', async () => {
+    const { trainMutate } = setupMocks({});
+    renderWithProviders(<TechniqueProgressPanel characterSheetId={10} />);
+
+    await userEvent.click(screen.getByTestId('technique-progress-train-11'));
+
+    expect(trainMutate).toHaveBeenCalledWith(
+      { techniqueId: 11, body: undefined },
+      expect.anything()
+    );
+  });
+
+  it('fires the train mutation with ap_to_invest when the AP input is filled in', async () => {
+    const { trainMutate } = setupMocks({});
+    renderWithProviders(<TechniqueProgressPanel characterSheetId={10} />);
+
+    await userEvent.type(screen.getByTestId('technique-progress-ap-input-11'), '3');
+    await userEvent.click(screen.getByTestId('technique-progress-train-11'));
+
+    expect(trainMutate).toHaveBeenCalledWith(
+      { techniqueId: 11, body: { ap_to_invest: 3 } },
+      expect.anything()
+    );
+  });
+
+  it('renders the training-session outcome after a successful train call', async () => {
+    const { trainMutate } = setupMocks({});
+    trainMutate.mockImplementation((_variables, { onSuccess }) => {
+      onSuccess({
+        technique_id: 11,
+        outcome_name: 'Solid Progress',
+        points_before: 4,
+        points_after: 6,
+        total_required: 10,
+        technique_acquired: false,
+        self_study: false,
+      });
+    });
+    renderWithProviders(<TechniqueProgressPanel characterSheetId={10} />);
+
+    await userEvent.click(screen.getByTestId('technique-progress-train-11'));
+
+    expect(screen.getByTestId('technique-progress-result-11')).toHaveTextContent(
+      'Solid Progress: 6/10.'
+    );
+  });
+
+  it('renders the 400 detail message on a training error', async () => {
+    const { trainMutate } = setupMocks({
+      trainOverrides: { isError: true, error: new Error('Weekly training cap reached.') },
+    });
+    trainMutate.mockImplementation((_variables, { onError }) => {
+      onError();
+    });
+    renderWithProviders(<TechniqueProgressPanel characterSheetId={10} />);
+
+    await userEvent.click(screen.getByTestId('technique-progress-train-11'));
+
+    expect(screen.getByTestId('technique-progress-error-11')).toHaveTextContent(
+      'Weekly training cap reached.'
+    );
+  });
+});

--- a/frontend/src/magic/components/TechniqueProgressPanel.test.tsx
+++ b/frontend/src/magic/components/TechniqueProgressPanel.test.tsx
@@ -4,7 +4,7 @@
  * Mirrors MotifStylePanel.test.tsx's mock-the-hook-module idiom (no msw).
  */
 
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { renderWithProviders } from '@/test/utils/renderWithProviders';
@@ -128,6 +128,25 @@ describe('TechniqueProgressPanel', () => {
 
     expect(trainMutate).toHaveBeenCalledWith(
       { techniqueId: 11, body: { ap_to_invest: 3 } },
+      expect.anything()
+    );
+  });
+
+  it('treats a non-integer AP input as unset rather than sending a fractional value', async () => {
+    const { trainMutate } = setupMocks({});
+    renderWithProviders(<TechniqueProgressPanel characterSheetId={10} />);
+
+    fireEvent.change(screen.getByTestId('technique-progress-ap-input-11'), {
+      target: { value: '2.5' },
+    });
+    // fireEvent.submit dispatches the submit event directly, bypassing the
+    // browser's native step-mismatch constraint validation (which a real click
+    // on the Train button would trigger, given `step={1}` on the input) — this
+    // isolates the JS-level Number.isInteger guard the fix added.
+    fireEvent.submit(screen.getAllByTestId('technique-progress-row')[0]);
+
+    expect(trainMutate).toHaveBeenCalledWith(
+      { techniqueId: 11, body: undefined },
       expect.anything()
     );
   });

--- a/frontend/src/magic/components/TechniqueProgressPanel.tsx
+++ b/frontend/src/magic/components/TechniqueProgressPanel.tsx
@@ -42,7 +42,8 @@ export function TechniqueProgressPanel({ characterSheetId }: Props) {
     event.preventDefault();
     const raw = apInputs[techniqueId];
     const parsed = raw ? Number(raw) : undefined;
-    const body = parsed && parsed > 0 ? { ap_to_invest: parsed } : undefined;
+    const body =
+      parsed && Number.isInteger(parsed) && parsed > 0 ? { ap_to_invest: parsed } : undefined;
     setFailedTechniqueId(null);
     train.mutate(
       { techniqueId, body },
@@ -117,6 +118,7 @@ export function TechniqueProgressPanel({ characterSheetId }: Props) {
                         data-testid={`technique-progress-ap-input-${meter.technique_id}`}
                         type="number"
                         min={1}
+                        step={1}
                         className="h-9 w-24 rounded-md border border-input bg-transparent px-2 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
                         value={apInputs[meter.technique_id] ?? ''}
                         onChange={(event) =>

--- a/frontend/src/magic/components/TechniqueProgressPanel.tsx
+++ b/frontend/src/magic/components/TechniqueProgressPanel.tsx
@@ -1,0 +1,166 @@
+/**
+ * TechniqueProgressPanel (#2739 Task 3) — player-facing training-meter list.
+ *
+ * Lists the owning character's in-progress `TechniqueProgress` meters
+ * (technique name, progress bar/fraction, teacher-or-self-study, weekly
+ * remaining) with a Train button (+ optional AP-to-invest input) per row.
+ * Mounted below MotifStylePanel in SpellbookTab, own-view only — mirrors its
+ * query/mutation idiom (#2030).
+ *
+ * Wire contract: TechniqueProgressViewSet
+ * (src/world/magic/views_technique_progress.py) — list/train dispatch
+ * TrainTechniqueAction (src/actions/definitions/technique_training.py). 400s
+ * (no meter, weekly cap hit, can't afford the AP, stale meter) carry a
+ * `{detail}` string surfaced verbatim below the row that triggered them.
+ */
+
+import { useState, type FormEvent } from 'react';
+
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Progress } from '@/components/ui/progress';
+import { useTechniqueProgress, useTrainTechnique } from '@/magic/queries';
+import type { TrainTechniqueResult } from '@/magic/types';
+
+interface Props {
+  /** CharacterSheet pk (shared with the character ObjectDB pk) of the acting character. */
+  characterSheetId: number;
+}
+
+export function TechniqueProgressPanel({ characterSheetId }: Props) {
+  const { data: meters, isLoading } = useTechniqueProgress(characterSheetId);
+  const train = useTrainTechnique(characterSheetId);
+
+  const [apInputs, setApInputs] = useState<Record<number, string>>({});
+  const [lastResult, setLastResult] = useState<Record<number, TrainTechniqueResult>>({});
+  const [failedTechniqueId, setFailedTechniqueId] = useState<number | null>(null);
+
+  const rows = meters ?? [];
+
+  function handleTrain(event: FormEvent, techniqueId: number) {
+    event.preventDefault();
+    const raw = apInputs[techniqueId];
+    const parsed = raw ? Number(raw) : undefined;
+    const body = parsed && parsed > 0 ? { ap_to_invest: parsed } : undefined;
+    setFailedTechniqueId(null);
+    train.mutate(
+      { techniqueId, body },
+      {
+        onSuccess: (data) => {
+          setLastResult((prev) => ({ ...prev, [techniqueId]: data }));
+        },
+        onError: () => {
+          setFailedTechniqueId(techniqueId);
+        },
+      }
+    );
+  }
+
+  return (
+    <Card data-testid="technique-progress-panel">
+      <CardHeader>
+        <CardTitle className="text-base">Training</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {isLoading ? (
+          <p className="text-sm text-muted-foreground">Loading training meters…</p>
+        ) : rows.length === 0 ? (
+          <p className="text-sm text-muted-foreground" data-testid="technique-progress-empty">
+            Nothing in training right now.
+          </p>
+        ) : (
+          <div className="space-y-3" data-testid="technique-progress-list">
+            {rows.map((meter) => {
+              const pct =
+                meter.total_required > 0
+                  ? Math.min(
+                      100,
+                      Math.round((meter.points_accumulated / meter.total_required) * 100)
+                    )
+                  : 0;
+              const result = lastResult[meter.technique_id];
+
+              return (
+                <form
+                  key={meter.id}
+                  onSubmit={(event) => handleTrain(event, meter.technique_id)}
+                  className="space-y-2 rounded-md border p-3"
+                  data-testid="technique-progress-row"
+                >
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <span className="font-medium">{meter.technique_name}</span>
+                    <Badge variant="outline">
+                      {meter.teacher_name ? `Taught by ${meter.teacher_name}` : 'Self-study'}
+                    </Badge>
+                  </div>
+                  <Progress
+                    value={pct}
+                    data-testid={`technique-progress-bar-${meter.technique_id}`}
+                  />
+                  <div className="flex flex-wrap items-center justify-between gap-2 text-sm text-muted-foreground">
+                    <span>
+                      {meter.points_accumulated}/{meter.total_required} — {meter.source_label}
+                    </span>
+                    {meter.weekly_remaining !== null && (
+                      <span>{meter.weekly_remaining} AP left this week</span>
+                    )}
+                  </div>
+                  <div className="flex flex-wrap items-end gap-2">
+                    <label
+                      className="flex flex-col gap-1 text-xs text-muted-foreground"
+                      htmlFor={`technique-progress-ap-${meter.technique_id}`}
+                    >
+                      AP to invest (optional)
+                      <input
+                        id={`technique-progress-ap-${meter.technique_id}`}
+                        data-testid={`technique-progress-ap-input-${meter.technique_id}`}
+                        type="number"
+                        min={1}
+                        className="h-9 w-24 rounded-md border border-input bg-transparent px-2 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring"
+                        value={apInputs[meter.technique_id] ?? ''}
+                        onChange={(event) =>
+                          setApInputs((prev) => ({
+                            ...prev,
+                            [meter.technique_id]: event.target.value,
+                          }))
+                        }
+                      />
+                    </label>
+                    <Button
+                      type="submit"
+                      size="sm"
+                      disabled={train.isPending}
+                      data-testid={`technique-progress-train-${meter.technique_id}`}
+                    >
+                      Train
+                    </Button>
+                  </div>
+                  {result && (
+                    <p
+                      className="text-sm text-muted-foreground"
+                      data-testid={`technique-progress-result-${meter.technique_id}`}
+                    >
+                      {result.technique_acquired
+                        ? `Your training pays off — you've learned ${meter.technique_name}!`
+                        : `${result.outcome_name}: ${result.points_after}/${result.total_required}.`}
+                    </p>
+                  )}
+                  {train.isError && failedTechniqueId === meter.technique_id && (
+                    <p
+                      role="alert"
+                      data-testid={`technique-progress-error-${meter.technique_id}`}
+                      className="text-sm font-medium text-red-500"
+                    >
+                      {train.error?.message}
+                    </p>
+                  )}
+                </form>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/magic/queries.ts
+++ b/frontend/src/magic/queries.ts
@@ -923,7 +923,13 @@ export function useTechniqueProgress(characterId: number) {
  * scoping convention as `useBindMotifStyle`).
  *
  * On success invalidates the meter list so the refetched progress/teacher/
- * weekly-remaining figures reflect the session immediately.
+ * weekly-remaining figures reflect the session immediately, plus the
+ * character-sheet query (`['character-sheets', characterSheetId]`, per
+ * `character_sheets/queries.ts`' `useCharacterSheetQuery` — same pattern as
+ * `useBindMotifStyle`/`useUnbindMotifStyle` above) — a completed session can
+ * mint a `CharacterTechnique`, which `SpellbookTab` renders from that sheet
+ * payload, not from this meter list. Unconditional (not gated on
+ * `technique_acquired`) to match that precedent.
  */
 export function useTrainTechnique(characterSheetId: number) {
   const qc = useQueryClient();
@@ -934,6 +940,7 @@ export function useTrainTechnique(characterSheetId: number) {
       qc.invalidateQueries({ queryKey: magicKeys.techniqueProgress(characterSheetId) }).catch(
         () => {}
       );
+      qc.invalidateQueries({ queryKey: ['character-sheets', characterSheetId] }).catch(() => {});
     },
   });
 }

--- a/frontend/src/magic/queries.ts
+++ b/frontend/src/magic/queries.ts
@@ -31,6 +31,7 @@ import type {
   SineatingRespondRequest,
   StageAdvanceRespondRequest,
   TechniqueDesignRequest,
+  TrainTechniqueRequest,
   UnbindMotifStyleRequest,
   WeaveThreadRequest,
 } from './types';
@@ -94,6 +95,9 @@ export const magicKeys = {
   motifStyleBindings: (characterId: number) =>
     [...magicKeys.all, 'motif-styles', 'bindings', characterId] as const,
   styleCatalog: () => [...magicKeys.all, 'motif-styles', 'catalog'] as const,
+
+  techniqueProgress: (characterId: number) =>
+    [...magicKeys.all, 'technique-progress', characterId] as const,
 };
 
 // ---------------------------------------------------------------------------
@@ -898,4 +902,38 @@ export function useToggleGlimpseDistinction(auraId: number, characterSheetId: nu
     },
     isPending: link.isPending || unlink.isPending,
   };
+}
+
+// ---------------------------------------------------------------------------
+// Technique progress meters, #2739
+// ---------------------------------------------------------------------------
+
+/** The given character's in-progress technique training meters. Disabled when id ≤ 0. */
+export function useTechniqueProgress(characterId: number) {
+  return useQuery({
+    queryKey: magicKeys.techniqueProgress(characterId),
+    queryFn: () => api.getTechniqueProgress(characterId),
+    enabled: characterId > 0,
+  });
+}
+
+/**
+ * Run one training session against a technique's meter for the given
+ * character (`characterSheetId` backs the `X-Character-ID` header, same
+ * scoping convention as `useBindMotifStyle`).
+ *
+ * On success invalidates the meter list so the refetched progress/teacher/
+ * weekly-remaining figures reflect the session immediately.
+ */
+export function useTrainTechnique(characterSheetId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ techniqueId, body }: { techniqueId: number; body?: TrainTechniqueRequest }) =>
+      api.trainTechnique(characterSheetId, techniqueId, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: magicKeys.techniqueProgress(characterSheetId) }).catch(
+        () => {}
+      );
+    },
+  });
 }

--- a/frontend/src/magic/types.ts
+++ b/frontend/src/magic/types.ts
@@ -574,3 +574,44 @@ export interface TechniqueSignature {
   narrative_snippet: string;
   intensity_delta: number;
 }
+
+// ---------------------------------------------------------------------------
+// Technique progress meters, #2739
+//
+// GET /api/magic/technique-progress/, POST .../{technique_id}/train/ are a
+// plain ViewSet (no @extend_schema yet), so the generated schema records
+// "No response body" for both — these are local, hand-rolled to mirror
+// TechniqueProgressSerializer / TrainTechniqueAction.execute's `data` dict
+// (src/world/magic/serializers.py, src/actions/definitions/technique_training.py).
+// ---------------------------------------------------------------------------
+
+/** One row from GET /api/magic/technique-progress/ — a learner's in-progress training meter. */
+export interface TechniqueProgressMeter {
+  id: number;
+  technique_id: number;
+  technique_name: string;
+  points_accumulated: number;
+  total_required: number;
+  /** Anonymity-respecting display name (RosterTenure.display_name), or null for self-study. */
+  teacher_name: string | null;
+  /** TechniqueProgress.get_source_display() — e.g. "Teaching Offer" / "Academy Training". */
+  source_label: string;
+  /** Remaining weekly training points for this technique, or null when unavailable. */
+  weekly_remaining: number | null;
+}
+
+/** Request body for POST /api/magic/technique-progress/{technique_id}/train/. */
+export interface TrainTechniqueRequest {
+  ap_to_invest?: number;
+}
+
+/** Response for a successful training session — TrainTechniqueAction's result.data. */
+export interface TrainTechniqueResult {
+  technique_id: number;
+  outcome_name: string;
+  points_before: number;
+  points_after: number;
+  total_required: number;
+  technique_acquired: boolean;
+  self_study: boolean;
+}

--- a/src/actions/definitions/technique_training.py
+++ b/src/actions/definitions/technique_training.py
@@ -1,0 +1,171 @@
+"""TrainTechniqueAction — the action.run() seam for check-based technique training (#2739).
+
+Both the telnet ``train`` command and (a later task's) web endpoint converge on
+this action's ``run()``. It is the missing production caller of
+``resolve_training_check`` (#2727) — the check-resolution layer was built and
+tested but unreachable by any player until this action existed.
+
+Location policy (Decision 3a, issue #2739): self-study needs no location. A
+teacher only contributes their skill bonus when their tenure's character is
+co-present in the learner's room at session time; otherwise the session
+silently falls back to self-study rates. This is true for BOTH PC-teacher
+meters and Academy TRAIN meters — there is never a location hard-block.
+
+AP handling: the seam (``resolve_training_check`` → ``contribute_to_technique_progress``)
+spends AP in full itself and raises cleanly on pool/cap overruns
+(``WeeklyTrainingCapExceeded`` / insufficient-AP). This action does not
+pre-bound ``ap_to_invest`` beyond defaulting it when omitted and rejecting a
+non-positive value — pre-bounding here would duplicate (and could contradict)
+the seam's "AP is always spent in full" contract.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from actions.base import Action
+from actions.types import ActionResult, TargetType
+
+if TYPE_CHECKING:
+    from evennia.objects.models import ObjectDB
+
+    from actions.types import ActionContext
+    from world.magic.models import TechniqueProgress
+    from world.roster.models import RosterTenure
+
+# No "base training session cost" constant exists on GiftAcquisitionConfig or
+# on the resolve_training_check seam today (verified 2026-08-07) — defaults to
+# 1 AP per session until one is authored.
+_DEFAULT_AP_TO_INVEST = 1
+
+
+def _co_present_teacher(actor: ObjectDB, progress: TechniqueProgress) -> RosterTenure | None:
+    """Return ``progress.teacher_tenure`` iff that tenure's character shares the actor's room.
+
+    Silent fallback to ``None`` (self-study rates) whenever the tenure is unset, has
+    no live character, or that character isn't co-present — never a hard block
+    (Decision 3a).
+    """
+    tenure = progress.teacher_tenure
+    if tenure is None:
+        return None
+    teacher_character = tenure.character
+    if teacher_character is None:
+        return None
+    if teacher_character.location != actor.location:
+        return None
+    return tenure
+
+
+@dataclass
+class TrainTechniqueAction(Action):
+    """Run one training session against an in-progress ``TechniqueProgress`` meter.
+
+    kwargs:
+        technique_id: PK of the ``Technique`` being trained (required). Resolved
+            against the learner's own ``TechniqueProgress`` meter — a technique
+            with no meter fails cleanly, naming the front doors that create one
+            (accepting a teaching offer, or an Academy TRAIN offer).
+        ap_to_invest: AP to invest this session. Omitted defaults to
+            ``_DEFAULT_AP_TO_INVEST``; a supplied value of 0 or less is rejected.
+            The seam itself spends this AP in full and raises on pool/cap
+            overruns — this action maps those raises to failure results rather
+            than pre-bounding.
+    """
+
+    key: str = "train_technique"
+    name: str = "Train Technique"
+    icon: str = "book"
+    category: str = "magic"
+    target_type: TargetType = TargetType.SELF
+
+    def execute(
+        self,
+        actor: ObjectDB,
+        context: ActionContext | None = None,
+        *,
+        technique_id: int,
+        ap_to_invest: int | None = None,
+        **kwargs: Any,
+    ) -> ActionResult:
+        """Resolve the learner's meter, the co-present teacher (if any), and train.
+
+        Returns:
+            ``success=True`` with ``data`` describing the session outcome when the
+            session resolves (including a botch — a botch still spends AP and
+            still "succeeds" as a session). ``success=False`` with a player-safe
+            ``message`` when there's no meter to train, AP is non-positive, the
+            weekly cap is hit, or the learner can't afford the AP.
+        """
+        from world.magic.exceptions import MagicError, WeeklyTrainingCapExceeded  # noqa: PLC0415
+        from world.magic.models import TechniqueProgress  # noqa: PLC0415
+        from world.magic.services.technique_training import resolve_training_check  # noqa: PLC0415
+
+        if ap_to_invest is None:
+            ap_to_invest = _DEFAULT_AP_TO_INVEST
+        elif ap_to_invest <= 0:
+            return ActionResult(
+                success=False,
+                message="You must invest a positive amount of AP.",
+            )
+
+        learner = actor.sheet_data
+
+        progress = (
+            TechniqueProgress.objects.filter(
+                character_sheet=learner,
+                technique_id=technique_id,
+            )
+            .select_related("technique", "teacher_tenure")
+            .first()
+        )
+        if progress is None:
+            return ActionResult(
+                success=False,
+                message=(
+                    "You aren't training that technique. Accept a teaching offer or "
+                    "an Academy TRAIN offer to start a meter first."
+                ),
+            )
+
+        teacher = _co_present_teacher(actor, progress)
+        technique_name = progress.technique.name
+        points_before = progress.points_accumulated
+        total_required = progress.total_required
+
+        try:
+            result = resolve_training_check(
+                learner,
+                progress,
+                ap_to_invest=ap_to_invest,
+                teacher=teacher,
+            )
+        except WeeklyTrainingCapExceeded as exc:
+            return ActionResult(success=False, message=exc.user_message)
+        except MagicError as exc:
+            return ActionResult(success=False, message=exc.user_message)
+
+        points_after = min(points_before + result.dev_points_contributed, total_required)
+
+        if result.technique_acquired is not None:
+            message = f"Your training pays off — you've learned {technique_name}!"
+        else:
+            message = (
+                f"You train {technique_name} ({result.outcome_name}): "
+                f"{points_after}/{total_required}."
+            )
+
+        return ActionResult(
+            success=True,
+            message=message,
+            data={
+                "technique_id": technique_id,
+                "outcome_name": result.outcome_name,
+                "points_before": points_before,
+                "points_after": points_after,
+                "total_required": total_required,
+                "technique_acquired": result.technique_acquired is not None,
+                "self_study": teacher is None,
+            },
+        )

--- a/src/actions/definitions/technique_training.py
+++ b/src/actions/definitions/technique_training.py
@@ -144,9 +144,7 @@ class TrainTechniqueAction(Action):
                 ap_to_invest=ap_to_invest,
                 teacher=teacher,
             )
-        except WeeklyTrainingCapExceeded as exc:
-            return ActionResult(success=False, message=exc.user_message)
-        except MagicError as exc:
+        except (WeeklyTrainingCapExceeded, MagicError) as exc:
             return ActionResult(success=False, message=exc.user_message)
         except ValueError as exc:
             # learn_technique (the meter-completion mint, reached via
@@ -156,6 +154,22 @@ class TrainTechniqueAction(Action):
             # grant, a TechniqueGrant item). Map it to a clean failure instead of
             # letting it escape as a traceback to telnet/web.
             return ActionResult(success=False, message=str(exc))
+        except TechniqueProgress.DoesNotExist:
+            # contribute_to_technique_progress re-gets the meter by pk under
+            # select_for_update (technique_progress.py:132-138) so two concurrent
+            # sessions serialize on the weekly-tracker lock rather than racing --
+            # but if the first session's contribution completed (and deleted) the
+            # meter while this one was blocked on the lock, the re-get raises this
+            # instead of returning a stale row. Same message shape as the
+            # already-knows failure above: training just finished, nothing left
+            # to train.
+            return ActionResult(
+                success=False,
+                message=(
+                    f"Your training in {technique_name} just completed. "
+                    "There's no meter left to train."
+                ),
+            )
 
         points_after = min(points_before + result.dev_points_contributed, total_required)
 

--- a/src/actions/definitions/technique_training.py
+++ b/src/actions/definitions/technique_training.py
@@ -96,7 +96,10 @@ class TrainTechniqueAction(Action):
             session resolves (including a botch — a botch still spends AP and
             still "succeeds" as a session). ``success=False`` with a player-safe
             ``message`` when there's no meter to train, AP is non-positive, the
-            weekly cap is hit, or the learner can't afford the AP.
+            weekly cap is hit, the learner can't afford the AP, or the session
+            would complete a meter for a technique the learner already knows
+            (a stale meter left open after the technique arrived by another
+            route, e.g. a staff grant or a TechniqueGrant item).
         """
         from world.magic.exceptions import MagicError, WeeklyTrainingCapExceeded  # noqa: PLC0415
         from world.magic.models import TechniqueProgress  # noqa: PLC0415
@@ -145,6 +148,14 @@ class TrainTechniqueAction(Action):
             return ActionResult(success=False, message=exc.user_message)
         except MagicError as exc:
             return ActionResult(success=False, message=exc.user_message)
+        except ValueError as exc:
+            # learn_technique (the meter-completion mint, reached via
+            # contribute_to_technique_progress) raises a bare ValueError when the
+            # learner already holds the CharacterTechnique — reachable when a meter
+            # is left open and the technique arrives by another route (a staff
+            # grant, a TechniqueGrant item). Map it to a clean failure instead of
+            # letting it escape as a traceback to telnet/web.
+            return ActionResult(success=False, message=str(exc))
 
         points_after = min(points_before + result.dev_points_contributed, total_required)
 

--- a/src/actions/registry.py
+++ b/src/actions/registry.py
@@ -442,6 +442,7 @@ from actions.definitions.tasking import (
     SuppressListenerAction,
 )
 from actions.definitions.technique_authoring import AuthorTechniqueAction
+from actions.definitions.technique_training import TrainTechniqueAction
 from actions.definitions.threads import WeaveThreadAction
 from actions.definitions.traps import (
     ArmTrapAction,
@@ -604,6 +605,7 @@ _ALL_ACTIONS: list[Action] = [
     PlaceChallengeAction(),
     PerformRitualAction(),
     AuthorTechniqueAction(),
+    TrainTechniqueAction(),
     ImbueAction(),
     WeaveThreadAction(),
     StartRoundAction(),

--- a/src/actions/tests/test_base.py
+++ b/src/actions/tests/test_base.py
@@ -361,6 +361,7 @@ class ActionRegistryTests(TestCase):
             "give_writeup_kudos",
             "file_writeup_complaint",
             "author_technique",
+            "train_technique",
             "engage_covenant_membership",
             "disengage_covenant_membership",
             "leave_covenant",

--- a/src/actions/tests/test_technique_training_action.py
+++ b/src/actions/tests/test_technique_training_action.py
@@ -9,6 +9,7 @@ tiers — since this action is the seam's first production caller.
 from __future__ import annotations
 
 from decimal import Decimal
+from unittest.mock import patch
 
 from django.test import TestCase
 
@@ -276,3 +277,34 @@ class TrainTechniqueActionFailureTests(TrainTechniqueActionTestBase):
             ).count(),
             1,
         )
+
+    def test_meter_deleted_mid_session_maps_to_failure_result_not_raise(self):
+        """A concurrent session completes+deletes the meter before this one's seam call.
+
+        contribute_to_technique_progress re-gets TechniqueProgress by pk under
+        select_for_update (technique_progress.py:132-138) -- two concurrent
+        sessions serialize on the weekly-tracker lock rather than racing on the
+        meter row itself, but if the first session's contribution completes
+        (and deletes) the meter while the second is blocked on that lock, the
+        second's re-get raises TechniqueProgress.DoesNotExist instead of
+        returning a stale row. A true concurrency repro is out of scope here;
+        this simulates the same observable seam-raise deterministically by
+        monkeypatching resolve_training_check to raise it directly (#2739
+        final-review finding).
+        """
+        self._make_progress(total_required=20)
+
+        # execute() does a local `from world.magic.services.technique_training
+        # import resolve_training_check` (a lint-suppressed local import) --
+        # it re-imports the name fresh from the source module on every call,
+        # so the patch target is the source module's attribute, not a
+        # module-level binding on actions.definitions.technique_training
+        # (there isn't one).
+        with patch(
+            "world.magic.services.technique_training.resolve_training_check",
+            side_effect=TechniqueProgress.DoesNotExist,
+        ):
+            result = self._run(technique_id=self.technique.pk, ap_to_invest=20)
+
+        self.assertFalse(result.success)
+        self.assertTrue(result.message)

--- a/src/actions/tests/test_technique_training_action.py
+++ b/src/actions/tests/test_technique_training_action.py
@@ -1,0 +1,251 @@
+"""TDD tests for TrainTechniqueAction (#2739).
+
+Step 1: write failing tests before implementing the action. Setup mirrors
+world/magic/tests/test_technique_training.py's ResolveTrainingCheckTest (the
+seam this action wraps) — same check-content seeding, same canonical outcome
+tiers — since this action is the seam's first production caller.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.test import TestCase
+
+from actions.definitions.technique_training import TrainTechniqueAction
+from evennia_extensions.factories import ObjectDBFactory
+from world.action_points.models import ActionPointPool
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.test_helpers import force_check_outcome
+from world.magic.constants import TargetKind
+from world.magic.factories import ResonanceFactory, TechniqueFactory
+from world.magic.models import (
+    CharacterGift,
+    CharacterTechnique,
+    TechniqueProgress,
+    Thread,
+    TrainingOutcomeAward,
+)
+from world.roster.factories import RosterTenureFactory
+from world.traits.models import CheckOutcome
+
+# Canonical outcome tiers (name -> success_level), matching seeds/checks.py.
+_CANONICAL_OUTCOMES = [
+    ("Critical Failure", -2),
+    ("Failure", -1),
+    ("Partial Success", 0),
+    ("Success", 1),
+    ("Critical Success", 2),
+]
+
+
+def _ensure_outcome(name: str, success_level: int) -> CheckOutcome:
+    outcome, _ = CheckOutcome.objects.get_or_create(
+        name=name, defaults={"success_level": success_level}
+    )
+    return outcome
+
+
+class TrainTechniqueActionTestBase(TestCase):
+    def setUp(self):
+        self.room = ObjectDBFactory(
+            db_key="TrainingRoom", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        self.learner = CharacterSheetFactory()
+        self.learner.character.location = self.room
+        self.learner.character.save()
+
+        self.pool = ActionPointPool.get_or_create_for_character(self.learner.character)
+        self.pool.current = 500
+        self.pool.save()
+
+        self.technique = TechniqueFactory()
+        CharacterGift.objects.create(character=self.learner, gift=self.technique.gift)
+        Thread.objects.create(
+            owner=self.learner,
+            resonance=ResonanceFactory(),
+            target_kind=TargetKind.GIFT,
+            target_gift=self.technique.gift,
+            level=0,
+        )
+
+        self.outcomes = {name: _ensure_outcome(name, sl) for name, sl in _CANONICAL_OUTCOMES}
+        self._seed_award_rows()
+        self._seed_check_content()
+
+    def _seed_award_rows(self):
+        multipliers = {
+            "Critical Failure": Decimal("0.00"),
+            "Failure": Decimal("0.00"),
+            "Partial Success": Decimal("0.50"),
+            "Success": Decimal("1.00"),
+            "Critical Success": Decimal("1.50"),
+        }
+        for name, mult in multipliers.items():
+            TrainingOutcomeAward.objects.update_or_create(
+                outcome_tier=self.outcomes[name],
+                defaults={"dev_point_multiplier": mult},
+            )
+
+    def _seed_check_content(self):
+        """Minimal CheckType so the seam can resolve a check."""
+        from world.checks.models import CheckCategory, CheckType, CheckTypeTrait
+        from world.skills.models import Skill
+        from world.traits.models import Trait, TraitCategory, TraitType
+
+        arcane_trait, _ = Trait.objects.get_or_create(
+            name="Arcane Theory",
+            defaults={
+                "trait_type": TraitType.SKILL,
+                "category": TraitCategory.MAGIC,
+                "is_public": True,
+            },
+        )
+        Skill.objects.get_or_create(
+            trait=arcane_trait,
+            defaults={
+                "tooltip": "Understanding the theoretical underpinnings of magical techniques.",
+                "display_order": 0,
+                "is_active": True,
+            },
+        )
+        intellect_trait, _ = Trait.objects.get_or_create(
+            name="intellect",
+            defaults={
+                "trait_type": TraitType.STAT,
+                "category": TraitCategory.MENTAL,
+                "is_public": True,
+            },
+        )
+        category, _ = CheckCategory.objects.get_or_create(
+            name="Magic",
+            defaults={"description": "Magic checks.", "display_order": 40},
+        )
+        check_type, _ = CheckType.objects.get_or_create(
+            name="Technique Training",
+            category=category,
+            defaults={"is_active": True, "display_order": 10},
+        )
+        w = Decimal("1.0")
+        CheckTypeTrait.objects.update_or_create(
+            check_type=check_type, trait=intellect_trait, defaults={"weight": w}
+        )
+        CheckTypeTrait.objects.update_or_create(
+            check_type=check_type, trait=arcane_trait, defaults={"weight": w}
+        )
+
+    def _make_progress(self, *, total_required=50, teacher_tenure=None):
+        return TechniqueProgress.objects.create(
+            character_sheet=self.learner,
+            technique=self.technique,
+            total_required=total_required,
+            source="gift_acquisition",
+            teacher_tenure=teacher_tenure,
+        )
+
+    def _run(self, **kwargs):
+        return TrainTechniqueAction().run(self.learner.character, **kwargs)
+
+
+class TrainTechniqueActionHappyPathTests(TrainTechniqueActionTestBase):
+    def test_happy_session_advances_meter(self):
+        progress = self._make_progress(total_required=50)
+        with force_check_outcome(self.outcomes["Success"]):
+            result = self._run(technique_id=self.technique.pk, ap_to_invest=20)
+        self.assertTrue(result.success, result.message)
+        progress.refresh_from_db()
+        self.assertEqual(progress.points_accumulated, 20)
+        self.assertFalse(result.data["technique_acquired"])
+
+    def test_completion_mints_character_technique(self):
+        progress = self._make_progress(total_required=20)
+        with force_check_outcome(self.outcomes["Success"]):
+            result = self._run(technique_id=self.technique.pk, ap_to_invest=20)
+        self.assertTrue(result.success, result.message)
+        self.assertTrue(result.data["technique_acquired"])
+        self.assertTrue(
+            CharacterTechnique.objects.filter(
+                character=self.learner, technique=self.technique
+            ).exists()
+        )
+        self.assertFalse(TechniqueProgress.objects.filter(pk=progress.pk).exists())
+
+    def test_self_study_with_no_teacher_tenure(self):
+        self._make_progress(total_required=50)
+        with force_check_outcome(self.outcomes["Success"]):
+            result = self._run(technique_id=self.technique.pk, ap_to_invest=20)
+        self.assertTrue(result.success, result.message)
+        self.assertTrue(result.data["self_study"])
+
+    def test_teacher_absent_falls_back_to_self_study(self):
+        """Tenure set but not co-present -> still succeeds, self-study branch."""
+        teacher_tenure = RosterTenureFactory()
+        elsewhere = ObjectDBFactory(
+            db_key="ElsewhereRoom", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        teacher_tenure.character.location = elsewhere
+        teacher_tenure.character.save()
+        self._make_progress(total_required=50, teacher_tenure=teacher_tenure)
+
+        with force_check_outcome(self.outcomes["Success"]):
+            result = self._run(technique_id=self.technique.pk, ap_to_invest=20)
+
+        self.assertTrue(result.success, result.message)
+        self.assertTrue(result.data["self_study"])
+
+    def test_teacher_co_present_is_not_self_study(self):
+        teacher_tenure = RosterTenureFactory()
+        teacher_tenure.character.location = self.room
+        teacher_tenure.character.save()
+        self._make_progress(total_required=50, teacher_tenure=teacher_tenure)
+
+        with force_check_outcome(self.outcomes["Success"]):
+            result = self._run(technique_id=self.technique.pk, ap_to_invest=20)
+
+        self.assertTrue(result.success, result.message)
+        self.assertFalse(result.data["self_study"])
+
+    def test_omitted_ap_defaults_to_positive_amount(self):
+        self._make_progress(total_required=50)
+        with force_check_outcome(self.outcomes["Success"]):
+            result = self._run(technique_id=self.technique.pk)
+        self.assertTrue(result.success, result.message)
+
+
+class TrainTechniqueActionFailureTests(TrainTechniqueActionTestBase):
+    def test_no_meter_fails_cleanly(self):
+        result = self._run(technique_id=self.technique.pk, ap_to_invest=20)
+        self.assertFalse(result.success)
+        self.assertTrue(result.message)
+
+    def test_non_positive_ap_rejected(self):
+        self._make_progress(total_required=50)
+        result = self._run(technique_id=self.technique.pk, ap_to_invest=0)
+        self.assertFalse(result.success)
+
+    def test_cap_exceeded_maps_to_failure_result_not_raise(self):
+        self._make_progress(total_required=500)
+        from world.magic.services.gift_acquisition import get_gift_acquisition_config
+
+        config = get_gift_acquisition_config()
+        config.weekly_training_cap = 5
+        config.save()
+
+        with force_check_outcome(self.outcomes["Success"]):
+            first = self._run(technique_id=self.technique.pk, ap_to_invest=5)
+            second = self._run(technique_id=self.technique.pk, ap_to_invest=5)
+
+        self.assertTrue(first.success, first.message)
+        self.assertFalse(second.success)
+        self.assertTrue(second.message)
+
+    def test_ap_short_maps_to_failure_result_not_raise(self):
+        self._make_progress(total_required=500)
+        self.pool.current = 2
+        self.pool.save()
+
+        with force_check_outcome(self.outcomes["Success"]):
+            result = self._run(technique_id=self.technique.pk, ap_to_invest=20)
+
+        self.assertFalse(result.success)
+        self.assertTrue(result.message)

--- a/src/actions/tests/test_technique_training_action.py
+++ b/src/actions/tests/test_technique_training_action.py
@@ -249,3 +249,30 @@ class TrainTechniqueActionFailureTests(TrainTechniqueActionTestBase):
 
         self.assertFalse(result.success)
         self.assertTrue(result.message)
+
+    def test_already_known_completion_maps_to_failure_result_not_raise(self):
+        """A stale open meter for a technique already learned by another route.
+
+        (e.g. a staff grant or a TechniqueGrant item) mints nothing further —
+        learn_technique's bare ValueError must be caught, not escape as a
+        traceback (#2739 review finding).
+        """
+        progress = self._make_progress(total_required=20)
+        CharacterTechnique.objects.create(character=self.learner, technique=self.technique)
+
+        with force_check_outcome(self.outcomes["Success"]):
+            result = self._run(technique_id=self.technique.pk, ap_to_invest=20)
+
+        self.assertFalse(result.success)
+        self.assertIn("already knows", result.message)
+        # contribute_to_technique_progress is @transaction.atomic, so the
+        # ValueError rolls back everything the session would have written
+        # (meter progress, AP spend) -- the meter survives untouched and no
+        # duplicate CharacterTechnique appears.
+        self.assertTrue(TechniqueProgress.objects.filter(pk=progress.pk).exists())
+        self.assertEqual(
+            CharacterTechnique.objects.filter(
+                character=self.learner, technique=self.technique
+            ).count(),
+            1,
+        )

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -166,6 +166,7 @@ from commands.story import CmdStory
 from commands.story_rooms import CmdJoinRoom, CmdLeaveRoom, CmdSceneRoom  # #2450
 from commands.technique import CmdTechnique
 from commands.threads import CmdThreads
+from commands.training import CmdTrain  # #2739
 from commands.travel import CmdTravel  # #2163
 from commands.turf import CmdTurf  # #2862 gap close
 from commands.vault import CmdVault
@@ -258,6 +259,8 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             CmdSignature,
             # #2030 — motif style-binding namespace (bindstyle/unbindstyle/list).
             CmdMotif,
+            # #2739 — technique training sessions (bare = list meters).
+            CmdTrain,
             # #2183 — dramatic-moment suggestion inbox (suggestions/confirm/dismiss).
             CmdMoment,
             CmdWeaveThread,

--- a/src/commands/tests/test_training_command.py
+++ b/src/commands/tests/test_training_command.py
@@ -71,6 +71,12 @@ class CmdTrainBareListingTests(CmdTrainTestBase):
         self.assertIn("teacher: -", msg)
 
     def test_bare_train_lists_meter_with_teacher_name(self):
+        """The teacher column renders the tenure's display_name (#2739 final-review fix).
+
+        Not the bare character key -- mirrors the web serializer's
+        teacher_name (TechniqueProgressSerializer.get_teacher_name), which
+        also reads teacher_tenure.display_name, so telnet and web agree.
+        """
         technique = TechniqueFactory(name="Ember Lance")
         teacher_tenure = RosterTenureFactory()
         TechniqueProgress.objects.create(
@@ -87,7 +93,7 @@ class CmdTrainBareListingTests(CmdTrainTestBase):
             cmd.func()
 
         msg = mock_msg.call_args[0][0]
-        self.assertIn(teacher_tenure.character.key, msg)
+        self.assertIn(teacher_tenure.display_name, msg)
 
 
 class CmdTrainDispatchTests(CmdTrainTestBase):

--- a/src/commands/tests/test_training_command.py
+++ b/src/commands/tests/test_training_command.py
@@ -1,0 +1,162 @@
+"""Tests for CmdTrain (#2739) — dispatch wiring + bare meter listing.
+
+Mirrors CmdTravel's test shape (commands/tests/test_travel_command.py):
+overrides func() directly, so these tests drive func() and assert on
+caller.msg / CommandError surfacing rather than going through
+dispatch_player_action. The full training-session mechanics (check content,
+outcome tiers, etc.) are covered by TrainTechniqueAction's own suite
+(actions/tests/test_technique_training_action.py) — these tests cover only
+name resolution, argument parsing, and dispatch wiring.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from actions.types import ActionResult
+from commands.training import CmdTrain
+from evennia_extensions.factories import ObjectDBFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.magic.factories import TechniqueFactory
+from world.magic.models import TechniqueProgress
+from world.roster.factories import RosterTenureFactory
+
+
+class CmdTrainTestBase(TestCase):
+    def setUp(self):
+        self.room = ObjectDBFactory(
+            db_key="TrainingRoom", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        self.learner_sheet = CharacterSheetFactory()
+        self.learner_sheet.character.location = self.room
+        self.learner_sheet.character.save()
+        self.caller = self.learner_sheet.character
+
+    def _make_cmd(self, args):
+        cmd = CmdTrain()
+        cmd.caller = self.caller
+        cmd.args = args
+        cmd.raw_string = f"train {args}"
+        return cmd
+
+
+class CmdTrainBareListingTests(CmdTrainTestBase):
+    def test_bare_train_no_meters_shows_hint(self):
+        cmd = self._make_cmd("")
+        with patch.object(self.caller, "msg") as mock_msg:
+            cmd.func()
+        mock_msg.assert_called_once()
+        msg = mock_msg.call_args[0][0]
+        self.assertIn("aren't training", msg.lower())
+
+    def test_bare_train_lists_meter_self_study(self):
+        technique = TechniqueFactory(name="Ember Lance")
+        TechniqueProgress.objects.create(
+            character_sheet=self.learner_sheet,
+            technique=technique,
+            total_required=50,
+            points_accumulated=10,
+            source="gift_acquisition",
+        )
+
+        cmd = self._make_cmd("")
+        with patch.object(self.caller, "msg") as mock_msg:
+            cmd.func()
+
+        msg = mock_msg.call_args[0][0]
+        self.assertIn("Ember Lance", msg)
+        self.assertIn("10/50", msg)
+        self.assertIn("teacher: -", msg)
+
+    def test_bare_train_lists_meter_with_teacher_name(self):
+        technique = TechniqueFactory(name="Ember Lance")
+        teacher_tenure = RosterTenureFactory()
+        TechniqueProgress.objects.create(
+            character_sheet=self.learner_sheet,
+            technique=technique,
+            total_required=50,
+            points_accumulated=5,
+            source="teaching",
+            teacher_tenure=teacher_tenure,
+        )
+
+        cmd = self._make_cmd("")
+        with patch.object(self.caller, "msg") as mock_msg:
+            cmd.func()
+
+        msg = mock_msg.call_args[0][0]
+        self.assertIn(teacher_tenure.character.key, msg)
+
+
+class CmdTrainDispatchTests(CmdTrainTestBase):
+    def test_unknown_technique_name_raises_message(self):
+        cmd = self._make_cmd("Nonexistent Technique")
+        with patch.object(self.caller, "msg") as mock_msg:
+            cmd.func()
+        mock_msg.assert_called_once()
+        msg = mock_msg.call_args[0][0]
+        self.assertIn("no technique called", msg.lower())
+
+    def test_bare_equals_with_no_name_is_usage_error(self):
+        cmd = self._make_cmd("=20")
+        with patch.object(self.caller, "msg") as mock_msg:
+            cmd.func()
+        msg = mock_msg.call_args[0][0]
+        self.assertIn("usage", msg.lower())
+
+    def test_invalid_ap_amount_raises_message(self):
+        TechniqueFactory(name="Ember Lance")
+        cmd = self._make_cmd("Ember Lance=notanumber")
+        with patch.object(self.caller, "msg") as mock_msg:
+            cmd.func()
+        msg = mock_msg.call_args[0][0]
+        self.assertIn("not a valid ap amount", msg.lower())
+
+    def test_resolves_technique_id_and_dispatches_with_default_ap(self):
+        technique = TechniqueFactory(name="Ember Lance")
+        cmd = self._make_cmd("Ember Lance")
+        with (
+            patch.object(self.caller, "msg"),
+            patch(
+                "commands.training.TrainTechniqueAction.run",
+                return_value=ActionResult(success=True, message="ok"),
+            ) as mock_run,
+        ):
+            cmd.func()
+        mock_run.assert_called_once()
+        _actor_args, called_kwargs = mock_run.call_args
+        self.assertEqual(called_kwargs.get("technique_id"), technique.pk)
+        self.assertNotIn("ap_to_invest", called_kwargs)
+
+    def test_resolves_technique_id_and_ap_to_invest(self):
+        technique = TechniqueFactory(name="Ember Lance")
+        cmd = self._make_cmd("Ember Lance=15")
+        with (
+            patch.object(self.caller, "msg"),
+            patch(
+                "commands.training.TrainTechniqueAction.run",
+                return_value=ActionResult(success=True, message="ok"),
+            ) as mock_run,
+        ):
+            cmd.func()
+        mock_run.assert_called_once()
+        _actor_args, called_kwargs = mock_run.call_args
+        self.assertEqual(called_kwargs.get("technique_id"), technique.pk)
+        self.assertEqual(called_kwargs.get("ap_to_invest"), 15)
+
+    def test_technique_name_matched_case_insensitively(self):
+        technique = TechniqueFactory(name="Ember Lance")
+        cmd = self._make_cmd("ember lance")
+        with (
+            patch.object(self.caller, "msg"),
+            patch(
+                "commands.training.TrainTechniqueAction.run",
+                return_value=ActionResult(success=True, message="ok"),
+            ) as mock_run,
+        ):
+            cmd.func()
+        mock_run.assert_called_once()
+        _actor_args, called_kwargs = mock_run.call_args
+        self.assertEqual(called_kwargs.get("technique_id"), technique.pk)

--- a/src/commands/training.py
+++ b/src/commands/training.py
@@ -1,0 +1,93 @@
+"""Telnet `train` command (#2739) — dispatches TrainTechniqueAction.
+
+Modeled on CmdTravel (commands/travel.py): overrides func() directly rather
+than the base ArxCommand._execute() single-action-dispatch recipe, since bare
+`train` needs a meter-listing read path with no action dispatch, and
+resolving the technique name to a technique_id needs custom logic before
+dispatch. No business logic lives here — meter listing is a plain read, and
+the session itself is entirely `TrainTechniqueAction`'s.
+"""
+
+from __future__ import annotations
+
+from actions.definitions.technique_training import TrainTechniqueAction
+from commands.command import ArxCommand
+from commands.exceptions import CommandError
+
+
+class CmdTrain(ArxCommand):
+    """Invest AP in a technique training session, or list your meters.
+
+    Usage:
+      train                    - list your in-progress technique meters
+      train <technique>        - train, investing the default AP
+      train <technique>=<ap>   - train, investing a specific amount of AP
+    """
+
+    key = "train"
+    locks = "cmd:all()"
+
+    def func(self) -> None:
+        raw = (self.args or "").strip()
+        if not raw:
+            self._list_meters()
+            return
+
+        try:
+            self._do_train(raw)
+        except CommandError as err:
+            self.msg(str(err))
+
+    def _list_meters(self) -> None:
+        from world.magic.models import TechniqueProgress  # noqa: PLC0415
+
+        sheet = self.caller.sheet_data
+        meters = TechniqueProgress.objects.filter(character_sheet=sheet).select_related(
+            "technique",
+            "teacher_tenure",
+        )
+        if not meters:
+            self.msg("You aren't training any techniques.")
+            return
+
+        lines = ["Your in-progress technique meters:"]
+        for meter in meters:
+            tenure = meter.teacher_tenure
+            teacher_character = tenure.character if tenure is not None else None
+            teacher_name = teacher_character.key if teacher_character is not None else "-"
+            lines.append(
+                f"  {meter.technique.name}: {meter.points_accumulated}/"
+                f"{meter.total_required} (teacher: {teacher_name})"
+            )
+        self.msg("\n".join(lines))
+
+    def _do_train(self, raw: str) -> None:
+        from world.magic.models import Technique  # noqa: PLC0415
+
+        name_part, _sep, ap_part = raw.partition("=")
+        name = name_part.strip()
+        if not name:
+            msg = "Usage: train <technique>[=<ap>]."
+            raise CommandError(msg)
+
+        ap_to_invest = None
+        ap_part = ap_part.strip()
+        if ap_part:
+            try:
+                ap_to_invest = int(ap_part)
+            except ValueError:
+                msg = f"'{ap_part}' is not a valid AP amount."
+                raise CommandError(msg) from None
+
+        technique = Technique.objects.filter(name__iexact=name).first()
+        if technique is None:
+            msg = f"There is no technique called '{name}'."
+            raise CommandError(msg)
+
+        kwargs = {"technique_id": technique.pk}
+        if ap_to_invest is not None:
+            kwargs["ap_to_invest"] = ap_to_invest
+
+        result = TrainTechniqueAction().run(self.caller, **kwargs)
+        if result.message:
+            self.msg(result.message)

--- a/src/commands/training.py
+++ b/src/commands/training.py
@@ -53,8 +53,7 @@ class CmdTrain(ArxCommand):
         lines = ["Your in-progress technique meters:"]
         for meter in meters:
             tenure = meter.teacher_tenure
-            teacher_character = tenure.character if tenure is not None else None
-            teacher_name = teacher_character.key if teacher_character is not None else "-"
+            teacher_name = tenure.display_name if tenure is not None else "-"
             lines.append(
                 f"  {meter.technique.name}: {meter.points_accumulated}/"
                 f"{meter.total_required} (teacher: {teacher_name})"

--- a/src/schema.json
+++ b/src/schema.json
@@ -19048,6 +19048,64 @@ paths:
               schema:
                 $ref: '#/components/schemas/AcceptTechniqueOfferResponse'
           description: ''
+  /api/magic/technique-progress/:
+    get:
+      operationId: magic_technique_progress_retrieve
+      description: |-
+        List the acting character's technique-progress meters; train one via POST.
+
+        ``list`` returns the scoped character's own ``TechniqueProgress`` rows —
+        another account's meters are never visible. ``POST <technique_id>/train/``
+        dispatches :class:`TrainTechniqueAction` (#2739 Task 1); the ``<id>`` path
+        segment is the ``Technique`` pk (matching the action's own ``technique_id``
+        kwarg), not the ``TechniqueProgress`` row's pk, so a technique with no
+        meter yet cleanly surfaces the action's own "you aren't training that"
+        failure as a 400 rather than a router-level 404.
+
+        Character scoping mirrors ``MotifStyleViewSet`` (#2030): an
+        ``X-Character-ID`` header, once validated as owned via
+        ``CharacterContextMixin``, takes precedence over the caller's active
+        puppet; no header falls back to the puppet (400 if none); a header
+        naming an unowned character 404s rather than silently falling back.
+      tags:
+      - magic
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          description: No response body
+  /api/magic/technique-progress/{id}/train/:
+    post:
+      operationId: magic_technique_progress_train_create
+      description: |-
+        List the acting character's technique-progress meters; train one via POST.
+
+        ``list`` returns the scoped character's own ``TechniqueProgress`` rows —
+        another account's meters are never visible. ``POST <technique_id>/train/``
+        dispatches :class:`TrainTechniqueAction` (#2739 Task 1); the ``<id>`` path
+        segment is the ``Technique`` pk (matching the action's own ``technique_id``
+        kwarg), not the ``TechniqueProgress`` row's pk, so a technique with no
+        meter yet cleanly surfaces the action's own "you aren't training that"
+        failure as a 400 rather than a router-level 404.
+
+        Character scoping mirrors ``MotifStyleViewSet`` (#2030): an
+        ``X-Character-ID`` header, once validated as owned via
+        ``CharacterContextMixin``, takes precedence over the caller's active
+        puppet; no header falls back to the puppet (400 if none); a header
+        naming an unowned character 404s rather than silently falling back.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: string
+        required: true
+      tags:
+      - magic
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          description: No response body
   /api/magic/techniques/:
     get:
       operationId: magic_techniques_list

--- a/src/world/magic/CLAUDE.md
+++ b/src/world/magic/CLAUDE.md
@@ -380,6 +380,61 @@ serializer (`_RemovedConditionSpecSerializer`), admin (`TechniqueRemovedConditio
   now forwards `ritual=ritual` to the service function, so technique-granting
   rituals can resolve their `TechniqueGrant` row.
 
+### Check-based training + its player-facing trigger (#2727, #2739)
+
+`resolve_training_check(learner, progress, *, ap_to_invest, teacher=None)`
+(`services/technique_training.py`, #2727) is the check layer sitting on top of
+`contribute_to_technique_progress` (above): the learner rolls intellect + "Arcane
+Theory" (the "Technique Training" `CheckType`, seeded by
+`ensure_technique_training_content()`) against `target_difficulty = (technique.tier
+× step) − (learner_level // divisor) − teacher_skill_bonus + (self_study_penalty
+if teacher is None)`, and the outcome maps to a dev-point multiplier via
+`TrainingOutcomeAward(OutcomeTierAward)` (botch/failure 0×, partial 0.5×, success
+1.0×, critical 1.5×) — AP is always spent regardless of outcome; only the
+dev-point yield varies. Four tuning knobs live on `GiftAcquisitionConfig`. This
+seam shipped with no production caller until #2739:
+
+- **Action** — `TrainTechniqueAction` (`actions/definitions/technique_training.py`,
+  key `train_technique`, REGISTRY, `category="magic"`, `target_type=SELF`). Kwargs
+  `technique_id` (the `Technique` pk, resolved against the learner's own open
+  `TechniqueProgress` meter — no meter is a clean failure naming the two front
+  doors above that create one) and `ap_to_invest` (defaults to 1; a value ≤ 0 is
+  rejected; the seam spends it in full and raises on pool/cap overruns rather than
+  this action pre-bounding it). Resolves a co-present teacher —
+  `progress.teacher_tenure` counts only when that tenure's live character shares
+  the learner's room *at session time*; otherwise self-study rates apply silently
+  (Decision 3a — never a location hard-block; true for both PC-teacher meters and
+  Academy TRAIN meters). Maps `WeeklyTrainingCapExceeded`/`MagicError` to a failure
+  `ActionResult`; also catches a bare `ValueError` from `learn_technique` (reached
+  on meter completion, raised when the learner already holds the
+  `CharacterTechnique` — a stale meter left open after the technique arrived by
+  another route) the same way. Success `data`:
+  `{technique_id, outcome_name, points_before, points_after, total_required,
+  technique_acquired, self_study}`.
+- **Telnet** — `CmdTrain` (`commands/training.py`, key `train`, verified free).
+  `train <technique>[=<ap>]` resolves the technique by name and dispatches the
+  action; bare `train` lists the caller's open `TechniqueProgress` meters (name,
+  progress/total, teacher-or-dash) — a read path, no dispatch.
+- **Web** — `TechniqueProgressViewSet` (`views_technique_progress.py`, routed at
+  `/api/magic/technique-progress/` in `urls.py`). `list` returns the scoped
+  character's own meters via `TechniqueProgressSerializer` (technique id/name,
+  `points_accumulated`/`total_required`, `teacher_name` — `RosterTenure
+  .display_name`, null for self-study — `source_label` from
+  `TechniqueProgress.get_source_display()`, and `weekly_remaining`, computed by one
+  batched query over the listed meters' technique ids so the list stays O(1)
+  queries regardless of meter count). `POST <technique_id>/train/`
+  (`TrainTechniqueRequestSerializer`, body `{ap_to_invest?}`) dispatches the
+  action, mapping a failure `ActionResult` to HTTP 400 `{detail}`. `<technique_id>`
+  is the `Technique` pk (matching the action's own kwarg), not the
+  `TechniqueProgress` row's pk, so a technique with no meter surfaces the action's
+  own "you aren't training that" failure as a clean 400 rather than a
+  router-level 404. Character scoping mirrors `MotifStyleViewSet` (#2030): an
+  `X-Character-ID` header, validated as owned via `CharacterContextMixin`, takes
+  precedence over the caller's active puppet.
+- **Frontend** — `TechniqueProgressPanel` (`frontend/src/magic/components/`),
+  mounted in `SpellbookTab` below `MotifStylePanel`, own-view only. See
+  `frontend/src/magic/CLAUDE.md` for the query/mutation wire contract.
+
 ### Starter Gift Catalog (CG Technique Picks, #2426; content pipeline #2474)
 
 The pre-#2426 design used a staff-curated `Cantrip` starter-technique-template model

--- a/src/world/magic/serializers.py
+++ b/src/world/magic/serializers.py
@@ -57,6 +57,7 @@ from world.magic.models import (
     SceneEntryEndorsement,
     StylePresentationEndorsement,
     Technique,
+    TechniqueProgress,
     TechniqueStyle,
     Thread,
     ThreadLevelUnlock,
@@ -3644,3 +3645,61 @@ class CrossingResultSerializer(serializers.Serializer):
     option_name = serializers.CharField()
     effect_kind = serializers.CharField()
     crossing_level = serializers.IntegerField()
+
+
+# =============================================================================
+# Technique progress meters — web surface for check-based training (#2739)
+# =============================================================================
+
+
+class TechniqueProgressSerializer(serializers.ModelSerializer):
+    """Read serializer for a learner's ``TechniqueProgress`` meter (#2739 Task 2).
+
+    ``weekly_remaining`` is populated only when the view supplies a
+    ``weekly_remaining_by_technique_id`` mapping in the serializer context — a
+    single batched query the view runs once per request (never per-row) — so
+    it degrades to ``None`` rather than firing an N+1 query when omitted.
+    """
+
+    technique_id = serializers.IntegerField(read_only=True)
+    technique_name = serializers.CharField(source="technique.name", read_only=True)
+    teacher_name = serializers.SerializerMethodField()
+    source_label = serializers.SerializerMethodField()
+    weekly_remaining = serializers.SerializerMethodField()
+
+    class Meta:
+        model = TechniqueProgress
+        fields = [
+            "id",
+            "technique_id",
+            "technique_name",
+            "points_accumulated",
+            "total_required",
+            "teacher_name",
+            "source_label",
+            "weekly_remaining",
+        ]
+        read_only_fields = fields
+
+    @extend_schema_field(serializers.CharField(allow_null=True))
+    def get_teacher_name(self, obj: TechniqueProgress) -> str | None:
+        """The teacher's anonymity-respecting display name, or ``None`` for self-study."""
+        if obj.teacher_tenure_id is None:
+            return None
+        return obj.teacher_tenure.display_name
+
+    def get_source_label(self, obj: TechniqueProgress) -> str:
+        return obj.get_source_display()
+
+    @extend_schema_field(serializers.IntegerField(allow_null=True))
+    def get_weekly_remaining(self, obj: TechniqueProgress) -> int | None:
+        remaining_by_id = self.context.get("weekly_remaining_by_technique_id")
+        if remaining_by_id is None:
+            return None
+        return remaining_by_id.get(obj.technique_id)
+
+
+class TrainTechniqueRequestSerializer(serializers.Serializer):
+    """Request shape for ``POST .../technique-progress/<technique_id>/train/``."""
+
+    ap_to_invest = serializers.IntegerField(required=False, min_value=1)

--- a/src/world/magic/tests/test_technique_progress_e2e.py
+++ b/src/world/magic/tests/test_technique_progress_e2e.py
@@ -4,10 +4,14 @@ Covers: create offer → accept → train over sessions → complete.
 Also covers cross-path multiplier and grant_path_magic bypass.
 """
 
+from decimal import Decimal
+
 from django.test import TestCase
 
+from actions.definitions.technique_training import TrainTechniqueAction
 from world.action_points.models import ActionPointPool
 from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.test_helpers import force_check_outcome
 from world.classes.factories import PathFactory
 from world.magic.constants import TargetKind
 from world.magic.factories import (
@@ -22,6 +26,7 @@ from world.magic.models import (
     TechniqueProgress,
     TechniqueTeachingOffer,
     Thread,
+    TrainingOutcomeAward,
 )
 from world.magic.services.gift_acquisition import accept_technique_offer
 from world.magic.services.path_magic import grant_path_magic
@@ -30,6 +35,23 @@ from world.magic.services.technique_progress import (
 )
 from world.progression.factories import CharacterPathHistoryFactory
 from world.roster.factories import RosterTenureFactory
+from world.traits.models import CheckOutcome
+
+# Canonical outcome tiers (name -> success_level), matching seeds/checks.py.
+_CANONICAL_OUTCOMES = [
+    ("Critical Failure", -2),
+    ("Failure", -1),
+    ("Partial Success", 0),
+    ("Success", 1),
+    ("Critical Success", 2),
+]
+
+
+def _ensure_outcome(name: str, success_level: int) -> CheckOutcome:
+    outcome, _ = CheckOutcome.objects.get_or_create(
+        name=name, defaults={"success_level": success_level}
+    )
+    return outcome
 
 
 class TechniqueProgressE2ETest(TestCase):
@@ -165,3 +187,146 @@ class TechniqueProgressE2ETest(TestCase):
                 character_sheet=self.learner, technique=self.technique
             ).exists()
         )
+
+
+class TrainTechniqueActionJourneyE2ETest(TestCase):
+    """Front door through the dispatch seam (#2739 final-review fold-in).
+
+    Threads the production front door -- accepting a teaching offer via
+    ``accept_technique_offer`` (#2711/#2726, the same acquisition seam
+    ``TechniqueProgressE2ETest`` above exercises) -- through the
+    player-facing session action ``TrainTechniqueAction.run()``
+    (#2739) all the way to meter completion, rather than calling
+    ``contribute_to_technique_progress``/``resolve_training_check`` directly
+    as the action's own unit tests and ``ResolveTrainingCheckTest`` do (both
+    start from an already-existing ``TechniqueProgress`` row). Setup mirrors
+    ``TechniqueProgressE2ETest`` above; check-content seeding mirrors
+    ``TrainTechniqueActionTestBase`` in
+    ``actions/tests/test_technique_training_action.py``.
+    """
+
+    def setUp(self):
+        self.learner = CharacterSheetFactory()
+        self.learner_pool = ActionPointPool.get_or_create_for_character(self.learner.character)
+        self.learner_pool.current = 500
+        self.learner_pool.save()
+
+        self.teacher_tenure = RosterTenureFactory()
+        self.teacher_pool = ActionPointPool.get_or_create_for_character(
+            self.teacher_tenure.character
+        )
+        self.teacher_pool.current = 500
+        self.teacher_pool.banked = 20
+        self.teacher_pool.save()
+
+        self.gift = GiftFactory()
+        self.technique = TechniqueFactory(gift=self.gift)
+        CharacterGift.objects.create(character=self.learner, gift=self.gift)
+        Thread.objects.create(
+            owner=self.learner,
+            resonance=ResonanceFactory(),
+            target_kind=TargetKind.GIFT,
+            target_gift=self.gift,
+            level=0,
+        )
+
+        self.outcomes = {name: _ensure_outcome(name, sl) for name, sl in _CANONICAL_OUTCOMES}
+        self._seed_award_rows()
+        self._seed_check_content()
+
+    def _seed_award_rows(self):
+        multipliers = {
+            "Critical Failure": Decimal("0.00"),
+            "Failure": Decimal("0.00"),
+            "Partial Success": Decimal("0.50"),
+            "Success": Decimal("1.00"),
+            "Critical Success": Decimal("1.50"),
+        }
+        for name, mult in multipliers.items():
+            TrainingOutcomeAward.objects.update_or_create(
+                outcome_tier=self.outcomes[name],
+                defaults={"dev_point_multiplier": mult},
+            )
+
+    def _seed_check_content(self):
+        """Minimal CheckType so resolve_training_check can resolve a check."""
+        from world.checks.models import CheckCategory, CheckType, CheckTypeTrait
+        from world.skills.models import Skill
+        from world.traits.models import Trait, TraitCategory, TraitType
+
+        arcane_trait, _ = Trait.objects.get_or_create(
+            name="Arcane Theory",
+            defaults={
+                "trait_type": TraitType.SKILL,
+                "category": TraitCategory.MAGIC,
+                "is_public": True,
+            },
+        )
+        Skill.objects.get_or_create(
+            trait=arcane_trait,
+            defaults={
+                "tooltip": "Understanding the theoretical underpinnings of magical techniques.",
+                "display_order": 0,
+                "is_active": True,
+            },
+        )
+        intellect_trait, _ = Trait.objects.get_or_create(
+            name="intellect",
+            defaults={
+                "trait_type": TraitType.STAT,
+                "category": TraitCategory.MENTAL,
+                "is_public": True,
+            },
+        )
+        category, _ = CheckCategory.objects.get_or_create(
+            name="Magic",
+            defaults={"description": "Magic checks.", "display_order": 40},
+        )
+        check_type, _ = CheckType.objects.get_or_create(
+            name="Technique Training",
+            category=category,
+            defaults={"is_active": True, "display_order": 10},
+        )
+        w = Decimal("1.0")
+        CheckTypeTrait.objects.update_or_create(
+            check_type=check_type, trait=intellect_trait, defaults={"weight": w}
+        )
+        CheckTypeTrait.objects.update_or_create(
+            check_type=check_type, trait=arcane_trait, defaults={"weight": w}
+        )
+
+    def test_accept_offer_then_train_sessions_complete_meter(self):
+        offer = TechniqueTeachingOffer.objects.create(
+            teacher=self.teacher_tenure,
+            technique=self.technique,
+            pitch="I will teach you",
+            learn_ap_cost=20,
+            banked_ap=20,
+        )
+
+        # Front door: accepting the offer mints the meter (no CharacterTechnique yet).
+        progress = accept_technique_offer(self.learner, offer)
+        self.assertIsInstance(progress, TechniqueProgress)
+        self.assertEqual(progress.total_required, 20)
+        self.assertFalse(
+            CharacterTechnique.objects.filter(
+                character=self.learner, technique=self.technique
+            ).exists()
+        )
+
+        # Dispatch seam: TrainTechniqueAction.run() drives the session to completion.
+        with force_check_outcome(self.outcomes["Success"]):
+            result = TrainTechniqueAction().run(
+                self.learner.character,
+                technique_id=self.technique.pk,
+                ap_to_invest=20,
+            )
+
+        self.assertTrue(result.success, result.message)
+        self.assertTrue(result.data["technique_acquired"])
+        self.assertTrue(
+            CharacterTechnique.objects.filter(
+                character=self.learner, technique=self.technique
+            ).exists()
+        )
+        self.assertFalse(TechniqueProgress.objects.filter(pk=progress.pk).exists())

--- a/src/world/magic/tests/test_technique_progress_views.py
+++ b/src/world/magic/tests/test_technique_progress_views.py
@@ -1,0 +1,410 @@
+"""Tests for TechniqueProgressViewSet — HTTP contract for list/train (#2739 Task 2).
+
+Exercises the endpoints the way the web frontend hits them:
+  • GET  /api/magic/technique-progress/                  → the actor's own meters
+  • POST /api/magic/technique-progress/<technique_id>/train/ → run one session
+  • no puppet → 400 "No active character."
+  • unauthenticated → 401/403
+  • another account's meters never appear in list
+  • train 200 happy path; 400 mappings (cap-exceeded, AP-short, already-known,
+    no-such-meter)
+  • X-Character-ID header scopes to that (owned, non-puppeted) character; an
+    unowned character 404s rather than falling back to the puppet
+
+Setup mirrors ``actions/tests/test_technique_training_action.py`` (the seam
+this viewset dispatches through) for the check-content + meter seeding.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from types import SimpleNamespace
+
+from django.test import TestCase
+from rest_framework.test import APIClient, APIRequestFactory, force_authenticate
+
+from evennia_extensions.factories import ObjectDBFactory
+from world.action_points.models import ActionPointPool
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.test_helpers import force_check_outcome
+from world.magic.constants import TargetKind
+from world.magic.factories import ResonanceFactory, TechniqueFactory
+from world.magic.models import (
+    CharacterGift,
+    CharacterTechnique,
+    TechniqueProgress,
+    Thread,
+    TrainingOutcomeAward,
+)
+from world.magic.views_technique_progress import TechniqueProgressViewSet
+from world.traits.models import CheckOutcome
+
+# Canonical outcome tiers (name -> success_level), matching seeds/checks.py.
+_CANONICAL_OUTCOMES = [
+    ("Critical Failure", -2),
+    ("Failure", -1),
+    ("Partial Success", 0),
+    ("Success", 1),
+    ("Critical Success", 2),
+]
+
+
+def _ensure_outcome(name: str, success_level: int) -> CheckOutcome:
+    outcome, _ = CheckOutcome.objects.get_or_create(
+        name=name, defaults={"success_level": success_level}
+    )
+    return outcome
+
+
+def _actor_user(character, *, available_characters=None):
+    """Fake authenticated user whose ``puppet`` is ``character``.
+
+    Mirrors ``test_motif_style_views._actor_user``.
+    """
+    owned = available_characters if available_characters is not None else [character]
+    return SimpleNamespace(
+        is_authenticated=True,
+        is_staff=False,
+        pk=character.db_account_id,
+        puppet=character,
+        get_available_characters=lambda: owned,
+    )
+
+
+def _no_puppet_user(*, available_characters=None):
+    return SimpleNamespace(
+        is_authenticated=True,
+        is_staff=False,
+        pk=None,
+        puppet=None,
+        get_available_characters=lambda: available_characters or [],
+    )
+
+
+class TechniqueProgressViewSetTestBase(TestCase):
+    """One learner with check-content seeded so a real training session can resolve."""
+
+    def setUp(self) -> None:
+        from evennia.utils.idmapper.models import flush_cache
+
+        flush_cache()
+        self.factory = APIRequestFactory()
+
+        self.room = ObjectDBFactory(
+            db_key="TrainingRoom", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        self.learner = CharacterSheetFactory()
+        self.learner.character.location = self.room
+        self.learner.character.save()
+
+        self.pool = ActionPointPool.get_or_create_for_character(self.learner.character)
+        self.pool.current = 500
+        self.pool.save()
+
+        self.technique = TechniqueFactory()
+        CharacterGift.objects.create(character=self.learner, gift=self.technique.gift)
+        Thread.objects.create(
+            owner=self.learner,
+            resonance=ResonanceFactory(),
+            target_kind=TargetKind.GIFT,
+            target_gift=self.technique.gift,
+            level=0,
+        )
+
+        self.outcomes = {name: _ensure_outcome(name, sl) for name, sl in _CANONICAL_OUTCOMES}
+        self._seed_award_rows()
+        self._seed_check_content()
+
+    def _seed_award_rows(self) -> None:
+        multipliers = {
+            "Critical Failure": Decimal("0.00"),
+            "Failure": Decimal("0.00"),
+            "Partial Success": Decimal("0.50"),
+            "Success": Decimal("1.00"),
+            "Critical Success": Decimal("1.50"),
+        }
+        for name, mult in multipliers.items():
+            TrainingOutcomeAward.objects.update_or_create(
+                outcome_tier=self.outcomes[name],
+                defaults={"dev_point_multiplier": mult},
+            )
+
+    def _seed_check_content(self) -> None:
+        """Minimal CheckType so the seam can resolve a check."""
+        from world.checks.models import CheckCategory, CheckType, CheckTypeTrait
+        from world.skills.models import Skill
+        from world.traits.models import Trait, TraitCategory, TraitType
+
+        arcane_trait, _ = Trait.objects.get_or_create(
+            name="Arcane Theory",
+            defaults={
+                "trait_type": TraitType.SKILL,
+                "category": TraitCategory.MAGIC,
+                "is_public": True,
+            },
+        )
+        Skill.objects.get_or_create(
+            trait=arcane_trait,
+            defaults={
+                "tooltip": "Understanding the theoretical underpinnings of magical techniques.",
+                "display_order": 0,
+                "is_active": True,
+            },
+        )
+        intellect_trait, _ = Trait.objects.get_or_create(
+            name="intellect",
+            defaults={
+                "trait_type": TraitType.STAT,
+                "category": TraitCategory.MENTAL,
+                "is_public": True,
+            },
+        )
+        category, _ = CheckCategory.objects.get_or_create(
+            name="Magic",
+            defaults={"description": "Magic checks.", "display_order": 40},
+        )
+        check_type, _ = CheckType.objects.get_or_create(
+            name="Technique Training",
+            category=category,
+            defaults={"is_active": True, "display_order": 10},
+        )
+        w = Decimal("1.0")
+        CheckTypeTrait.objects.update_or_create(
+            check_type=check_type, trait=intellect_trait, defaults={"weight": w}
+        )
+        CheckTypeTrait.objects.update_or_create(
+            check_type=check_type, trait=arcane_trait, defaults={"weight": w}
+        )
+
+    def _make_progress(self, *, total_required=50, technique=None, teacher_tenure=None):
+        return TechniqueProgress.objects.create(
+            character_sheet=self.learner,
+            technique=technique or self.technique,
+            total_required=total_required,
+            source="gift_acquisition",
+            teacher_tenure=teacher_tenure,
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _get_list(self, puppet, *, character_id=None):
+        extra = {"HTTP_X_CHARACTER_ID": str(character_id)} if character_id is not None else {}
+        request = self.factory.get("/api/magic/technique-progress/", **extra)
+        force_authenticate(request, user=puppet)
+        view = TechniqueProgressViewSet.as_view({"get": "list"})
+        return view(request)
+
+    def _post_train(self, puppet, technique_id, payload=None, *, character_id=None):
+        extra = {"HTTP_X_CHARACTER_ID": str(character_id)} if character_id is not None else {}
+        request = self.factory.post(
+            f"/api/magic/technique-progress/{technique_id}/train/",
+            payload or {},
+            format="json",
+            **extra,
+        )
+        force_authenticate(request, user=puppet)
+        view = TechniqueProgressViewSet.as_view({"post": "train"})
+        return view(request, pk=str(technique_id))
+
+
+# ===========================================================================
+# list
+# ===========================================================================
+
+
+class TechniqueProgressListEndpointTests(TechniqueProgressViewSetTestBase):
+    def test_list_no_puppet_returns_400(self) -> None:
+        resp = self._get_list(_no_puppet_user())
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("active character", resp.data["detail"].lower())
+
+    def test_list_anonymous_user_denied(self) -> None:
+        client = APIClient()
+        response = client.get("/api/magic/technique-progress/")
+        # DRF returns 403 for unauthenticated SessionAuthentication, 401 for
+        # TokenAuthentication (mirrors test_session_views.py).
+        self.assertIn(response.status_code, (401, 403))
+
+    def test_list_returns_own_meters_with_contract_keys(self) -> None:
+        self._make_progress(total_required=50)
+
+        resp = self._get_list(_actor_user(self.learner.character))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.data), 1)
+        row = resp.data[0]
+        self.assertEqual(
+            set(row.keys()),
+            {
+                "id",
+                "technique_id",
+                "technique_name",
+                "points_accumulated",
+                "total_required",
+                "teacher_name",
+                "source_label",
+                "weekly_remaining",
+            },
+        )
+        self.assertEqual(row["technique_id"], self.technique.pk)
+        self.assertEqual(row["technique_name"], self.technique.name)
+        self.assertEqual(row["points_accumulated"], 0)
+        self.assertEqual(row["total_required"], 50)
+        self.assertIsNone(row["teacher_name"])
+        self.assertTrue(row["source_label"])
+        self.assertIsNotNone(row["weekly_remaining"])
+
+    def test_list_scopes_to_own_meters_not_another_accounts(self) -> None:
+        self._make_progress(total_required=50)
+
+        other_sheet = CharacterSheetFactory()
+        other_technique = TechniqueFactory()
+        CharacterGift.objects.create(character=other_sheet, gift=other_technique.gift)
+        TechniqueProgress.objects.create(
+            character_sheet=other_sheet,
+            technique=other_technique,
+            total_required=30,
+            source="gift_acquisition",
+        )
+
+        resp = self._get_list(_actor_user(self.learner.character))
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.data), 1)
+        self.assertEqual(resp.data[0]["technique_id"], self.technique.pk)
+
+
+# ===========================================================================
+# train
+# ===========================================================================
+
+
+class TechniqueProgressTrainEndpointTests(TechniqueProgressViewSetTestBase):
+    def test_train_no_puppet_returns_400(self) -> None:
+        self._make_progress(total_required=50)
+
+        resp = self._post_train(_no_puppet_user(), self.technique.pk)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("active character", resp.data["detail"].lower())
+
+    def test_train_happy_path_returns_200_and_advances_meter(self) -> None:
+        progress = self._make_progress(total_required=50)
+
+        with force_check_outcome(self.outcomes["Success"]):
+            resp = self._post_train(
+                _actor_user(self.learner.character), self.technique.pk, {"ap_to_invest": 20}
+            )
+
+        self.assertEqual(resp.status_code, 200, resp.data)
+        self.assertEqual(resp.data["technique_id"], self.technique.pk)
+        self.assertFalse(resp.data["technique_acquired"])
+        progress.refresh_from_db()
+        self.assertEqual(progress.points_accumulated, 20)
+
+    def test_train_no_such_meter_returns_400(self) -> None:
+        # No TechniqueProgress row exists for this technique at all.
+        resp = self._post_train(_actor_user(self.learner.character), self.technique.pk)
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("detail", resp.data)
+
+    def test_train_cap_exceeded_returns_400(self) -> None:
+        self._make_progress(total_required=500)
+        from world.magic.services.gift_acquisition import get_gift_acquisition_config
+
+        config = get_gift_acquisition_config()
+        config.weekly_training_cap = 5
+        config.save()
+
+        with force_check_outcome(self.outcomes["Success"]):
+            first = self._post_train(
+                _actor_user(self.learner.character), self.technique.pk, {"ap_to_invest": 5}
+            )
+            second = self._post_train(
+                _actor_user(self.learner.character), self.technique.pk, {"ap_to_invest": 5}
+            )
+
+        self.assertEqual(first.status_code, 200, first.data)
+        self.assertEqual(second.status_code, 400)
+        self.assertIn("detail", second.data)
+
+    def test_train_ap_short_returns_400(self) -> None:
+        self._make_progress(total_required=500)
+        self.pool.current = 2
+        self.pool.save()
+
+        with force_check_outcome(self.outcomes["Success"]):
+            resp = self._post_train(
+                _actor_user(self.learner.character), self.technique.pk, {"ap_to_invest": 20}
+            )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("detail", resp.data)
+
+    def test_train_already_known_returns_400(self) -> None:
+        self._make_progress(total_required=20)
+        CharacterTechnique.objects.create(character=self.learner, technique=self.technique)
+
+        with force_check_outcome(self.outcomes["Success"]):
+            resp = self._post_train(
+                _actor_user(self.learner.character), self.technique.pk, {"ap_to_invest": 20}
+            )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertIn("already knows", resp.data["detail"])
+
+
+# ===========================================================================
+# X-Character-ID scoping (mirrors #2030's MotifStyleViewSet review fix)
+# ===========================================================================
+
+
+class TechniqueProgressCharacterHeaderScopingTests(TechniqueProgressViewSetTestBase):
+    def setUp(self) -> None:
+        super().setUp()
+        self.alt_sheet = CharacterSheetFactory()
+        self.alt_technique = TechniqueFactory()
+        CharacterGift.objects.create(character=self.alt_sheet, gift=self.alt_technique.gift)
+        TechniqueProgress.objects.create(
+            character_sheet=self.alt_sheet,
+            technique=self.alt_technique,
+            total_required=40,
+            source="gift_acquisition",
+        )
+
+        self.unowned_sheet = CharacterSheetFactory()
+
+    def test_list_scopes_to_header_character_not_puppet(self) -> None:
+        self._make_progress(total_required=50)
+        user = _actor_user(
+            self.learner.character,
+            available_characters=[self.learner.character, self.alt_sheet.character],
+        )
+
+        resp = self._get_list(user, character_id=self.alt_sheet.character.pk)
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(len(resp.data), 1)
+        self.assertEqual(resp.data[0]["technique_id"], self.alt_technique.pk)
+
+    def test_list_header_naming_unowned_character_returns_404_not_puppet_fallback(self) -> None:
+        user = _actor_user(self.learner.character, available_characters=[self.learner.character])
+
+        resp = self._get_list(user, character_id=self.unowned_sheet.character.pk)
+
+        self.assertEqual(resp.status_code, 404)
+        self.assertIn("character", resp.data["detail"].lower())
+
+    def test_train_header_naming_unowned_character_returns_404(self) -> None:
+        self._make_progress(total_required=50)
+        user = _actor_user(self.learner.character, available_characters=[self.learner.character])
+
+        resp = self._post_train(
+            user, self.technique.pk, character_id=self.unowned_sheet.character.pk
+        )
+
+        self.assertEqual(resp.status_code, 404)

--- a/src/world/magic/urls.py
+++ b/src/world/magic/urls.py
@@ -151,6 +151,11 @@ from world.magic.views_motif_style import MotifStyleViewSet  # noqa: E402
 
 router.register("motif-styles", MotifStyleViewSet, basename="motif-style")
 
+# #2739 Task 2 — Technique progress meter web surface
+from world.magic.views_technique_progress import TechniqueProgressViewSet  # noqa: E402
+
+router.register("technique-progress", TechniqueProgressViewSet, basename="technique-progress")
+
 
 urlpatterns = [
     # Literal paths MUST come before *router.urls so that "rituals/perform/" is

--- a/src/world/magic/views_technique_progress.py
+++ b/src/world/magic/views_technique_progress.py
@@ -1,0 +1,149 @@
+"""Technique progress meter API views (#2739 Task 2).
+
+Web DRF surface over ``TrainTechniqueAction`` (#2739 Task 1) — telnet's
+``train`` command and this endpoint converge on ``action.run()``, mirroring
+``MotifStyleViewSet`` (#2030) for character scoping.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rest_framework import status, viewsets
+from rest_framework.decorators import action
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+
+from actions.definitions.technique_training import TrainTechniqueAction
+from web.api.mixins import CharacterContextMixin
+from world.game_clock.week_services import get_current_game_week
+from world.magic.models import TechniqueProgress, TechniqueProgressWeekly
+from world.magic.serializers import TechniqueProgressSerializer, TrainTechniqueRequestSerializer
+from world.magic.services.gift_acquisition import get_gift_acquisition_config
+from world.magic.views_actor import PuppetActorMixin
+
+#: Error detail returned when the request has no active character to act as.
+NO_ACTIVE_CHARACTER_DETAIL = "No active character."
+#: Error detail when an explicit X-Character-ID header doesn't resolve to one
+#: of the requesting account's own characters (mirrors CharacterContextMixin
+#: consumers such as MotifStyleViewSet/PathIntentViewSet/CharacterGoalViewSet).
+CHARACTER_NOT_FOUND_DETAIL = "No character found."
+#: Error detail when the ``<id>`` path segment on the ``train`` action isn't a
+#: technique pk at all (never surfaced by a well-formed frontend request).
+TECHNIQUE_NOT_FOUND_DETAIL = "No such technique."
+
+
+class TechniqueProgressViewSet(CharacterContextMixin, PuppetActorMixin, viewsets.ViewSet):
+    """List the acting character's technique-progress meters; train one via POST.
+
+    ``list`` returns the scoped character's own ``TechniqueProgress`` rows —
+    another account's meters are never visible. ``POST <technique_id>/train/``
+    dispatches :class:`TrainTechniqueAction` (#2739 Task 1); the ``<id>`` path
+    segment is the ``Technique`` pk (matching the action's own ``technique_id``
+    kwarg), not the ``TechniqueProgress`` row's pk, so a technique with no
+    meter yet cleanly surfaces the action's own "you aren't training that"
+    failure as a 400 rather than a router-level 404.
+
+    Character scoping mirrors ``MotifStyleViewSet`` (#2030): an
+    ``X-Character-ID`` header, once validated as owned via
+    ``CharacterContextMixin``, takes precedence over the caller's active
+    puppet; no header falls back to the puppet (400 if none); a header
+    naming an unowned character 404s rather than silently falling back.
+    """
+
+    permission_classes = [IsAuthenticated]
+
+    def _resolve_scoped_actor(self, request: Any) -> tuple[Any, Response | None]:
+        """Resolve the acting character for this request.
+
+        Returns ``(actor, None)`` on success or ``(None, error_response)`` on
+        failure. Mirrors ``MotifStyleViewSet._resolve_scoped_actor``.
+        """
+        if request.headers.get("X-Character-ID"):
+            character = self._get_character(request)
+            if character is None:
+                return None, Response(
+                    {"detail": CHARACTER_NOT_FOUND_DETAIL}, status=status.HTTP_404_NOT_FOUND
+                )
+            return character, None
+        actor = self._resolve_actor(request)
+        if actor is None:
+            return None, Response(
+                {"detail": NO_ACTIVE_CHARACTER_DETAIL}, status=status.HTTP_400_BAD_REQUEST
+            )
+        return actor, None
+
+    def list(self, request: Any) -> Response:
+        actor, error = self._resolve_scoped_actor(request)
+        if error is not None:
+            return error
+        # RoomProfile/CharacterSheet share ObjectDB's pk (both primary_key=True
+        # O2Os onto it) — filter directly off the puppet's pk, no extra fetch.
+        rows = list(
+            TechniqueProgress.objects.filter(character_sheet_id=actor.pk)
+            .select_related(
+                "technique",
+                # FK chain consumed by TechniqueProgressSerializer.teacher_name
+                # (RosterTenure.display_name walks roster_entry → character_sheet
+                # → character; mirrors ThreadWeavingTeachingOfferViewSet).
+                "teacher_tenure__roster_entry__character_sheet__character",
+            )
+            .order_by("technique__name")
+        )
+        serializer = TechniqueProgressSerializer(
+            rows,
+            many=True,
+            context={"weekly_remaining_by_technique_id": self._weekly_remaining(actor, rows)},
+        )
+        return Response(serializer.data)
+
+    @staticmethod
+    def _weekly_remaining(actor: Any, rows: list[TechniqueProgress]) -> dict[int, int]:
+        """Batch-compute remaining weekly training points per technique.
+
+        One ``GameWeek`` lookup, one config lookup (both cached singletons),
+        and one batched query over the listed meters' technique ids — never
+        per-row, so this stays cheap regardless of how many meters a
+        character has open. ``TechniqueProgressSerializer.get_weekly_remaining``
+        degrades to ``None`` when this mapping is absent.
+        """
+        if not rows:
+            return {}
+        game_week = get_current_game_week()
+        config = get_gift_acquisition_config()
+        contributed = dict(
+            TechniqueProgressWeekly.objects.filter(
+                character_sheet_id=actor.pk,
+                game_week=game_week,
+                technique_id__in=[row.technique_id for row in rows],
+            ).values_list("technique_id", "points_contributed")
+        )
+        remaining: dict[int, int] = {}
+        for row in rows:
+            cap = config.weekly_training_cap
+            if row.is_cross_path and config.cross_path_cap_divisor > 1:
+                cap = config.weekly_training_cap // config.cross_path_cap_divisor
+            remaining[row.technique_id] = max(0, cap - contributed.get(row.technique_id, 0))
+        return remaining
+
+    @action(detail=True, methods=["post"], url_path="train")
+    def train(self, request: Any, pk: str | None = None) -> Response:
+        actor, error = self._resolve_scoped_actor(request)
+        if error is not None:
+            return error
+        serializer = TrainTechniqueRequestSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        try:
+            technique_id = int(pk)
+        except (TypeError, ValueError):
+            return Response(
+                {"detail": TECHNIQUE_NOT_FOUND_DETAIL}, status=status.HTTP_400_BAD_REQUEST
+            )
+        result = TrainTechniqueAction().run(
+            actor=actor,
+            technique_id=technique_id,
+            ap_to_invest=serializer.validated_data.get("ap_to_invest"),
+        )
+        if not result.success:
+            return Response({"detail": result.message}, status=status.HTTP_400_BAD_REQUEST)
+        return Response(result.data)


### PR DESCRIPTION
Closes #2739

## Summary

The check-based technique training layer (#2729) was complete but unreachable: resolve_training_check had no production caller and the TechniqueProgress meter was invisible on every surface, so a player who accepted a teaching offer or Academy TRAIN got a meter they could neither see nor fill. This PR closes the level-1 learning loop: TrainTechniqueAction (key train_technique) is the layer's first production caller — teacher co-presence resolves the meter's tenure only when actually in the room (ratified Decision 3a: never a location hard-block; Academy/absent-teacher sessions silently proceed at self-study rates), AP handling defers to the seam's own exceptions, and the completion race (meter deleted by a concurrent session) plus the already-known mint case both map to clean failures instead of tracebacks. Meters are visible on all three surfaces: telnet (bare 'train' lists them; 'train <technique>[=<ap>]' trains), web (TechniqueProgressViewSet — list + train-by-technique-pk, N+1-free, leak-tested scoping), and the Spellbook (TechniqueProgressPanel with a Train button; minting invalidates the character-sheet cache so the new technique appears immediately). A front-door journey test threads accept_technique_offer → TrainTechniqueAction.run() → mint through production seams. Docs updated in tandem (systems/magic.md, INDEX, character-progression roadmap, magic CLAUDE.md); no migration. The inherited teacher-tenure succession edge is documented on #2711 rather than changed here. #2740/#2741 remain open by design (NPC teacher bonus = 0 until #2741 rules).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2739 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased clean onto main after #3031/#3032 merged; post-rebase 'just gen-api-types' produced zero diff (generated types already consistent). No migrations on this branch.

<!-- last-addressed-comment: 0 -->