### PR TITLE
Wire per-check development points at the perform_check chokepoint

### DIFF
--- a/docs/roadmap/character-progression.md
+++ b/docs/roadmap/character-progression.md
@@ -188,8 +188,14 @@ The central spine connecting every system in the game. Characters develop throug
   and use the fatigue pipeline, need action type definitions and resonance integration
 - **Action type definitions** — define base fatigue costs per action, which pool each draws from,
   and wire into the scene action request system
-- ~~**Development point hooks**~~ — DONE: dp awarded per check via action pipeline,
-  threshold-based level-ups, WeeklySkillUsage accumulator, weekly rust + audit cron
+- ~~**Development point hooks**~~ — DONE (#3039): dp awarded at the `perform_check`
+  chokepoint (`world.checks.services._award_check_development`), threshold-based
+  level-ups, WeeklySkillUsage accumulator, weekly rust + audit cron. Previously this
+  lived only in `world.fatigue.action_pipeline._execute_action_with_fatigue`, whose
+  public wrapper (`execute_action_with_fatigue`) had zero production callers — no
+  character ever accrued dp organically. The pipeline no longer awards; hooking on
+  `perform_check` instead covers every check path (combat, scenes, the test-rig
+  forced-outcome path included) in one place.
 - **Integration test for fatigue → check pipeline** — end-to-end test with real CheckRank/ResultChart
   fixture data (currently mocked)
 - **Unified dice roll system** — fatigue checks use perform_check but the broader game needs a

--- a/docs/systems/progression.md
+++ b/docs/systems/progression.md
@@ -179,6 +179,18 @@ dev = DevelopmentPoints.objects.get(character=character, trait=trait)
 dev.award_points(5)
 ```
 
+**Check-based accrual (#3039).** `world.progression.services.skill_development
+.award_check_development(character_sheet, check_type, effort_level, path_level)`
+writes both `WeeklySkillUsage` (accumulator for the weekly audit/rust cron) and
+`DevelopmentPoints` (via `award_points`) for every trait the check used. Its sole
+caller is `world.checks.services._award_check_development`, hooked at the
+`perform_check` chokepoint — every check path (combat, scene actions, the test-rig
+forced-outcome path) awards, whether or not it goes through the fatigue action
+pipeline. Effort-gated: `effort_level is None` (or an effort level with 0 base dp,
+e.g. very-low/low) is a no-op, so the hook self-scopes to effort-bearing checks. A
+character with no `CharacterSheet` (objects, ephemeral opponents) is skipped
+silently.
+
 ### KudosClaimCategory
 
 ```python
@@ -648,9 +660,11 @@ Dispatches `SetPathIntentAction` / `ClearPathIntentAction`
 - **Traits**: `DevelopmentPoints.award_points()` auto-applies to `CharacterTraitValue`.
 - **Classes**: `ClassLevelUnlock`, `ClassXPCost`, and requirements reference `CharacterClass` and class levels.
 - **Scenes**: Scene completion (`on_scene_finished`) grants vote-budget bonuses. It does
-  not award development points — development comes from resolved checks
-  (`award_check_development`) and GM fiat (`GMAwardAction`). Awarding development from
-  scene participation is recorded as intent in `docs/roadmap/planned-systems.md`.
+  not award development points — development comes from resolved checks (hooked at the
+  `perform_check` chokepoint, #3039 — see "Check-based accrual" above) and GM fiat
+  (`GMAwardAction`). Awarding development from scene participation itself (independent
+  of any check resolved within it) is recorded as intent in
+  `docs/roadmap/planned-systems.md`.
 - **Character Creation**: CG-to-XP conversion via `award_cg_conversion_xp()` creates locked (non-transferable) `CharacterXP`.
 - **Magic — Ritual of the Durance (#1352):** `advance_class_level_via_session` is
   dispatched by `fire_session` for the "Ritual of the Durance" `Ritual` row (seeded via

--- a/src/world/checks/CLAUDE.md
+++ b/src/world/checks/CLAUDE.md
@@ -66,6 +66,14 @@ The checks app defines types of checks (Stealth, Diplomacy, Perception, etc.) an
    fired here if engaged, announces `"your vow lies dormant — {perk.name} would have answered
    here"` to the checker alone (never the room) — see `world.covenants.perks.services
    .dormant_perk_firings`/`announce_dormant_perks`.
+8. Check-based development points (#3039): `perform_check`'s own `_award_check_development`
+   forwards to `world.progression.services.skill_development.award_check_development`
+   for every trait the check used — the ONE chokepoint for check-driven dp accrual.
+   Runs after both the rolled path and the test-rig forced-outcome path (each exactly
+   once). Cheap no-op when `effort_level is None`; silently skipped when the character
+   has no `CharacterSheet`. Previously this lived only in `world.fatigue.action_pipeline
+   ._execute_action_with_fatigue`, whose public wrapper had zero production callers — the
+   pipeline no longer awards at all.
 
 ## Opposed checks — two mutually exclusive answers for the opposing side (#2707, ADR-0166)
 

--- a/src/world/checks/services.py
+++ b/src/world/checks/services.py
@@ -17,7 +17,10 @@ from world.checks.types import CheckResult, ModifierBreakdown, ModifierContribut
 from world.classes.models import PathAspect
 from world.fatigue.constants import EFFORT_CHECK_MODIFIER
 from world.progression.models import CharacterPathHistory
-from world.progression.services.skill_development import get_character_path_level
+from world.progression.services.skill_development import (
+    award_check_development,
+    get_character_path_level,
+)
 from world.traits.constants import PrimaryStat
 from world.traits.models import (
     CheckOutcome,
@@ -70,7 +73,11 @@ def perform_check(  # noqa: PLR0913 - optional effort/fatigue params extend exis
     6. Roll 1-100
     7. Apply rollmod: effective = max(1, min(100, roll + rollmod))
     8. Look up outcome on chart using effective roll
-    9. Return CheckResult
+    9. Award check-based development points (#3039) via ``_award_check_development`` —
+       the sole chokepoint for ``world.progression.services.skill_development
+       .award_check_development``. Covers both the rolled path and the test-rig
+       forced-outcome path (``_build_forced_check_result``) exactly once each.
+    10. Return CheckResult
 
     Args:
         character: The character performing the check.
@@ -111,7 +118,7 @@ def perform_check(  # noqa: PLR0913 - optional effort/fatigue params extend exis
 
     forced_outcome = _consume_forced_outcome()
     if forced_outcome is not None:
-        return _build_forced_check_result(
+        result = _build_forced_check_result(
             character=character,
             check_type=check_type,
             forced_outcome=forced_outcome,
@@ -124,6 +131,8 @@ def perform_check(  # noqa: PLR0913 - optional effort/fatigue params extend exis
             level_override=level_override,
             stat_override=stat_override,
         )
+        _award_check_development(character, check_type, effort_level)
+        return result
 
     breakdown = _compute_check_breakdown(
         character,
@@ -144,7 +153,48 @@ def perform_check(  # noqa: PLR0913 - optional effort/fatigue params extend exis
     outcome = _get_outcome_for_roll(breakdown.chart, effective_roll) if breakdown.chart else None
     outcome = _apply_outcome_guarantees(character, outcome, breakdown.chart, situation_ctx)
 
-    return _check_result(check_type, outcome, breakdown, effective_roll=effective_roll)
+    result = _check_result(check_type, outcome, breakdown, effective_roll=effective_roll)
+    _award_check_development(character, check_type, effort_level)
+    return result
+
+
+def _award_check_development(
+    character: "ObjectDB",
+    check_type: "CheckType",
+    effort_level: str | None,
+) -> None:
+    """Award check-based development points at the ``perform_check`` chokepoint (#3039).
+
+    Previously this lived in ``world.fatigue.action_pipeline
+    ._execute_action_with_fatigue``, whose public wrapper
+    (``execute_action_with_fatigue``) had zero production callers — combat and
+    scene action-resolution paths call ``perform_check``/``perform_check_with_modifiers``
+    directly, so no character ever accrued weekly skill usage or development points.
+    Hooking here instead covers every production check path in one place, including
+    the test-rig forced-outcome path (deliberate — integration tests that force an
+    outcome should observe the same accrual production checks do).
+
+    Cheap short-circuit on ``effort_level is None``: ``award_check_development``
+    itself also no-ops on ``None``, but checking here first skips the
+    ``CharacterSheet`` lookup entirely for the (common) no-effort case.
+
+    Skips silently, without raising, when *character* has no ``CharacterSheet``
+    (an ephemeral NPC, a GM puppet, or any non-character object) — development
+    points don't apply to non-characters.
+    """
+    if effort_level is None:
+        return
+
+    sheet = character.character_sheet  # type: ignore[attr-defined] — ObjectDB typeclass extension
+    if sheet is None:
+        return
+
+    award_check_development(
+        character_sheet=sheet,
+        check_type=check_type,
+        effort_level=effort_level,
+        path_level=get_character_path_level(character),
+    )
 
 
 def perform_check_with_modifiers(  # noqa: PLR0913 - mirrors perform_check signature

--- a/src/world/checks/tests/test_services.py
+++ b/src/world/checks/tests/test_services.py
@@ -25,10 +25,13 @@ from world.checks.services import (
     perform_check,
     preview_check_difficulty,
 )
+from world.checks.test_helpers import force_check_outcome
 from world.classes.factories import PathFactory
 from world.classes.models import Aspect, PathAspect, PathStage
 from world.conditions.factories import CapabilityTypeFactory
-from world.progression.models import CharacterPathHistory
+from world.fatigue.constants import EffortLevel
+from world.progression.models import CharacterPathHistory, DevelopmentPoints, WeeklySkillUsage
+from world.progression.services.skill_development import calculate_check_dev_points
 from world.traits.factories import CheckSystemSetupFactory
 from world.traits.models import (
     CharacterTraitValue,
@@ -683,3 +686,148 @@ class ComputeResistIncrementTests(TestCase):
         CheckType.objects.filter(name="Composure").delete()
         result = compute_resist_increment(self.character, resist_effort_level="high")
         assert result == 0
+
+
+class PerformCheckDevelopmentAwardTests(TestCase):
+    """#3039: perform_check is the sole chokepoint for check-based dp accrual.
+
+    Previously this only happened inside world.fatigue.action_pipeline
+    ._execute_action_with_fatigue, whose public wrapper had zero production
+    callers -- no character ever accrued WeeklySkillUsage/DevelopmentPoints.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        Trait.flush_instance_cache()
+        cls.setup = CheckSystemSetupFactory.create()
+        PointConversionRange.objects.get_or_create(
+            trait_type=TraitType.STAT,
+            min_value=1,
+            defaults={"max_value": 100, "points_per_level": 1},
+        )
+        for rank_val, min_pts, name in [
+            (0, 0, "DpEffortNone"),
+            (1, 10, "DpEffortNovice"),
+            (2, 25, "DpEffortCompetent"),
+            (3, 50, "DpEffortExpert"),
+        ]:
+            CheckRank.objects.get_or_create(
+                rank=rank_val,
+                defaults={"min_points": min_pts, "name": name},
+            )
+        cls.sheet = CharacterSheetFactory()
+        cls.character = cls.sheet.character
+        cls.trait, _ = Trait.objects.get_or_create(
+            name="dp_award_test_strength",
+            defaults={
+                "trait_type": TraitType.STAT,
+                "category": TraitCategory.PHYSICAL,
+            },
+        )
+        cls.category = CheckCategoryFactory(name="dp_award_test_category")
+        cls.check_type = CheckTypeFactory(name="dp_award_test_strike", category=cls.category)
+        CheckTypeTraitFactory(
+            check_type=cls.check_type,
+            trait=cls.trait,
+            weight=Decimal("1.0"),
+        )
+
+    def setUp(self):
+        Trait.flush_instance_cache()
+        CharacterTraitValue.flush_instance_cache()
+        WeeklySkillUsage.flush_instance_cache()
+        DevelopmentPoints.flush_instance_cache()
+        ResultChart.clear_cache()
+        WeeklySkillUsage.objects.filter(character_sheet=self.sheet).delete()
+        DevelopmentPoints.objects.filter(character_sheet=self.sheet).delete()
+        CharacterTraitValue.objects.create(
+            character=self.character.sheet_data, trait=self.trait, value=30
+        )
+
+    def test_medium_effort_creates_usage_and_dev_points(self):
+        """A check with effort_level creates WeeklySkillUsage + DevelopmentPoints."""
+        perform_check(
+            self.character,
+            self.check_type,
+            target_difficulty=0,
+            effort_level=EffortLevel.MEDIUM,
+        )
+
+        expected_dp = calculate_check_dev_points(EffortLevel.MEDIUM, path_level=1)
+        usage = WeeklySkillUsage.objects.get(character_sheet=self.sheet, trait=self.trait)
+        assert usage.check_count == 1
+        assert usage.points_earned == expected_dp
+
+        dev = DevelopmentPoints.objects.get(character_sheet=self.sheet, trait=self.trait)
+        assert dev.total_earned == expected_dp
+
+    def test_none_effort_writes_nothing(self):
+        """A check with no effort_level writes no accrual rows."""
+        perform_check(
+            self.character,
+            self.check_type,
+            target_difficulty=0,
+            effort_level=None,
+        )
+
+        assert not WeeklySkillUsage.objects.filter(character_sheet=self.sheet).exists()
+        assert not DevelopmentPoints.objects.filter(character_sheet=self.sheet).exists()
+
+    def test_no_character_sheet_does_not_crash(self):
+        """A sheetless character (object/ephemeral opponent) is skipped silently."""
+        sheetless = CharacterFactory()
+
+        result = perform_check(
+            sheetless,
+            self.check_type,
+            target_difficulty=0,
+            effort_level=EffortLevel.MEDIUM,
+        )
+
+        assert result is not None
+        assert not WeeklySkillUsage.objects.filter(trait=self.trait).exists()
+        assert not DevelopmentPoints.objects.filter(trait=self.trait).exists()
+
+    def test_second_check_same_week_increments(self):
+        """A second check in the same game week upserts via the F() increment path,
+        rather than duplicating the WeeklySkillUsage row."""
+        perform_check(
+            self.character,
+            self.check_type,
+            target_difficulty=0,
+            effort_level=EffortLevel.MEDIUM,
+        )
+        perform_check(
+            self.character,
+            self.check_type,
+            target_difficulty=0,
+            effort_level=EffortLevel.MEDIUM,
+        )
+
+        expected_dp = calculate_check_dev_points(EffortLevel.MEDIUM, path_level=1)
+        usages = WeeklySkillUsage.objects.filter(character_sheet=self.sheet, trait=self.trait)
+        assert usages.count() == 1
+        usage_data = usages.values("check_count", "points_earned").first()
+        assert usage_data["check_count"] == 2
+        assert usage_data["points_earned"] == expected_dp * 2
+
+    def test_forced_outcome_path_also_awards(self):
+        """The test-rig forced-outcome path (force_check_outcome) awards too --
+        deliberate: integration tests that force an outcome should observe the
+        same accrual production checks do (#3039)."""
+        success_outcome = self.setup["outcomes"]["success"]
+        with force_check_outcome(success_outcome):
+            perform_check(
+                self.character,
+                self.check_type,
+                target_difficulty=0,
+                effort_level=EffortLevel.MEDIUM,
+            )
+
+        expected_dp = calculate_check_dev_points(EffortLevel.MEDIUM, path_level=1)
+        usage = WeeklySkillUsage.objects.get(character_sheet=self.sheet, trait=self.trait)
+        assert usage.check_count == 1
+        assert usage.points_earned == expected_dp
+
+        dev = DevelopmentPoints.objects.get(character_sheet=self.sheet, trait=self.trait)
+        assert dev.total_earned == expected_dp

--- a/src/world/fatigue/action_pipeline.py
+++ b/src/world/fatigue/action_pipeline.py
@@ -2,6 +2,14 @@
 
 Orchestrates the full action pipeline: apply fatigue cost, compute effort/fatigue
 modifiers for checks, and handle collapse risk.
+
+Does NOT award development points. Check-based development accrual (#3039) lives
+on the ``world.checks.services.perform_check`` chokepoint (via
+``_award_check_development``), which every check path reaches whether or not it
+goes through this pipeline — previously this pipeline was the only caller of
+``award_check_development``, but its public wrapper (``execute_action_with_fatigue``)
+had zero production callers, so no character ever accrued development points.
+Hooking on ``perform_check`` instead means every check awards, this pipeline or not.
 """
 
 from __future__ import annotations
@@ -21,10 +29,6 @@ from world.fatigue.services import (
     should_check_collapse,
 )
 from world.fatigue.types import ActionResult
-from world.progression.services.skill_development import (
-    award_check_development,
-    get_character_path_level,
-)
 
 
 def execute_action_with_fatigue(
@@ -43,6 +47,10 @@ def execute_action_with_fatigue(
         4. If check_fn provided, execute it with (effort_modifier, fatigue_penalty).
         5. Check collapse risk (based on zone AFTER fatigue applied).
         6. Return result with all details.
+
+    Does NOT award development points — if ``check_fn`` calls ``perform_check``/
+    ``perform_check_with_modifiers``, development accrual already happened inside
+    that call (#3039). ``ActionResult.level_ups`` is always empty here.
 
     Args:
         character_sheet: The character's sheet.
@@ -86,18 +94,12 @@ def _execute_action_with_fatigue(
 
     # 4. Execute check if provided
     check_result = None
-    level_ups: list[tuple[str, int, int]] = []
     if check_fn is not None:
         check_result = check_fn(effort_modifier, fatigue_penalty)
 
-    # 4b. Award development points for qualifying checks.
-    if check_result is not None and effort_level:
-        level_ups = award_check_development(
-            character_sheet=character_sheet,
-            check_type=check_result.check_type,
-            effort_level=effort_level,
-            path_level=get_character_path_level(character_sheet.character),
-        )
+    # Development-point accrual (#3039) happens inside perform_check itself when
+    # check_fn calls it — not here. level_ups is always empty on this ActionResult.
+    level_ups: list[tuple[str, int, int]] = []
 
     # 5. Collapse risk (based on zone AFTER fatigue applied)
     fatigue_zone = get_fatigue_zone(character_sheet, fatigue_category)

--- a/src/world/fatigue/tests/test_action_pipeline.py
+++ b/src/world/fatigue/tests/test_action_pipeline.py
@@ -83,8 +83,6 @@ class ExecuteActionBasicTests(TestCase):
         """Action with check_fn passes effort modifier and fatigue penalty."""
         captured_args = {}
         mock_result = MagicMock()
-        mock_result.check_type = MagicMock()
-        mock_result.check_type.traits.select_related.return_value.all.return_value = []
 
         def mock_check(effort_mod, fatigue_pen):
             captured_args["effort_mod"] = effort_mod
@@ -101,6 +99,24 @@ class ExecuteActionBasicTests(TestCase):
         assert result.check_result is mock_result
         assert captured_args["effort_mod"] == 4  # EXTREME modifier
         assert captured_args["fatigue_pen"] == 0  # FRESH zone, no penalty
+
+    def test_pipeline_does_not_award_development(self):
+        """#3039: the pipeline no longer calls award_check_development itself —
+
+        that now happens inside perform_check. A check_fn's return value is
+        never inspected for a check_type, so level_ups is always empty here,
+        even with a real check_fn and EFFORT levels that would earn dp.
+        """
+        mock_result = MagicMock()
+
+        result = execute_action_with_fatigue(
+            self.sheet,
+            ActionCategory.PHYSICAL,
+            5,
+            EffortLevel.EXTREME,
+            check_fn=lambda *_args: mock_result,
+        )
+        assert result.level_ups == []
 
     def test_result_contains_effort_level(self):
         """ActionResult includes the effort level used."""


### PR DESCRIPTION
Closes #3039

## Problem

`award_check_development` — the designed primary source of organic stat/skill growth — was only reachable through `execute_action_with_fatigue`, which has zero production callers (combat and scenes call the fatigue helpers directly). `WeeklySkillUsage` rows were never created, so the weekly development cron settled nothing and only applied rust; GM fiat was the sole `DevelopmentPoints` writer. `docs/systems/progression.md` claimed this was DONE; `docs/roadmap/character-progression.md`'s "hook MUST live on perform_check" was the accurate record.

## Fix

- New `_award_check_development` helper called at the end of `perform_check` (`world/checks/services.py`): cheap `effort_level is None` short-circuit, sheet resolved via the safe `character.character_sheet` accessor (sheetless actors skip silently), path level via the existing `get_character_path_level`. `award_check_development`'s own effort/dp gating makes the hook self-scoping — only effort-bearing checks accrue.
- Fires exactly once on both the rolled path and the forced-outcome test-rig path (deliberate: integration tests that force outcomes observe accrual like production). `perform_check_with_modifiers` inherits the hook by delegation.
- `_execute_action_with_fatigue` no longer awards (double-award removed); its `ActionResult.level_ups` is always empty — no production caller read it.

## Tests

- New `PerformCheckDevelopmentAwardTests` (checks app): effort check creates `WeeklySkillUsage` + `DevelopmentPoints`; no-effort writes nothing; sheetless character no-ops without crashing; second same-week check exercises the F() upsert (one row, check_count=2); forced-outcome path awards.
- Fatigue pipeline: new `test_pipeline_does_not_award_development`.
- Fast tier: checks test_services (40 OK), fatigue test_action_pipeline (20 OK), progression test_skill_development (46 OK), force/modifiers (9 OK), broader checks-app spot-check (70 OK). Ruff clean.

Docs updated in tandem: `docs/systems/progression.md`, `docs/roadmap/character-progression.md`, `src/world/checks/CLAUDE.md`.

Found during the 2026-08-07 alpha-readiness audit (#3038-#3046).

🤖 Generated with [Claude Code](https://claude.com/claude-code)