### PR TITLE
Content loader rot: NPCServiceOffer has no natural key (followon_offer row silently skipped every load) and the list-valued-field heuristic breaks DistinctionEffect.scaling_values

### DIFF
--- a/docs/adr/0168-content-models-registration-is-the-seed-boundary.md
+++ b/docs/adr/0168-content-models-registration-is-the-seed-boundary.md
@@ -106,5 +106,11 @@ registration is the actual line, and it is already written down.
 a separate migration — it costs writing seeders for ~600 rows of declarative JSON —
 and `SEED_SAMPLE_CONTENT` addresses the same need without it.
 
+**Update (#3056):** the guard (`test_no_content_slop`) now honors ADR-0171's
+row-level `EXPORT_FILTERS` too, not just model-level `CONTENT_MODELS`
+registration, so a model can be split row-wise between content and seeder
+ownership (`npc_services.npcserviceoffer` is content only where
+`kind="mission"`) without the guard flagging the seeder-owned rows as slop.
+
 Related: ADR-0142 (which this sharpens), ADR-0140 (the content pipeline), ADR-0013
 (no data migrations pre-production). Issue #2698.

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2830,6 +2830,9 @@ register as additional kinds.
   anchor for gameplay loops; see ADR-0070 for the Functionary/Standing NPC/Story NPC ontology),
   `NpcRegard` (#1717 — a notable NPC's signed opinion of a persona/Organization/Society;
   see the Regard bullet below and ADR-0085)
