### PR TITLE
Web character sheet shows real mechanics: 12 stats, skills, resonance balances

### DIFF
--- a/docs/roadmap/character-progression.md
+++ b/docs/roadmap/character-progression.md
@@ -23,6 +23,12 @@ The central spine connecting every system in the game. Characters develop throug
 - **Unlock system:** XPCostChart, ClassLevelUnlock, requirement types (Trait, Level, ClassLevel, MultiClass, Achievement, Relationship, Legend, Tier), CharacterUnlock, spend_xp_on_unlock service
 - **APIs:** Full viewsets/serializers for traits, skills, progression, classes (paths, character classes, aspects)
 - **Frontend:** XP/Kudos page in progression section
+- **Web character sheet mechanics (#3042):** the 12 stats and skill ratings (with
+  specializations + `at_boundary` breakthrough-ready flag) render on the character sheet's
+  Sheet tab, and claimed-resonance balances render on the Spellbook tab — the sheet API already
+  serialized all three (`CharacterSheetSerializer`), they just had no frontend consumer.
+  Per-trait development-point progress display is deferred to #3039's landing (not part of the
+  sheet payload yet).
 - **Audere Majora / Crossing the Threshold (#543):** the unified tier-crossing event. Per-boundary `AudereMajoraThreshold` rows (levels 5/10/15/20) gate a cast-time offer (intensity tier + deep Soulfray + engagement + active Audere + eligible next-stage path). Accepting atomically advances the level boundary, writes `CharacterPathHistory`, records an irreversible `AudereMajoraCrossing` receipt, and applies the Audere Majora power-spike condition (DeathDeferred — consequences resolve when the blaze ends). Ceremony content is DB-authored and spoiler-private. `PathIntent` lets players pre-declare their next path; the offer pre-selects it. REST + React offer surfaces mirror the Audere offer family
 - **Audere Majora legend-deed minting (#953):** `cross_threshold` now mints a full
   renown deed for the crosser. `AudereMajoraThreshold` inherits the new abstract

--- a/docs/systems/character_sheets.md
+++ b/docs/systems/character_sheets.md
@@ -24,6 +24,23 @@ allow-list lookup runs only when a section is actually FRIENDS-gated, so the all
 no query. Bio/story tiers (entangled with the presented-identity gating) and the player-facing
 tier-setting UI are follow-ups.
 
+## Web Sheet Mechanics Display (#3042)
+
+The `stats`/`skills` sections of `CharacterSheetSerializer` were always built (`_build_stats`/
+`_build_skills`) and gated by the tiers above, but had no frontend consumer — a player's own
+12 stats and skill ratings were invisible on the web sheet. `_build_stats` returns
+**display-scale** values (`tv.value // STAT_DISPLAY_DIVISOR`, ADR-0193 — stats store internal
+×10) so the client never has to know about the storage scale; `_build_skills` values are already
+true-scale (skills store and display the same number). `frontend/src/character_sheets/components/
+MechanicsSection.tsx` renders both on the character sheet's Sheet tab
+(`roster/pages/CharacterSheetPage.tsx`), reading `useCharacterSheetQuery` and rendering whatever
+`stats`/`skills` the API returns — it does not re-implement visibility client-side. The magic
+section's `resonances` (claimed-resonance balances, already serialized by `_build_magic_resonances`,
+#2032) similarly had no frontend consumer; `SpellbookTab.tsx` now renders a "Resonances" card
+alongside Gifts/Motif/Aura. Per-trait development-point progress is NOT part of this payload
+(deferred to #3039's landing) — the skill entry's `at_boundary` flag is the only progress signal
+shown today.
+
 ## Related Models
 
 All character-related models FK back to CharacterSheet:

--- a/frontend/src/character_sheets/api.ts
+++ b/frontend/src/character_sheets/api.ts
@@ -84,12 +84,21 @@ export interface CharacterSheetAura {
   can_finish_glimpse: boolean;
 }
 
+/** Mirrors `world.character_sheets.types.ResonanceBalanceEntry`. */
+export interface CharacterSheetResonanceBalance {
+  name: string;
+  balance: number;
+  lifetime_earned: number;
+}
+
 /** Mirrors `world.character_sheets.types.MagicSection`. */
 export interface CharacterSheetMagic {
   gifts: CharacterSheetGift[];
   motif: CharacterSheetMotif | null;
   anima_ritual: CharacterSheetAnimaRitual | null;
   aura: CharacterSheetAura | null;
+  /** Claimed-resonance spendable balances (#2032/#3042) — sorted by name server-side. */
+  resonances: CharacterSheetResonanceBalance[];
 }
 
 /** Mirrors `world.character_sheets.types.DistinctionEntry`. */
@@ -104,13 +113,37 @@ export interface CharacterSheetDistinction {
   is_from_glimpse: boolean;
 }
 
+/** Mirrors `world.character_sheets.types.SkillRef`. */
+export interface CharacterSheetSkillRef {
+  id: number;
+  name: string;
+  category: string;
+}
+
+/** Mirrors `world.character_sheets.types.SpecializationEntry`. */
+export interface CharacterSheetSpecialization {
+  id: number;
+  name: string;
+  value: number;
+}
+
+/** Mirrors `world.character_sheets.types.SkillEntry`. */
+export interface CharacterSheetSkill {
+  skill: CharacterSheetSkillRef;
+  value: number;
+  /** True when the skill is parked at an XP boundary (19/29/39/49) — a breakthrough check. */
+  at_boundary: boolean;
+  specializations: CharacterSheetSpecialization[];
+}
+
 /**
  * The full `/api/character-sheets/{id}/` payload.
  *
- * `identity`, `appearance`, `stats`, `skills`, `path`, `story`, `goals`, `personas`, `theming`,
- * `profile_picture`, and `current_residence` are left loosely typed here — this task only needs
- * `distinctions` and `magic` typed precisely (Tasks 9 & 10); refine the rest as their consuming
- * sections land.
+ * `identity`, `appearance`, `path`, `story`, `goals`, `personas`, `theming`, `profile_picture`,
+ * and `current_residence` are left loosely typed here — refine as their consuming sections land.
+ * `stats` and `skills` were typed precisely in #3042 (mirroring
+ * `world.character_sheets.types._build_stats`/`SkillEntry`); `distinctions` and `magic` in
+ * Tasks 9 & 10.
  */
 export interface CharacterSheetOriginSlot {
   slot_id: number;
@@ -131,8 +164,9 @@ export interface CharacterSheetPayload {
   can_edit: boolean;
   identity: Record<string, unknown>;
   appearance: Record<string, unknown>;
-  stats: Record<string, unknown>;
-  skills: unknown[];
+  /** Stat name -> display value (already ÷10 from the ×10 internal storage, ADR-0193). */
+  stats: Record<string, number>;
+  skills: CharacterSheetSkill[];
   path: Record<string, unknown> | null;
   distinctions: CharacterSheetDistinction[];
   magic: CharacterSheetMagic | null;

--- a/frontend/src/character_sheets/components/MechanicsSection.test.tsx
+++ b/frontend/src/character_sheets/components/MechanicsSection.test.tsx
@@ -1,0 +1,65 @@
+/**
+ * MechanicsSection tests (#3042).
+ *
+ * Covers: attribute grid rendering + display capitalization, empty-state lines for both
+ * stats and skills, skill rows with value/specializations/at_boundary badge.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { MechanicsSection } from './MechanicsSection';
+import type { CharacterSheetSkill } from '@/character_sheets/api';
+
+function makeSkill(overrides: Partial<CharacterSheetSkill> = {}): CharacterSheetSkill {
+  return {
+    skill: { id: 1, name: 'melee', category: 'combat' },
+    value: 25,
+    at_boundary: false,
+    specializations: [],
+    ...overrides,
+  };
+}
+
+describe('MechanicsSection', () => {
+  it('renders stat entries with capitalized names and display values', () => {
+    render(<MechanicsSection stats={{ strength: 3, agility: 4 }} skills={[]} />);
+    expect(screen.getByText('Strength')).toBeInTheDocument();
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('Agility')).toBeInTheDocument();
+    expect(screen.getByText('4')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no stats', () => {
+    render(<MechanicsSection stats={{}} skills={[]} />);
+    expect(screen.getByTestId('stats-empty-state')).toBeInTheDocument();
+  });
+
+  it('renders a skill row with its value and specializations', () => {
+    render(
+      <MechanicsSection
+        stats={{}}
+        skills={[
+          makeSkill({
+            skill: { id: 2, name: 'sewing', category: 'crafting' },
+            value: 40,
+            specializations: [{ id: 9, name: 'Embroidery', value: 5 }],
+          }),
+        ]}
+      />
+    );
+    expect(screen.getByText('Sewing')).toBeInTheDocument();
+    expect(screen.getByText('40')).toBeInTheDocument();
+    expect(screen.getByText('Embroidery (5)')).toBeInTheDocument();
+  });
+
+  it('shows the at-boundary badge when a skill is parked at an XP boundary', () => {
+    render(<MechanicsSection stats={{}} skills={[makeSkill({ at_boundary: true })]} />);
+    expect(screen.getByTestId('skill-at-boundary')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when there are no skills', () => {
+    render(<MechanicsSection stats={{}} skills={[]} />);
+    expect(screen.getByTestId('skills-empty-state')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/character_sheets/components/MechanicsSection.tsx
+++ b/frontend/src/character_sheets/components/MechanicsSection.tsx
@@ -1,0 +1,90 @@
+/**
+ * MechanicsSection (#3042) — the character sheet's Attributes + Skills display.
+ *
+ * Ungated: `stats`/`skills` on the sheet payload are already visibility-filtered server-side
+ * (`CharacterSheetSerializer.to_representation`, src/world/character_sheets/serializers.py —
+ * `show_stats`/`show_skills` per `stats_visibility`/`skills_visibility`), returning `{}`/`[]`
+ * for a viewer who isn't allowed to see them. This component only renders whatever
+ * `useCharacterSheetQuery` returns — it does NOT re-implement visibility client-side, and it
+ * can't distinguish "hidden" from "genuinely no data" (neither can the API response).
+ *
+ * Stat values arrive already converted to the single-digit display scale (÷10 from the ×10
+ * internal storage, ADR-0193) — this component renders them as-is.
+ */
+
+import type { CharacterSheetSkill } from '@/character_sheets/api';
+import { Badge } from '@/components/ui/badge';
+
+interface MechanicsSectionProps {
+  stats: Record<string, number>;
+  skills: CharacterSheetSkill[];
+}
+
+function capitalize(word: string): string {
+  return word.length === 0 ? word : word[0].toUpperCase() + word.slice(1);
+}
+
+export function MechanicsSection({ stats, skills }: MechanicsSectionProps) {
+  const statEntries = Object.entries(stats);
+
+  return (
+    <>
+      <section>
+        <h3 className="text-xl font-semibold">Attributes</h3>
+        {statEntries.length === 0 ? (
+          <p className="text-sm text-muted-foreground" data-testid="stats-empty-state">
+            No attributes shared.
+          </p>
+        ) : (
+          <dl
+            className="grid grid-cols-2 gap-x-4 gap-y-1 sm:grid-cols-3 md:grid-cols-4"
+            data-testid="stats-grid"
+          >
+            {statEntries.map(([name, value]) => (
+              <div key={name} className="flex justify-between gap-2 sm:block">
+                <dt className="text-sm text-muted-foreground">{capitalize(name)}</dt>
+                <dd className="font-medium tabular-nums">{value}</dd>
+              </div>
+            ))}
+          </dl>
+        )}
+      </section>
+
+      <section>
+        <h3 className="text-xl font-semibold">Skills</h3>
+        {skills.length === 0 ? (
+          <p className="text-sm text-muted-foreground" data-testid="skills-empty-state">
+            No skills shared.
+          </p>
+        ) : (
+          <ul className="space-y-1" data-testid="skills-list">
+            {skills.map((entry) => (
+              <li key={entry.skill.id} data-testid="skill-row">
+                <div className="flex items-center justify-between gap-2">
+                  <span>{capitalize(entry.skill.name)}</span>
+                  <span className="flex items-center gap-2">
+                    <span className="font-medium tabular-nums">{entry.value}</span>
+                    {entry.at_boundary && (
+                      <Badge variant="outline" data-testid="skill-at-boundary">
+                        Ready to break through
+                      </Badge>
+                    )}
+                  </span>
+                </div>
+                {entry.specializations.length > 0 && (
+                  <ul className="ml-4 text-sm text-muted-foreground">
+                    {entry.specializations.map((spec) => (
+                      <li key={spec.id}>
+                        {spec.name} ({spec.value})
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+    </>
+  );
+}

--- a/frontend/src/magic/components/SpellbookTab.test.tsx
+++ b/frontend/src/magic/components/SpellbookTab.test.tsx
@@ -11,7 +11,7 @@
  * mocked) live at the bottom of this file.
  */
 
-import { screen } from '@testing-library/react';
+import { screen, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { vi } from 'vitest';
 import { renderWithProviders } from '@/test/utils/renderWithProviders';
@@ -231,6 +231,7 @@ function makeMagic(overrides: Partial<CharacterSheetMagic> = {}): CharacterSheet
     },
     anima_ritual: null,
     aura: makeAura(),
+    resonances: [],
     ...overrides,
   };
 }
@@ -267,6 +268,31 @@ describe('SpellbookTab', () => {
     expect(screen.getByText('Sardonic')).toBeInTheDocument();
     // Aura is qualitative — no raw decimal percentages anywhere in the DOM.
     expect(screen.queryByText(/70/)).not.toBeInTheDocument();
+  });
+
+  it('renders resonance balances (#3042)', () => {
+    mockPayload(
+      makeMagic({
+        resonances: [
+          { name: 'Ember', balance: 4, lifetime_earned: 12 },
+          { name: 'Resolve', balance: 0, lifetime_earned: 3 },
+        ],
+      })
+    );
+    renderWithProviders(<SpellbookTab characterId={1} isMyCharacter={false} />);
+
+    const card = screen.getByTestId('spellbook-resonances');
+    const balances = within(card).getAllByTestId('resonance-balance');
+    expect(balances).toHaveLength(2);
+    expect(within(card).getByText('Ember')).toBeInTheDocument();
+    expect(within(card).getByText('4')).toBeInTheDocument();
+    expect(within(card).getByText('12 lifetime')).toBeInTheDocument();
+  });
+
+  it('omits the resonances card when there are no claimed resonances', () => {
+    mockPayload(makeMagic({ resonances: [] }));
+    renderWithProviders(<SpellbookTab characterId={1} isMyCharacter={false} />);
+    expect(screen.queryByTestId('spellbook-resonances')).not.toBeInTheDocument();
   });
 
   it('does not render workbench links for a foreign viewer', () => {

--- a/frontend/src/magic/components/SpellbookTab.tsx
+++ b/frontend/src/magic/components/SpellbookTab.tsx
@@ -209,6 +209,29 @@ export function SpellbookTab({ characterId, isMyCharacter }: Props) {
         </div>
       )}
 
+      {magic && magic.resonances.length > 0 && (
+        <Card data-testid="spellbook-resonances">
+          <CardHeader>
+            <CardTitle className="text-base">Resonances</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <dl className="grid grid-cols-2 gap-x-4 gap-y-2 sm:grid-cols-3">
+              {magic.resonances.map((resonance) => (
+                <div key={resonance.name} data-testid="resonance-balance">
+                  <dt className="text-sm text-muted-foreground">{resonance.name}</dt>
+                  <dd className="flex items-baseline gap-2">
+                    <span className="text-lg font-semibold tabular-nums">{resonance.balance}</span>
+                    <span className="text-xs text-muted-foreground">
+                      {resonance.lifetime_earned} lifetime
+                    </span>
+                  </dd>
+                </div>
+              ))}
+            </dl>
+          </CardContent>
+        </Card>
+      )}
+
       {magic?.motif && (
         <Card data-testid="spellbook-motif">
           <CardHeader>

--- a/frontend/src/roster/pages/CharacterSheetPage.tsx
+++ b/frontend/src/roster/pages/CharacterSheetPage.tsx
@@ -23,6 +23,7 @@ import { CluesTab } from '@/clues/components/CluesTab';
 import { CrimeTab } from '@/justice/components/CrimeTab';
 import { TitlesPanel } from '@/achievements/components/TitlesPanel';
 import { MaturationPanel } from '@/character_sheets/components/MaturationPanel';
+import { MechanicsSection } from '@/character_sheets/components/MechanicsSection';
 import { OriginStoryEditorDialog } from '@/character_sheets/components/OriginStoryEditorDialog';
 import { useCharacterSheetQuery } from '@/character_sheets/queries';
 import { DistinctionsTab } from '@/distinctions/components/DistinctionsTab';
@@ -163,6 +164,9 @@ export function CharacterSheetPage() {
             vocation={entry.character.vocation}
             socialRank={entry.character.social_rank}
           />
+          {sheetPayload && (
+            <MechanicsSection stats={sheetPayload.stats} skills={sheetPayload.skills} />
+          )}
           <GalleriesSection galleries={entry.character.galleries} />
           <ApplicationSlot entry={entry} account={account} />
           {isMyCharacter && (

--- a/src/world/character_sheets/serializers.py
+++ b/src/world/character_sheets/serializers.py
@@ -89,7 +89,7 @@ from world.scenes.constants import PersonaType
 from world.scenes.models import Persona
 from world.skills.models import CharacterSkillValue, CharacterSpecializationValue
 from world.skills.services import is_skill_at_xp_boundary
-from world.traits.models import CharacterTraitValue, TraitType
+from world.traits.models import STAT_DISPLAY_DIVISOR, CharacterTraitValue, TraitType
 
 
 class OriginSlotInputSerializer(serializers.Serializer):
@@ -547,11 +547,14 @@ _STATS_PREFETCH_RELATED: tuple[str | Prefetch, ...] = (
 
 
 def _build_stats(sheet: CharacterSheet) -> dict[str, int]:
-    """Build the stats section: a flat dict mapping stat name to value.
+    """Build the stats section: a flat dict mapping stat name to its display value.
 
-    The queryset is pre-filtered to stat-type traits via Prefetch in the viewset.
+    Stats store internal ×10 (ADR-0193, #2894: stat 2 -> stored 20); this converts to the
+    single-digit display scale (÷10) every other stat surface shows (the Maturation panel,
+    character creation) at the API edge, so the client never has to know about the storage
+    scale. The queryset is pre-filtered to stat-type traits via Prefetch in the viewset.
     """
-    return {tv.trait.name: tv.value for tv in sheet.cached_trait_values}
+    return {tv.trait.name: tv.value // STAT_DISPLAY_DIVISOR for tv in sheet.cached_trait_values}
 
 
 _SKILLS_SELECT_RELATED: tuple[str, ...] = ()

--- a/src/world/character_sheets/tests/test_privacy_tiers.py
+++ b/src/world/character_sheets/tests/test_privacy_tiers.py
@@ -22,8 +22,9 @@ class PrivacyTierTests(APITestCase):
         sheet = roster_entry.character_sheet
         sheet.stats_visibility = stats_visibility
         sheet.save()
+        # value=50 stores as internal ×10 (ADR-0193); the sheet shows the display value (5).
         CharacterTraitValueFactory(
-            character=sheet, trait=StatTraitFactory(name="strength"), value=5
+            character=sheet, trait=StatTraitFactory(name="strength"), value=50
         )
         return sheet
 

--- a/src/world/character_sheets/tests/test_profile_identity_privacy.py
+++ b/src/world/character_sheets/tests/test_profile_identity_privacy.py
@@ -187,8 +187,9 @@ class ProfileIdentityPrivacyTests(APITestCase):
     def test_owner_sees_their_private_mechanical_sections(self) -> None:
         owner = AccountFactory()
         sheet = self._character_sheet(owner, fake_active=False)
+        # value=50 stores as internal ×10 (ADR-0193); the sheet shows the display value (5).
         CharacterTraitValueFactory(
-            character=sheet, trait=StatTraitFactory(name="strength"), value=5
+            character=sheet, trait=StatTraitFactory(name="strength"), value=50
         )
         data = self._get(sheet, owner).data
         assert data["stats"] == {"strength": 5}

--- a/src/world/character_sheets/tests/test_viewset.py
+++ b/src/world/character_sheets/tests/test_viewset.py
@@ -609,10 +609,10 @@ class TestStatsSection(TestCase):
         return response.data["stats"]
 
     def test_stats_contains_expected_values(self) -> None:
-        """Stats section maps stat names to their values."""
+        """Stats section maps stat names to their display values (stored ×10, ADR-0193)."""
         stats = self._get_stats()
-        assert stats["strength"] == 30
-        assert stats["agility"] == 40
+        assert stats["strength"] == 3
+        assert stats["agility"] == 4
 
     def test_stats_only_contains_stat_traits(self) -> None:
         """Stats section only contains traits with trait_type='stat', not skills."""


### PR DESCRIPTION
Closes #3042

## Problem

A player could not see their own mechanics anywhere on the web: the sheet's "Stats" section rendered demographics only (no mechanical stats, no skills), and resonance balances — already serialized by the backend — were missing from the frontend's hand-mirrored magic type, so only telnet could show them.

## Fix

- **New `MechanicsSection`** on the Sheet tab: the 12 stats as a grid, skills with specializations and a "Ready to break through" badge from the existing `at_boundary` signal. Renders what the API returns — server-side visibility gating respected as-is.
- **Spellbook tab gains a Resonances card** (balance + lifetime earned per claimed resonance), following the existing Motif/Aura card patterns; `CharacterSheetMagic` type now carries `resonances`.
- **Backend bug found and fixed during investigation:** `_build_stats` returned the raw internal ×10-scaled stat values instead of the display values every other surface uses (ADR-0193 `STAT_DISPLAY_DIVISOR`) — the web sheet would have shown Strength 30 for Strength 3. Fixed to divide; the three test modules asserting the raw scale updated.
- Development-point progress display deliberately skipped: the sheet payload carries no per-trait DP data yet — follows #3039's landing (noted in the roadmap doc).

## Verification

- Backend fast tier: character_sheets viewset/privacy modules, 151 tests OK; ruff clean.
- Frontend: typecheck/lint/build clean; 28/28 on the touched test files (5 new MechanicsSection tests, 2 new SpellbookTab cases).

Docs updated in tandem: `docs/systems/character_sheets.md`, `docs/roadmap/character-progression.md`.

Found during the 2026-08-07 alpha-readiness audit (#3038-#3046).

🤖 Generated with [Claude Code](https://claude.com/claude-code)