### PR TITLE
Admit ActionEnhancement, TechniqueVariant and MagicalAlterationTemplate to the content catalog (#3034)

### DIFF
--- a/docs/roadmap/magic.md
+++ b/docs/roadmap/magic.md
@@ -401,10 +401,16 @@ non-test consumer):
   (`_seed_hallowed_threshold_story`) — test fixture only, no production destination.
 - The "Social Arts" `Gift` + 6 `Technique`s + 6 `ActionEnhancement`s + variants
   (`MagicContent.create_all()`) — lore fixture; `MagicContent` survives as a
-  test-fixture builder.
+  test-fixture builder. `actions.ActionEnhancement` and `magic.TechniqueVariant`
+  joined `CONTENT_MODELS` in #3034 — that lore-fixture destination was aspirational
+  until then (neither model carried a natural key or a registry entry, so the six
+  enhancements + their variants had no way to actually be authored); the lore repo
+  can now ship them (ArxII-lore#69).
 - 2 Corruption `ConditionTemplate`s + 12 `MagicalAlterationTemplate` twists
   (`author_reference_corruption_content()`) — lore fixture; the factory survives as
   a test-fixture builder for `test_reference_corruption_content.py`.
+  `magic.MagicalAlterationTemplate` joined `CONTENT_MODELS` in #3034 (NK
+  `["condition_template"]`; player-authored rows excluded via `EXPORT_FILTERS`).
 - 5 hallowed reaction `ConditionTemplate`s + the achievement bridge
   (`_seed_hallowed_reaction_conditions`/`_seed_hallowed_achievement_bridge`) —
   lore fixture; KEEP-side consequence pools resolve them by name via

--- a/docs/systems/magic.md
+++ b/docs/systems/magic.md
@@ -1342,7 +1342,7 @@ now say "Mage Scars."
 
 | Model | Purpose | Key Fields |
 |-------|---------|------------|