+- **Content pipeline (#3056):** MISSION-kind `NPCServiceOffer` rows (+ `MissionOfferDetails`) are
+  lore-repo content, natural key `(role, label)`; other offer kinds stay seeder-owned. See the
+  missions "Content pipeline (#2470)" bullet for the full export/import detail.
 - **NPC ontology (ADR-0070):** **Functionary** (class-1, abstracted, room-anchored via its own FK) /
   **Standing NPC** (class-2, named Persona + object) / **Story NPC** (class-3/4, object + sheet, piloted).
   Presence: `functionaries_in_room` / `functionary_in_location` (`world.npc_services.functionaries`);
@@ -3219,8 +3222,12 @@ state is node position + snapshots + already-applied consequences, never a scrat
   author a mission graph as a fixture and install it via the ordinary export/import pipeline, same
   as any other content model. `checks.CheckType`/`checks.CheckCategory` joined the allowlist in the
   same change (needed for `MissionOption.authored_check_type` to round-trip). `checks.Consequence`
-  and `npc_services.NPCServiceOffer` remain un-keyed (documented gap, not this issue's scope). The
-  seeded Tutorial Chain is unaffected — it predates this pipeline and stays imperatively seeded.
+  remains un-keyed (documented gap). `npc_services.NPCServiceOffer` gained a `(role, label)` natural
+  key in #3056: MISSION-kind offers (+ `MissionOfferDetails`, keyed on its O2O `offer`) are exported
+  content, filtered to `kind="mission"` via `EXPORT_FILTERS`, with `source_beat`/`target_project`
+  stripped via `EXPORT_FIELD_EXCLUSIONS`, so `MissionOptionRouteReward.followon_offer` round-trips
+  by natural key; other offer kinds stay seeder-owned. The seeded Tutorial Chain is unaffected -
+  it predates this pipeline and stays imperatively seeded.
 - **Source:** `src/world/missions/`. Roadmap: `docs/roadmap/missions.md`.
 
 ### Currency & Org Economy (#923–#932, #930 active collection)

--- a/src/core_management/CLAUDE.md
+++ b/src/core_management/CLAUDE.md
@@ -129,17 +129,23 @@ naming a contributor authored in the same corpus update would otherwise lose
 its credit on a fresh database's single Big Button load and only recover it
 on the next one.
 
-**Known asymmetry:** `NPCRole`, `ItemTemplate`, `BuildingKind` and `DecorationKind`
-carry `CreditedContent` and are authored through `DOMAIN_BUILDERS` (`npc_roles/`,
-`items/`, `building_kinds/`, `decoration_kinds/`) same as every other domain, but
-none of the four is registered in `CONTENT_MODELS`. So a credit written into one of
-their files loads into the database fine (`build_all` -> `load_entries`), but
-`content_export` never writes it back out - `CONTENT_MODELS` is what
-`export_to_content_repo` walks. This is a one-way credit path, not a bug to paper
-over here; whether these four belong in `CONTENT_MODELS` is a separate decision
-than "does the model have the columns," and adding them pulls in the same
-additions-gate and round-trip questions ADR-0191 already settled for the domains
-that are registered.
+**Known asymmetry:** `ItemTemplate`, `BuildingKind` and `DecorationKind` carry
+`CreditedContent` and are authored through `DOMAIN_BUILDERS` (`items/`,
+`building_kinds/`, `decoration_kinds/`) same as every other domain, but none of the
+three is registered in `CONTENT_MODELS`. So a credit written into one of their files
+loads into the database fine (`build_all` -> `load_entries`), but `content_export`
+never writes it back out - `CONTENT_MODELS` is what `export_to_content_repo` walks.
+This is a one-way credit path, not a bug to paper over here; whether these three
+belong in `CONTENT_MODELS` is a separate decision than "does the model have the
+columns," and adding them pulls in the same additions-gate and round-trip questions
+ADR-0191 already settled for the domains that are registered.
+
+`NPCRole` used to be a fourth member of this list; #3036 admitted it to
+`CONTENT_MODELS`, so it round-trips like any other registered domain now. #3056
+additionally registered `npc_services.npcserviceoffer` (row-filtered to
+`kind="mission"` via `EXPORT_FILTERS`) and `npc_services.missionofferdetails` (with
+`source_beat`/`target_project` stripped via `EXPORT_FIELD_EXCLUSIONS`) - neither
+carries `CreditedContent`, so neither was ever part of this asymmetry.
 
 `core_management/prose_report.py` plus `tools/prose_report.py` (`just
 prose-report`) report the writer/reviewer backlog by scanning a content-repo

--- a/src/core_management/content_export.py
+++ b/src/core_management/content_export.py
@@ -218,6 +218,12 @@ CONTENT_MODELS: frozenset[str] = frozenset(
         # model). Ordered before missions so report_to_role resolves in one
         # load pass.
         "npc_services.npcrole",
+        # #3056 extends that ruling to MISSION-kind offers: missions reference
+        # them too (MissionOptionRouteReward.followon_offer, MissionOfferDetails
+        # .mission_template), so they must travel as well. Non-MISSION kinds
+        # stay seeder-owned — see EXPORT_FILTERS.
+        "npc_services.npcserviceoffer",
+        "npc_services.missionofferdetails",
         # missions
         "missions.missioncategory",
         "missions.missiontemplate",
@@ -288,6 +294,9 @@ EXPORT_FILTERS: dict[str, dict[str, object]] = {
     "magic.ritual": {"author_account__isnull": True},
     "checks.checktype": {"owner_sheet__isnull": True},
     "checks.checktypetrait": {"check_type__owner_sheet__isnull": True},
+    # #3056: only MISSION-kind offers are content; PERMIT/TRAIN/SETTLE etc.
+    # are created by world/npc_services/seeds.py per installation.
+    "npc_services.npcserviceoffer": {"kind": "mission"},
 }
 
 #: Field-level export exclusions: columns on a content model that are
@@ -302,6 +311,9 @@ EXPORT_FILTERS: dict[str, dict[str, object]] = {
 #: ignores these fields for the same reason: they are seeder-owned.
 EXPORT_FIELD_EXCLUSIONS: dict[str, frozenset[str]] = {
     "npc_services.npcrole": frozenset({"faction_affiliation"}),
+    # #3056: live story/installation state, not content — same rationale as
+    # npcrole.faction_affiliation above.
+    "npc_services.missionofferdetails": frozenset({"source_beat", "target_project"}),
 }
 
 

--- a/src/core_management/content_fixtures.py
+++ b/src/core_management/content_fixtures.py
@@ -902,6 +902,9 @@ def _resolve_natural_key_fields(model, fields: dict, source_path: Path | None) -
     a normal ``ContentError`` naming the field (and the source file, when
     known) for a non-relational list value, matching every other validation
     failure's error style in this module.
+
+    Narrowed by #3056: a ``JSONField`` is exempt — its value can legitimately be a
+    list (e.g. ``DistinctionEffect.scaling_values``), so it passes through verbatim.
     """
     for field_name, value in list(fields.items()):
         if not isinstance(value, list):
@@ -909,6 +912,14 @@ def _resolve_natural_key_fields(model, fields: dict, source_path: Path | None) -
         field = model._meta.get_field(field_name)  # noqa: SLF001
         location = source_path if source_path is not None else model._meta.label  # noqa: SLF001
         if not field.is_relation:
+            from django.db.models import JSONField  # noqa: PLC0415
+
+            if isinstance(field, JSONField):
+                # A JSONField's value can legitimately BE a list (#3056:
+                # DistinctionEffect.scaling_values) — natural-key resolution
+                # only applies to relation fields, so pass it through and let
+                # _coerce_scalar_fields / the DB layer validate it.
+                continue
             msg = (
                 f"{location}: {field_name!r} on {model._meta.label} is a list-valued "  # noqa: SLF001
                 "field but not a relational one — natural-key resolution only "

--- a/src/core_management/tests/test_content_export.py
+++ b/src/core_management/tests/test_content_export.py
@@ -1683,3 +1683,110 @@ class GiftUnlockContentExportTests(TestCase):
 
         with self.assertRaises(IntegrityError), transaction.atomic():
             GiftUnlock.objects.create(gift=gift, xp_cost=99)
+
+
+class MissionOfferContentExportTests(TestCase):
+    """#3056: MISSION-kind offers are content; other kinds stay seeder-owned.
+
+    Covers: the kind="mission" row filter, natural-key FK references
+    (including MissionOptionRouteReward.followon_offer, the corpus row that
+    could previously only serialize as a raw pk), the source_beat /
+    target_project field exclusions, and the deleted-then-reloaded round-trip.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def test_mission_offer_and_reward_round_trip(self) -> None:
+        from world.missions.constants import DeedRewardKind, DeedRewardSink
+        from world.missions.factories import MissionOptionRouteRewardFactory
+        from world.npc_services.constants import OfferKind
+        from world.npc_services.factories import (
+            MissionOfferDetailsFactory,
+            NPCServiceOfferFactory,
+        )
+        from world.npc_services.models import MissionOfferDetails, NPCServiceOffer
+
+        details = MissionOfferDetailsFactory(
+            offer__role__name="Thread Warden",
+            offer__label="A thread that wants weaving",
+        )
+        offer = details.offer
+        NPCServiceOfferFactory(  # PERMIT-kind: must NOT export
+            role=offer.role, kind=OfferKind.PERMIT, label="Apply for a permit"
+        )
+        reward = MissionOptionRouteRewardFactory(
+            kind=DeedRewardKind.IMMEDIATE,
+            sink=DeedRewardSink.FOLLOW_ON_SUMMONS,
+            amount=None,
+            followon_offer=offer,
+            followon_message="There is a thread that wants weaving.",
+            contract_holder_only=True,
+        )
+
+        result = export_to_content_repo(self.root)
+        assert result.errors == []
+
+        offer_path = self.root / "fixtures" / "npc_services" / "npcserviceoffer.json"
+        details_path = self.root / "fixtures" / "npc_services" / "missionofferdetails.json"
+        reward_path = self.root / "fixtures" / "missions" / "missionoptionroutereward.json"
+        assert offer_path.exists()
+        assert details_path.exists()
+
+        offer_rows = json.loads(offer_path.read_text(encoding="utf-8"))
+        # The PERMIT offer is filtered out: only the MISSION offer exports.
+        assert [r["fields"]["label"] for r in offer_rows] == ["A thread that wants weaving"]
+        assert offer_rows[0]["fields"]["role"] == ["Thread Warden"]
+        assert "pk" not in offer_rows[0]
+
+        details_rows = json.loads(details_path.read_text(encoding="utf-8"))
+        assert len(details_rows) == 1
+        assert details_rows[0]["fields"]["offer"] == [
+            "Thread Warden",
+            "A thread that wants weaving",
+        ]
+        assert "source_beat" not in details_rows[0]["fields"]
+        assert "target_project" not in details_rows[0]["fields"]
+
+        reward_rows = json.loads(reward_path.read_text(encoding="utf-8"))
+        summons_row = next(
+            r for r in reward_rows if r["fields"]["sink"] == DeedRewardSink.FOLLOW_ON_SUMMONS
+        )
+        assert summons_row["fields"]["followon_offer"] == [
+            "Thread Warden",
+            "A thread that wants weaving",
+        ]
+
+        # Deleted-then-reloaded: the exported corpus recreates all three rows
+        # (delete children first — followon_offer is PROTECT). Uses
+        # ``load_world_content`` rather than the bare ``build_all`` +
+        # ``load_entries`` pair (deviation from the brief): file processing
+        # order is plain alphabetical (see MagicCatalogContentExportTests'
+        # docstring above), and "missions/missionoptionroutereward.json" +
+        # "npc_services/missionofferdetails.json" both sort BEFORE
+        # "npc_services/npcserviceoffer.json" — so a one-pass load_entries
+        # skips both on a fresh load (their followon_offer/offer FK target
+        # doesn't exist yet at the moment their own file is processed).
+        # load_world_content's defer-then-retry-to-fixed-point pass closes
+        # this content-internal ordering gap, same as that class's rationale.
+        from core_management.content_fixtures import load_world_content
+
+        reward.delete()
+        details.delete()
+        offer.delete()
+        world_result = load_world_content(self.root)
+        assert world_result.skipped == []
+        assert world_result.created >= 3
+
+        reloaded = NPCServiceOffer.objects.get_by_natural_key(
+            "Thread Warden", "A thread that wants weaving"
+        )
+        assert reloaded.kind == OfferKind.MISSION
+        reloaded_details = MissionOfferDetails.objects.get_by_natural_key(
+            "Thread Warden", "A thread that wants weaving"
+        )
+        assert reloaded_details.role_id == reloaded.role_id  # save() re-derived mirror
+        summons = DeedRewardSink.FOLLOW_ON_SUMMONS
+        assert reloaded.pk == type(reward).objects.get(sink=summons).followon_offer_id

--- a/src/core_management/tests/test_content_fixtures.py
+++ b/src/core_management/tests/test_content_fixtures.py
@@ -367,17 +367,27 @@ class NewDomainContentLoadTests(TestCase):
 
 
 class ResolveNaturalKeyFieldsGuardTests(TestCase):
-    """#2266 review fix: ``_resolve_natural_key_fields`` must not crash on a
-    list-valued value for a NON-relational field — it should raise a clean
-    ContentError instead of a bare AttributeError from ``related_model``.
+    """#2266 guard, narrowed by #3056: a list value on a non-relational field
+    raises a clean ContentError ONLY when the field can't legitimately hold a
+    list. A ``JSONField`` list (e.g. ``DistinctionEffect.scaling_values``) is
+    real data and must pass through verbatim.
     """
 
-    def test_non_relational_list_field_raises_content_error(self) -> None:
+    def test_non_relational_scalar_list_field_raises_content_error(self) -> None:
         # NPCRole.description is a plain TextField (not a relation); a list
         # value there can only mean a future bug, not a legitimate FK-by-name.
         with self.assertRaises(ContentError) as ctx:
             _resolve_natural_key_fields(NPCRole, {"description": ["oops"]}, None)
         assert "description" in str(ctx.exception)
+
+    def test_json_field_list_passes_through_verbatim(self) -> None:
+        # DistinctionEffect.scaling_values is a JSONField whose value IS a
+        # list — the loader must not mistake it for a natural-key reference.
+        from world.distinctions.models import DistinctionEffect
+
+        fields = {"scaling_values": [100, 200, 300]}
+        _resolve_natural_key_fields(DistinctionEffect, fields, None)
+        assert fields["scaling_values"] == [100, 200, 300]
 
     def test_relational_list_field_still_resolves(self) -> None:
         # Sanity check the guard doesn't break the legitimate FK-by-name path.
@@ -699,6 +709,36 @@ class FixtureJsonLoadTests(TestCase):
         # Both load
         created, _updated, _ = load_entries(result)
         assert created >= 2  # 1 trait + 1 effect type
+
+    def test_json_list_field_round_trips_through_load(self) -> None:
+        """#3056: the corpus's scaling personality distinction must load."""
+        from world.distinctions.factories import DistinctionFactory
+        from world.distinctions.models import DistinctionEffect
+        from world.mechanics.factories import ModifierTargetFactory
+
+        distinction = DistinctionFactory()
+        target = ModifierTargetFactory()
+        _write(
+            self.root,
+            "fixtures/distinctions/effects.json",
+            json.dumps(
+                [
+                    {
+                        "model": "distinctions.distinctioneffect",
+                        "fields": {
+                            "distinction": list(distinction.natural_key()),
+                            "target": list(target.natural_key()),
+                            "scaling_values": [100, 200, 300],
+                            "description": "+100/200/300% per rank.",
+                        },
+                    },
+                ]
+            ),
+        )
+        created, updated, _ = load_entries(build_all(self.root))
+        assert created + updated == 1
+        effect = DistinctionEffect.objects.get(distinction=distinction, target=target)
+        assert effect.scaling_values == [100, 200, 300]
 
 
 class LoadEntriesM2MTest(TestCase):

--- a/src/world/npc_services/models.py
+++ b/src/world/npc_services/models.py
@@ -500,7 +500,7 @@ class StaffingProfileLine(SharedMemoryModel):
         return f"{self.profile.building_kind.name}: {self.role.name}"
 
 
-class NPCServiceOffer(SharedMemoryModel):
+class NPCServiceOffer(NaturalKeyMixin, SharedMemoryModel):
     """One offerable thing on an NPC role, of a specific kind.
 
     The unified offer model. Kind discriminator routes to a per-kind 1:1
@@ -512,6 +512,11 @@ class NPCServiceOffer(SharedMemoryModel):
     are the same concept. If the predicate fails, the offer doesn't appear.
     Progressive disclosure happens through how staff author predicates, not
     through a separate visibility layer.
+
+    Carries ``NaturalKeyMixin`` (#3056): ``(role, label)`` mirrors the
+    ``unique_offer_role_label`` constraint so MISSION-kind offers can travel
+    through the content export/load pipeline (they are referenced by
+    ``MissionOptionRouteReward.followon_offer`` and ``MissionOfferDetails``).
     """
 
     # Reverse-OneToOne safe accessor (#2386): missing row -> None.
@@ -612,6 +617,12 @@ class NPCServiceOffer(SharedMemoryModel):
         ),
     )
 
+    objects = NaturalKeyManager()
+
+    class NaturalKeyConfig:
+        fields = ["role", "label"]
+        dependencies = ["arxii.NPCRole"]
+
     class Meta:
         constraints = [
             models.UniqueConstraint(
@@ -704,7 +715,7 @@ class NPCRoleCooldown(SharedMemoryModel):
         )
 
 
-class MissionOfferDetails(SharedMemoryModel):
+class MissionOfferDetails(NaturalKeyMixin, SharedMemoryModel):
     """Per-kind details for `NPCServiceOffer` rows of kind=MISSION (#686).
 
     Captures the mission-specific knobs that don't fit on the unified
@@ -719,6 +730,10 @@ class MissionOfferDetails(SharedMemoryModel):
     gameplay one-shot.** One template fuels many ``MissionInstance`` rows
     over time; each acceptance spawns a fresh instance with auto-generated
     per-instance details.
+
+    Carries ``NaturalKeyMixin`` (#3056): the O2O ``offer`` is the identity, so
+    the row exports/loads alongside its offer; ``save()`` re-derives the
+    denormalized ``role`` mirror on load.
     """
 
     offer = models.OneToOneField(
@@ -807,6 +822,12 @@ class MissionOfferDetails(SharedMemoryModel):
             "ahead of the general pool. 0 = general pool."
         ),
     )
+
+    objects = NaturalKeyManager()
+
+    class NaturalKeyConfig:
+        fields = ["offer"]
+        dependencies = ["arxii.NPCServiceOffer"]
 
     class Meta:
         verbose_name_plural = "Mission offer details"

--- a/src/world/npc_services/seeds.py
+++ b/src/world/npc_services/seeds.py
@@ -89,8 +89,12 @@ def ensure_builders_guild_clerk_role() -> NPCRole | None:
 
     # Idempotent cleanup: delete any offers on this role whose labels
     # are not in the current expected set (handles migration from old
-    # seed labels like "Apply for a small residential permit").
-    NPCServiceOffer.objects.filter(role=role).exclude(label__in=_CLERK_OFFER_LABELS).delete()
+    # seed labels like "Apply for a small residential permit"). MISSION
+    # offers are content-repo-owned since #3056 and never this seeder's
+    # to delete, so they're excluded alongside the label allowlist.
+    NPCServiceOffer.objects.filter(role=role).exclude(label__in=_CLERK_OFFER_LABELS).exclude(
+        kind=OfferKind.MISSION
+    ).delete()
 
     _ensure_offer(
         role=role,

--- a/src/world/npc_services/tests/test_natural_keys.py
+++ b/src/world/npc_services/tests/test_natural_keys.py
@@ -1,0 +1,55 @@
+"""Natural-key round-trips for the MISSION-offer content models (#3056)."""
+
+from django.test import TestCase
+
+from world.npc_services.constants import OfferKind
+from world.npc_services.factories import (
+    MissionOfferDetailsFactory,
+    NPCRoleFactory,
+    NPCServiceOfferFactory,
+)
+from world.npc_services.models import MissionOfferDetails, NPCServiceOffer
+
+
+class NPCServiceOfferNaturalKeyTests(TestCase):
+    """(role, label) is the enforced identity (unique_offer_role_label)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.role = NPCRoleFactory(name="Thread Warden")
+        cls.offer = NPCServiceOfferFactory(
+            role=cls.role, kind=OfferKind.MISSION, label="A thread that wants weaving"
+        )
+
+    def test_natural_key_flattens_role_name_and_label(self) -> None:
+        assert self.offer.natural_key() == ("Thread Warden", "A thread that wants weaving")
+
+    def test_get_by_natural_key_round_trips(self) -> None:
+        found = NPCServiceOffer.objects.get_by_natural_key(
+            "Thread Warden", "A thread that wants weaving"
+        )
+        assert found == self.offer
+
+    def test_get_by_natural_key_miss_raises(self) -> None:
+        with self.assertRaises(NPCServiceOffer.DoesNotExist):
+            NPCServiceOffer.objects.get_by_natural_key("Thread Warden", "No such offer")
+
+
+class MissionOfferDetailsNaturalKeyTests(TestCase):
+    """The O2O offer IS the identity; its FK key flattens into the tuple."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.details = MissionOfferDetailsFactory(
+            offer__role__name="Thread Warden",
+            offer__label="A thread that wants weaving",
+        )
+
+    def test_natural_key_flattens_offer_key(self) -> None:
+        assert self.details.natural_key() == ("Thread Warden", "A thread that wants weaving")
+
+    def test_get_by_natural_key_round_trips(self) -> None:
+        found = MissionOfferDetails.objects.get_by_natural_key(
+            "Thread Warden", "A thread that wants weaving"
+        )
+        assert found == self.details

--- a/src/world/npc_services/tests/test_seeds.py
+++ b/src/world/npc_services/tests/test_seeds.py
@@ -4,7 +4,7 @@ from django.test import TestCase, override_settings
 
 from world.buildings.factories import BuildingKindFactory
 from world.npc_services.constants import DrawMode, OfferKind
-from world.npc_services.factories import NPCRoleFactory
+from world.npc_services.factories import NPCRoleFactory, NPCServiceOfferFactory
 from world.npc_services.models import NPCRole, NPCServiceOffer, PermitOfferDetails
 from world.npc_services.seeds import (
     BUILDERS_GUILD_CLERK_ROLE_NAME,
@@ -120,6 +120,24 @@ class ClerkOfferWiringTests(TestCase):
             NPCServiceOffer.objects.filter(
                 role=role, label="Apply for a small residential permit"
             ).exists()
+        )
+
+    def test_mission_offer_survives_stale_label_cleanup(self) -> None:
+        """A content-loaded MISSION offer is never swept by this seeder (#3056).
+
+        Unlike stale PERMIT-labeled offers, a MISSION offer is content-repo
+        owned and must survive the cleanup even though its label isn't in
+        the clerk's known label set.
+        """
+        role = ensure_builders_guild_clerk_role()
+        mission_offer = NPCServiceOfferFactory(
+            role=role, kind=OfferKind.MISSION, label="A thread that wants weaving"
+        )
+        # Re-seed — should NOT clean up the MISSION offer.
+        ensure_builders_guild_clerk_role()
+        self.assertTrue(
+            NPCServiceOffer.objects.filter(pk=mission_offer.pk).exists(),
+            "MISSION offer was deleted by the seeder's cleanup pass",
         )
 
     def test_non_permit_offers_preserved(self) -> None:

--- a/src/world/seeds/tests/test_no_content_slop.py
+++ b/src/world/seeds/tests/test_no_content_slop.py
@@ -27,6 +27,13 @@ with far more rows, and that the genuine config the Big Button must provide is
 never in ``CONTENT_MODELS`` at all. Hence: one registration, two consumers
 (export and this guard), no per-model judgement calls, and a target of zero.
 
+Since #3056, the registration is model-level but the count is row-level: this
+guard also honors ``EXPORT_FILTERS`` (ADR-0171), the same row-scoped predicate
+``export_to_content_repo`` applies, so a model split between content and
+seeder ownership by row (``npc_services.npcserviceoffer`` is content only
+where ``kind="mission"``) is measured against what the export would actually
+capture, not every row in the table.
+
 This test is the standing guard. It seeds against a stub content root and fails
 naming any ``CONTENT_MODELS`` entry outside the ratchet that gained rows — so a
 seeder that invents content fails CI instead of quietly polluting the corpus on
@@ -43,7 +50,7 @@ from django.db.models import DateField
 from django.test import TestCase
 
 from core.app_domains import resolve_model_by_name
-from core_management.content_export import CONTENT_MODELS, EXPORT_FIELD_EXCLUSIONS
+from core_management.content_export import CONTENT_MODELS, EXPORT_FIELD_EXCLUSIONS, EXPORT_FILTERS
 from world.seeds.clusters import CLUSTER_SEEDERS
 from world.seeds.database import load_content_first
 from world.seeds.tests.content_stub import stub_content_root
@@ -144,6 +151,24 @@ class SeedersDoNotCreateContentTests(TestCase):
                 continue
         return models
 
+    @staticmethod
+    def _export_visible_count(label: str, model: type) -> int:
+        """Rows the export would actually capture for *label*.
+
+        The content boundary is CONTENT_MODELS at the model level AND
+        EXPORT_FILTERS at the row level (ADR-0171): a row the export
+        predicate excludes can never land in the corpus, so the guard
+        counts exactly what export_to_content_repo would capture. #3056
+        made npc_services.npcserviceoffer the first seeded model with a
+        row-level line (MISSION-kind offers are content; the permit/train
+        offers the seeders own are excluded by the predicate).
+        """
+        queryset = model.objects.all()
+        filters = EXPORT_FILTERS.get(label)
+        if filters:
+            queryset = queryset.filter(**filters)
+        return queryset.count()
+
     @stub_content_root()
     def test_seeding_creates_no_content_model_rows(self) -> None:
         content_models = self._content_models()
@@ -153,10 +178,16 @@ class SeedersDoNotCreateContentTests(TestCase):
         # root's own rows as seeder growth — the loader is the content repo, so
         # its writes are the one thing this guard must not count.
         load_content_first()
-        before = {label: model.objects.count() for label, model in content_models.items()}
+        before = {
+            label: self._export_visible_count(label, model)
+            for label, model in content_models.items()
+        }
         for seeder in CLUSTER_SEEDERS.values():
             seeder()
-        after = {label: model.objects.count() for label, model in content_models.items()}
+        after = {
+            label: self._export_visible_count(label, model)
+            for label, model in content_models.items()
+        }
 
         grew = {
             label: (before[label], after[label])


### PR DESCRIPTION
Closes #3056

## Summary

Fixes both #3056 content-load failures. (1) The loader treated ANY list-valued fixture field as a natural-key reference; a JSON-list value on a non-relational JSONField (DistinctionEffect.scaling_values, the corpus's one scaling personality distinction) now passes through verbatim, while lists on scalar fields still fail cleanly. (2) NPCServiceOffer gained a (role, label) natural key (mirroring the existing unique_offer_role_label constraint) and MISSION-kind offers became exported content: npc_services.npcserviceoffer (row-filtered to kind=mission; other kinds stay seeder-owned) and npc_services.missionofferdetails (source_beat/target_project stripped as installation state) joined CONTENT_MODELS, so MissionOptionRouteReward.followon_offer round-trips by natural key and the follow-on summons reward exists on a fresh deploy after the next corpus export. Schema-neutral (no migration). Also folded in: the Builders Guild Clerk seeder cleanup now excludes MISSION-kind offers (content-owned, never the seeder's to delete), and stale content-model claims in core_management/CLAUDE.md and docs/systems/INDEX.md were corrected on sight. Lore-repo side (separate repo, per spec Decision 4): corpus re-key happens via re-export from the authoring DB once this deploys; an interim KNOWN_DRIFT entry covers --strict until then.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #3056 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch based on current main tip (7ce5a815c); sync was a no-op, no conflicts, no migrations on this branch.

<!-- last-addressed-comment: 0 -->