### PR TITLE
GM combat lifecycle on web: encounter creation, NPC opponent spawn, manual round control, ready-toggle wiring (#3067)

### DIFF
--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -78,7 +78,7 @@ limits, IC-vs-UI placement, etc. — see [`design-tenets.md`](design-tenets.md).
 | [Character Progression & XP](character-progression.md) | in-progress | XP, skills, path steps, Audere Majora, power tiers, the Durance |
 | [Magic System](magic.md) | in-progress | Affinities, resonances, gifts, techniques, threads, spells |
 | [Capabilities & Challenges](capabilities-and-challenges.md) | in-progress | Properties, capabilities, applications, action generation, challenges, situations |
-| [Combat](combat.md) | in-progress | Party combat (Phases 1–9 + clash + web UI + escalation/passives/aftermath complete; NPC-tier gap tracked), battle scenes, duels |
+| [Combat](combat.md) | in-progress | Party combat (Phases 1–9 + clash + web UI, now including the GM lifecycle panel [#3067: create/spawn NPC/manual round control/ready-toggle] + escalation/passives/aftermath complete; NPC-tier gap tracked), battle scenes, duels — champion-duel/battle staging still telnet-first |
 | [Missions & Living Grid](missions.md) | in-progress | Branching narrative quests, world consequences, co-op group beats, support moves |
 | [Crafting, Fashion & Economy](crafting-economy.md) | in-progress | Crafting expressiveness arc (#2881) + market/fence + fashion cachet economy (#2959) shipped; housing purchase, p2p trade (#2990), harvesting (#2998) remain |
 | [Items & Equipment](items-equipment.md) | in-progress | Worn items, body slots, layered coverage + Reveal (#2965) shipped; body markings (#2985) and visible-equipment web polish remain |

--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -1,8 +1,12 @@
 # Combat — Status
 
-**Status:** core party and duel combat ship end-to-end; the authored effect palette shipped (#1584,
-combat-wired for battlefield shaping by #2206); the frontier is embodied combat (companions, mounts,
-war) and *proving* the WIRED-UNPROVEN paths — not the round engine.
+**Status:** core party and duel combat ship end-to-end, on both telnet and web — the GM lifecycle
+(start an encounter, spawn an NPC opponent, add/remove a PC, manual round control) got its web
+surface in #3067, closing the last "server-only" gap in the party-combat REST API; the authored
+effect palette shipped (#1584, combat-wired for battlefield shaping by #2206); the frontier is
+embodied combat (companions, mounts, war) and *proving* the WIRED-UNPROVEN paths — not the round
+engine. Champion-duel challenge issuance and Battle staging (`CmdBattle`) remain telnet-first — no
+web GM surface for those two yet.
 
 This is the combat **status map**. Per-capability tiers, the MVP bar, and sequencing live in the
 [`player-capability-ledger.md`](player-capability-ledger.md) (the spine — read it first). The
@@ -161,7 +165,12 @@ outcome** (a closed issue or a "SHIPPED" line is not proof). See the ledger's go
   moment every ACTIVE participant is ready (`maybe_resolve_on_ready`, wired into
   `combat ready` / the web `ready` endpoint via `ReadyAction`); a lone ready participant
   provably does not trigger it (`world/combat/tests/test_pace_mode_ready.py`). TIMED keeps
-  the game-clock sweep; MANUAL keeps GM-only resolution.
+  the game-clock sweep; MANUAL keeps GM-only resolution. The REST `ready` endpoint existed
+  server-side from #2120, but the web client never called it — `YourTurn`'s "Submit
+  declarations" button only declared the round action (which resets `is_ready=False`) and
+  never dispatched `combat_ready` after, so READY-pace early resolution could not fire from
+  web. Closed by #3067: submit now dispatches `combat_ready` afterward, but only in READY
+  pace — TIMED/MANUAL behavior is unchanged.
 - **Tactical placement, end-to-end (#2005).** Voluntary `take_position` (entry onto the
   position graph), GM `gm_place_in_position` (unchecked staging teleport), and positioned
   opponent spawn (`add_opponent(..., position=...)`) close the last placement gaps —

--- a/frontend/src/combat/__tests__/GMEncounterControls.test.tsx
+++ b/frontend/src/combat/__tests__/GMEncounterControls.test.tsx
@@ -1,0 +1,514 @@
+/**
+ * Tests for GMEncounterControls (#3067) — the GM's home for encounter
+ * lifecycle actions (create, add_opponent, add/remove_participant,
+ * begin_round, resolve_round, pause).
+ *
+ * Mocks '../queries' and '@/roster/usePersonaSearch' (mirrors YourTurn.test.tsx's
+ * mock-the-hook-module idiom). Interacts with the REAL Dialog + Select
+ * primitives (Radix) — jsdom's pointer-capture/scrollIntoView polyfills for
+ * Radix Select already live in src/test/setup.ts (see FuryDeclaration usage
+ * in YourTurn.test.tsx for the click-trigger-then-click-item pattern this
+ * file mirrors), so no need to mock Select away.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import type { ReactNode } from 'react';
+
+vi.mock('../queries', () => ({
+  useThreatPools: vi.fn(),
+  useOpponentDefaults: vi.fn(),
+  useCreateEncounter: vi.fn(),
+  useAddOpponent: vi.fn(),
+  useAddParticipant: vi.fn(),
+  useBeginRound: vi.fn(),
+  useResolveRound: vi.fn(),
+  usePauseEncounter: vi.fn(),
+  useRemoveParticipant: vi.fn(),
+}));
+
+vi.mock('@/roster/usePersonaSearch', () => ({
+  usePersonaSearch: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+import * as combatQueries from '../queries';
+import { usePersonaSearch } from '@/roster/usePersonaSearch';
+import { GMEncounterControls } from '../sections/GMEncounterControls';
+import type { ThreatPool } from '../api';
+import type { EncounterDetail, Participant, PositionNode } from '../types';
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: 0 } },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeEncounter(overrides: Partial<EncounterDetail> = {}): EncounterDetail {
+  return {
+    id: 1,
+    is_gm: true,
+    pace_mode: 'timed',
+    status: 'between_rounds',
+    is_paused: false,
+    participants: [],
+    position_nodes: [],
+    ...overrides,
+  } as unknown as EncounterDetail;
+}
+
+function makeParticipant(id: number, name: string): Participant {
+  return { id, character_name: name } as unknown as Participant;
+}
+
+// ---------------------------------------------------------------------------
+// Mocked hooks
+// ---------------------------------------------------------------------------
+
+const mockedUseThreatPools = combatQueries.useThreatPools as ReturnType<typeof vi.fn>;
+const mockedUseOpponentDefaults = combatQueries.useOpponentDefaults as ReturnType<typeof vi.fn>;
+const mockedUseCreateEncounter = combatQueries.useCreateEncounter as ReturnType<typeof vi.fn>;
+const mockedUseAddOpponent = combatQueries.useAddOpponent as ReturnType<typeof vi.fn>;
+const mockedUseAddParticipant = combatQueries.useAddParticipant as ReturnType<typeof vi.fn>;
+const mockedUseBeginRound = combatQueries.useBeginRound as ReturnType<typeof vi.fn>;
+const mockedUseResolveRound = combatQueries.useResolveRound as ReturnType<typeof vi.fn>;
+const mockedUsePauseEncounter = combatQueries.usePauseEncounter as ReturnType<typeof vi.fn>;
+const mockedUseRemoveParticipant = combatQueries.useRemoveParticipant as ReturnType<typeof vi.fn>;
+const mockedUsePersonaSearch = usePersonaSearch as unknown as ReturnType<typeof vi.fn>;
+
+interface MutateOpts {
+  onSuccess?: (data?: unknown) => void;
+  onError?: (err: Error) => void;
+}
+
+const mockCreateMutate = vi.fn(
+  (_vars: { paceMode?: string; encounterType?: string }, _opts?: MutateOpts) => {}
+);
+const mockAddOpponentMutate = vi.fn(
+  (
+    _vars: { name: string; tier: string; threatPoolId: number; positionId: number | null },
+    _opts?: MutateOpts
+  ) => {}
+);
+const mockAddParticipantMutate = vi.fn(
+  (_vars: { characterSheetId: number; covenantRoleId?: number | null }, _opts?: MutateOpts) => {}
+);
+const mockBeginRoundMutate = vi.fn((_vars: undefined, _opts?: MutateOpts) => {});
+const mockResolveRoundMutate = vi.fn((_vars: undefined, _opts?: MutateOpts) => {});
+const mockPauseMutate = vi.fn((_vars: undefined, _opts?: MutateOpts) => {});
+const mockRemoveParticipantMutate = vi.fn((_vars: number, _opts?: MutateOpts) => {});
+
+const defaultPools: ThreatPool[] = [
+  { id: 7, name: 'Goblin Raiders', description: '' } as unknown as ThreatPool,
+];
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockedUseThreatPools.mockReturnValue({ data: defaultPools });
+  mockedUseOpponentDefaults.mockReturnValue({ data: undefined });
+  mockedUseCreateEncounter.mockReturnValue({ mutate: mockCreateMutate, isPending: false });
+  mockedUseAddOpponent.mockReturnValue({
+    mutate: mockAddOpponentMutate,
+    isPending: false,
+    error: null,
+    isError: false,
+  });
+  mockedUseAddParticipant.mockReturnValue({
+    mutate: mockAddParticipantMutate,
+    isPending: false,
+    error: null,
+    isError: false,
+  });
+  mockedUseBeginRound.mockReturnValue({ mutate: mockBeginRoundMutate, isPending: false });
+  mockedUseResolveRound.mockReturnValue({ mutate: mockResolveRoundMutate, isPending: false });
+  mockedUsePauseEncounter.mockReturnValue({ mutate: mockPauseMutate, isPending: false });
+  mockedUseRemoveParticipant.mockReturnValue({
+    mutate: mockRemoveParticipantMutate,
+    isPending: false,
+  });
+  mockedUsePersonaSearch.mockReturnValue({ results: [], isFetching: false });
+});
+
+// ---------------------------------------------------------------------------
+// No active encounter — Start Encounter affordance
+// ---------------------------------------------------------------------------
+
+describe('GMEncounterControls — no active encounter', () => {
+  it('shows the Start Encounter card when the viewer can GM', () => {
+    render(<GMEncounterControls sceneId={5} encounter={null} viewerCanGm={true} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.getByTestId('start-encounter-card')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the viewer cannot GM', () => {
+    render(<GMEncounterControls sceneId={5} encounter={null} viewerCanGm={false} />, {
+      wrapper: createWrapper(),
+    });
+
+    expect(screen.queryByTestId('start-encounter-card')).not.toBeInTheDocument();
+  });
+
+  it('calls create with the selected pace mode', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(<GMEncounterControls sceneId={5} encounter={null} viewerCanGm={true} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(screen.getByTestId('start-encounter-btn'));
+
+    expect(mockCreateMutate).toHaveBeenCalledWith(
+      { paceMode: 'timed' },
+      expect.objectContaining({ onError: expect.any(Function) })
+    );
+  });
+
+  it('creates with a GM-selected pace mode', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(<GMEncounterControls sceneId={5} encounter={null} viewerCanGm={true} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(screen.getByTestId('start-encounter-pace-select'));
+    const manualOption = await screen.findByRole('option', { name: /Manual/ });
+    await user.click(manualOption);
+
+    await user.click(screen.getByTestId('start-encounter-btn'));
+
+    expect(mockCreateMutate).toHaveBeenCalledWith(
+      { paceMode: 'manual' },
+      expect.objectContaining({ onError: expect.any(Function) })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Active encounter — GM gate
+// ---------------------------------------------------------------------------
+
+describe('GMEncounterControls — active-encounter GM gate', () => {
+  it('renders full controls when the viewer is the encounter GM', () => {
+    render(
+      <GMEncounterControls
+        sceneId={5}
+        encounter={makeEncounter({ is_gm: true })}
+        viewerCanGm={false}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByTestId('gm-encounter-controls')).toBeInTheDocument();
+  });
+
+  it('renders nothing when the viewer is not the encounter GM', () => {
+    render(
+      <GMEncounterControls
+        sceneId={5}
+        encounter={makeEncounter({ is_gm: false })}
+        viewerCanGm={true}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.queryByTestId('gm-encounter-controls')).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Add opponent
+// ---------------------------------------------------------------------------
+
+describe('GMEncounterControls — add opponent', () => {
+  it('submits the right payload (no position)', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(<GMEncounterControls sceneId={5} encounter={makeEncounter()} viewerCanGm={false} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(screen.getByTestId('add-opponent-trigger'));
+    await user.type(screen.getByTestId('add-opponent-name'), 'Goblin');
+
+    await user.click(screen.getByTestId('add-opponent-pool-select'));
+    const poolOption = await screen.findByRole('option', { name: 'Goblin Raiders' });
+    await user.click(poolOption);
+
+    await user.click(screen.getByTestId('add-opponent-submit'));
+
+    expect(mockAddOpponentMutate).toHaveBeenCalledWith(
+      { name: 'Goblin', tier: 'mook', threatPoolId: 7, positionId: null },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      })
+    );
+  });
+
+  it('submits the selected tier and position', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const encounter = makeEncounter({
+      position_nodes: [{ id: 12, name: 'North Wall' } as unknown as PositionNode],
+    });
+    render(<GMEncounterControls sceneId={5} encounter={encounter} viewerCanGm={false} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(screen.getByTestId('add-opponent-trigger'));
+    await user.type(screen.getByTestId('add-opponent-name'), 'Ogre');
+
+    await user.click(screen.getByTestId('add-opponent-tier-select'));
+    await user.click(await screen.findByRole('option', { name: 'Boss' }));
+
+    await user.click(screen.getByTestId('add-opponent-pool-select'));
+    await user.click(await screen.findByRole('option', { name: 'Goblin Raiders' }));
+
+    await user.click(screen.getByTestId('add-opponent-position-select'));
+    await user.click(await screen.findByRole('option', { name: 'North Wall' }));
+
+    await user.click(screen.getByTestId('add-opponent-submit'));
+
+    expect(mockAddOpponentMutate).toHaveBeenCalledWith(
+      { name: 'Ogre', tier: 'boss', threatPoolId: 7, positionId: 12 },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+  });
+
+  it('shows the scaling defaults preview when available', async () => {
+    mockedUseOpponentDefaults.mockReturnValue({
+      data: {
+        max_health: 30,
+        soak_value: 2,
+        probing_threshold: null,
+        swarm_count: null,
+        body_toughness: null,
+        bodies_per_attack: null,
+        barrier_strength: null,
+        phases: [],
+        stakes_ok: false,
+        stakes_message: 'Escalate the stakes first.',
+      },
+    });
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(<GMEncounterControls sceneId={5} encounter={makeEncounter()} viewerCanGm={false} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(screen.getByTestId('add-opponent-trigger'));
+
+    expect(screen.getByTestId('add-opponent-defaults-preview')).toHaveTextContent('Health 30');
+    expect(screen.getByTestId('add-opponent-stakes-warning')).toHaveTextContent(
+      'Escalate the stakes first.'
+    );
+  });
+
+  it('keeps submit disabled until name and threat pool are set', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(<GMEncounterControls sceneId={5} encounter={makeEncounter()} viewerCanGm={false} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(screen.getByTestId('add-opponent-trigger'));
+
+    expect(screen.getByTestId('add-opponent-submit')).toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Add participant
+// ---------------------------------------------------------------------------
+
+describe('GMEncounterControls — add participant', () => {
+  it('submits the selected character_sheet id', async () => {
+    mockedUsePersonaSearch.mockReturnValue({
+      results: [{ id: 99, name: 'Aerande', character_sheet: 55 }],
+      isFetching: false,
+    });
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(<GMEncounterControls sceneId={5} encounter={makeEncounter()} viewerCanGm={false} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(screen.getByTestId('add-participant-trigger'));
+    await user.type(screen.getByTestId('add-participant-search'), 'Aer');
+    await user.click(screen.getByTestId('add-participant-option-99'));
+    await user.click(screen.getByTestId('add-participant-submit'));
+
+    expect(mockAddParticipantMutate).toHaveBeenCalledWith(
+      { characterSheetId: 55 },
+      expect.objectContaining({ onSuccess: expect.any(Function) })
+    );
+  });
+
+  it('keeps submit disabled until a character is selected', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(<GMEncounterControls sceneId={5} encounter={makeEncounter()} viewerCanGm={false} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(screen.getByTestId('add-participant-trigger'));
+
+    expect(screen.getByTestId('add-participant-submit')).toBeDisabled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Remove participant
+// ---------------------------------------------------------------------------
+
+describe('GMEncounterControls — remove participant', () => {
+  it('calls the remove mutation with the participant id', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    const encounter = makeEncounter({ participants: [makeParticipant(42, 'Aerande')] });
+    render(<GMEncounterControls sceneId={5} encounter={encounter} viewerCanGm={false} />, {
+      wrapper: createWrapper(),
+    });
+
+    await user.click(screen.getByTestId('remove-participant-btn-42'));
+
+    expect(mockRemoveParticipantMutate).toHaveBeenCalledWith(
+      42,
+      expect.objectContaining({ onError: expect.any(Function) })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Manual round control
+// ---------------------------------------------------------------------------
+
+describe('GMEncounterControls — manual round control', () => {
+  it('shows Begin Round only in MANUAL pace + between_rounds status', () => {
+    render(
+      <GMEncounterControls
+        sceneId={5}
+        encounter={makeEncounter({ pace_mode: 'manual', status: 'between_rounds' })}
+        viewerCanGm={false}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByTestId('begin-round-btn')).toBeInTheDocument();
+    expect(screen.queryByTestId('resolve-round-btn')).not.toBeInTheDocument();
+  });
+
+  it('shows Resolve Round only in MANUAL pace + declaring status', () => {
+    render(
+      <GMEncounterControls
+        sceneId={5}
+        encounter={makeEncounter({ pace_mode: 'manual', status: 'declaring' })}
+        viewerCanGm={false}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByTestId('resolve-round-btn')).toBeInTheDocument();
+    expect(screen.queryByTestId('begin-round-btn')).not.toBeInTheDocument();
+  });
+
+  it('hides both round-control buttons outside MANUAL pace', () => {
+    render(
+      <GMEncounterControls
+        sceneId={5}
+        encounter={makeEncounter({ pace_mode: 'timed', status: 'between_rounds' })}
+        viewerCanGm={false}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.queryByTestId('begin-round-btn')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('resolve-round-btn')).not.toBeInTheDocument();
+  });
+
+  it('begin round button calls the begin_round mutation', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(
+      <GMEncounterControls
+        sceneId={5}
+        encounter={makeEncounter({ pace_mode: 'manual', status: 'between_rounds' })}
+        viewerCanGm={false}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    await user.click(screen.getByTestId('begin-round-btn'));
+
+    expect(mockBeginRoundMutate).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ onError: expect.any(Function) })
+    );
+  });
+
+  it('resolve round button calls the resolve_round mutation', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(
+      <GMEncounterControls
+        sceneId={5}
+        encounter={makeEncounter({ pace_mode: 'manual', status: 'declaring' })}
+        viewerCanGm={false}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    await user.click(screen.getByTestId('resolve-round-btn'));
+
+    expect(mockResolveRoundMutate).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ onError: expect.any(Function) })
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Pause
+// ---------------------------------------------------------------------------
+
+describe('GMEncounterControls — pause toggle', () => {
+  it('calls the pause mutation and shows Pause when not paused', async () => {
+    const user = userEvent.setup({ pointerEventsCheck: 0 });
+    render(
+      <GMEncounterControls
+        sceneId={5}
+        encounter={makeEncounter({ is_paused: false })}
+        viewerCanGm={false}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByTestId('pause-toggle-btn')).toHaveTextContent('Pause');
+    await user.click(screen.getByTestId('pause-toggle-btn'));
+
+    expect(mockPauseMutate).toHaveBeenCalledWith(
+      undefined,
+      expect.objectContaining({ onError: expect.any(Function) })
+    );
+  });
+
+  it('shows Unpause when the encounter is already paused', () => {
+    render(
+      <GMEncounterControls
+        sceneId={5}
+        encounter={makeEncounter({ is_paused: true })}
+        viewerCanGm={false}
+      />,
+      { wrapper: createWrapper() }
+    );
+
+    expect(screen.getByTestId('pause-toggle-btn')).toHaveTextContent('Unpause');
+  });
+});

--- a/frontend/src/combat/__tests__/YourTurn.test.tsx
+++ b/frontend/src/combat/__tests__/YourTurn.test.tsx
@@ -811,6 +811,102 @@ describe('YourTurn — Task 7.3 submit declarations', () => {
 });
 
 // ---------------------------------------------------------------------------
+// PaceMode.READY early-resolution ready-toggle wiring (#3067)
+// ---------------------------------------------------------------------------
+
+describe('YourTurn — PaceMode.READY ready-toggle dispatch (#3067)', () => {
+  it('dispatches combat_ready after a successful submit in READY pace', async () => {
+    setupMocks();
+
+    render(<YourTurn {...defaultProps({ encounter: makeEncounter({ pace_mode: 'ready' }) })} />, {
+      wrapper: createWrapper(),
+    });
+
+    await userEvent.click(screen.getByTestId('submit-declarations-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ready-badge')).toBeInTheDocument();
+    });
+
+    expect(mockMutateAsync).toHaveBeenCalledWith({
+      ref: { backend: 'registry', registry_key: 'combat_ready' },
+      kwargs: {},
+    });
+  });
+
+  it('does not dispatch combat_ready in TIMED pace', async () => {
+    setupMocks();
+
+    render(<YourTurn {...defaultProps({ encounter: makeEncounter({ pace_mode: 'timed' }) })} />, {
+      wrapper: createWrapper(),
+    });
+
+    await userEvent.click(screen.getByTestId('submit-declarations-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ready-badge')).toBeInTheDocument();
+    });
+
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('does not dispatch combat_ready in MANUAL pace', async () => {
+    setupMocks();
+
+    render(<YourTurn {...defaultProps({ encounter: makeEncounter({ pace_mode: 'manual' }) })} />, {
+      wrapper: createWrapper(),
+    });
+
+    await userEvent.click(screen.getByTestId('submit-declarations-btn'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('ready-badge')).toBeInTheDocument();
+    });
+
+    expect(mockMutateAsync).not.toHaveBeenCalled();
+  });
+
+  it('surfaces an error and does not mark ready when the combat_ready dispatch fails', async () => {
+    setupMocks();
+    mockMutateAsync.mockResolvedValueOnce({
+      backend: 'REGISTRY',
+      deferred: false,
+      success: false,
+      message: 'Not in active round.',
+    });
+
+    render(<YourTurn {...defaultProps({ encounter: makeEncounter({ pace_mode: 'ready' }) })} />, {
+      wrapper: createWrapper(),
+    });
+
+    await userEvent.click(screen.getByTestId('submit-declarations-btn'));
+
+    const alert = await screen.findByRole('alert');
+    expect(alert).toHaveTextContent('Not in active round.');
+    expect(screen.queryByTestId('ready-badge')).not.toBeInTheDocument();
+  });
+
+  it('shows "mark ready" wording only in READY pace', () => {
+    setupMocks();
+
+    const { rerender } = render(
+      <YourTurn {...defaultProps({ encounter: makeEncounter({ pace_mode: 'ready' }) })} />,
+      { wrapper: createWrapper() }
+    );
+    expect(screen.getByTestId('submit-declarations-btn')).toHaveTextContent('mark ready');
+
+    rerender(
+      <QueryClientProvider
+        client={new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })}
+      >
+        <YourTurn {...defaultProps({ encounter: makeEncounter({ pace_mode: 'timed' }) })} />
+      </QueryClientProvider>
+    );
+    expect(screen.getByTestId('submit-declarations-btn')).not.toHaveTextContent('mark ready');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Task 7.1 — readOnly prop locks the panel from the start
 // ---------------------------------------------------------------------------
 

--- a/frontend/src/combat/api.ts
+++ b/frontend/src/combat/api.ts
@@ -37,6 +37,24 @@ export type DuelChallengeRole = 'incoming' | 'outgoing';
  */
 export type OutcomeDisplayRow = components['schemas']['OutcomeDisplayRow'];
 
+/** One row of the ThreatPool catalog (GET /api/combat/threat-pools/, #3067). */
+export type ThreatPool = components['schemas']['ThreatPool'];
+
+/**
+ * List authored ThreatPools (NPC move-sets), optionally name-filtered — the
+ * GM add-opponent picker's data source (#3067).
+ * GET /api/combat/threat-pools/[?search=<term>]
+ */
+export async function fetchThreatPools(search?: string): Promise<ThreatPool[]> {
+  const url = search
+    ? `/api/combat/threat-pools/?search=${encodeURIComponent(search)}`
+    : '/api/combat/threat-pools/';
+  const res = await apiFetch(url);
+  if (!res.ok) throw new Error('Failed to load threat pools');
+  const data = (await res.json()) as { results?: ThreatPool[]; count?: number };
+  return data.results ?? [];
+}
+
 // ---------------------------------------------------------------------------
 // Encounter
 // ---------------------------------------------------------------------------
@@ -65,6 +83,191 @@ export async function fetchEncountersForScene(sceneId: number): Promise<Encounte
   if (!res.ok) throw new Error('Failed to load encounters for scene');
   const data = (await res.json()) as { results?: EncounterListItem[]; count?: number };
   return data.results ?? [];
+}
+
+// ---------------------------------------------------------------------------
+// GM lifecycle (#3067) — encounter creation, NPC opponent spawn, manual round
+// control. All gated server-side by IsEncounterGMOrStaff (CombatEncounterViewSet).
+// ---------------------------------------------------------------------------
+
+export type PaceMode = components['schemas']['PaceModeEnum'];
+export type EncounterType = components['schemas']['EncounterTypeEnum'];
+export type OpponentTier = components['schemas']['Tier756Enum'];
+
+/**
+ * Create a combat encounter for a scene (GM only) — the "Start encounter"
+ * affordance (#3067). Only `scene` is required; the server defaults `room`
+ * from the scene's current location (`CombatEncounterViewSet.perform_create`)
+ * and `pace_mode`/`encounter_type`/etc. from their model defaults when
+ * omitted.
+ * POST /api/combat/
+ */
+export async function createEncounter(
+  sceneId: number,
+  options: { paceMode?: PaceMode; encounterType?: EncounterType } = {}
+): Promise<EncounterDetail> {
+  const res = await apiFetch('/api/combat/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      scene: sceneId,
+      ...(options.paceMode !== undefined ? { pace_mode: options.paceMode } : {}),
+      ...(options.encounterType !== undefined ? { encounter_type: options.encounterType } : {}),
+    }),
+  });
+  if (!res.ok) await throwApiError(res, 'Failed to start encounter');
+  return res.json() as Promise<EncounterDetail>;
+}
+
+/** One row of the opponent-defaults scaling preview (GET .../opponent-defaults/). */
+export interface OpponentDefaults {
+  max_health: number;
+  soak_value: number;
+  probing_threshold: number | null;
+  swarm_count: number | null;
+  body_toughness: number | null;
+  bodies_per_attack: number | null;
+  barrier_strength: number | null;
+  phases: { phase_number: number; health_trigger_percentage: number | null }[];
+  stakes_ok: boolean;
+  stakes_message: string;
+}
+
+/**
+ * Preview the scaling formula's stat block for a tier, plus the stakes-gate
+ * advisory (never blocks the preview itself — only a real add_opponent call).
+ * GET /api/combat/{encounterId}/opponent-defaults/?tier=<tier>
+ */
+export async function fetchOpponentDefaults(
+  encounterId: number,
+  tier: OpponentTier
+): Promise<OpponentDefaults> {
+  const res = await apiFetch(
+    `/api/combat/${encounterId}/opponent-defaults/?tier=${encodeURIComponent(tier)}`
+  );
+  if (!res.ok) await throwApiError(res, 'Failed to load opponent defaults');
+  return res.json() as Promise<OpponentDefaults>;
+}
+
+/** Body for postAddOpponent — mirrors AddOpponentSerializer. */
+export interface AddOpponentPayload {
+  name: string;
+  tier: OpponentTier;
+  threatPoolId: number;
+  maxHealth?: number | null;
+  level?: number | null;
+  description?: string;
+  soakValue?: number;
+  probingThreshold?: number | null;
+  positionId?: number | null;
+}
+
+/**
+ * Add an NPC opponent to the encounter (GM only). Omitting `maxHealth` selects
+ * auto-scaling mode (the formula fills every stat field); `positionId` (#2005)
+ * spawns the opponent already placed, must name a Position in the encounter's
+ * own room.
+ * POST /api/combat/{encounterId}/add_opponent/
+ */
+export async function postAddOpponent(
+  encounterId: number,
+  payload: AddOpponentPayload
+): Promise<EncounterDetail> {
+  const res = await apiFetch(`/api/combat/${encounterId}/add_opponent/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      name: payload.name,
+      tier: payload.tier,
+      threat_pool_id: payload.threatPoolId,
+      max_health: payload.maxHealth ?? undefined,
+      level: payload.level ?? undefined,
+      description: payload.description ?? '',
+      soak_value: payload.soakValue ?? 0,
+      probing_threshold: payload.probingThreshold ?? undefined,
+      position_id: payload.positionId ?? undefined,
+    }),
+  });
+  if (!res.ok) await throwApiError(res, 'Failed to add opponent');
+  return res.json() as Promise<EncounterDetail>;
+}
+
+/**
+ * Add a PC to the encounter (GM only) — unlike `postJoin`, names any
+ * character_sheet without an ownership requirement.
+ * POST /api/combat/{encounterId}/add_participant/
+ */
+export async function postAddParticipant(
+  encounterId: number,
+  characterSheetId: number,
+  covenantRoleId?: number | null
+): Promise<EncounterDetail> {
+  const res = await apiFetch(`/api/combat/${encounterId}/add_participant/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      character_sheet_id: characterSheetId,
+      ...(covenantRoleId != null ? { covenant_role_id: covenantRoleId } : {}),
+    }),
+  });
+  if (!res.ok) await throwApiError(res, 'Failed to add participant');
+  return res.json() as Promise<EncounterDetail>;
+}
+
+/**
+ * Remove a PC from the encounter (GM only).
+ * POST /api/combat/{encounterId}/remove_participant/
+ */
+export async function postRemoveParticipant(
+  encounterId: number,
+  participantId: number
+): Promise<EncounterDetail> {
+  const res = await apiFetch(`/api/combat/${encounterId}/remove_participant/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ participant_id: participantId }),
+  });
+  if (!res.ok) await throwApiError(res, 'Failed to remove participant');
+  return res.json() as Promise<EncounterDetail>;
+}
+
+/**
+ * Begin a new declaration phase (GM only) — manual round control.
+ * POST /api/combat/{encounterId}/begin_round/
+ */
+export async function postBeginRound(encounterId: number): Promise<EncounterDetail> {
+  const res = await apiFetch(`/api/combat/${encounterId}/begin_round/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) await throwApiError(res, 'Failed to begin round');
+  return res.json() as Promise<EncounterDetail>;
+}
+
+/**
+ * Resolve the current round (GM only) — manual round control.
+ * POST /api/combat/{encounterId}/resolve_round/
+ */
+export async function postResolveRound(encounterId: number): Promise<EncounterDetail> {
+  const res = await apiFetch(`/api/combat/${encounterId}/resolve_round/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) await throwApiError(res, 'Failed to resolve round');
+  return res.json() as Promise<EncounterDetail>;
+}
+
+/**
+ * Toggle pause on the encounter timer (GM only).
+ * POST /api/combat/{encounterId}/pause/
+ */
+export async function postPause(encounterId: number): Promise<EncounterDetail> {
+  const res = await apiFetch(`/api/combat/${encounterId}/pause/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+  });
+  if (!res.ok) await throwApiError(res, 'Failed to toggle pause');
+  return res.json() as Promise<EncounterDetail>;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/combat/queries.ts
+++ b/frontend/src/combat/queries.ts
@@ -7,7 +7,12 @@
 
 import { useMutation, useQuery, useQueryClient, type QueryClient } from '@tanstack/react-query';
 import * as api from './api';