-| `MagicalAlterationTemplate` | OneToOne on ConditionTemplate; magic-specific alteration metadata | `tier`, `origin_affinity`, `origin_resonance`, `is_library`, `visibility_required` |
+| `MagicalAlterationTemplate` | OneToOne on ConditionTemplate; magic-specific alteration metadata. `NaturalKeyMixin`, `CONTENT_MODELS` (`magic.magicalalterationtemplate`, #3034) — NK `["condition_template"]` (already DB-unique). Only staff/system rows (`authored_by` NULL) export; a player's "author from scratch" row is filtered via `EXPORT_FILTERS` | `tier`, `origin_affinity`, `origin_resonance`, `is_library`, `visibility_required` |
 | `PendingAlteration` | Queued unresolved Mage Scar | `character` FK, `status` (OPEN/RESOLVED/STAFF_CLEARED), `scene` FK, triggering-state snapshot fields |
 | `MagicalAlterationEvent` | Immutable provenance audit log | `pending`, `event_type`, `data`, `created_at` |
 
@@ -1360,7 +1360,7 @@ resonance instantly re-specializes every affected technique with no regeneration
 | Model | Purpose | Key Fields |
 |-------|---------|------------|
 | `AbstractSpecializedVariant` | Shared abstract base (SharedMemoryModel) — the "one specialization engine" | `parent` discriminator contract, `matching_variant` selection predicate (highest `unlock_thread_level ≤ thread level` at the thread's resonance), `newly_crossed_variants` discovery query, `discovery_narrative(is_first)` ceremony contract |
-| `TechniqueVariant` | Concrete subclass — a resonance-specialized form of a parent `Technique` | `parent_technique` (self-FK, `related_name="variants"`), `resonance` FK, `unlock_thread_level` (≥3 = variant), `name_override`, `intensity_delta`, `control_delta`, `discovery_achievement` FK, `codex_entry` FK. Unique per `(parent_technique, resonance, unlock_thread_level)` |
+| `TechniqueVariant` | Concrete subclass — a resonance-specialized form of a parent `Technique`. `NaturalKeyMixin`, `CONTENT_MODELS` (`magic.techniquevariant`, #3034) — NK `(parent_technique, resonance, unlock_thread_level)`, the same triple the `UniqueConstraint` already enforces | `parent_technique` (self-FK, `related_name="variants"`), `resonance` FK, `unlock_thread_level` (≥3 = variant), `name_override`, `intensity_delta`, `control_delta`, `discovery_achievement` FK, `codex_entry` FK. Unique per `(parent_technique, resonance, unlock_thread_level)` |
 | `CovenantRole` | Refactored to inherit `AbstractSpecializedVariant` (schema no-op) | existing sub-role fields; `parent_role` (`related_name="sub_roles"`) is the variant parent |
 
 **Resolver — `resolve_specialized_variant(*, entity, character)`** (`world/magic/specialization/services.py`):
@@ -1461,7 +1461,9 @@ threshold the parent technique is returned unchanged. `MagicContent.create_all()
 (`world/seeds/game_content/magic.py`) builds starter `TechniqueVariant` rows so a suite
 has variants to exercise, but it is a test-fixture builder only — it left the production
 `seed_magic_dev()` path in #2973, so a fresh dev environment has none until the lore repo
-authors them. The
+authors them. `TechniqueVariant` joined `CONTENT_MODELS` in #3034 (NK `(parent_technique,
+resonance, unlock_thread_level)`), so that authoring path now exists — it did not before.
+The
 gift-thread confers the standard always-in-action thread bonus (passive `ThreadPullEffect`
 tier-0 rows; `_ALWAYS_IN_ACTION_KINDS` — already wired in #1580); cast-time variant
 resolution is the new addition in #1581.

--- a/src/actions/models/enhancement.py
+++ b/src/actions/models/enhancement.py
@@ -8,12 +8,13 @@ from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
 from actions.constants import EnhancementSourceType
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 
 if TYPE_CHECKING:
     from actions.types import ActionContext
 
 
-class ActionEnhancement(SharedMemoryModel):
+class ActionEnhancement(NaturalKeyMixin, SharedMemoryModel):
     """A relationship record: "this source modifies this base action in this way."
 
     The source (a technique, distinction, condition) gates *whether* the
@@ -21,6 +22,20 @@ class ActionEnhancement(SharedMemoryModel):
     owns *what* the enhancement does via effect config rows and ``apply()``.
 
     Exactly one source FK must be non-null, matching ``source_type``.
+
+    Carries ``NaturalKeyMixin`` (#3034) so an enhancement can be authored in
+    the lore repo — e.g. the six social-magic enhancements (Intimidate,
+    Persuade, Deceive, Flirt, Perform, Entrance) #2973 requires but which no
+    production seeder creates. ``(base_action_key, variant_name)`` is the
+    identity: it is already the de facto key every production call site
+    (``world.conditions.berserk_content.ensure_restore_to_sense_effect``,
+    ``MagicContent.create_all()``) uses in its own ``get_or_create`` lookup,
+    and it is the "this base action, in this way" pair the class docstring
+    above already names as the row's meaning. No DB ``UniqueConstraint``
+    backs it (mirrors ``conditions.ConditionCheckModifier`` — a natural key
+    does not require DB enforcement) since several tests create rows via
+    ``ActionEnhancement.objects.create(...)`` directly and a new constraint
+    would risk colliding with those.
     """
 
     base_action_key = models.CharField(max_length=100, db_index=True)
@@ -54,6 +69,11 @@ class ActionEnhancement(SharedMemoryModel):
         on_delete=models.CASCADE,
         related_name="action_enhancements",
     )
+
+    objects = NaturalKeyManager()
+
+    class NaturalKeyConfig:
+        fields = ["base_action_key", "variant_name"]
 
     class Meta:
         app_label = "arxii"

--- a/src/core_management/content_export.py
+++ b/src/core_management/content_export.py
@@ -70,6 +70,13 @@ CONTENT_MODELS: frozenset[str] = frozenset(
         "achievements.achievementreward",
         "achievements.rewarddefinition",
         "achievements.conditionstatrule",
+        # actions — #3034: the six social-magic ActionEnhancement rows #2973
+        # requires (Intimidate/Persuade/Deceive/Flirt/Perform/Entrance) had no
+        # production seeder and no CONTENT_MODELS entry, so "magical
+        # persuade/intimidate" had no path to becoming dispatchable on a real
+        # deploy. MagicContent.create_all() (test-fixture only since #2973)
+        # is the only place these six were ever created.
+        "actions.actionenhancement",
         # areas
         "areas.rampartelementprofile",
         "areas.rampartelementresistance",
@@ -179,6 +186,11 @@ CONTENT_MODELS: frozenset[str] = frozenset(
         "magic.glimpsetag",
         "magic.glimpsetagdistinctionsuggestion",
         "magic.intensitytier",
+        # #3034: the row-level "authored_by IS NULL" split lives in
+        # EXPORT_FILTERS below — a player's "author from scratch" Mage Scar
+        # must never ship in the corpus, mirroring magic.ritual's
+        # author_account split.
+        "magic.magicalalterationtemplate",
         "magic.pathgiftgrant",
         "magic.portalanchorkind",
         "magic.resonance",
@@ -195,6 +207,11 @@ CONTENT_MODELS: frozenset[str] = frozenset(
         "magic.techniqueoutcomemodifier",
         "magic.techniqueremovedcondition",
         "magic.techniquestyle",
+        # #3034: the resonance-specialized ("Social Arts" gift-technique) forms
+        # #2973 requires. Same test-fixture-only creation gap as
+        # actions.actionenhancement above — MagicContent.create_all() minted
+        # these, and nothing else did.
+        "magic.techniquevariant",
         "magic.threadweavingunlock",
         "magic.tradition",
         "magic.traditiongiftgrant",
@@ -292,6 +309,10 @@ CONTENT_MODELS: frozenset[str] = frozenset(
 EXPORT_FILTERS: dict[str, dict[str, object]] = {
     "evennia_extensions.media": {"slug__isnull": False},  # pre-existing behavior
     "magic.ritual": {"author_account__isnull": True},
+    # #3034: a player's "author from scratch" Mage Scar (authored_by set) is
+    # player data, not lore; only staff/system-seed rows (authored_by NULL,
+    # per the model's own docstring) are content.
+    "magic.magicalalterationtemplate": {"authored_by__isnull": True},
     "checks.checktype": {"owner_sheet__isnull": True},
     "checks.checktypetrait": {"check_type__owner_sheet__isnull": True},
     # #3056: only MISSION-kind offers are content; PERMIT/TRAIN/SETTLE etc.

--- a/src/core_management/prose_fields.py
+++ b/src/core_management/prose_fields.py
@@ -79,6 +79,7 @@ NON_PROSE_TEXT_FIELDS = frozenset(
     {
         "action_key",
         "admin_notes",
+        "base_action_key",
         "cloudinary_public_id",
         "cloudinary_url",
         "color_hex",
@@ -95,6 +96,7 @@ NON_PROSE_TEXT_FIELDS = frozenset(
         "label",
         "latin_name",
         "name",
+        "name_override",
         "notes",
         "ref",
         "reward_value",
@@ -103,6 +105,7 @@ NON_PROSE_TEXT_FIELDS = frozenset(
         "target_object_name",
         "title",
         "variable_name",
+        "variant_name",
     }
 )
 

--- a/src/core_management/tests/test_content_export.py
+++ b/src/core_management/tests/test_content_export.py
@@ -498,6 +498,7 @@ class ContentExportTests(TestCase):
         self.assertIn("checks.checktype", EXPORT_FILTERS)
         self.assertIn("checks.checktypetrait", EXPORT_FILTERS)
         self.assertIn("evennia_extensions.media", EXPORT_FILTERS)
+        self.assertIn("magic.magicalalterationtemplate", EXPORT_FILTERS)
 
 
 class MagicCatalogContentExportTests(TestCase):
@@ -1790,3 +1791,194 @@ class MissionOfferContentExportTests(TestCase):
         assert reloaded_details.role_id == reloaded.role_id  # save() re-derived mirror
         summons = DeedRewardSink.FOLLOW_ON_SUMMONS
         assert reloaded.pk == type(reward).objects.get(sink=summons).followon_offer_id
+
+
+class ActionEnhancementContentExportTests(TestCase):
+    """Round-trip coverage for ActionEnhancement (#3034).
+
+    ``actions.actionenhancement`` was added to ``CONTENT_MODELS`` with natural
+    key ``(base_action_key, variant_name)`` — the six social-magic
+    enhancements #2973 requires (Intimidate/Persuade/Deceive/Flirt/Perform/
+    Entrance) had no production seeder and no way to be authored;
+    ``MagicContent.create_all()`` (test-fixture only since #2973) was the only
+    place they were ever created.
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def test_action_enhancement_round_trips(self) -> None:
+        from actions.constants import EnhancementSourceType
+        from actions.models import ActionEnhancement
+        from world.magic.factories import TechniqueFactory
+
+        technique = TechniqueFactory(name="Round Trip Soul Crush", damage_profile=False)
+        enhancement = ActionEnhancement.objects.create(
+            base_action_key="intimidate",
+            variant_name="Magical Intimidate",
+            is_involuntary=False,
+            source_type=EnhancementSourceType.TECHNIQUE,
+            technique=technique,
+        )
+
+        result = export_to_content_repo(self.root)
+        assert result.errors == []
+
+        enh_path = self.root / "fixtures" / "actions" / "actionenhancement.json"
+        assert enh_path.exists()
+
+        records = json.loads(enh_path.read_text(encoding="utf-8"))
+        assert len(records) == 1
+        record = records[0]
+        assert "pk" not in record
+        assert record["fields"]["base_action_key"] == "intimidate"
+        assert record["fields"]["variant_name"] == "Magical Intimidate"
+        assert record["fields"]["technique"] == [technique.gift.name, "Round Trip Soul Crush"]
+
+        from core_management.content_fixtures import build_all, load_entries
+
+        created, _updated, _ = load_entries(build_all(self.root))
+        assert created == 0, f"Round-trip created {created} new records (expected 0)"
+
+        enhancement.refresh_from_db()
+        assert enhancement.technique_id == technique.pk
+
+        resolved = ActionEnhancement.objects.get_by_natural_key("intimidate", "Magical Intimidate")
+        assert resolved.pk == enhancement.pk
+
+
+class TechniqueVariantContentExportTests(TestCase):
+    """Round-trip coverage for TechniqueVariant (#3034).
+
+    ``magic.techniquevariant`` was added to ``CONTENT_MODELS`` with natural
+    key ``(parent_technique, resonance, unlock_thread_level)`` — exactly the
+    fields the existing ``technique_variant_unique_parent_resonance_level``
+    ``UniqueConstraint`` already enforces. Same test-fixture-only creation gap
+    as ``ActionEnhancement`` above: ``MagicContent.create_all()`` minted these
+    and nothing else did (#2973).
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def test_technique_variant_round_trips(self) -> None:
+        from world.magic.factories import (
+            ResonanceFactory,
+            TechniqueFactory,
+            TechniqueVariantFactory,
+        )
+        from world.magic.specialization.models import TechniqueVariant
+
+        technique = TechniqueFactory(name="Round Trip Heartstring Pull", damage_profile=False)
+        resonance = ResonanceFactory(name="Round Trip Devotion")
+        variant = TechniqueVariantFactory(
+            parent_technique=technique,
+            resonance=resonance,
+            unlock_thread_level=3,
+            name_override="Round Trip Ardent Pull",
+            intensity_delta=2,
+            control_delta=1,
+        )
+
+        result = export_to_content_repo(self.root)
+        assert result.errors == []
+
+        variant_path = self.root / "fixtures" / "magic" / "techniquevariant.json"
+        assert variant_path.exists()
+
+        records = json.loads(variant_path.read_text(encoding="utf-8"))
+        assert len(records) == 1
+        record = records[0]
+        assert "pk" not in record
+        assert record["fields"]["parent_technique"] == [technique.gift.name, technique.name]
+        assert record["fields"]["resonance"] == [resonance.name]
+        assert record["fields"]["unlock_thread_level"] == 3
+        assert record["fields"]["name_override"] == "Round Trip Ardent Pull"
+
+        from core_management.content_fixtures import build_all, load_entries
+
+        created, _updated, _ = load_entries(build_all(self.root))
+        assert created == 0, f"Round-trip created {created} new records (expected 0)"
+
+        variant.refresh_from_db()
+        assert variant.intensity_delta == 2
+
+        resolved = TechniqueVariant.objects.get_by_natural_key(
+            technique.gift.name, technique.name, resonance.name, 3
+        )
+        assert resolved.pk == variant.pk
+
+
+class MagicalAlterationTemplateContentExportTests(TestCase):
+    """Round-trip coverage for MagicalAlterationTemplate (#3034).
+
+    ``magic.magicalalterationtemplate`` was added to ``CONTENT_MODELS`` keyed
+    on ``condition_template`` — already DB-unique (a ``OneToOneField``), and
+    the row's real identity anyway. Only staff/system-seed rows
+    (``authored_by`` NULL) are content; a player's "author from scratch" Mage
+    Scar must never export (mirrors ``magic.ritual``'s ``author_account``
+    split).
+    """
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.tmp.cleanup)
+        self.root = Path(self.tmp.name)
+
+    def test_staff_authored_alteration_round_trips(self) -> None:
+        from world.magic.factories import MagicalAlterationTemplateFactory
+        from world.magic.models import MagicalAlterationTemplate
+
+        alteration = MagicalAlterationTemplateFactory(
+            condition_template__name="Round Trip Scar",
+            authored_by=None,
+        )
+
+        result = export_to_content_repo(self.root)
+        assert result.errors == []
+
+        path = self.root / "fixtures" / "magic" / "magicalalterationtemplate.json"
+        assert path.exists()
+
+        records = json.loads(path.read_text(encoding="utf-8"))
+        assert len(records) == 1
+        record = records[0]
+        assert "pk" not in record
+        assert record["fields"]["condition_template"] == ["Round Trip Scar"]
+        assert record["fields"]["authored_by"] is None
+
+        from core_management.content_fixtures import build_all, load_entries
+
+        created, _updated, _ = load_entries(build_all(self.root))
+        assert created == 0, f"Round-trip created {created} new records (expected 0)"
+
+        alteration.refresh_from_db()
+
+        resolved = MagicalAlterationTemplate.objects.get_by_natural_key("Round Trip Scar")
+        assert resolved.pk == alteration.pk
+
+    def test_player_authored_alteration_is_not_exported(self) -> None:
+        """#3034: a player's "author from scratch" Mage Scar must not ship in the corpus."""
+        from evennia_extensions.factories import AccountFactory
+        from world.magic.factories import MagicalAlterationTemplateFactory
+
+        MagicalAlterationTemplateFactory(condition_template__name="Staff Scar", authored_by=None)
+        MagicalAlterationTemplateFactory(
+            condition_template__name="Player Scar", authored_by=AccountFactory()
+        )
+
+        result = export_to_content_repo(self.root)
+        assert result.errors == []
+
+        path = self.root / "fixtures" / "magic" / "magicalalterationtemplate.json"
+        assert path.exists()
+        names = {
+            r["fields"]["condition_template"][0]
+            for r in json.loads(path.read_text(encoding="utf-8"))
+        }
+        assert "Staff Scar" in names
+        assert "Player Scar" not in names

--- a/src/world/magic/models/alterations.py
+++ b/src/world/magic/models/alterations.py
@@ -13,12 +13,13 @@ from django.db import models
 from django.db.models import Q
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.magic.constants import AlterationKind, AlterationTier, PendingAlterationStatus
 from world.magic.models.affinity import Affinity, Resonance
 from world.magic.models.techniques import Technique
 
 
-class MagicalAlterationTemplate(SharedMemoryModel):
+class MagicalAlterationTemplate(NaturalKeyMixin, SharedMemoryModel):
     """Template for a Mage Scar (permanent magical alteration).
 
     Mage-specific metadata layered on top of a ConditionTemplate. A Mage
@@ -29,6 +30,17 @@ class MagicalAlterationTemplate(SharedMemoryModel):
 
     Note: the class and table names retain the "MagicalAlteration" prefix
     for database stability; the player-facing label is "Mage Scar".
+
+    Carries ``NaturalKeyMixin`` (#3034) so a library-entry Mage Scar / a
+    CORRUPTION_TWIST can be authored in the lore repo. ``condition_template``
+    is a ``OneToOneField`` — already DB-unique, so it needs no new
+    constraint — and it is the row's real identity anyway (a Mage Scar IS its
+    backing condition; this table only layers magic-specific metadata on
+    top). Player-authored rows (``authored_by`` set — the "author from
+    scratch" resolution path) are excluded from export via ``EXPORT_FILTERS``
+    (``authored_by__isnull=True``), mirroring ``magic.ritual``'s
+    ``author_account`` split — only staff/system-seed (``authored_by=None``)
+    rows are lore-repo content.
     """
 
     condition_template = models.OneToOneField(
@@ -122,6 +134,12 @@ class MagicalAlterationTemplate(SharedMemoryModel):
         blank=True,
         help_text="Required for CORRUPTION_TWIST; null for MAGE_SCAR. Range 1-5.",
     )
+
+    objects = NaturalKeyManager()
+
+    class NaturalKeyConfig:
+        fields = ["condition_template"]
+        dependencies = ["arxii.ConditionTemplate"]
 
     class Meta:
         verbose_name = "mage scar"

--- a/src/world/magic/specialization/models.py
+++ b/src/world/magic/specialization/models.py
@@ -22,6 +22,7 @@ from django.db.models import Q
 from django.utils.functional import cached_property
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+from core.natural_keys import NaturalKeyManager, NaturalKeyMixin
 from world.magic.models.techniques import (
     AbstractAppliedCondition,
     AbstractCapabilityGrant,
@@ -182,7 +183,7 @@ class AbstractSpecializedVariant(SharedMemoryModel):
 # ---------------------------------------------------------------------------
 
 
-class TechniqueVariant(AbstractSpecializedVariant):
+class TechniqueVariant(NaturalKeyMixin, AbstractSpecializedVariant):
     """A resonance-specialized variant of a Technique.
 
     A parent ``Technique`` has variant rows keyed by ``(parent_technique,
@@ -194,6 +195,13 @@ class TechniqueVariant(AbstractSpecializedVariant):
 
     The base ``_variant_queryset`` default resolves via ``parent.variants``
     (the ``related_name`` below); no override is needed.
+
+    Carries ``NaturalKeyMixin`` (#3034) so a resonance-specialized form can be
+    authored in the lore repo — the natural key is exactly the fields the
+    existing ``technique_variant_unique_parent_resonance_level``
+    ``UniqueConstraint`` (below) already enforces, mirroring how
+    ``CovenantRole`` (the sibling ``AbstractSpecializedVariant`` subclass)
+    carries the mixin.
     """
 
     parent_technique = models.ForeignKey(
@@ -215,6 +223,12 @@ class TechniqueVariant(AbstractSpecializedVariant):
         default=0,
         help_text="Added to the parent technique's control when this variant resolves.",
     )
+
+    objects = NaturalKeyManager()
+
+    class NaturalKeyConfig:
+        fields = ["parent_technique", "resonance", "unlock_thread_level"]
+        dependencies = ["arxii.Technique", "arxii.Resonance"]
 
     class Meta:
         constraints = [


### PR DESCRIPTION
Closes #3034.

## What

Admits the three social-magic payload models to the content catalog so the lore repo can author them (the six social-magic `ActionEnhancement` rows are the only thing between "Social Arts techniques exist" and "magical persuade/intimidate are dispatchable" — no production path creates them since #2973):

- **`ActionEnhancement`** — natural key `(base_action_key, variant_name)`, the exact tuple every production `get_or_create` site already keys on. No new DB constraint (mirrors the `ConditionCheckModifier` precedent; several tests create rows directly and a new constraint risked collisions).
- **`TechniqueVariant`** — natural key `(parent_technique, resonance, unlock_thread_level)`, identical to the existing `technique_variant_unique_parent_resonance_level` UniqueConstraint.
- **`MagicalAlterationTemplate`** — natural key `(condition_template)` (already unique via O2O), with a new `EXPORT_FILTERS` row-level split (`authored_by__isnull=True`) because the model genuinely mixes authored content with player-authored scratch alterations — mirrors `magic.ritual`'s author split.

No migration: `NaturalKeyMixin` adds no columns, no new constraints (`makemigrations --dry-run` clean).

## Tests

145 green across `core_management.tests.test_content_export` (three new round-trip classes + a player-authored-exclusion test + the owner-discriminated-coverage guard extended), the seeds no-content-slop guard, and the actions/magic modules touching the three models. ruff + pre-commit clean.

## Follow-on

The lore-repo authoring this unblocks (six social enhancements, Social Arts variants, corruption twist rows) is ArxII-lore#69's human-owned scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
