### PR TITLE
Training check fails loudly when the Technique Training CheckType is unauthored

### DIFF
--- a/docs/systems/magic.md
+++ b/docs/systems/magic.md
@@ -1635,6 +1635,18 @@ the learner's level, and any teacher's skill bonus (self-study takes a flat
 penalty) — but shipped with no production caller: nothing dispatched it from telnet
 or the web. #2739 is that trigger, one seam for both surfaces:
 
+**Content dependency, loud failure (#3043).** The check rolled is the "Technique
+Training" `CheckType`, resolved by exact name. That row (plus the "Arcane Theory"
+trait it weights) is authored content, not seeded — as of 2026-08-07 it does not
+exist in any shipped content bundle (tracked in ArxII-lore#72). `resolve_training_check`
+used to fall back to `CheckType.objects.first()` on `DoesNotExist` — an arbitrary,
+unrelated check silently rolled in training's place on any deploy missing the row.
+It now raises `TechniqueTrainingNotConfigured` (`world/magic/exceptions.py`)
+instead, whose `user_message` ("Technique training is not configured on this
+server yet.") is what `TrainTechniqueAction`'s existing `except (…, MagicError)`
+clause surfaces — a clean failure `ActionResult` on telnet, HTTP 400 `{"detail": …}`
+on the web endpoint below. No player-facing string carries an em-dash.
+
 - **Action** — `TrainTechniqueAction` (`actions/definitions/technique_training.py`,
   key `train_technique`, REGISTRY, `category="magic"`, `target_type=SELF`). Kwargs:
   `technique_id` (the `Technique` pk — resolved against the learner's own open

--- a/src/actions/tests/test_technique_training_action.py
+++ b/src/actions/tests/test_technique_training_action.py
@@ -308,3 +308,46 @@ class TrainTechniqueActionFailureTests(TrainTechniqueActionTestBase):
 
         self.assertFalse(result.success)
         self.assertTrue(result.message)
+
+
+class TrainTechniqueActionMissingCheckTypeTests(TestCase):
+    """#3043: a missing "Technique Training" CheckType surfaces as a clean failure.
+
+    Setup deliberately skips ``_seed_check_content`` -- mirrors a real deploy
+    where the content half of #3043 (ArxII-lore#72) hasn't shipped yet.
+    """
+
+    def setUp(self):
+        self.room = ObjectDBFactory(
+            db_key="TrainingRoom", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        self.learner = CharacterSheetFactory()
+        self.learner.character.location = self.room
+        self.learner.character.save()
+
+        self.pool = ActionPointPool.get_or_create_for_character(self.learner.character)
+        self.pool.current = 500
+        self.pool.save()
+
+        self.technique = TechniqueFactory()
+        CharacterGift.objects.create(character=self.learner, gift=self.technique.gift)
+        Thread.objects.create(
+            owner=self.learner,
+            resonance=ResonanceFactory(),
+            target_kind=TargetKind.GIFT,
+            target_gift=self.technique.gift,
+            level=0,
+        )
+        self.progress = TechniqueProgress.objects.create(
+            character_sheet=self.learner,
+            technique=self.technique,
+            total_required=50,
+            source="gift_acquisition",
+        )
+
+    def test_missing_check_type_surfaces_as_clean_failure_result(self):
+        result = TrainTechniqueAction().run(
+            self.learner.character, technique_id=self.technique.pk, ap_to_invest=20
+        )
+        self.assertFalse(result.success)
+        self.assertEqual(result.message, "Technique training is not configured on this server yet.")

--- a/src/world/magic/CLAUDE.md
+++ b/src/world/magic/CLAUDE.md
@@ -385,14 +385,29 @@ serializer (`_RemovedConditionSpecSerializer`), admin (`TechniqueRemovedConditio
 `resolve_training_check(learner, progress, *, ap_to_invest, teacher=None)`
 (`services/technique_training.py`, #2727) is the check layer sitting on top of
 `contribute_to_technique_progress` (above): the learner rolls intellect + "Arcane
-Theory" (the "Technique Training" `CheckType`, seeded by
-`ensure_technique_training_content()`) against `target_difficulty = (technique.tier
+Theory" (the "Technique Training" `CheckType`) against `target_difficulty = (technique.tier
 × step) − (learner_level // divisor) − teacher_skill_bonus + (self_study_penalty
 if teacher is None)`, and the outcome maps to a dev-point multiplier via
 `TrainingOutcomeAward(OutcomeTierAward)` (botch/failure 0×, partial 0.5×, success
 1.0×, critical 1.5×) — AP is always spent regardless of outcome; only the
 dev-point yield varies. Four tuning knobs live on `GiftAcquisitionConfig`. This
-seam shipped with no production caller until #2739:
+seam shipped with no production caller until #2739.
+
+**Content dependency, loud failure (#3043).** The "Technique Training" `CheckType`
+and its "Arcane Theory" trait are content models (`CONTENT_MODELS`, #2698), not
+unconditionally-seeded config — `ensure_technique_training_content()`
+(`world/seeds/game_content/magic.py`) resolves them via `authored_or_sample`
+(content-repo lookup first, sample stand-in only under `SEED_SAMPLE_CONTENT`,
+off by default) and always seeds the `TrainingOutcomeAward` tuning rows regardless.
+As of 2026-08-07 the CheckType/trait have not shipped in the lore repo
+(ArxII-lore#72), so a real deploy has no "Technique Training" `CheckType` yet.
+`resolve_training_check` used to fall back to `CheckType.objects.first()` on
+`DoesNotExist` — an arbitrary, unrelated check silently rolled in training's
+place. It now raises `TechniqueTrainingNotConfigured` (`exceptions.py`) instead;
+`TrainTechniqueAction`'s existing `except (…, MagicError)` clause already catches
+it (no widening needed) and surfaces `user_message` ("Technique training is not
+configured on this server yet.") as a failure `ActionResult` — a clean telnet
+message and an HTTP 400 `{"detail": …}` on the web endpoint below, never a 500.
 
 - **Action** — `TrainTechniqueAction` (`actions/definitions/technique_training.py`,
   key `train_technique`, REGISTRY, `category="magic"`, `target_type=SELF`). Kwargs

--- a/src/world/magic/exceptions.py
+++ b/src/world/magic/exceptions.py
@@ -693,3 +693,16 @@ class WeeklyTrainingCapExceeded(TechniqueProgressError):
     """Raised when a learner tries to contribute past the weekly training cap."""
 
     user_message = "You've trained as much as you can this week."
+
+
+class TechniqueTrainingNotConfigured(MagicError):
+    """Raised when the "Technique Training" CheckType has not been authored (#3043).
+
+    ``resolve_training_check`` (``services/technique_training.py``) used to fall back
+    to ``CheckType.objects.first()`` on a missing row — an arbitrary, unrelated check
+    silently rolled in place of training. Subclasses ``MagicError`` (not
+    ``TechniqueProgressError``) so it is caught by ``TrainTechniqueAction``'s existing
+    ``except (WeeklyTrainingCapExceeded, MagicError)`` clause without widening it.
+    """
+
+    user_message = "Technique training is not configured on this server yet."

--- a/src/world/magic/services/technique_training.py
+++ b/src/world/magic/services/technique_training.py
@@ -51,19 +51,24 @@ def resolve_training_check(
         the minted CharacterTechnique if the meter filled.
 
     Raises:
+        TechniqueTrainingNotConfigured: If the "Technique Training" CheckType has
+            not been authored (content tracked in ArxII-lore#72).
         WeeklyTrainingCapExceeded: If the weekly cap is reached (from the seam).
         MagicError: If the learner can't afford the AP (from the seam).
     """
     from world.checks.models import CheckType  # noqa: PLC0415
+    from world.magic.exceptions import TechniqueTrainingNotConfigured  # noqa: PLC0415
 
     config = get_gift_acquisition_config()
     technique = progress.technique
 
-    # 1. Resolve the check type.
+    # 1. Resolve the check type. No silent fallback (#3043) — an arbitrary
+    # unrelated CheckType rolled in place of training is worse than a loud,
+    # named failure naming the missing content row.
     try:
         check_type = CheckType.objects.get(name=TECHNIQUE_TRAINING_CHECK_TYPE_NAME)
-    except CheckType.DoesNotExist:
-        check_type = CheckType.objects.first()
+    except CheckType.DoesNotExist as exc:
+        raise TechniqueTrainingNotConfigured from exc
 
     # 2. Compute target_difficulty from the three drivers.
     target_difficulty = technique.tier * config.training_tier_difficulty_step

--- a/src/world/magic/tests/test_technique_progress_views.py
+++ b/src/world/magic/tests/test_technique_progress_views.py
@@ -408,3 +408,70 @@ class TechniqueProgressCharacterHeaderScopingTests(TechniqueProgressViewSetTestB
         )
 
         self.assertEqual(resp.status_code, 404)
+
+
+# ===========================================================================
+# missing "Technique Training" CheckType (#3043)
+# ===========================================================================
+
+
+class TechniqueProgressTrainMissingCheckTypeTests(TestCase):
+    """No silent CheckType.objects.first() fallback -- a clean 400 instead (#3043).
+
+    Setup mirrors ``TechniqueProgressViewSetTestBase`` but deliberately skips
+    seeding the "Technique Training" CheckType, mirroring a real deploy where
+    the content half of #3043 (ArxII-lore#72) hasn't shipped yet.
+    """
+
+    def setUp(self) -> None:
+        from evennia.utils.idmapper.models import flush_cache
+
+        flush_cache()
+        self.factory = APIRequestFactory()
+
+        self.room = ObjectDBFactory(
+            db_key="TrainingRoom", db_typeclass_path="typeclasses.rooms.Room"
+        )
+        self.learner = CharacterSheetFactory()
+        self.learner.character.location = self.room
+        self.learner.character.save()
+
+        self.pool = ActionPointPool.get_or_create_for_character(self.learner.character)
+        self.pool.current = 500
+        self.pool.save()
+
+        self.technique = TechniqueFactory()
+        CharacterGift.objects.create(character=self.learner, gift=self.technique.gift)
+        Thread.objects.create(
+            owner=self.learner,
+            resonance=ResonanceFactory(),
+            target_kind=TargetKind.GIFT,
+            target_gift=self.technique.gift,
+            level=0,
+        )
+        TechniqueProgress.objects.create(
+            character_sheet=self.learner,
+            technique=self.technique,
+            total_required=50,
+            source="gift_acquisition",
+        )
+
+    def _post_train(self, puppet, technique_id, payload=None):
+        request = self.factory.post(
+            f"/api/magic/technique-progress/{technique_id}/train/",
+            payload or {},
+            format="json",
+        )
+        force_authenticate(request, user=puppet)
+        view = TechniqueProgressViewSet.as_view({"post": "train"})
+        return view(request, pk=str(technique_id))
+
+    def test_train_missing_check_type_returns_400_plain_message(self) -> None:
+        resp = self._post_train(
+            _actor_user(self.learner.character), self.technique.pk, {"ap_to_invest": 20}
+        )
+
+        self.assertEqual(resp.status_code, 400)
+        self.assertEqual(
+            resp.data["detail"], "Technique training is not configured on this server yet."
+        )

--- a/src/world/magic/tests/test_technique_training.py
+++ b/src/world/magic/tests/test_technique_training.py
@@ -252,3 +252,51 @@ class ResolveTrainingCheckTest(TestCase):
             resolve_training_check(self.sheet, self.progress, ap_to_invest=20)
 
         self.assertGreater(difficulties[1], difficulties[0])
+
+
+class ResolveTrainingCheckMissingCheckTypeTest(TestCase):
+    """#3043: no silent objects.first() fallback when "Technique Training" is unauthored.
+
+    The old fallback picked an arbitrary, unrelated CheckType on
+    ``DoesNotExist`` -- every training roll on a real deploy (where the
+    content half of #3043, ArxII-lore#72, hasn't shipped yet) silently rolled
+    the wrong check. This proves the fix fails loudly instead, even when
+    other CheckType rows exist to be picked by ``objects.first()``.
+    """
+
+    def setUp(self):
+        from world.checks.factories import CheckTypeFactory
+        from world.magic.constants import TargetKind
+        from world.magic.factories import ResonanceFactory
+        from world.magic.models import CharacterGift, Thread
+
+        self.sheet = CharacterSheetFactory()
+        self.technique = TechniqueFactory()
+        self.pool = ActionPointPool.get_or_create_for_character(self.sheet.character)
+        self.pool.current = 500
+        self.pool.save()
+
+        CharacterGift.objects.create(character=self.sheet, gift=self.technique.gift)
+        Thread.objects.create(
+            owner=self.sheet,
+            resonance=ResonanceFactory(),
+            target_kind=TargetKind.GIFT,
+            target_gift=self.technique.gift,
+            level=0,
+        )
+        self.progress = TechniqueProgress.objects.create(
+            character_sheet=self.sheet,
+            technique=self.technique,
+            total_required=50,
+            source="gift_acquisition",
+        )
+        # An unrelated CheckType exists (proves the old objects.first()
+        # fallback would have silently picked it up), but none named
+        # "Technique Training".
+        CheckTypeFactory(name="Unrelated Check")
+
+    def test_raises_technique_training_not_configured(self):
+        from world.magic.exceptions import TechniqueTrainingNotConfigured
+
+        with self.assertRaises(TechniqueTrainingNotConfigured):
+            resolve_training_check(self.sheet, self.progress, ap_to_invest=20)


### PR DESCRIPTION
Closes #3043 (code half; content half tracked in ArxII-lore#72)

## Problem

`resolve_training_check` fell back to `CheckType.objects.first()` when the "Technique Training" CheckType was missing — and it IS missing on any real deploy (the CheckType and the "Arcane Theory" trait are CONTENT_MODELS-owned and unauthored). Every training roll from the #3033 player-facing trigger silently rolled an arbitrary unrelated check.

## Fix

- New `TechniqueTrainingNotConfigured(MagicError)` with a plain `user_message` ("Technique training is not configured on this server yet."), following the #3032 `CraftingNotConfigured` precedent; `resolve_training_check` raises it instead of falling back.
- Callers already surface it cleanly (verified, no changes needed): telnet `train` prints the action failure message; the web train endpoint maps the failed ActionResult to HTTP 400 with the plain detail.
- `teacher_skill_bonus`/check composition untouched — #2740/#2741 remain open design issues.

## Tests

- Service raises with the CheckType absent even when unrelated CheckTypes exist (proves the fallback is gone, not just an empty-DB accident); action returns `success=False` with the exact message; web endpoint returns 400 with the plain detail. 41 tests OK across the four touched modules; ruff clean.

Docs updated in tandem: `src/world/magic/CLAUDE.md`, `docs/systems/magic.md` (content dependency + loud-failure behavior recorded).

Found during the 2026-08-07 alpha-readiness audit (#3038-#3046).

🤖 Generated with [Claude Code](https://claude.com/claude-code)