-import type { DispatchActionRequest, DispatchResult, EncounterListItem } from './types';
+import type {
+  DispatchActionRequest,
+  DispatchResult,
+  EncounterDetail,
+  EncounterListItem,
+} from './types';
 import { availableActionsKeys, useAvailableActionsQuery } from '@/scenes/actionQueries';
 import type { PlayerAction } from '@/scenes/actionTypes';
 
@@ -34,6 +39,11 @@ export const combatKeys = {
 
   duelChallenges: (role?: api.DuelChallengeRole) =>
     [...combatKeys.duelChallengesAll(), role ?? 'all'] as const,
+
+  threatPools: (search?: string) => [...combatKeys.all, 'threat-pools', search ?? ''] as const,
+
+  opponentDefaults: (encounterId: number, tier: api.OpponentTier) =>
+    [...combatKeys.all, 'opponent-defaults', encounterId, tier] as const,
 };
 
 /**
@@ -405,4 +415,92 @@ export function useConsequenceOutcomes(params: api.ConsequenceOutcomesParams) {
     enabled: hasFilter,
     staleTime: 5_000,
   });
+}
+
+// ---------------------------------------------------------------------------
+// GM lifecycle hooks (#3067) — encounter creation, NPC opponent spawn,
+// manual round control. All gated server-side by IsEncounterGMOrStaff.
+// ---------------------------------------------------------------------------
+
+/**
+ * List the ThreatPool catalog for the add-opponent picker, optionally
+ * name-filtered. Not encounter-scoped — authored content, long staleTime.
+ */
+export function useThreatPools(search?: string) {
+  return useQuery({
+    queryKey: combatKeys.threatPools(search),
+    queryFn: () => api.fetchThreatPools(search),
+    staleTime: 60_000,
+  });
+}
+
+/**
+ * Preview the scaling formula's stat block + stakes-gate advisory for a tier.
+ * Disabled until a tier is chosen.
+ */
+export function useOpponentDefaults(encounterId: number, tier: api.OpponentTier | null) {
+  return useQuery({
+    queryKey: combatKeys.opponentDefaults(encounterId, tier ?? 'mook'),
+    queryFn: () => api.fetchOpponentDefaults(encounterId, tier as api.OpponentTier),
+    enabled: encounterId > 0 && tier !== null,
+  });
+}
+
+/**
+ * Create an encounter for a scene (GM only) — the "Start encounter"
+ * affordance. Invalidates the scene's encounter-list key on success so
+ * useEncounterForScene picks up the new encounter without a manual refetch.
+ */
+export function useCreateEncounter(sceneId: number) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (options: { paceMode?: api.PaceMode; encounterType?: api.EncounterType } = {}) =>
+      api.createEncounter(sceneId, options),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: combatKeys.encountersForScene(sceneId) }).catch(() => {});
+    },
+  });
+}
+
+/** Add an NPC opponent to the encounter (GM only). */
+export function useAddOpponent(encounterId: number) {
+  return useEncounterMutation<EncounterDetail, api.AddOpponentPayload>(encounterId, (payload) =>
+    api.postAddOpponent(encounterId, payload)
+  );
+}
+
+/** Add a PC to the encounter (GM only) — names any character_sheet, no ownership check. */
+export function useAddParticipant(encounterId: number) {
+  return useEncounterMutation<
+    EncounterDetail,
+    { characterSheetId: number; covenantRoleId?: number | null }
+  >(encounterId, ({ characterSheetId, covenantRoleId }) =>
+    api.postAddParticipant(encounterId, characterSheetId, covenantRoleId)
+  );
+}
+
+/** Remove a PC from the encounter (GM only). */
+export function useRemoveParticipant(encounterId: number) {
+  return useEncounterMutation<EncounterDetail, number>(encounterId, (participantId) =>
+    api.postRemoveParticipant(encounterId, participantId)
+  );
+}
+
+/** Begin a new declaration phase (GM only) — manual round control. */
+export function useBeginRound(encounterId: number) {
+  return useEncounterMutation<EncounterDetail, void>(encounterId, () =>
+    api.postBeginRound(encounterId)
+  );
+}
+
+/** Resolve the current round (GM only) — manual round control. */
+export function useResolveRound(encounterId: number) {
+  return useEncounterMutation<EncounterDetail, void>(encounterId, () =>
+    api.postResolveRound(encounterId)
+  );
+}
+
+/** Toggle pause on the encounter timer (GM only). */
+export function usePauseEncounter(encounterId: number) {
+  return useEncounterMutation<EncounterDetail, void>(encounterId, () => api.postPause(encounterId));
 }

