### PR TITLE
Fix the drifted acceptance.sh settings-overlay check and wire acceptance.sh into CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,9 +12,15 @@ name: Infra Validate
 
 on:
   push:
-    paths: ["infra/**", ".github/workflows/validate.yml"]
+    # src/server/conf/settings.py is included because acceptance.sh asserts
+    # cross-file contracts against it (the prod secret_settings overlay
+    # guard) — a src-side refactor drifted that check undetected once
+    # (2026-08-07) precisely because only infra/** triggered this workflow.
+    paths:
+      ["infra/**", ".github/workflows/validate.yml", "src/server/conf/settings.py"]
   pull_request:
-    paths: ["infra/**", ".github/workflows/validate.yml"]
+    paths:
+      ["infra/**", ".github/workflows/validate.yml", "src/server/conf/settings.py"]
   workflow_dispatch:
 
 permissions:
@@ -167,3 +173,10 @@ jobs:
             # static gate.
             "$bin" adapt --config "$rendered" --adapter caddyfile >/dev/null
           done
+
+  acceptance:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: acceptance.sh (cross-file infra safety contracts)
+        run: bash infra/scripts/acceptance.sh

--- a/infra/ansible/roles/django_hardening/templates/secret_settings.py.j2
+++ b/infra/ansible/roles/django_hardening/templates/secret_settings.py.j2
@@ -1,6 +1,7 @@
 # Managed by Ansible (django_hardening). Evennia imports server/conf/
 # secret_settings.py LAST (see settings.py's guarded
-# `from server.conf.secret_settings import *` at the very end) — this is
+# `import server.conf.secret_settings` + globals().update() at the very
+# end) — this is
 # the prod hardening overlay for values env() alone can't express (booleans,
 # lists, cookie/proxy toggles). SECRET_KEY, DATABASE_URL, the Cloudinary
 # trio, RESEND_API_KEY, FRONTEND_URL, and SITE_URL are all handled by

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -245,7 +245,7 @@ chk   "django_hardening fails closed on empty ALLOWED_HOSTS" \
 # CLOUDINARY_CLOUD_NAME+API_KEY+API_SECRET settings.py's env() calls
 # actually use) was the #2236 review's headline finding.
 chk   "settings.py guards the prod secret_settings overlay import" \
-  "grep -q 'from server.conf.secret_settings import' src/server/conf/settings.py"
+  "grep -q 'import server.conf.secret_settings' src/server/conf/settings.py && grep -B1 'import server.conf.secret_settings' src/server/conf/settings.py | grep -q 'contextlib.suppress(ImportError)'"
 chk   "secrets_vault's EnvironmentFile renders SECRET_KEY and DATABASE_URL (settings.py's actual env-read contract)" \
   "grep -q 'ARXII_DJANGO_SECRET_KEY: SECRET_KEY' infra/ansible/roles/secrets_vault/defaults/main.yml && grep -q '^DATABASE_URL=' infra/ansible/roles/secrets_vault/templates/arxii.env.j2"
 


### PR DESCRIPTION
## Problem

`infra/scripts/acceptance.sh` — the infra stack's cross-file safety contract checker — had one check failing live: the SonarCloud refactor (`68a56e3a3`) changed `settings.py`'s prod secret-settings overlay from `from ... import *` to a guarded module import + `globals().update()`, and the check grepped for the old literal string. Nothing caught the drift because acceptance.sh is not invoked by any CI workflow, despite its own header calling itself the tests for these invariants.

## Fix

- The check now asserts the current import shape AND its `contextlib.suppress(ImportError)` guard — the actual safety property, not the old syntax.
- `secret_settings.py.j2`'s header comment updated to describe the real shape.
- `validate.yml` gains an `acceptance` job running `acceptance.sh` (no creds needed — pure static greps), and its trigger paths now include `src/server/conf/settings.py`, the one src file the script asserts contracts against — so a src-side refactor can't silently drift it again.

Verified: `bash infra/scripts/acceptance.sh` now reports all checks PASS (was 1 FAILED).

Found during the 2026-08-07 ops-readiness verification pass (see the #2236 comment of the same date).

🤖 Generated with [Claude Code](https://claude.com/claude-code)