### PR TITLE
Group combo discoveries are shared-for-all: one grant_achievement call per combo group + shared flag on DiscoverySerializer (#3063)

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2721,6 +2721,21 @@ gains a discoverable content item for the first time.
   `can_earn_achievements(character_sheet) -> bool` (current, non-staff `RosterTenure`; #3024,
   ADR-0202), `apply_achievement_rewards(sheet, achievement)`,
   `get_stat(sheet, stat_def) -> int`, `increment_stat(sheet, stat_def, n) -> int`
+- **Display rule (#3063):** `DiscoverySerializer.shared` (`world/achievements/serializers.py`)
+  is `True` iff `shared_with_tenures` is non-empty — the primary `discovered_by_tenure` FK is
+  pure bookkeeping in the group case (it has to point somewhere) and must never be read as a
+  display privilege; every co-discoverer displays symmetrically as "shared". **A group grant
+  must be ONE `grant_achievement(achievement, sheets)` call, never a per-sheet loop** — looping
+  `grant_achievement`/`execute_ceremony_beat` once per participant lets the first iteration's
+  call claim the sole `Discovery` row before the others run, so co-participants earn the
+  `CharacterAchievement` but never land in `shared_with_tenures`. `fire_combo_discovery`
+  (`world/combat/combo_discovery.py`) is the reference implementation: it grants the whole combo
+  participant group in one call rather than routing through the single-sheet
+  `execute_ceremony_beat` helper (see that module's docstring). Two other group-earning
+  moments — combat encounter completion and relationship reciprocation — currently reach
+  `grant_achievement` only through the single-sheet `StatHandler.increment` →
+  `_check_achievements` indirection and are NOT yet batched; a follow-up is needed before they
+  can claim shared credit.
 - **Access-change + discovery surface (`world/achievements/discovery.py` — ADR-0061):**
   - `announce_access_change(character_sheet, *, gained, lost, source)` — sends an ABILITY
     `NarrativeMessage` to the character listing what techniques/capabilities changed, then for

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -24403,6 +24403,16 @@ export interface components {
        *     ``CharacterAchievement.discovery`` FK to walk).
        */
       readonly discoverer_names: string[];
+      /**
+       * @description True iff this was a simultaneous group discovery (#3063).
+       *
+       *     ``shared_with_tenures`` non-empty is the whole rule -- the primary
+       *     ``discovered_by_tenure`` FK is bookkeeping in the group case (it had
+       *     to point somewhere), never a display privilege. Every group
+       *     participant must read identically as "shared"; do not special-case
+       *     ``discovered_by_tenure`` here.
+       */
+      readonly shared: boolean;
     };
     /**
      * @description * `obvious` - Obvious (visible if capability met)

--- a/src/schema.json
+++ b/src/schema.json
@@ -41811,9 +41811,21 @@ components:
             the character's display name (#3055 -- there is no longer a
             ``CharacterAchievement.discovery`` FK to walk).
           readOnly: true
+        shared:
+          type: boolean
+          description: |-
+            True iff this was a simultaneous group discovery (#3063).
+
+            ``shared_with_tenures`` non-empty is the whole rule -- the primary
+            ``discovered_by_tenure`` FK is bookkeeping in the group case (it had
+            to point somewhere), never a display privilege. Every group
+            participant must read identically as "shared"; do not special-case
+            ``discovered_by_tenure`` here.
+          readOnly: true
       required:
       - discovered_at
       - discoverer_names
+      - shared
     DiscoveryTypeEnum:
       enum:
       - obvious

--- a/src/world/achievements/CLAUDE.md
+++ b/src/world/achievements/CLAUDE.md
@@ -72,6 +72,26 @@ First-time-earned record. OneToOne to Achievement.
   (#3055 ruling). Later earners of the same achievement get neither — they were not
   part of the first-discovery moment.
 
+**Display rule (#3063, ruled 2026-08-07):** shared iff `shared_with_tenures` is
+non-empty; the primary `discovered_by_tenure` FK is pure bookkeeping in the group case
+(it has to point somewhere) and must never be read as a display privilege — every
+participant of a group discovery displays symmetrically as "shared". Implemented as
+`DiscoverySerializer.shared` (`serializers.py`).
+
+**Group grants must be ONE `grant_achievement` call, never a per-sheet loop.** Calling
+`grant_achievement(achievement, [sheet])` (or the `execute_ceremony_beat` wrapper around
+it) once per participant lets the first iteration's call create the sole `Discovery` row
+before the rest ever run — every later participant earns a `CharacterAchievement` but
+never lands in `shared_with_tenures`, so a party discovery looks solo to everyone but the
+first sheet. Pass the whole eligible group to a single `grant_achievement(achievement,
+sheets)` call instead (`world/combat/combo_discovery.py::fire_combo_discovery` is the
+reference implementation — see its module docstring for why it bypasses
+`execute_ceremony_beat`'s per-sheet shape). Two other group-earning moments — combat
+encounter completion (`world/combat/services.py`) and relationship reciprocation
+(`world/relationships/services.py`) — currently reach `grant_achievement` only through the
+single-sheet `StatHandler.increment` → `_check_achievements` indirection and are NOT yet
+batched; fixing them needs a batch stat-check seam, tracked as a follow-up, not fixed here.
+
 ### CharacterAchievement
 Records when a character earned an achievement.
 - Required `earned_by_tenure` FK -> `roster.RosterTenure` (`on_delete=PROTECT`, #3055):

--- a/src/world/achievements/serializers.py
+++ b/src/world/achievements/serializers.py
@@ -30,11 +30,23 @@ class DiscoverySerializer(serializers.ModelSerializer):
     """Serializer for discovery records."""
 
     discoverer_names = serializers.SerializerMethodField()
+    shared = serializers.SerializerMethodField()
 
     class Meta:
         model = Discovery
-        fields = ["discovered_at", "discoverer_names"]
+        fields = ["discovered_at", "discoverer_names", "shared"]
         read_only_fields = fields
+
+    def get_shared(self, obj: Discovery) -> bool:
+        """True iff this was a simultaneous group discovery (#3063).
+
+        ``shared_with_tenures`` non-empty is the whole rule -- the primary
+        ``discovered_by_tenure`` FK is bookkeeping in the group case (it had
+        to point somewhere), never a display privilege. Every group
+        participant must read identically as "shared"; do not special-case
+        ``discovered_by_tenure`` here.
+        """
+        return obj.shared_with_tenures.exists()
 
     def get_discoverer_names(self, obj: Discovery) -> list[str]:
         """Return display names of the tenures who discovered this achievement.

--- a/src/world/achievements/tests/test_views.py
+++ b/src/world/achievements/tests/test_views.py
@@ -163,3 +163,26 @@ class CharacterAchievementViewSetTests(TestCase):
             status.HTTP_401_UNAUTHORIZED,
             status.HTTP_403_FORBIDDEN,
         )
+
+    def test_discovery_shared_false_for_solo_discovery(self) -> None:
+        """DiscoverySerializer.shared is False when no co-discoverers (#3063)."""
+        DiscoveryFactory(
+            achievement=self.achievement1, discovered_by_tenure=self.ca1.earned_by_tenure
+        )
+
+        response = self.client.get(f"/api/achievements/character-achievements/{self.ca1.id}/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["achievement"]["discovery"]["shared"] is False
+
+    def test_discovery_shared_true_for_group_discovery(self) -> None:
+        """DiscoverySerializer.shared is True whenever shared_with_tenures is non-empty,
+        regardless of which tenure holds the primary discovered_by_tenure FK (#3063)."""
+        co_discoverer_tenure = RosterTenureFactory()
+        discovery = DiscoveryFactory(
+            achievement=self.achievement1, discovered_by_tenure=self.ca1.earned_by_tenure
+        )
+        discovery.shared_with_tenures.add(co_discoverer_tenure)
+
+        response = self.client.get(f"/api/achievements/character-achievements/{self.ca1.id}/")
+        assert response.status_code == status.HTTP_200_OK
+        assert response.data["achievement"]["discovery"]["shared"] is True

--- a/src/world/combat/combo_discovery.py
+++ b/src/world/combat/combo_discovery.py
@@ -1,12 +1,28 @@
 """Discovery ceremony for combos — fired the first time a party triggers a combo in combat.
 
 Writes ``ComboLearning`` rows for each participant, fires the achievement
-ceremony (gamewide first-ever + personal thereafter) via
-``execute_ceremony_beat``, and grants a flat resonance reward via
-``grant_resonance``.
+ceremony (gamewide first-ever + personal thereafter), and grants a flat
+resonance reward via ``grant_resonance``.
 
 Modeled on ``fire_variant_discoveries`` (the specialization engine's
 discovery ceremony) but for combat combos rather than thread crossings.
+
+**Achievement grant is a single group call, never a per-sheet loop (#3063).**
+``world.magic.crossing.ceremony.execute_ceremony_beat`` is the shared
+single-sheet ceremony beat (grant + optional codex unlock + announce) used
+everywhere else in the codebase — every other caller fires one ``Thread``
+owned by one character, so "one sheet per beat" is the right shape there.
+Combo discovery is the one ceremony trigger that is inherently a *group*
+event (every combo contributor discovers it simultaneously), so it does NOT
+route through ``execute_ceremony_beat``: looping that per-sheet helper once
+per participant called ``grant_achievement(achievement, [sheet])`` once per
+sheet, and the FIRST call claimed the sole ``Discovery`` row before the
+others ever ran — co-discoverers got a ``CharacterAchievement`` but never
+landed in ``Discovery.shared_with_tenures``. Instead this module calls
+``grant_achievement`` and ``announce_achievement`` directly, once each, for
+the whole eligible participant group. ``execute_ceremony_beat``'s
+``codex_entry`` param is unused here (combos don't unlock codex entries), so
+skipping it costs nothing.
 """
 
 from __future__ import annotations
@@ -16,7 +32,6 @@ from typing import TYPE_CHECKING
 
 from world.combat.constants import COMBO_DISCOVERY_GRANT, ComboLearningMethod
 from world.magic.constants import GainSource
-from world.magic.crossing.ceremony import CeremonyNarrative, execute_ceremony_beat
 
 if TYPE_CHECKING:
     from world.character_sheets.models import CharacterSheet
@@ -38,8 +53,9 @@ def fire_combo_discovery(
     1. Writes ``ComboLearning(combo=combo, learned_via=COMBAT)`` for each
        participant (idempotent via ``get_or_create``).
     2. If ``combo.discovery_achievement`` is set and ceremony copy is authored,
-       calls ``execute_ceremony_beat`` for each participant — grants the
-       achievement and announces (gamewide on first-ever, personal otherwise).
+       grants the achievement to the whole group in ONE ``grant_achievement``
+       call and announces once (gamewide on first-ever, personal otherwise —
+       see the module docstring for why this is not a per-participant loop).
     3. Calls ``grant_resonance`` for each participant using the first slot's
        ``resonance_requirement`` that has one; skips the grant if no slot
        has a resonance requirement.
@@ -59,22 +75,35 @@ def fire_combo_discovery(
             defaults={"learned_via": ComboLearningMethod.COMBAT},
         )
 
-    # Step 2: Fire the achievement ceremony if configured.
+    # Step 2: Fire the achievement ceremony if configured -- ONE grant for the
+    # whole group (see the module docstring for why this doesn't route
+    # through execute_ceremony_beat's per-sheet loop, #3063).
     achievement = combo.discovery_achievement
     has_ceremony_copy = bool(combo.discovery_first_body or combo.discovery_personal_body)
     if achievement is not None and has_ceremony_copy:
+        from world.achievements.discovery import announce_achievement  # noqa: PLC0415
+        from world.achievements.models import CharacterAchievement  # noqa: PLC0415
+        from world.achievements.services import grant_achievement  # noqa: PLC0415
         from world.narrative.constants import NarrativeCategory  # noqa: PLC0415
 
-        narrative = CeremonyNarrative(
-            first_body=combo.discovery_first_body,
-            personal_body=combo.discovery_personal_body,
-            category=NarrativeCategory.ABILITY,
+        # Idempotency gate mirrors execute_ceremony_beat's per-sheet re-fire
+        # guard: a participant who already earned this achievement (a stale
+        # replay of an already-fired combo) sits out the ceremony entirely.
+        already_earned_ids = set(
+            CharacterAchievement.objects.filter(
+                character_sheet__in=participant_sheets, achievement=achievement
+            ).values_list("character_sheet_id", flat=True)
         )
-        for sheet in participant_sheets:
-            execute_ceremony_beat(
-                sheet=sheet,
-                narrative=narrative,
-                achievement=achievement,
+        unearned_sheets = [s for s in participant_sheets if s.pk not in already_earned_ids]
+        if unearned_sheets:
+            result = grant_achievement(achievement, unearned_sheets)
+            is_first = result.created_discovery is not None
+            announce_achievement(
+                unearned_sheets,
+                is_first=is_first,
+                first_body=combo.discovery_first_body,
+                personal_body=combo.discovery_personal_body,
+                category=NarrativeCategory.ABILITY,
             )
 
     # Step 3: Grant resonance to each participant.

--- a/src/world/combat/tests/test_combo_discovery.py
+++ b/src/world/combat/tests/test_combo_discovery.py
@@ -100,3 +100,52 @@ class FireComboDiscoveryTests(TestCase):
                 character_sheet=sheet,
             ).exists()
         )
+
+    def test_group_discovery_shares_credit_across_all_participants(self) -> None:
+        """A combo triggered by a party claims ONE shared Discovery (#3063).
+
+        Regression test for the bug where looping ``execute_ceremony_beat``
+        once per participant let the first sheet's call claim a sole
+        Discovery before the other participants' achievement grants ran.
+        With the fix, all three participants earn the achievement AND all
+        three are recorded as co-discoverers on the single Discovery row --
+        the triggering sheet as the primary FK, the other two shared.
+        """
+        from world.achievements.models import CharacterAchievement, Discovery
+
+        achievement = AchievementFactory()
+        combo = ComboDefinitionFactory(
+            discoverable_via_combat=True,
+            discovery_first_body="A new combo has been discovered!",
+            discovery_personal_body="You discovered a combo!",
+        )
+        combo.discovery_achievement = achievement
+        combo.save()
+        effect_type = EffectTypeFactory()
+        ComboSlotFactory(combo=combo, required_action_type=effect_type)
+
+        sheets = [CharacterSheetFactory() for _ in range(3)]
+        tenures = [grant_test_tenure(sheet) for sheet in sheets]
+        triggering_tenure, other_tenures = tenures[0], tenures[1:]
+
+        fire_combo_discovery(combo=combo, participant_sheets=sheets)
+
+        # Exactly one Discovery row for this achievement.
+        self.assertEqual(Discovery.objects.filter(achievement=achievement).count(), 1)
+        discovery = Discovery.objects.get(achievement=achievement)
+
+        # Primary FK is the triggering (first) sheet's tenure.
+        self.assertEqual(discovery.discovered_by_tenure_id, triggering_tenure.pk)
+
+        # The other two participants are shared co-discoverers.
+        shared_ids = set(discovery.shared_with_tenures.values_list("id", flat=True))
+        self.assertEqual(shared_ids, {t.pk for t in other_tenures})
+
+        # Every participant earned the achievement individually.
+        for sheet in sheets:
+            self.assertTrue(
+                CharacterAchievement.objects.filter(
+                    achievement=achievement,
+                    character_sheet=sheet,
+                ).exists()
+            )


### PR DESCRIPTION
Closes #3063.

## What

Group combo discoveries now claim first-ever slots as shared-for-all, per the ruled semantics (2026-08-07):

- **`fire_combo_discovery`** no longer loops `execute_ceremony_beat` per participant (the first sheet's call claimed the sole Discovery before the rest ran). It computes the idempotency-gated `unearned_sheets` list and calls `grant_achievement(achievement, unearned_sheets)` + `announce_achievement` exactly once for the whole group — one Discovery, primary tenure = triggering sheet, co-participants in `shared_with_tenures`, every earner stamped. `execute_ceremony_beat`'s single-sheet contract is deliberately untouched (combo discovery never used its codex path; every other caller is inherently single-sheet via Thread ownership) — choice documented in the module docstring.
- **`DiscoverySerializer.shared`** — the ruled display flag (shared iff `shared_with_tenures` non-empty; the primary FK is bookkeeping in the group case). The display half is otherwise greenfield: no frontend/telnet component consumes Discovery data yet, and `discoverer_names` already lists all discoverers symmetrically.
- Display rule + "group grants must be ONE grant_achievement call, never a per-sheet loop" documented beside the model (`world/achievements/CLAUDE.md`, INDEX).

## What this deliberately does not do

The caller inventory (2026-08-08) found two more genuine group moments — combat encounter completion and relationship reciprocation — that reach `grant_achievement` only through the single-sheet `StatHandler.increment` → `_check_achievements` indirection. Batching those needs a new seam with a crossing-set wrinkle; filed as #3075.

## Tests

43 passing: new `test_group_discovery_shares_credit_across_all_participants` (3 participants → one shared Discovery) exercising the real combo-discovery production path, plus solo/group `shared` serializer tests. ruff + pre-commit clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