--- a/frontend/src/combat/sections/GMEncounterControls.tsx
+++ b/frontend/src/combat/sections/GMEncounterControls.tsx
@@ -1,0 +1,552 @@
+/**
+ * GMEncounterControls — the GM's home for encounter-lifecycle actions (#3067):
+ * starting a combat encounter, spawning NPC opponents, adding/removing PCs,
+ * and manual round control. Two render modes, based on whether an active
+ * encounter exists for the scene:
+ *
+ * - No encounter: a "Start Encounter" affordance, shown only when
+ *   `viewerCanGm` — mirrors `Scene.get_viewer_can_gm`
+ *   (staff-or-GM-or-owner), which is also what the backend's create gate now
+ *   checks (`IsEncounterGMOrStaff.has_permission`, #3067).
+ * - Active encounter: full lifecycle controls, shown only when
+ *   `encounter.is_gm` — the backend's `IsEncounterGMOrStaff.has_object_permission`
+ *   gate every other action here already uses (narrower than viewer_can_gm —
+ *   no owner bypass — matching the existing, tested round-control actions).
+ *
+ * End Encounter (#876) stays on RoundFlow — not duplicated here; this panel
+ * is the home for the lifecycle affordances #3067 newly wires (create,
+ * add_opponent, add/remove_participant, begin_round, resolve_round, pause).
+ */
+
+import { useState } from 'react';
+import type React from 'react';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { usePersonaSearch } from '@/roster/usePersonaSearch';
+import type { OpponentTier, PaceMode } from '../api';
+import {
+  useAddOpponent,
+  useAddParticipant,
+  useBeginRound,
+  useCreateEncounter,
+  useOpponentDefaults,
+  usePauseEncounter,
+  useRemoveParticipant,
+  useResolveRound,
+  useThreatPools,
+} from '../queries';
+import type { EncounterDetail, PositionNode } from '../types';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface GMEncounterControlsProps {
+  sceneId: number;
+  /** The scene's active (non-completed) encounter, or null when none exists. */
+  encounter: EncounterDetail | null;
+  /**
+   * Scene-level "can GM" signal for the no-encounter empty state (mirrors
+   * `scene.viewer_can_gm`). Ignored once `encounter` exists —
+   * `encounter.is_gm` governs then (see file docstring for why the two
+   * signals differ).
+   */
+  viewerCanGm: boolean;
+}
+
+const TIER_OPTIONS: { value: OpponentTier; label: string }[] = [
+  { value: 'mook', label: 'Mook' },
+  { value: 'elite', label: 'Elite' },
+  { value: 'boss', label: 'Boss' },
+  { value: 'hero_killer', label: 'Hero Killer' },
+  { value: 'swarm', label: 'Swarm' },
+];
+
+const PACE_OPTIONS: { value: PaceMode; label: string }[] = [
+  { value: 'timed', label: 'Timed — auto-resolves on a timer' },
+  { value: 'ready', label: 'Ready — resolves once everyone is ready' },
+  { value: 'manual', label: 'Manual — GM controls each round' },
+];
+
+// ---------------------------------------------------------------------------
+// Root
+// ---------------------------------------------------------------------------
+
+export function GMEncounterControls({ sceneId, encounter, viewerCanGm }: GMEncounterControlsProps) {
+  if (!encounter) {
+    if (!viewerCanGm) return null;
+    return <StartEncounterCard sceneId={sceneId} />;
+  }
+  if (!encounter.is_gm) return null;
+  return <ActiveGMControls encounter={encounter} />;
+}
+
+// ---------------------------------------------------------------------------
+// Start encounter (no active encounter yet)
+// ---------------------------------------------------------------------------
+
+function StartEncounterCard({ sceneId }: { sceneId: number }) {
+  const [paceMode, setPaceMode] = useState<PaceMode>('timed');
+  const { mutate, isPending } = useCreateEncounter(sceneId);
+
+  function handleStart() {
+    mutate(
+      { paceMode },
+      { onError: (err: Error) => toast.error(err.message || 'Failed to start encounter.') }
+    );
+  }
+
+  return (
+    <div
+      className="space-y-2 rounded-md border border-border bg-card p-3"
+      data-testid="start-encounter-card"
+    >
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">Combat</p>
+      <Select
+        value={paceMode}
+        onValueChange={(v) => setPaceMode(v as PaceMode)}
+        disabled={isPending}
+      >
+        <SelectTrigger data-testid="start-encounter-pace-select" className="h-8 text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {PACE_OPTIONS.map((opt) => (
+            <SelectItem key={opt.value} value={opt.value} className="text-xs">
+              {opt.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+      <Button
+        className="w-full"
+        size="sm"
+        disabled={isPending}
+        onClick={handleStart}
+        data-testid="start-encounter-btn"
+      >
+        {isPending ? 'Starting…' : 'Start Encounter'}
+      </Button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Active encounter — full GM controls
+// ---------------------------------------------------------------------------
+
+function ActiveGMControls({ encounter }: { encounter: EncounterDetail }) {
+  const beginRound = useBeginRound(encounter.id);
+  const resolveRound = useResolveRound(encounter.id);
+  const pause = usePauseEncounter(encounter.id);
+  const removeParticipant = useRemoveParticipant(encounter.id);
+
+  // Manual round control is only meaningful in MANUAL pace — TIMED resolves on
+  // its own timer, READY resolves once every participant readies up.
+  const isManual = encounter.pace_mode === 'manual';
+  const canBegin = isManual && encounter.status === 'between_rounds';
+  const canResolve = isManual && encounter.status === 'declaring';
+
+  function handleRemove(participantId: number) {
+    removeParticipant.mutate(participantId, {
+      onError: (err: Error) => toast.error(err.message || 'Failed to remove participant.'),
+    });
+  }
+
+  function handleBeginRound() {
+    beginRound.mutate(undefined, {
+      onError: (err: Error) => toast.error(err.message || 'Failed to begin round.'),
+    });
+  }
+
+  function handleResolveRound() {
+    resolveRound.mutate(undefined, {
+      onError: (err: Error) => toast.error(err.message || 'Failed to resolve round.'),
+    });
+  }
+
+  function handlePause() {
+    pause.mutate(undefined, {
+      onError: (err: Error) => toast.error(err.message || 'Failed to toggle pause.'),
+    });
+  }
+
+  return (
+    <div
+      className="space-y-3 rounded-md border border-border bg-card p-3"
+      data-testid="gm-encounter-controls"
+    >
+      <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+        GM Controls
+      </p>
+
+      <div className="flex flex-wrap gap-2">
+        <AddOpponentDialog encounterId={encounter.id} positions={encounter.position_nodes ?? []} />
+        <AddParticipantDialog encounterId={encounter.id} />
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={handlePause}
+          disabled={pause.isPending}
+          data-testid="pause-toggle-btn"
+        >
+          {pause.isPending ? 'Working…' : encounter.is_paused ? 'Unpause' : 'Pause'}
+        </Button>
+      </div>
+
+      {isManual && (canBegin || canResolve) && (
+        <div className="flex gap-2">
+          {canBegin && (
+            <Button
+              size="sm"
+              onClick={handleBeginRound}
+              disabled={beginRound.isPending}
+              data-testid="begin-round-btn"
+            >
+              {beginRound.isPending ? 'Beginning…' : 'Begin Round'}
+            </Button>
+          )}
+          {canResolve && (
+            <Button
+              size="sm"
+              onClick={handleResolveRound}
+              disabled={resolveRound.isPending}
+              data-testid="resolve-round-btn"
+            >
+              {resolveRound.isPending ? 'Resolving…' : 'Resolve Round'}
+            </Button>
+          )}
+        </div>
+      )}
+
+      {encounter.participants.length > 0 && (
+        <div className="space-y-1" data-testid="gm-participants-list">
+          <p className="text-[10px] uppercase tracking-wide text-muted-foreground">Participants</p>
+          {encounter.participants.map((p) => (
+            <div
+              key={p.id}
+              className="flex items-center justify-between text-xs"
+              data-testid={`gm-participant-row-${p.id}`}
+            >
+              <span>{p.character_name}</span>
+              <button
+                type="button"
+                className="text-destructive hover:underline disabled:opacity-50"
+                onClick={() => handleRemove(p.id)}
+                disabled={removeParticipant.isPending}
+                data-testid={`remove-participant-btn-${p.id}`}
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Add opponent dialog
+// ---------------------------------------------------------------------------
+
+function AddOpponentDialog({
+  encounterId,
+  positions,
+}: {
+  encounterId: number;
+  positions: PositionNode[];
+}) {
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState('');
+  const [tier, setTier] = useState<OpponentTier>('mook');
+  const [threatPoolId, setThreatPoolId] = useState<number | null>(null);
+  const [positionId, setPositionId] = useState<number | null>(null);
+
+  const { data: pools = [] } = useThreatPools();
+  // Only fetch the scaling preview while the dialog is open — avoids a
+  // background poll for a picker nobody's looking at.
+  const { data: defaults } = useOpponentDefaults(encounterId, open ? tier : null);
+  const { mutate, isPending, error, isError } = useAddOpponent(encounterId);
+
+  function reset() {
+    setName('');
+    setTier('mook');
+    setThreatPoolId(null);
+    setPositionId(null);
+  }
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) reset();
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!name.trim() || threatPoolId === null) return;
+    mutate(
+      { name: name.trim(), tier, threatPoolId, positionId },
+      {
+        onSuccess: () => handleOpenChange(false),
+        onError: () => {
+          /* surfaced inline below via isError */
+        },
+      }
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline" data-testid="add-opponent-trigger">
+          Add Opponent
+        </Button>
+      </DialogTrigger>
+      <DialogContent data-testid="add-opponent-dialog">
+        <DialogHeader>
+          <DialogTitle>Add Opponent</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="opponent-name">Name</Label>
+            <Input
+              id="opponent-name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="Goblin Raider"
+              data-testid="add-opponent-name"
+            />
+          </div>
+
+          <div className="space-y-1.5">
+            <Label>Tier</Label>
+            <Select value={tier} onValueChange={(v) => setTier(v as OpponentTier)}>
+              <SelectTrigger data-testid="add-opponent-tier-select">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                {TIER_OPTIONS.map((opt) => (
+                  <SelectItem key={opt.value} value={opt.value}>
+                    {opt.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {defaults && (
+            <div
+              className="rounded border border-border bg-muted/30 p-2 text-xs"
+              data-testid="add-opponent-defaults-preview"
+            >
+              <p>
+                Health {defaults.max_health} · Soak {defaults.soak_value}
+                {defaults.probing_threshold !== null
+                  ? ` · Probing ${defaults.probing_threshold}`
+                  : ''}
+              </p>
+              {!defaults.stakes_ok && (
+                <p className="mt-1 text-amber-500" data-testid="add-opponent-stakes-warning">
+                  {defaults.stakes_message}
+                </p>
+              )}
+            </div>
+          )}
+
+          <div className="space-y-1.5">
+            <Label>Threat Pool</Label>
+            <Select
+              value={threatPoolId !== null ? String(threatPoolId) : ''}
+              onValueChange={(v) => setThreatPoolId(Number(v))}
+            >
+              <SelectTrigger data-testid="add-opponent-pool-select">
+                <SelectValue placeholder="Select a threat pool…" />
+              </SelectTrigger>
+              <SelectContent>
+                {pools.map((p) => (
+                  <SelectItem key={p.id} value={String(p.id)}>
+                    {p.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+
+          {positions.length > 0 && (
+            <div className="space-y-1.5">
+              <Label>Position (optional)</Label>
+              <Select
+                value={positionId !== null ? String(positionId) : ''}
+                onValueChange={(v) => setPositionId(v === '' ? null : Number(v))}
+              >
+                <SelectTrigger data-testid="add-opponent-position-select">
+                  <SelectValue placeholder="Unplaced" />
+                </SelectTrigger>
+                <SelectContent>
+                  {positions.map((pos) => (
+                    <SelectItem key={pos.id} value={String(pos.id)}>
+                      {pos.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+          )}
+
+          {isError && (
+            <p role="alert" className="text-sm text-destructive" data-testid="add-opponent-error">
+              {error instanceof Error ? error.message : 'Failed to add opponent.'}
+            </p>
+          )}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={isPending || !name.trim() || threatPoolId === null}
+              data-testid="add-opponent-submit"
+            >
+              {isPending ? 'Adding…' : 'Add'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Add participant (PC) dialog
+// ---------------------------------------------------------------------------
+
+function AddParticipantDialog({ encounterId }: { encounterId: number }) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [selected, setSelected] = useState<{ characterSheetId: number; name: string } | null>(null);
+  const { results } = usePersonaSearch(query);
+  const { mutate, isPending, error, isError } = useAddParticipant(encounterId);
+
+  function reset() {
+    setQuery('');
+    setSelected(null);
+  }
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) reset();
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (selected === null) return;
+    mutate(
+      { characterSheetId: selected.characterSheetId },
+      { onSuccess: () => handleOpenChange(false) }
+    );
+  }
+
+  const showResults = results.length > 0 && (selected === null || selected.name !== query);
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button size="sm" variant="outline" data-testid="add-participant-trigger">
+          Add PC
+        </Button>
+      </DialogTrigger>
+      <DialogContent data-testid="add-participant-dialog">
+        <DialogHeader>
+          <DialogTitle>Add PC</DialogTitle>
+        </DialogHeader>
+        <form onSubmit={handleSubmit} className="space-y-3">
+          <div className="space-y-1.5">
+            <Label htmlFor="participant-search">Character</Label>
+            <Input
+              id="participant-search"
+              value={query}
+              onChange={(e) => {
+                setQuery(e.target.value);
+                setSelected(null);
+              }}
+              placeholder="Search for a character…"
+              data-testid="add-participant-search"
+            />
+            {showResults && (
+              <ul className="rounded border border-border" data-testid="add-participant-results">
+                {results.map((p) => (
+                  <li key={p.id}>
+                    <button
+                      type="button"
+                      className="w-full px-2 py-1 text-left text-xs hover:bg-muted disabled:opacity-50"
+                      disabled={p.character_sheet === null}
+                      onClick={() => {
+                        if (p.character_sheet === null) return;
+                        setSelected({ characterSheetId: p.character_sheet, name: p.name });
+                        setQuery(p.name);
+                      }}
+                      data-testid={`add-participant-option-${p.id}`}
+                    >
+                      {p.name}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            )}
+          </div>
+
+          {isError && (
+            <p
+              role="alert"
+              className="text-sm text-destructive"
+              data-testid="add-participant-error"
+            >
+              {error instanceof Error ? error.message : 'Failed to add participant.'}
+            </p>
+          )}
+
+          <DialogFooter>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => handleOpenChange(false)}
+              disabled={isPending}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="submit"
+              disabled={isPending || selected === null}
+              data-testid="add-participant-submit"
+            >
+              {isPending ? 'Adding…' : 'Add'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/combat/sections/YourTurn.tsx
+++ b/frontend/src/combat/sections/YourTurn.tsx
@@ -911,6 +911,25 @@ export function YourTurn({
           return;
         }
       }
+      // PaceMode.READY early-resolution (#3067): `declare_action` resets
+      // `is_ready=False` on every declaration, so submitting alone never
+      // marks the participant ready — a READY-pace encounter would then
+      // wait out the TIMED-style sweep instead of resolving the instant
+      // everyone's in. Dispatch the same `combat_ready` registry action the
+      // REST `ready` endpoint / telnet `combat ready` use, mirroring
+      // `ReadyAction.execute` -> `maybe_resolve_on_ready`. Only meaningful in
+      // READY pace — TIMED resolves on its timer and MANUAL waits for the GM,
+      // so this is skipped for both to leave their behavior unchanged.
+      if (encounter?.pace_mode === 'ready') {
+        const readyResult = await dispatchAction({
+          ref: { backend: 'registry', registry_key: 'combat_ready' },
+          kwargs: {},
+        });
+        if (isDispatchFailure(readyResult)) {
+          setSubmitError(readyResult.message ?? 'Submit failed. Try again.');
+          return;
+        }
+      }
       setSubmitted(true);
       // Refresh the encounter (carries the server's is_ready) and the "Last
       // Outcome" panel now that every declared job succeeded (#2423).
@@ -1433,7 +1452,11 @@ export function YourTurn({
             : 'border-primary bg-primary text-primary-foreground hover:bg-primary/90'
         )}
       >
-        {dispatchPending ? 'Submitting…' : 'Submit declarations · mark ready'}
+        {dispatchPending
+          ? 'Submitting…'
+          : encounter?.pace_mode === 'ready'
+            ? 'Submit declarations · mark ready'
+            : 'Submit declarations'}
       </button>
 
       {/* Inline submit error — shown when a dispatch rejects */}

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -3867,7 +3867,18 @@ export interface paths {
     /** @description ViewSet for combat encounter lifecycle and player actions. */
     get: operations['combat_list'];
     put?: never;
-    /** @description ViewSet for combat encounter lifecycle and player actions. */
+    /**
+     * @description Create, then re-serialize through the prefetch-primed queryset (#3067).
+     *
+     *     ``EncounterDetailSerializer``'s nested fields (participants/opponents/
+     *     clashes/etc.) read ``*_cached`` attrs that only exist on instances
+     *     fetched through ``_base_queryset()``'s ``Prefetch(..., to_attr=...)``
+     *     calls. The bare instance ``perform_create`` leaves on ``serializer``
+     *     doesn't carry them, so DRF's default ``CreateModelMixin.create()``
+     *     (serializing that bare instance) raises ``AttributeError`` — this
+     *     endpoint had no caller before the web GM-start-encounter flow, so the
+     *     gap was never exercised.
+     */
     post: operations['combat_create'];
     delete?: never;
     options?: never;
@@ -4458,6 +4469,58 @@ export interface paths {
      *     played characters, so it never leaks other players' challenges.
      */
     get: operations['combat_duel_challenges_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/combat/threat-pools/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Read-only catalog listing for the GM add-opponent picker (#3067).
+     *
+     *     ThreatPool is authored content (a named NPC move-set, e.g. "Goblin
+     *     Raiders") — not encounter- or scene-scoped — so this is a flat,
+     *     unfiltered-by-default listing. Any authenticated user may browse it: the
+     *     catalog itself carries nothing sensitive (no encounter state, no player
+     *     data); the sensitive step is spawning an opponent with it, which stays
+     *     gated by ``IsEncounterGMOrStaff`` on ``add_opponent``.
+     */
+    get: operations['combat_threat_pools_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/combat/threat-pools/{id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Read-only catalog listing for the GM add-opponent picker (#3067).
+     *
+     *     ThreatPool is authored content (a named NPC move-set, e.g. "Goblin
+     *     Raiders") — not encounter- or scene-scoped — so this is a flat,
+     *     unfiltered-by-default listing. Any authenticated user may browse it: the
+     *     catalog itself carries nothing sensitive (no encounter state, no player
+     *     data); the sensitive step is spawning an opponent with it, which stays
+     *     gated by ``IsEncounterGMOrStaff`` on ``add_opponent``.
+     */
+    get: operations['combat_threat_pools_retrieve'];
     put?: never;
     post?: never;
     delete?: never;
@@ -24887,6 +24950,8 @@ export interface components {
     EncounterDetail: {
       readonly id: number;
       scene: number;
+      /** @description Room where the encounter takes place. Ephemeral CombatNPC ObjectDBs are placed here at creation. */
+      room?: number | null;
       encounter_type?: components['schemas']['EncounterTypeEnum'];
       status?: components['schemas']['Status4e6Enum'];
       readonly outcome:
@@ -24979,6 +25044,8 @@ export interface components {
     /** @description Full encounter state with covenant-filtered action visibility. */
     EncounterDetailRequest: {
       scene: number;
+      /** @description Room where the encounter takes place. Ephemeral CombatNPC ObjectDBs are placed here at creation. */
+      room?: number | null;
       encounter_type?: components['schemas']['EncounterTypeEnum'];
       status?: components['schemas']['Status4e6Enum'];
       round_number?: number;
@@ -32311,6 +32378,21 @@ export interface components {
       previous?: string | null;
       results: components['schemas']['ThreadWeavingTeachingOffer'][];
     };
+    PaginatedThreatPoolList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['ThreatPool'][];
+    };
     PaginatedTransitionList: {
       /** @example 123 */
       count: number;
@@ -32847,6 +32929,8 @@ export interface components {
     /** @description Full encounter state with covenant-filtered action visibility. */
     PatchedEncounterDetailRequest: {
       scene?: number;
+      /** @description Room where the encounter takes place. Ephemeral CombatNPC ObjectDBs are placed here at creation. */
+      room?: number | null;
       encounter_type?: components['schemas']['EncounterTypeEnum'];
       status?: components['schemas']['Status4e6Enum'];
       round_number?: number;
@@ -39154,6 +39238,19 @@ export interface components {
       readonly pitch: string;
       /** @description Gold price the teacher charges (XP cost stays on the unlock). */
       readonly gold_cost: number;
+    };
+    /**
+     * @description Read serializer for the ThreatPool catalog (#3067).
+     *
+     *     ThreatPool is authored content (a named NPC move-set — e.g. "Goblin
+     *     Raiders"), never a per-encounter/per-scene row, so this is a flat
+     *     id/name/description listing for the GM's add-opponent picker — no
+     *     encounter-scoped fields to compute.
+     */
+    ThreatPool: {
+      readonly id: number;
+      readonly name: string;
+      readonly description: string;
     };
     /**
      * @description * `crown` - Crown
@@ -45884,6 +45981,54 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['DuelChallenge'];
+        };
+      };
+    };
+  };
+  combat_threat_pools_list: {
+    parameters: {
+      query?: {
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        /** @description Number of results to return per page. */
+        page_size?: number;
+        /** @description A search term. */
+        search?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedThreatPoolList'];
+        };
+      };
+    };
+  };
+  combat_threat_pools_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this threat pool. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['ThreatPool'];
         };
       };
     };

--- a/frontend/src/scenes/pages/SceneDetailPage.tsx
+++ b/frontend/src/scenes/pages/SceneDetailPage.tsx
@@ -28,8 +28,9 @@ import { PendingActionAttachments } from '../components/PendingActionAttachments
 import { usePendingUnlinkedActions } from '../hooks/usePendingUnlinkedActions';
 import { useBattleForSceneQuery } from '@/battles/queries';
 import { RitualProposedChip } from '@/rituals/components/RitualProposedChip';
-import { useEncounterForScene } from '@/combat/queries';
+import { useCombatEncounter, useEncounterForScene } from '@/combat/queries';
 import { CombatRail } from '@/combat/components/CombatRail';
+import { GMEncounterControls } from '@/combat/sections/GMEncounterControls';
 import { LinkedStoriesPanel } from '@/crossover/components/LinkedStoriesPanel';
 
 export function SceneDetailPage() {
@@ -53,6 +54,10 @@ export function SceneDetailPage() {
   const { data: encounterListItem, isLoading: encounterLoading } = useEncounterForScene(sceneIdNum);
   const hasActiveEncounter = !encounterLoading && encounterListItem != null;
   const encounterId = encounterListItem?.id ?? 0;
+  // Full encounter detail (carries is_gm) for the GM controls panel (#3067) —
+  // shares the combatKeys.encounter(encounterId) cache with CombatTurnPanel's
+  // own useCombatEncounter call inside CombatRail, so this doesn't double-fetch.
+  const { data: gmEncounterDetail } = useCombatEncounter(encounterId);
 
   // Scroll the rail into view the moment an encounter first appears
   // (none -> active transition) so a player mid-pose notices combat starting.
@@ -210,6 +215,15 @@ export function SceneDetailPage() {
         {placesRoomId && <SpeakerQueueBar roomId={placesRoomId} />}
         <SceneTacticalMap sceneId={id} />
         <HighlightReel sceneId={id} canGm={scene?.viewer_can_gm} />
+        {/* GM "Start Encounter" affordance (#3067) — only while no encounter is
+            active; the active-encounter controls mount in the combat rail below. */}
+        {!encounterLoading && !hasActiveEncounter && (
+          <GMEncounterControls
+            sceneId={sceneIdNum}
+            encounter={null}
+            viewerCanGm={scene?.viewer_can_gm ?? false}
+          />
+        )}
         {scene && <LinkedStoriesPanel sceneId={id} />}
       </div>
 
@@ -278,9 +292,16 @@ export function SceneDetailPage() {
         {hasActiveEncounter && (
           <div
             ref={railRef}
-            className="min-h-0 overflow-y-auto"
+            className="min-h-0 space-y-3 overflow-y-auto"
             data-testid="scene-detail-combat-rail"
           >
+            {gmEncounterDetail?.is_gm && (
+              <GMEncounterControls
+                sceneId={sceneIdNum}
+                encounter={gmEncounterDetail}
+                viewerCanGm={scene?.viewer_can_gm ?? false}
+              />
+            )}
             <CombatRail sceneId={sceneIdNum} encounterId={encounterId} />
           </div>
         )}

--- a/frontend/src/scenes/pages/__tests__/SceneDetailPage.test.tsx
+++ b/frontend/src/scenes/pages/__tests__/SceneDetailPage.test.tsx
@@ -151,14 +151,23 @@ const mockUseEncounterForScene = vi.fn(
   })
 );
 
+// GMEncounterControls' gate reads useCombatEncounter's full detail (is_gm) —
+// stub it too (default: no data) so it never falls through to the real
+// useQuery mock above, which eagerly calls any non-'scene' queryFn for real
+// (an uncaught /api/combat/<id>/ fetch that jsdom can't resolve, #3067).
+const mockUseCombatEncounter = vi.fn((): { data: { id: number; is_gm: boolean } | undefined } => ({
+  data: undefined,
+}));
+
 vi.mock('@/combat/queries', async (importOriginal) => {
   // SceneTacticalMap (rendered in the header) also pulls real hooks (e.g.
   // useDispatchPlayerAction) from this module — preserve everything else and
-  // only override useEncounterForScene.
+  // only override useEncounterForScene/useCombatEncounter.
   const actual = await importOriginal<typeof import('@/combat/queries')>();
   return {
     ...actual,
     useEncounterForScene: () => mockUseEncounterForScene(),
+    useCombatEncounter: () => mockUseCombatEncounter(),
   };
 });
 
@@ -166,6 +175,30 @@ vi.mock('@/combat/components/CombatRail', () => ({
   CombatRail: ({ sceneId, encounterId }: { sceneId: number; encounterId: number }) => (
     <div data-testid="combat-rail-stub" data-scene-id={sceneId} data-encounter-id={encounterId}>
       CombatRail [{encounterId}]
+    </div>
+  ),
+}));
+
+// GMEncounterControls (#3067) calls useCombatEncounter directly (real fetch) —
+// stub it out here the same way CombatRail is stubbed above, so this page
+// test doesn't need to mock @/combat/queries' useCombatEncounter too.
+vi.mock('@/combat/sections/GMEncounterControls', () => ({
+  GMEncounterControls: ({
+    sceneId,
+    encounter,
+    viewerCanGm,
+  }: {
+    sceneId: number;
+    encounter: { id: number } | null;
+    viewerCanGm: boolean;
+  }) => (
+    <div
+      data-testid="gm-encounter-controls-stub"
+      data-scene-id={sceneId}
+      data-encounter-id={encounter?.id ?? 'none'}
+      data-viewer-can-gm={String(viewerCanGm)}
+    >
+      GMEncounterControls
     </div>
   ),
 }));
@@ -330,6 +363,7 @@ describe('SceneDetailPage', () => {
       isLoading: false,
       isError: false,
     });
+    mockUseCombatEncounter.mockReturnValue({ data: undefined });
   });
 
   it('renders without crashing', () => {

--- a/src/schema.json
+++ b/src/schema.json
@@ -5627,7 +5627,17 @@ paths:
           description: ''
     post:
       operationId: combat_create
-      description: ViewSet for combat encounter lifecycle and player actions.
+      description: |-
+        Create, then re-serialize through the prefetch-primed queryset (#3067).
+
+        ``EncounterDetailSerializer``'s nested fields (participants/opponents/
+        clashes/etc.) read ``*_cached`` attrs that only exist on instances
+        fetched through ``_base_queryset()``'s ``Prefetch(..., to_attr=...)``
+        calls. The bare instance ``perform_create`` leaves on ``serializer``
+        doesn't carry them, so DRF's default ``CreateModelMixin.create()``
+        (serializing that bare instance) raises ``AttributeError`` — this
+        endpoint had no caller before the web GM-start-encounter flow, so the
+        gap was never exercised.
       tags:
       - combat
       requestBody:
@@ -6570,6 +6580,78 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DuelChallenge'
+          description: ''
+  /api/combat/threat-pools/:
+    get:
+      operationId: combat_threat_pools_list
+      description: |-
+        Read-only catalog listing for the GM add-opponent picker (#3067).
+
+        ThreatPool is authored content (a named NPC move-set, e.g. "Goblin
+        Raiders") — not encounter- or scene-scoped — so this is a flat,
+        unfiltered-by-default listing. Any authenticated user may browse it: the
+        catalog itself carries nothing sensitive (no encounter state, no player
+        data); the sensitive step is spawning an opponent with it, which stays
+        gated by ``IsEncounterGMOrStaff`` on ``add_opponent``.
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - name: search
+        required: false
+        in: query
+        description: A search term.
+        schema:
+          type: string
+      tags:
+      - combat
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedThreatPoolList'
+          description: ''
+  /api/combat/threat-pools/{id}/:
+    get:
+      operationId: combat_threat_pools_retrieve
+      description: |-
+        Read-only catalog listing for the GM add-opponent picker (#3067).
+
+        ThreatPool is authored content (a named NPC move-set, e.g. "Goblin
+        Raiders") — not encounter- or scene-scoped — so this is a flat,
+        unfiltered-by-default listing. Any authenticated user may browse it: the
+        catalog itself carries nothing sensitive (no encounter state, no player
+        data); the sensitive step is spawning an opponent with it, which stays
+        gated by ``IsEncounterGMOrStaff`` on ``add_opponent``.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this threat pool.
+        required: true
+      tags:
+      - combat
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ThreatPool'
           description: ''
   /api/companions/companion-archetypes/:
     get:
@@ -42925,6 +43007,11 @@ components:
           readOnly: true
         scene:
           type: integer
+        room:
+          type: integer
+          nullable: true
+          description: Room where the encounter takes place. Ephemeral CombatNPC ObjectDBs
+            are placed here at creation.
         encounter_type:
           $ref: '#/components/schemas/EncounterTypeEnum'
         status:
@@ -43123,6 +43210,11 @@ components:
       properties:
         scene:
           type: integer
+        room:
+          type: integer
+          nullable: true
+          description: Room where the encounter takes place. Ephemeral CombatNPC ObjectDBs
+            are placed here at creation.
         encounter_type:
           $ref: '#/components/schemas/EncounterTypeEnum'
         status:
@@ -56752,6 +56844,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ThreadWeavingTeachingOffer'
+    PaginatedThreatPoolList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/ThreatPool'
     PaginatedTransitionList:
       type: object
       required:
@@ -57661,6 +57776,11 @@ components:
       properties:
         scene:
           type: integer
+        room:
+          type: integer
+          nullable: true
+          description: Room where the encounter takes place. Ephemeral CombatNPC ObjectDBs
+            are placed here at creation.
         encounter_type:
           $ref: '#/components/schemas/EncounterTypeEnum'
         status:
@@ -70166,6 +70286,29 @@ components:
       - unlock_display_name
       - unlock_target_kind
       - unlock_xp_cost
+    ThreatPool:
+      type: object
+      description: |-
+        Read serializer for the ThreatPool catalog (#3067).
+
+        ThreatPool is authored content (a named NPC move-set — e.g. "Goblin
+        Raiders"), never a per-encounter/per-scene row, so this is a flat
+        id/name/description listing for the GM's add-opponent picker — no
+        encounter-scoped fields to compute.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+        description:
+          type: string
+          readOnly: true
+      required:
+      - description
+      - id
+      - name
     Tier34dEnum:
       enum:
       - crown

--- a/src/world/combat/permissions.py
+++ b/src/world/combat/permissions.py
@@ -6,6 +6,8 @@ from rest_framework.views import APIView
 
 from world.combat.models import CombatEncounter
 
+_CREATE_ACTION = "create"
+
 
 def can_view_encounter_effects(user: object, encounter: CombatEncounter) -> bool:
     """Return True iff ``user`` may view an encounter's effect details.
@@ -55,6 +57,41 @@ class IsEncounterGMOrStaff(BasePermission):
     Uses Scene.is_gm() which reads from participations_cached — no query
     if the scene is already in the identity map.
     """
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        """Gate ``create`` to the named scene's GM/owner (or staff) (#3067).
+
+        ``create`` has no object yet, so DRF never calls
+        ``has_object_permission`` for it — every other action here is
+        detail-routed (``get_object()`` runs first, then the object check
+        below). Without this override, any authenticated user could POST an
+        encounter into a scene they don't GM. Not a behavior change for any
+        other action: they still fall through to the unconditional ``True``.
+
+        Staff-or-GM-or-owner mirrors the established "can this user do
+        GM-ish things to this scene" predicate used elsewhere for scene
+        write actions (``Scene.get_viewer_can_gm``,
+        ``world.scenes.permissions.IsSceneGMOrOwnerOrStaff``) rather than
+        the narrower is_gm-only check ``has_object_permission`` below uses
+        for the existing round-control actions — the web "Start encounter"
+        button reads ``scene.viewer_can_gm`` to decide whether to render at
+        all, so the create gate must match that signal exactly or a scene
+        owner who isn't separately flagged ``is_gm`` would see a button the
+        server then 403s.
+        """
+        if view.action != _CREATE_ACTION:
+            return True
+        if request.user.is_staff:
+            return True
+        scene_id = request.data.get("scene")
+        if not scene_id:
+            return False
+        from world.scenes.models import Scene  # noqa: PLC0415
+
+        scene = Scene.objects.filter(pk=scene_id).first()
+        if scene is None:
+            return False
+        return scene.is_gm(request.user) or scene.is_owner(request.user)
 
     def has_object_permission(
         self,

--- a/src/world/combat/serializers.py
+++ b/src/world/combat/serializers.py
@@ -35,6 +35,7 @@ from world.combat.models import (
     DramaticSurgeRecord,
     DuelChallenge,
     EscalationCurve,
+    ThreatPool,
 )
 from world.conditions.serializers import ConditionInstanceSerializer
 from world.conditions.services import get_active_conditions
@@ -759,6 +760,21 @@ class DuelChallengeSerializer(serializers.ModelSerializer):
         read_only_fields = fields
 
 
+class ThreatPoolSerializer(serializers.ModelSerializer):
+    """Read serializer for the ThreatPool catalog (#3067).
+
+    ThreatPool is authored content (a named NPC move-set — e.g. "Goblin
+    Raiders"), never a per-encounter/per-scene row, so this is a flat
+    id/name/description listing for the GM's add-opponent picker — no
+    encounter-scoped fields to compute.
+    """
+
+    class Meta:
+        model = ThreatPool
+        fields = ["id", "name", "description"]
+        read_only_fields = fields
+
+
 # ---------------------------------------------------------------------------
 # List and detail serializers
 # ---------------------------------------------------------------------------
@@ -874,6 +890,7 @@ class EncounterDetailSerializer(serializers.ModelSerializer):
         fields = [
             "id",
             "scene",
+            "room",
             "encounter_type",
             "status",
             "outcome",

--- a/src/world/combat/tests/test_views.py
+++ b/src/world/combat/tests/test_views.py
@@ -21,7 +21,7 @@ from world.combat.factories import (
     ThreatPoolEntryFactory,
     ThreatPoolFactory,
 )
-from world.combat.models import CombatOpponentAction, CombatRoundAction
+from world.combat.models import CombatEncounter, CombatOpponentAction, CombatRoundAction
 from world.conditions.factories import DamageSuccessLevelMultiplierFactory
 from world.conditions.models import ConditionInstance
 from world.magic.factories import (
@@ -247,6 +247,95 @@ class GMLifecycleTest(CombatEncounterViewSetTestBase):
             ActionDispatchError.TECHNIQUE_NOT_COMBAT_READY
         ).user_message
         self.assertEqual(response.data["detail"], expected_message)
+
+
+class CreateEncounterTest(CombatEncounterViewSetTestBase):
+    """Tests for POST /api/combat/ — the web GM start-encounter flow (#3067)."""
+
+    def test_create_as_gm_defaults_room_from_scene_location(self) -> None:
+        """room is unset in the payload; perform_create fills it from scene.location."""
+        room = ObjectDBFactory()
+        scene = SceneFactory(location=room)
+        SceneParticipationFactory(scene=scene, account=self.gm_account, is_gm=True)
+        client = APIClient()
+        client.force_authenticate(user=self.gm_account)
+        response = client.post("/api/combat/", {"scene": scene.pk}, format="json")
+        self.assertEqual(response.status_code, http_status.HTTP_201_CREATED)
+        encounter = CombatEncounter.objects.get(pk=response.data["id"])
+        self.assertEqual(encounter.room_id, room.pk)
+
+    def test_create_as_gm_allowed(self) -> None:
+        client = APIClient()
+        client.force_authenticate(user=self.gm_account)
+        response = client.post("/api/combat/", {"scene": self.scene.pk}, format="json")
+        self.assertEqual(response.status_code, http_status.HTTP_201_CREATED)
+
+    def test_create_as_staff_allowed(self) -> None:
+        staff_account = AccountFactory(username="teststaff", is_staff=True)
+        client = APIClient()
+        client.force_authenticate(user=staff_account)
+        response = client.post("/api/combat/", {"scene": self.scene.pk}, format="json")
+        self.assertEqual(response.status_code, http_status.HTTP_201_CREATED)
+
+    def test_create_as_scene_owner_without_gm_flag_allowed(self) -> None:
+        """A scene owner not separately flagged is_gm can still start combat (#3067).
+
+        Matches Scene.get_viewer_can_gm / IsSceneGMOrOwnerOrStaff's
+        staff-or-GM-or-owner predicate — the frontend's "Start encounter"
+        button reads viewer_can_gm, so the create gate must agree with it.
+        """
+        owner_account = AccountFactory(username="testowner")
+        SceneParticipationFactory(
+            scene=self.scene, account=owner_account, is_owner=True, is_gm=False
+        )
+        client = APIClient()
+        client.force_authenticate(user=owner_account)
+        response = client.post("/api/combat/", {"scene": self.scene.pk}, format="json")
+        self.assertEqual(response.status_code, http_status.HTTP_201_CREATED)
+
+    def test_create_non_gm_denied(self) -> None:
+        """A non-GM player cannot POST an encounter into a scene they don't GM.
+
+        Regression guard for the request-level gap this issue closed: create
+        has no object yet, so has_object_permission alone never ran for it.
+        """
+        client = APIClient()
+        client.force_authenticate(user=self.player_account)
+        response = client.post("/api/combat/", {"scene": self.scene.pk}, format="json")
+        self.assertEqual(response.status_code, http_status.HTTP_403_FORBIDDEN)
+
+    def test_create_unauthenticated_denied(self) -> None:
+        client = APIClient()
+        response = client.post("/api/combat/", {"scene": self.scene.pk}, format="json")
+        self.assertEqual(response.status_code, http_status.HTTP_403_FORBIDDEN)
+
+
+class ThreatPoolViewSetTest(CombatEncounterViewSetTestBase):
+    """Tests for GET /api/combat/threat-pools/ — the GM add-opponent picker (#3067)."""
+
+    def test_list_requires_auth(self) -> None:
+        client = APIClient()
+        response = client.get("/api/combat/threat-pools/")
+        self.assertEqual(response.status_code, http_status.HTTP_403_FORBIDDEN)
+
+    def test_list_returns_catalog(self) -> None:
+        pool = ThreatPoolFactory(name="Goblin Raiders")
+        client = APIClient()
+        client.force_authenticate(user=self.player_account)
+        response = client.get("/api/combat/threat-pools/")
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        names = [row["name"] for row in response.data["results"]]
+        self.assertIn(pool.name, names)
+
+    def test_search_filters_by_name(self) -> None:
+        ThreatPoolFactory(name="Goblin Raiders")
+        wolves = ThreatPoolFactory(name="Wolf Pack")
+        client = APIClient()
+        client.force_authenticate(user=self.player_account)
+        response = client.get("/api/combat/threat-pools/?search=Wolf")
+        self.assertEqual(response.status_code, http_status.HTTP_200_OK)
+        names = [row["name"] for row in response.data["results"]]
+        self.assertEqual(names, [wolves.name])
 
 
 class PlayerActionTest(CombatEncounterViewSetTestBase):

--- a/src/world/combat/urls.py
+++ b/src/world/combat/urls.py
@@ -3,13 +3,14 @@
 from django.urls import path
 from rest_framework.routers import DefaultRouter
 
-from world.combat.views import CombatEncounterViewSet, DuelChallengeViewSet
+from world.combat.views import CombatEncounterViewSet, DuelChallengeViewSet, ThreatPoolViewSet
 from world.combat.views_outcome_details import ActionOutcomeDetailsView
 
 router = DefaultRouter()
 # Register before the empty-prefix encounter route: the encounter detail regex
-# ``^(?P<pk>[^/.]+)/$`` would otherwise capture ``duel-challenges/`` as a pk.
+# ``^(?P<pk>[^/.]+)/$`` would otherwise capture ``duel-challenges/``/``threat-pools/`` as a pk.
 router.register("duel-challenges", DuelChallengeViewSet, basename="duel-challenge")
+router.register("threat-pools", ThreatPoolViewSet, basename="threat-pool")
 router.register("", CombatEncounterViewSet, basename="combat-encounter")
 
 app_name = "combat"

--- a/src/world/combat/views.py
+++ b/src/world/combat/views.py
@@ -15,6 +15,7 @@ from evennia.accounts.models import AccountDB
 from evennia.objects.models import ObjectDB
 from rest_framework import status
 from rest_framework.decorators import action
+from rest_framework.filters import SearchFilter
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -68,6 +69,7 @@ from world.combat.serializers import (
     OpponentTargetSerializer,
     RemoveParticipantSerializer,
     RoundActionSerializer,
+    ThreatPoolSerializer,
     UpgradeComboSerializer,
     UseItemSerializer,
 )
@@ -131,6 +133,25 @@ class DuelChallengeViewSet(ReadOnlyModelViewSet):
         )
 
 
+class ThreatPoolViewSet(ReadOnlyModelViewSet):
+    """Read-only catalog listing for the GM add-opponent picker (#3067).
+
+    ThreatPool is authored content (a named NPC move-set, e.g. "Goblin
+    Raiders") — not encounter- or scene-scoped — so this is a flat,
+    unfiltered-by-default listing. Any authenticated user may browse it: the
+    catalog itself carries nothing sensitive (no encounter state, no player
+    data); the sensitive step is spawning an opponent with it, which stays
+    gated by ``IsEncounterGMOrStaff`` on ``add_opponent``.
+    """
+
+    serializer_class = ThreatPoolSerializer
+    queryset = ThreatPool.objects.all().order_by("name")
+    pagination_class = StandardResultsSetPagination
+    filter_backends = [SearchFilter]
+    search_fields = ["name"]
+    permission_classes = [IsAuthenticated]
+
+
 class CombatEncounterViewSet(ModelViewSet):
     """ViewSet for combat encounter lifecycle and player actions."""
 
@@ -139,10 +160,46 @@ class CombatEncounterViewSet(ModelViewSet):
     pagination_class = StandardResultsSetPagination
 
     def perform_create(self, serializer: BaseSerializer[CombatEncounter]) -> None:
+        """Create the encounter, defaulting room from the scene's location.
+
+        The web GM-start-encounter flow (#3067) only supplies ``scene`` —
+        mirroring every other encounter-creation call site (duels,
+        cast_seed), which always thread an explicit room, this is the one
+        path where the caller doesn't have a room to hand yet. Default it to
+        the scene's current location so ephemeral opponent ObjectDBs
+        (``add_opponent`` -> ``create_object(..., location=encounter.room)``)
+        land somewhere instead of nowhere. An explicit ``room`` in the
+        request always wins.
+        """
         from world.combat.escalation import assign_default_escalation_curve  # noqa: PLC0415
 
         encounter = serializer.save()
+        if encounter.room_id is None and encounter.scene.location_id is not None:
+            encounter.room = encounter.scene.location
+            encounter.save(update_fields=["room"])
         assign_default_escalation_curve(encounter)
+
+    def create(self, request: Request, *args: object, **kwargs: object) -> Response:
+        """Create, then re-serialize through the prefetch-primed queryset (#3067).
+
+        ``EncounterDetailSerializer``'s nested fields (participants/opponents/
+        clashes/etc.) read ``*_cached`` attrs that only exist on instances
+        fetched through ``_base_queryset()``'s ``Prefetch(..., to_attr=...)``
+        calls. The bare instance ``perform_create`` leaves on ``serializer``
+        doesn't carry them, so DRF's default ``CreateModelMixin.create()``
+        (serializing that bare instance) raises ``AttributeError`` — this
+        endpoint had no caller before the web GM-start-encounter flow, so the
+        gap was never exercised.
+        """
+        serializer = self.get_serializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+        self.perform_create(serializer)
+        encounter = self._base_queryset().get(pk=serializer.instance.pk)
+        response = self._serialize_encounter(request, encounter)
+        response.status_code = status.HTTP_201_CREATED
+        for key, value in self.get_success_headers(serializer.data).items():
+            response[key] = value
+        return response
 
     def get_permissions(self) -> list:
         if self.action in ("list", "retrieve"):


### PR DESCRIPTION
Closes #3067.

## What

PC-vs-NPC combat becomes startable and runnable from the browser. New `GMEncounterControls` panel on the scene page (gated on the viewer's real GM standing): Start Encounter when none is active; Add Opponent (name/tier with `opponent_defaults` preview, threat-pool picker, optional position), Add/Remove PC, Begin/Resolve Round (MANUAL pace), and Pause when one is. Typed clients + react-query hooks for all eight lifecycle endpoints that previously had zero frontend callers.

Fold-ins from the issue:
- **Ready toggle now fires from web:** `YourTurn` dispatches `combat_ready` after a successful submit when the encounter is `PaceMode.READY`, so early resolution can actually trigger (previously every round waited out the 30s TIMED sweep).
- **Roadmap corrections:** `combat.md` / `ROADMAP.md` no longer claim party-combat web UI was complete; champion-duel/battle staging flagged as still telnet-first.

## Backend wiring the panel exposed (no new game behavior)

- `POST /api/combat/` was actually broken — plain `ModelViewSet.create()` raised `AttributeError`; it had zero callers so the gap was never hit. `perform_create` now defaults `room` from `scene.location` and re-serializes through the primed queryset.
- **Permission hole closed:** `IsEncounterGMOrStaff` never gated `create` (no object exists yet, so `has_object_permission` never ran) — any authenticated user could POST an encounter into a scene they don't GM. Now staff-or-scene-GM-or-owner, exactly matching `Scene.get_viewer_can_gm`, which is what the frontend gate reads.
- New read-only `ThreatPoolViewSet` (`GET /api/combat/threat-pools/`) — `add_opponent` requires a `threat_pool_id` and no catalog endpoint existed.

NPC behavior needs nothing further: once an opponent exists, the threat-pool machinery resolves its actions at round resolution.

## Tests

Backend: 54 green (`world.combat.tests.test_views` + `test_permissions`, incl. the create-permission gate). Frontend: 278 vitest green across `src/combat/` + scene page (20 new for GMEncounterControls, ready-dispatch coverage in YourTurn); `tsc -b`, eslint, prettier, `vite build` all clean.

## Notes

- End Encounter deliberately stays on `RoundFlow` — `GMEncounterControls` is the home for the NEW lifecycle affordances.
- Add-opponent omits manual stat overrides; tier auto-scaling is the documented path.
- Sibling GM surface (adjudication toolkit panel) is #3070, separately queued.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
