### PR TITLE
Stamp the default level-1 CharacterClassLevel at CG finalize and the select_initial_path recovery seam

### DIFF
--- a/docs/roadmap/character-progression.md
+++ b/docs/roadmap/character-progression.md
@@ -128,6 +128,19 @@ The central spine connecting every system in the game. Characters develop throug
       Deliberately does NOT grant the path's magic (unlike `cross_into_path`) — narrower scope
       than a full CG replay. Telnet `durance selectpath <path>`; REST
       `GET`/`POST /api/progression/select-path/` (`SelectPathViewSet`).
+    - **CG class-level stamp ✅ shipped (#3038).** A fourth launch-blocking gap: no
+      production path ever wrote a `CharacterClassLevel` row for a player character
+      (only `seed_durance_officiants`'s NPCs got one), so
+      `advance_class_level_via_session` raised `AdvancementRequirementsNotMet`
+      unconditionally for every real PC and the class term of
+      `derive_base_max_health` was always 0 — the Durance was reachable in principle
+      but never actually completable by a CG-finalized character.
+      `world.classes.services.ensure_default_character_class()` centralizes the
+      shared placeholder `CharacterClass` get-or-create (previously duplicated in
+      `seeds.py`); CG finalize (`_apply_character_mechanics`) now stamps a level-1
+      primary `CharacterClassLevel` on every character, and `select_initial_path`
+      stamps the same for CG-bypassing characters that have none yet (without
+      clobbering an existing one).
 - Path step requirements engine — scaling requirements from trivial (level 2: 100 XP, 30 in primary skill, 10 legend, find a trainer, some gold) to nearly impossible (level 21: Audere Majora 4th crossing, extreme achievements, god-tier trainer quest). The Audere Majora crossing itself is built (see What Exists); this engine adds the legend/XP/trainer prerequisites for the non-boundary steps and feeds the boundary steps
 - Trainer system — finding trainers, training costs, trainer tiers
 - Path switching/discovery mechanics

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -941,6 +941,10 @@ per-class, per-stage health rate authoring and the primary-class level service.
     — upserts the primary class level and triggers a full `recompute_max_health_with_threads`
     so vitals reflect the new level immediately. **Always use this, never mutate
     `CharacterClassLevel` rows directly.**
+  - `ensure_default_character_class() -> CharacterClass` — get-or-creates the single
+    shared placeholder `CharacterClass` (`DEFAULT_CHARACTER_CLASS_NAME`, "Adventurer")
+    every character is stamped with pre-class-selection (#3038); CG finalize and the
+    #2121 `select_initial_path` recovery seam both call it before stamping level 1.
 - **Key Methods:** `Path.parent_paths`, `Path.child_paths` (evolution hierarchy)
 - **Integrates with:** progression (level requirements), character_creation (Prospect
   selection), vitals (`derive_base_max_health` reads `ClassStageHealthRate` + `stage_for_level`)

--- a/docs/systems/MODEL_MAP.md
+++ b/docs/systems/MODEL_MAP.md
@@ -1767,6 +1767,7 @@
   - aspect -> classes.Aspect [FK]
 
 ### Service Functions
+- `ensure_default_character_class() -> world.classes.models.CharacterClass - Get or create the single shared default CharacterClass (#3038).`
 - `is_crossing_level(level: int) -> bool - Return True if ``level`` is a PathStage crossing boundary.`
 - `set_primary_class_level(character: object, character_class: object, level: int) -> object - Set the character's primary class level and recompute level-derived health.`
 - `stage_for_level(level: int) -> int - Map a class level to its PathStage value (clamps <1 to PROSPECT).`

--- a/docs/systems/character_creation.md
+++ b/docs/systems/character_creation.md
@@ -172,6 +172,23 @@ else a `SETTLED_BY_SPONSOR` row (`settled_at` stamped, `settled_by_token` left
 logged skip if the Academy isn't seeded. See `docs/systems/societies.md`'s
 Obligations section for the model/service detail.
 
+`finalize_character`'s `_apply_character_mechanics` also stamps a level-1 primary
+`CharacterClassLevel` on every finalized character (#3038,
+`_stamp_default_class_level`, called right after `_create_path_history`), via
+`world.classes.services.set_primary_class_level(character,
+ensure_default_character_class(), 1)`. Before this, no production path ever wrote
+a `CharacterClassLevel` for a player character, so `advance_class_level_via_session`
+(the Ritual of the Durance) raised `AdvancementRequirementsNotMet` unconditionally
+and the class term of `derive_base_max_health` was always 0.
+`ensure_default_character_class` (`world/classes/services.py`) get-or-creates the
+same single shared placeholder `CharacterClass` (`DEFAULT_CHARACTER_CLASS_NAME`,
+"Adventurer") the #2121 seeded Durance officiants and the level-2
+`ClassLevelUnlock` gate already anchor on — no class-selection UI exists yet, and
+advancement only ever reads `current_level`/Path lineage, never a specific
+`CharacterClass` name. The #2121 `select_initial_path` recovery seam
+(`world.progression.services.advancement`, for CG-bypassing characters) stamps the
+same level-1 class level when one is missing, without clobbering an existing one.
+
 ---
 
 ## Email Notifications (#2162)

--- a/docs/systems/classes.md
+++ b/docs/systems/classes.md
@@ -84,7 +84,11 @@ CharacterClassLevel.objects.get(character=character, is_primary=True)
 ### Services (`world.classes.services`)
 
 ```python
-from world.classes.services import stage_for_level, set_primary_class_level
+from world.classes.services import (
+    ensure_default_character_class,
+    set_primary_class_level,
+    stage_for_level,
+)
 
 # Map a level to its PathStage band (breakpoints L1/3/6/11/16/21)
 stage = stage_for_level(5)   # PathStage.POTENTIAL (3 <= 5 < 6)
@@ -93,6 +97,11 @@ stage = stage_for_level(11)  # PathStage.TRUE
 # Set a character's primary class level and immediately recompute max_health.
 # Always use this — never mutate CharacterClassLevel rows directly.
 ccl = set_primary_class_level(character, character_class, level=7)
+
+# Get-or-create the single shared placeholder CharacterClass every character is
+# stamped with pre-class-selection (#3038) — CG finalize and the #2121
+# select_initial_path recovery seam both call this before stamping level 1.
+default_class = ensure_default_character_class()
 ```
 
 ### PathAspect

--- a/docs/systems/progression.md
+++ b/docs/systems/progression.md
@@ -428,13 +428,28 @@ from world.progression.exceptions import PathAlreadySelectedError
 # (current_path_for_character stays None; assert_can_officiate can never
 # establish lineage). Raises PathAlreadySelectedError if a path is already
 # on record — one-time only, NOT a general path-change tool (cross_into_path
-# is that seam). Deliberately does NOT call grant_path_magic.
+# is that seam). Deliberately does NOT call grant_path_magic. Also stamps a
+# level-1 primary CharacterClassLevel when the character has none yet (#3038) —
+# never overwrites an existing one.
 select_initial_path(character, path)
 ```
 
 `SelectPathAction` (key `select_path`, `actions/definitions/progression_rewards.py`) is the
 action.run() seam both telnet (`durance selectpath <path name or id>`) and the web converge
 on; only the 5 PROSPECT paths are offered.
+
+**CG class-level stamp (#3038).** Before this, no production path ever wrote a
+`CharacterClassLevel` for a player character — only `seed_durance_officiants`'s
+NPCs got one — so `advance_class_level_via_session` raised
+`AdvancementRequirementsNotMet` unconditionally for every real PC.
+`world.classes.services.ensure_default_character_class()` centralizes the
+shared placeholder `CharacterClass` get-or-create that used to be duplicated
+across `seed_durance_officiants` and `seed_major_gift_technique_level_requirement`
+in `world/progression/seeds.py`. CG finalize (`character_creation.services.
+_apply_character_mechanics`) now calls `set_primary_class_level(character,
+ensure_default_character_class(), 1)` for every finalized character, and
+`select_initial_path` (above) does the same for CG-bypassing characters that
+have none yet.
 
 ### Path Selectors (`selectors.py` — #1700)
 

--- a/src/world/character_creation/services.py
+++ b/src/world/character_creation/services.py
@@ -719,6 +719,7 @@ def _apply_character_mechanics(character: ObjectDB, draft: CharacterDraft) -> No
     _create_distinctions(character, draft)
     _create_worship_declaration(character, draft)
     _create_path_history(character, draft)
+    _stamp_default_class_level(character)
     _establish_chosen_patronage(character, draft)
     _apply_post_cg_bonuses(character, draft, CharacterTraitValue)
 
@@ -778,6 +779,33 @@ def _create_path_history(character: ObjectDB, draft: CharacterDraft) -> None:
         character=character.sheet_data,
         path=draft.selected_path,
     )
+
+
+def _stamp_default_class_level(character: ObjectDB) -> None:
+    """Stamp the level-1 primary CharacterClassLevel every finalized character needs (#3038).
+
+    No production path wrote a CharacterClassLevel row for a player character before
+    this: without one, ``advance_class_level_via_session`` (the Ritual of the Durance)
+    raises ``AdvancementRequirementsNotMet`` unconditionally, and
+    ``derive_base_max_health``'s class term is always 0. Uses the same shared default
+    CharacterClass the #2121 seeded Durance officiants and the level-2 gate anchor on
+    (``ensure_default_character_class``) — no class-selection UI exists yet, and
+    advancement only ever reads ``current_level``/Path lineage, never a specific
+    CharacterClass name.
+
+    ``set_primary_class_level`` is itself an upsert (keyed on character +
+    character_class), so calling this again (e.g. a re-finalize) never duplicates
+    the row.
+
+    Args:
+        character: The newly created ``ObjectDB`` character.
+    """
+    from world.classes.services import (  # noqa: PLC0415
+        ensure_default_character_class,
+        set_primary_class_level,
+    )
+
+    set_primary_class_level(character, ensure_default_character_class(), 1)
 
 
 def _establish_chosen_patronage(character: ObjectDB, draft: CharacterDraft) -> None:

--- a/src/world/character_creation/tests/test_services.py
+++ b/src/world/character_creation/tests/test_services.py
@@ -757,6 +757,52 @@ class FinalizeCharacterPathHistoryTests(FinalizationTestMixin, TestCase):
         self.assertEqual(history.path, self.path)
 
 
+class FinalizeCharacterClassLevelTests(FinalizationTestMixin, TestCase):
+    """Tests for the level-1 CharacterClassLevel stamp during finalization (#3038)."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls._setup_finalization_base(
+            cls, prefix="Class Level Test", height_min=1300, height_max=1400
+        )
+
+    def setUp(self):
+        self._flush_common_caches()
+        self.account = AccountDB.objects.create(username=f"classleveltest_{id(self)}")
+
+    def _create_complete_draft(self):
+        return self._create_base_draft(first_name="ClassLevelTest", skills={}, specializations={})
+
+    def test_finalize_stamps_level_one_primary_class_level(self):
+        """finalize_character creates exactly one level-1 primary CharacterClassLevel."""
+        from world.classes.models import CharacterClassLevel
+        from world.classes.services import DEFAULT_CHARACTER_CLASS_NAME
+
+        draft = self._create_complete_draft()
+
+        character = finalize_character(draft, add_to_roster=True)
+
+        levels = CharacterClassLevel.objects.filter(character_id=character.pk)
+        self.assertEqual(levels.count(), 1)
+        level = levels.first()
+        self.assertEqual(level.level, 1)
+        self.assertTrue(level.is_primary)
+        self.assertEqual(level.character_class.name, DEFAULT_CHARACTER_CLASS_NAME)
+
+    def test_stamping_twice_does_not_duplicate(self):
+        """set_primary_class_level is an upsert, so re-stamping never duplicates the row."""
+        from world.classes.models import CharacterClassLevel
+        from world.classes.services import ensure_default_character_class, set_primary_class_level
+
+        draft = self._create_complete_draft()
+        character = finalize_character(draft, add_to_roster=True)
+
+        set_primary_class_level(character, ensure_default_character_class(), 1)
+
+        levels = CharacterClassLevel.objects.filter(character_id=character.pk)
+        self.assertEqual(levels.count(), 1)
+
+
 class FinalizeCharacterGoalsTests(FinalizationTestMixin, TestCase):
     """Tests for goal creation during character finalization."""
 

--- a/src/world/classes/services.py
+++ b/src/world/classes/services.py
@@ -1,6 +1,16 @@
 """Service helpers for the classes app."""
 
-from world.classes.models import PathStage
+from world.classes.models import CharacterClass, PathStage
+
+#: The single shared placeholder CharacterClass stamped on every character (PC or
+#: NPC) until real class selection exists. Originally introduced by
+#: world.progression.seeds.seed_durance_officiants (#2121) for seeded Durance
+#: officiants; CG finalize and the #2121 select_initial_path recovery seam
+#: (world.progression.services.advancement) now stamp it on every PC too (#3038)
+#: — advancement only ever reads current_level/Path lineage, never a specific
+#: CharacterClass name, so one shared class is the correct generic anchor
+#: everywhere a class level is required.
+DEFAULT_CHARACTER_CLASS_NAME = "Adventurer"
 
 # (min_level, stage) descending — first whose min_level <= level wins.
 _STAGE_THRESHOLDS: list[tuple[int, int]] = [
@@ -11,6 +21,27 @@ _STAGE_THRESHOLDS: list[tuple[int, int]] = [
     (3, PathStage.POTENTIAL),
     (1, PathStage.PROSPECT),
 ]
+
+
+def ensure_default_character_class() -> CharacterClass:
+    """Get or create the single shared default CharacterClass (#3038).
+
+    Idempotent via get_or_create; never overwrites a staff-adjusted description
+    on an existing row. Callers: the #2121 seeded Durance officiants, CG
+    finalize's level-1 stamp, and the #2121 select_initial_path recovery seam
+    — see ``DEFAULT_CHARACTER_CLASS_NAME`` for why one shared class is correct
+    everywhere.
+
+    Returns:
+        The default CharacterClass (created or fetched).
+    """
+    character_class, _ = CharacterClass.objects.get_or_create(
+        name=DEFAULT_CHARACTER_CLASS_NAME,
+        defaults={
+            "description": "Default class stamped on characters before class selection exists.",
+        },
+    )
+    return character_class
 
 
 def stage_for_level(level: int) -> int:

--- a/src/world/progression/seeds.py
+++ b/src/world/progression/seeds.py
@@ -151,10 +151,6 @@ def seed_kudos_content() -> None:
 
 # --- Durance officiant bootstrap (#2121) -----------------------------------
 
-#: PLACEHOLDER class stamped on every seeded Durance training officiant.
-#: assert_can_officiate never reads CharacterClass — only current_level (any
-#: class) and Path lineage — so one shared class suffices for all 5.
-_DURANCE_OFFICIANT_CLASS_NAME = "Adventurer"
 #: Comfortably above the only within-PROSPECT-stage Durance target (level 2 —
 #: PROSPECT covers levels 1-2; level 3 crosses to POTENTIAL via Audere Majora,
 #: not the Durance). assert_can_officiate only requires officiant > target.
@@ -209,19 +205,17 @@ def seed_durance_officiants() -> list:
 
     from world.areas.services import get_room_profile  # noqa: PLC0415
     from world.character_sheets.services import create_character_with_sheet  # noqa: PLC0415
-    from world.classes.models import CharacterClass, Path  # noqa: PLC0415
-    from world.classes.services import set_primary_class_level  # noqa: PLC0415
+    from world.classes.models import Path  # noqa: PLC0415
+    from world.classes.services import (  # noqa: PLC0415
+        ensure_default_character_class,
+        set_primary_class_level,
+    )
     from world.progression.models import CharacterPathHistory, DuranceTrainingSite  # noqa: PLC0415
     from world.seeds.character_creation import ensure_canonical_fallback_room  # noqa: PLC0415
 
     room = ensure_canonical_fallback_room()
     room_profile = get_room_profile(room)
-    officiant_class, _ = CharacterClass.objects.get_or_create(
-        name=_DURANCE_OFFICIANT_CLASS_NAME,
-        defaults={
-            "description": "PLACEHOLDER class stamped on seeded Durance training officiants.",
-        },
-    )
+    officiant_class = ensure_default_character_class()
 
     sites: list[DuranceTrainingSite] = []
     for path_name in _DURANCE_OFFICIANT_PATH_NAMES:
@@ -275,11 +269,13 @@ def seed_major_gift_technique_level_requirement() -> ClassLevelUnlock:
     (class, level) pair anywhere in the codebase yet (verified against code —
     this content is staff/admin-authored, never seeded) — this is the first.
 
-    Reuses the same PLACEHOLDER ``_DURANCE_OFFICIANT_CLASS_NAME`` ("Adventurer")
-    class ``seed_durance_officiants`` stamps on its officiants: per that
-    function's own docstring, ``assert_can_officiate`` and the Durance gate
-    read ``current_level``/Path lineage, never a specific ``CharacterClass``
-    name, so the same one shared class is the correct generic anchor for the
+    Reuses the same shared default CharacterClass
+    (``world.classes.services.ensure_default_character_class``) that
+    ``seed_durance_officiants`` stamps on its officiants and CG finalize now
+    stamps on every PC (#3038): per ``seed_durance_officiants``' own
+    docstring, ``assert_can_officiate`` and the Durance gate read
+    ``current_level``/Path lineage, never a specific ``CharacterClass`` name,
+    so the same one shared class is the correct generic anchor for the
     level-2 gate too. Idempotent via get_or_create; never overwrites a
     staff-adjusted row (an existing ``MajorGiftTechniqueRequirement`` for this
     unlock is left untouched, including a staff-retuned ``minimum_techniques``).
@@ -287,18 +283,13 @@ def seed_major_gift_technique_level_requirement() -> ClassLevelUnlock:
     Returns:
         The level-2 ``ClassLevelUnlock`` (created or fetched).
     """
-    from world.classes.models import CharacterClass  # noqa: PLC0415
+    from world.classes.services import ensure_default_character_class  # noqa: PLC0415
     from world.progression.models import (  # noqa: PLC0415
         ClassLevelUnlock,
         MajorGiftTechniqueRequirement,
     )
 
-    character_class, _ = CharacterClass.objects.get_or_create(
-        name=_DURANCE_OFFICIANT_CLASS_NAME,
-        defaults={
-            "description": "PLACEHOLDER class stamped on seeded Durance training officiants.",
-        },
-    )
+    character_class = ensure_default_character_class()
     unlock, _ = ClassLevelUnlock.objects.get_or_create(
         character_class=character_class, target_level=2
     )

--- a/src/world/progression/services/advancement.py
+++ b/src/world/progression/services/advancement.py
@@ -137,17 +137,28 @@ def select_initial_path(character: ObjectDB, path: Path) -> CharacterPathHistory
     recovery is meant to have; a bypassing character's magic provisioning (or
     lack of it) is a separate concern from "unblock the Durance."
 
+    Also stamps the level-1 primary CharacterClassLevel (#3038, the same shared
+    default CharacterClass CG finalize stamps) when the character has none yet —
+    the same CG-bypassing paths above never write one either, and
+    ``advance_class_level_via_session`` raises ``AdvancementRequirementsNotMet``
+    unconditionally with no class level on record. Never overwrites an existing
+    class level (a bypassing path could plausibly have set one some other way).
+
     Raises:
         PathAlreadySelectedError: the character already has a
             CharacterPathHistory row — this is not a general path-change tool
             (use ``cross_into_path`` for that).
     """
+    from world.classes.services import ensure_default_character_class, set_primary_class_level
     from world.progression.models import CharacterPathHistory
     from world.progression.selectors import current_path_for_character
 
     if current_path_for_character(character) is not None:
         raise PathAlreadySelectedError
-    return CharacterPathHistory.objects.create(character=character.sheet_data, path=path)
+    history = CharacterPathHistory.objects.create(character=character.sheet_data, path=path)
+    if primary_class_level(character) is None:
+        set_primary_class_level(character, ensure_default_character_class(), 1)
+    return history
 
 
 # =============================================================================

--- a/src/world/progression/tests/test_select_path.py
+++ b/src/world/progression/tests/test_select_path.py
@@ -16,12 +16,13 @@ from actions.definitions.progression_rewards import SelectPathAction
 from commands.durance import CmdDurance
 from evennia_extensions.factories import AccountFactory, CharacterFactory
 from world.character_sheets.factories import CharacterSheetFactory
-from world.classes.factories import PathFactory
-from world.classes.models import PathStage
+from world.classes.factories import CharacterClassLevelFactory, PathFactory
+from world.classes.models import CharacterClassLevel, PathStage
+from world.classes.services import DEFAULT_CHARACTER_CLASS_NAME
 from world.progression.exceptions import PathAlreadySelectedError
 from world.progression.factories import CharacterPathHistoryFactory
 from world.progression.selectors import current_path_for_character
-from world.progression.services.advancement import select_initial_path
+from world.progression.services.advancement import primary_class_level, select_initial_path
 
 URL = "/api/progression/select-path/"
 
@@ -64,6 +65,30 @@ class SelectInitialPathServiceTests(TestCase):
         with patch("world.magic.services.path_magic.grant_path_magic") as mock_grant:
             select_initial_path(self.character, self.path)
         mock_grant.assert_not_called()
+
+    def test_stamps_a_level_one_class_level_when_none_exists(self) -> None:
+        """(#3038) The recovery seam also unblocks the Durance's class-level gate."""
+        self.assertIsNone(primary_class_level(self.character))
+
+        select_initial_path(self.character, self.path)
+
+        level = primary_class_level(self.character)
+        self.assertIsNotNone(level)
+        self.assertEqual(level.level, 1)
+        self.assertTrue(level.is_primary)
+        self.assertEqual(level.character_class.name, DEFAULT_CHARACTER_CLASS_NAME)
+
+    def test_does_not_overwrite_an_existing_class_level(self) -> None:
+        """(#3038) A bypassing character that already has a class level keeps it."""
+        existing = CharacterClassLevelFactory(character=self.sheet, level=7, is_primary=True)
+
+        select_initial_path(self.character, self.path)
+
+        levels = CharacterClassLevel.objects.filter(character_id=self.character.pk)
+        self.assertEqual(levels.count(), 1)
+        level = levels.first()
+        self.assertEqual(level.pk, existing.pk)
+        self.assertEqual(level.level, 7)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #3038

## Problem

No production path ever created a `CharacterClassLevel` row for a player character — CG finalize wrote `CharacterPathHistory` only, and the sole caller of `set_primary_class_level` was the NPC officiant seeder. Every real PC's first Ritual of the Durance failed with "This character has no class level to advance," and `derive_base_max_health`'s class term was permanently zero.

## Fix

- `ensure_default_character_class()` in `world/classes/services.py` — single home for the shared default class (get-or-create); both progression seeders (`seed_durance_officiants`, `seed_major_gift_technique_level_requirement`) now use it instead of duplicating the name/defaults.
- CG finalize (`_apply_character_mechanics`) stamps `set_primary_class_level(character, default_class, 1)` right after path history. Idempotent via the existing upsert.
- `select_initial_path` (the #2121 recovery seam for CG-bypassing characters: GM-finalize quickstart, NPCAsset promotion) also stamps the level-1 class level when the character has none — never clobbering an existing level.

Design note for review: the shared "Adventurer" placeholder class is used deliberately, per the recorded intent in `seed_major_gift_technique_level_requirement`'s docstring (the Durance gate reads level/Path lineage, never a class name — one generic anchor class is correct until real classes are authored). `ClassStageHealthRate` rows for it remain a separate tuning follow-up.

## Tests

- `FinalizeCharacterClassLevelTests` (character_creation): finalize creates exactly one level-1 primary row; re-stamp doesn't duplicate.
- `SelectInitialPathServiceTests` (+2): stamps when missing; does not overwrite an existing class level.
- Fast tier: `world.character_creation.tests.test_services` (83 OK), `world.progression.tests.test_select_path` (21 OK), `world.classes.tests.test_services` + `world.progression.tests.test_seed_durance_officiants` (10 OK).

Docs updated in tandem: `character_creation.md`, `classes.md`, `progression.md`, `INDEX.md`, `character-progression.md` roadmap, `MODEL_MAP.md` regenerated.

Found during the 2026-08-07 alpha-readiness audit (#3038-#3046).

🤖 Generated with [Claude Code](https://claude.com/claude-code)