### PR TITLE
CG gate hardening: real email-verification gate, TRUST_REQUIRED fails closed, max_characters configurable

### DIFF
--- a/docs/systems/character_creation.md
+++ b/docs/systems/character_creation.md
@@ -148,7 +148,7 @@ from world.character_creation.services import (
     finalize_gm_character,        # GM path: full character + Available RosterEntry (GM_TABLE
                                   #   provenance + created_for_table) + Story/StoryParticipation
     get_accessible_starting_areas,# Filter areas by account access
-    can_create_character,         # Check eligibility (trust, limits)
+    can_create_character,         # Check eligibility (email verification, trust, limits)
     submit_draft_for_review,      # Create DraftApplication in SUBMITTED
     unsubmit_draft,               # Return to REVISIONS_REQUESTED
     resubmit_draft,               # Re-submit after revisions
@@ -161,6 +161,22 @@ from world.character_creation.services import (
     finalize_magic_data,          # Link the draft's chosen catalog Gift/Techniques to the character
 )
 ```
+
+**`can_create_character` eligibility gates (#3046):** staff bypass all three
+checks. (1) Email verification is real: it reuses
+`PlayerData.can_apply_for_characters()` (allauth `EmailAddress`, primary +
+verified), the same check that drives the frontend's `can_create_characters`
+field, rejecting with "Verify your email address to create a character." (2)
+Trust level defaults to 0 until the trust system lands. (3) `max_characters`
+is `settings.CG_MAX_CHARACTERS` (`CG_MAX_CHARACTERS` env var, default 3),
+counted against `account.character_drafts`.
+
+**`StartingArea.is_accessible_by` fails closed on `TRUST_REQUIRED`** (#3046):
+non-staff accounts have no `.trust` attribute yet (trust system unimplemented),
+so a `TRUST_REQUIRED` area is simply inaccessible to them rather than raising
+`NotImplementedError` — mirrors `Beginnings.is_accessible_by`'s existing
+fail-closed behavior. `get_accessible_starting_areas` therefore never 500s on
+a `TRUST_REQUIRED` area.
 
 `finalize_magic_data` also creates the CG-finalize Golden Hare Academy obligation
 row (#2428 Task 3, `_finalize_academy_entrance_obligation`): resolves the

--- a/src/server/conf/settings.py
+++ b/src/server/conf/settings.py
@@ -224,6 +224,10 @@ OVERWORLD_MAX_HOPS = env.int("OVERWORLD_MAX_HOPS", default=20)
 # cost, not a Project-scale grind (issue #2222 Decision 4).
 PORTAL_ANCHOR_INSTALL_COST = env.int("PORTAL_ANCHOR_INSTALL_COST", default=5000)
 
+# Max number of characters (drafts + owned) a non-staff account may hold at
+# once, enforced by character_creation.services.can_create_character (#3046).
+CG_MAX_CHARACTERS = env.int("CG_MAX_CHARACTERS", default=3)
+
 # Web frontend base URL — the React app's origin. Referenced by allauth's
 # headless redirect config below, CSRF_TRUSTED_ORIGINS, and telnet-side
 # signposts (connection screen, characterless post-login message; #2122)

--- a/src/world/character_creation/models.py
+++ b/src/world/character_creation/models.py
@@ -207,12 +207,14 @@ class StartingArea(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
             return False
 
         if self.access_level == self.AccessLevel.TRUST_REQUIRED:
-            # TODO: Implement trust system - this will raise AttributeError until then
+            # TODO: Implement trust system - fail closed until then. A single
+            # admin flipping an area to TRUST_REQUIRED must not 500 the origin
+            # stage for every non-staff account (#3046); mirrors
+            # Beginnings.is_accessible_by's own fail-closed AttributeError guard.
             try:
                 account_trust = account.trust
             except AttributeError:
-                msg = "Trust system not yet implemented on Account model"
-                raise NotImplementedError(msg) from None
+                return False
             return account_trust >= self.minimum_trust
 
         return True  # AccessLevel.ALL

--- a/src/world/character_creation/services.py
+++ b/src/world/character_creation/services.py
@@ -12,6 +12,7 @@ from datetime import timedelta
 import logging
 from typing import TYPE_CHECKING, Any
 
+from django.conf import settings
 from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.db.models import Prefetch, QuerySet
@@ -1289,10 +1290,15 @@ def can_create_character(account: AbstractBaseUser | AnonymousUser) -> tuple[boo
     if account.is_staff:
         return True, ""
 
-    # Check email verification
-    # TODO: Integrate with actual email verification system
-    if hasattr(account, "email_verified") and not account.email_verified:
-        return False, "Email verification required"
+    # Check email verification. PlayerData.can_apply_for_characters() is the
+    # account's single source of truth for this gate (mirrors
+    # AccountPlayerSerializer.get_email_verified's allauth EmailAddress query);
+    # it's already what drives the frontend's can_create_characters field, so
+    # reuse it here instead of a parallel check (#3046: the old hasattr(account,
+    # "email_verified") check was always False since that attribute only ever
+    # existed on the serializer, never on AccountDB, so this gate was dead).
+    if not account.player_data.can_apply_for_characters():
+        return False, "Verify your email address to create a character."
 
     # Check trust level
     # TODO: Implement trust system - default to 0 (trusted) until then
@@ -1301,8 +1307,7 @@ def can_create_character(account: AbstractBaseUser | AnonymousUser) -> tuple[boo
         return False, "Account trust level too low"
 
     # Check character limit
-    # TODO: Make this configurable via django settings or model
-    max_characters = 3
+    max_characters = settings.CG_MAX_CHARACTERS
     current_count = account.character_drafts.count()
     # TODO: Also count actual characters owned by account
     if current_count >= max_characters:

--- a/src/world/character_creation/tests/test_models.py
+++ b/src/world/character_creation/tests/test_models.py
@@ -370,6 +370,34 @@ class CharacterDraftStatsValidationTests(TestCase):
             assert final[name] == STAT_DEFAULT_VALUE
 
 
+class StartingAreaTrustRequiredAccessTests(TestCase):
+    """TRUST_REQUIRED areas must fail closed, not raise (#3046).
+
+    The trust system isn't implemented yet, so a non-staff account has no
+    ``.trust`` attribute. Before #3046 this raised ``NotImplementedError``
+    from ``is_accessible_by`` (a latent 500 the moment any area was flipped to
+    TRUST_REQUIRED); it must now simply be inaccessible.
+    """
+
+    def test_trust_required_area_denies_non_staff_without_raising(self):
+        """A non-staff account without .trust is denied, not a 500."""
+        area = StartingAreaFactory(
+            access_level=StartingArea.AccessLevel.TRUST_REQUIRED,
+            minimum_trust=5,
+        )
+        account = AccountFactory()
+        assert area.is_accessible_by(account) is False
+
+    def test_trust_required_area_allows_staff(self):
+        """Staff bypass the trust gate entirely, matching existing staff behavior."""
+        area = StartingAreaFactory(
+            access_level=StartingArea.AccessLevel.TRUST_REQUIRED,
+            minimum_trust=5,
+        )
+        account = AccountFactory(is_staff=True)
+        assert area.is_accessible_by(account) is True
+
+
 class BeginningsModelTests(TestCase):
     """Test Beginnings model."""
 

--- a/src/world/character_creation/tests/test_services.py
+++ b/src/world/character_creation/tests/test_services.py
@@ -12,7 +12,12 @@ from django.test.utils import CaptureQueriesContext
 from evennia.accounts.models import AccountDB
 
 from world.character_creation.models import Beginnings, CharacterDraft, StartingArea
-from world.character_creation.services import DraftIncompleteError, finalize_character
+from world.character_creation.services import (
+    DraftIncompleteError,
+    can_create_character,
+    finalize_character,
+    get_accessible_starting_areas,
+)
 from world.character_sheets.models import CharacterSheet, Gender
 from world.classes.factories import PathFactory
 from world.classes.models import PathStage
@@ -2252,3 +2257,126 @@ class FinalizeCharacterPreludeMissionTests(FinalizationTestMixin, TestCase):
 
         # Whole-transaction rollback: no Character/CharacterSheet left behind.
         assert CharacterSheet.objects.count() == sheet_count_before
+
+
+class CanCreateCharacterEmailVerificationTests(TestCase):
+    """can_create_character's email-verification gate (#3046).
+
+    The old ``hasattr(account, "email_verified")`` check was always False (that
+    attribute only ever existed on the serializer, never on AccountDB), so an
+    unverified account could create and submit characters. The real gate reuses
+    ``PlayerData.can_apply_for_characters()`` (allauth EmailAddress lookup) -
+    the same check that already drives the frontend's ``can_create_characters``
+    field.
+    """
+
+    def test_unverified_account_is_rejected_with_verification_reason(self):
+        from evennia_extensions.factories import AccountFactory, EmailAddressFactory
+
+        account = AccountFactory()
+        EmailAddressFactory(user=account, email=account.email, verified=False, primary=True)
+
+        can_create, reason = can_create_character(account)
+
+        assert can_create is False
+        assert reason == "Verify your email address to create a character."
+
+    def test_account_with_no_email_address_is_rejected(self):
+        from evennia_extensions.factories import AccountFactory
+
+        account = AccountFactory()
+        # No EmailAddress row at all - allauth has nothing to call verified.
+
+        can_create, reason = can_create_character(account)
+
+        assert can_create is False
+        assert reason == "Verify your email address to create a character."
+
+    def test_verified_account_passes_the_email_gate(self):
+        from evennia_extensions.factories import AccountFactory, EmailAddressFactory
+
+        account = AccountFactory()
+        EmailAddressFactory(user=account, email=account.email, verified=True, primary=True)
+
+        can_create, reason = can_create_character(account)
+
+        assert can_create is True
+        assert reason == ""
+
+    def test_staff_bypasses_the_email_gate(self):
+        from evennia_extensions.factories import AccountFactory
+
+        account = AccountFactory(is_staff=True)
+        # Deliberately no EmailAddress row - staff must not be blocked by it.
+
+        can_create, reason = can_create_character(account)
+
+        assert can_create is True
+        assert reason == ""
+
+
+class CanCreateCharacterMaxCharactersTests(TestCase):
+    """max_characters is configurable via CG_MAX_CHARACTERS (#3046, was hardcoded 3)."""
+
+    def test_max_characters_honors_settings_override(self):
+        from evennia_extensions.factories import AccountFactory, EmailAddressFactory
+        from world.character_creation.factories import CharacterDraftFactory
+
+        account = AccountFactory()
+        EmailAddressFactory(user=account, email=account.email, verified=True, primary=True)
+        CharacterDraftFactory(account=account)
+
+        with override_settings(CG_MAX_CHARACTERS=1):
+            can_create, reason = can_create_character(account)
+
+        assert can_create is False
+        assert reason == "Maximum of 1 characters reached"
+
+    def test_default_max_characters_is_three(self):
+        from django.conf import settings
+
+        assert settings.CG_MAX_CHARACTERS == 3
+
+
+class GetAccessibleStartingAreasTrustRequiredTests(TestCase):
+    """get_accessible_starting_areas must not 500 on a TRUST_REQUIRED area (#3046).
+
+    Before the fix, StartingArea.is_accessible_by raised NotImplementedError for
+    any non-staff account on a TRUST_REQUIRED area, and this function did not
+    catch it - one admin flipping an area's access level broke the origin stage
+    for everyone.
+    """
+
+    def test_trust_required_area_excluded_for_normal_account(self):
+        from evennia_extensions.factories import AccountFactory
+        from world.character_creation.factories import StartingAreaFactory
+        from world.character_creation.models import StartingArea
+
+        open_area = StartingAreaFactory(name="Open Area", access_level=StartingArea.AccessLevel.ALL)
+        gated_area = StartingAreaFactory(
+            name="Gated Area",
+            access_level=StartingArea.AccessLevel.TRUST_REQUIRED,
+            minimum_trust=5,
+        )
+        account = AccountFactory()
+
+        areas = get_accessible_starting_areas(account)
+
+        assert open_area in areas
+        assert gated_area not in areas
+
+    def test_trust_required_area_included_for_staff(self):
+        from evennia_extensions.factories import AccountFactory
+        from world.character_creation.factories import StartingAreaFactory
+        from world.character_creation.models import StartingArea
+
+        gated_area = StartingAreaFactory(
+            name="Gated Area Staff",
+            access_level=StartingArea.AccessLevel.TRUST_REQUIRED,
+            minimum_trust=5,
+        )
+        account = AccountFactory(is_staff=True)
+
+        areas = get_accessible_starting_areas(account)
+
+        assert gated_area in areas


### PR DESCRIPTION
Closes #3046

## Three small verified defects in the CG entry gates

1. **Email verification never gated.** `can_create_character` checked `hasattr(account, "email_verified")` on the raw AccountDB — the field only exists on the serializer, so the check was always-False dead code. Fixed by wiring the seam that already existed: `PlayerData.can_apply_for_characters()` does the correct allauth `EmailAddress` lookup and already drives the frontend's `can_create_characters` field — it was just never called here. Rejection reason is a plain sentence the CG page already renders (`canCreate?.reason`); staff bypass unchanged. (`ACCOUNT_EMAIL_VERIFICATION = "mandatory"` in settings, so the gate matches deployment policy — no conditional branch needed.)
2. **TRUST_REQUIRED starting areas fail closed** instead of raising `NotImplementedError` through `get_accessible_starting_areas` (which would have 500'd the whole origin stage the moment an admin flipped one area). Mirrors the fail-closed pattern `Beginnings.is_accessible_by` already uses for the identical TODO.
3. **`max_characters` is now `CG_MAX_CHARACTERS`** (env knob, default 3), following the existing settings env-int pattern.

## Tests

150 OK across character_creation test_models + test_services, including 8 new tests: unverified/verified/staff email gating, TRUST_REQUIRED fail-closed at both the model and service layer, and the `CG_MAX_CHARACTERS` override. Ruff + ty clean.

Docs updated in tandem: `docs/systems/character_creation.md` eligibility-gate section.

Found during the 2026-08-07 alpha-readiness audit (#3038-#3046).

🤖 Generated with [Claude Code](https://claude.com/claude-code)