### PR TITLE
GM adjudication on web: check invocation, awards, conditions, and situation placement panel (#3070)

### DIFF
--- a/docs/roadmap/gm-system.md
+++ b/docs/roadmap/gm-system.md
@@ -158,6 +158,31 @@ unlocks, never grants" makes XP scarce, so this is the pull). Built:
   `award_type="technique"` mints a `Technique` via the shared `learn_technique` seam
   with `origin=AcquisitionOrigin.GM_GRANT`. Telnet: `gm award <char> stat=<trait>` /
   `gm award <char> technique=<name>`.
+- **GM adjudication toolkit — web ✅ (#3070)** — before this, the only web-reachable
+  path to a `gm ...` verb was typing it into the scene composer, which posed it to the
+  room as IC text instead of running the action; a GM could not run a session from the
+  browser at all. `GMAdjudicationPanel` (`frontend/src/scenes/components/`), gated on
+  `scene.viewer_can_gm`, adds four tabs (Call Check, Award, Condition,
+  Situation/Challenge placement) to the scene detail page, dispatching
+  `gm_invoke_check`/`gm_award_progression`/`gm_apply_condition`/`set_situation`/
+  `place_challenge` directly over the generic REGISTRY REST dispatch seam
+  (`useDispatchPlayerAction` -> `POST /api/actions/characters/{id}/dispatch/`),
+  mirroring `PersonaContextMenu.tsx`'s pre-existing `challenge`/`identify` items —
+  none of these five actions carry an `ActionTemplate`, so they never appear in the
+  generic `get_player_actions` listing. The REST dispatch path does no ObjectDB
+  resolution of its own (`objectdb_target_kwargs` only helps the websocket
+  inputfunc), so `_resolve_gm_target` (`actions/definitions/gm_adjudication.py`) now
+  resolves the `target` kwarg from either an already-resolved `ObjectDB` (telnet) or
+  a plain int pk (the web panel sends the target character's id directly — a
+  `CharacterSheet`'s pk equals its owning `ObjectDB`'s pk). New read-only catalog
+  endpoint: `checks.CheckTypeViewSet` (`GET /api/checks/check-types/`, `IsGMOrStaff`,
+  `search`/`category` filters, excludes inactive and per-character-synthesized rows)
+  feeds the Call Check picker — the only one of the four GM catalogs that didn't
+  already have a ViewSet; `ConditionTemplateViewSet`/`SituationTemplateViewSet`/
+  `ChallengeTemplateViewSet` were verified present and reused as-is. No client-side
+  GM trust-tier check exists or was added — a below-tier GM's dispatch simply
+  surfaces the backend's own prerequisite-refusal message via toast, the same as any
+  other rejected dispatch.
 
 ### Staff Character and Staff Tooling
 - Staff has commands to edit world state, manage GMs, override any system

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2050,7 +2050,26 @@ GM at a given level may author (#2000, ADR-0097).
   <char> xp=<amount>|dev=<trait> amount=<n>|hare=<organization> reason=<text>|stat=<trait>|
   technique=<name>`, `gm condition <char>
   condition=<name> [severity=<n>] [duration=<n>] [note=<text>]` (`commands/gm_ops.py`'s
-  `CmdGMDashboard`).
+  `CmdGMDashboard`). **Web (#3070):** `GMAdjudicationPanel`
+  (`frontend/src/scenes/components/`), gated on `scene.viewer_can_gm`, rendered on the
+  scene detail page. Dispatches `gm_invoke_check`/`gm_award_progression`/
+  `gm_apply_condition` (plus `set_situation`/`place_challenge`, below) directly over
+  the generic REGISTRY REST dispatch seam (`useDispatchPlayerAction` ->
+  `POST /api/actions/characters/{id}/dispatch/`) — mirroring
+  `PersonaContextMenu.tsx`'s `challenge`/`identify` items, since none of these five
+  actions carry an `ActionTemplate` and so are absent from `get_player_actions`. The
+  REST dispatch path does no ObjectDB resolution of its own (`objectdb_target_kwargs`
+  only helps the websocket inputfunc), so `_resolve_gm_target`
+  (`actions/definitions/gm_adjudication.py`) resolves the `target` kwarg from either
+  an already-resolved `ObjectDB` (telnet) or a plain int pk (the web panel sends the
+  target character's id — a `CharacterSheet`'s pk equals its owning `ObjectDB`'s pk).
+  Catalog pickers: `checks.CheckTypeViewSet` (new, `GET /api/checks/check-types/`,
+  `IsGMOrStaff`, `search`/`category` filters, excludes inactive and
+  per-character-synthesized rows) for Call Check; the pre-existing
+  `conditions.ConditionTemplateViewSet` (`/api/conditions/templates/`),
+  `mechanics.SituationTemplateViewSet`/`ChallengeTemplateViewSet`
+  (`/api/mechanics/situation-templates/`/`challenge-templates/`) for Condition and
+  Situation/Challenge placement, reused as-is.
 - **Scenario catalog (#2127, ADR-0110):** extends the same "discovery, never invention"
   shape from checks to situations. `FindSituationAction` (key `gm_find_situation`,
   read-only, gated `MinimumGMLevelPrerequisite(GMLevel.STARTING)` — lower than
@@ -2101,7 +2120,12 @@ GM at a given level may author (#2000, ADR-0097).
   `InvokeCatalogCheckAction` via `actions/definitions/gm_shift.py`.
   `FindSituationAction` also searches `ChallengeTemplate` now, so one browse surface
   covers both placement verbs. Telnet: `setsituation challenge
-  <template>=<target name> [edge=<why>|setback=<why>]`. Two fold-ins:
+  <template>=<target name> [edge=<why>|setback=<why>]`. **Web (#3070):**
+  `GMAdjudicationPanel`'s Situation tab dispatches `set_situation`
+  (`situation_template_id`) or `place_challenge` (`challenge_template_id` +
+  `target_object_name` + optional edge/setback) the same generic REST way as the
+  check/award/condition tabs above — both act on the GM's own room
+  (`target_type=SELF`), so this tab has no participant picker. Two fold-ins:
   `ChallengeTemplate.severity` is re-expressed in `DIFFICULTY_VALUES` points (default
   `1` → `45`; it feeds `perform_check`'s `target_difficulty` directly, so the old
   scale resolved every authored challenge at the bottom rank), and

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -727,6 +727,62 @@ nested field serialized by `SceneRoundSerializer` (read-only). Fields:
 The `is_danger` field remains a read-side hint: the dialog uses it only to show the
 informational note above, never to disable controls (#1476 cleared the old danger lock).
 
+### Web GM adjudication panel — GMAdjudicationPanel (#3070)
+
+Before this, the GM adjudication toolkit (`gm_invoke_check`/`gm_award_progression`/
+`gm_apply_condition`/`set_situation`/`place_challenge` — see "Adjudication toolkit" in
+`docs/systems/INDEX.md`'s GM section) had zero web callers: a GM had to type `gm ...`
+into the scene composer, which poses the text to the room as an IC line instead of
+running the action.
+
+`GMAdjudicationPanel` (`frontend/src/scenes/components/GMAdjudicationPanel.tsx`) closes
+that gap. **Gate:** rendered only when `scene.viewer_can_gm` (mirrors `HighlightReel`'s
+`canGm` prop and `RoundSettingsDialog`'s gate) — no client-side GM trust-*tier* probe
+exists; a below-tier dispatch (e.g. a JUNIOR GM attempting `gm_invoke_check`, which
+requires SENIOR) simply surfaces the backend's prerequisite-refusal message via a toast.
+
+**Dispatch seam:** all five actions carry no `ActionTemplate`, so none appear in the
+generic `get_player_actions` listing (see the "Registry exclusion note" in
+`actions/player_interface.py`). The panel builds its `ActionRef`s directly and fires
+them through the plain REGISTRY REST path (`useDispatchPlayerAction` ->
+`POST /api/actions/characters/{id}/dispatch/`), mirroring `PersonaContextMenu.tsx`'s
+pre-existing `challenge`/`identify` items rather than adding a
+`_gm_adjudication_actions`-style availability adapter.
+
+**Target resolution:** the REST dispatch path (`dispatch_player_action` ->
+`_dispatch_registry`) does no ObjectDB resolution of its own — `objectdb_target_kwargs`
+only helps the *websocket* inputfunc. `_resolve_gm_target`
+(`actions/definitions/gm_adjudication.py`) now resolves the `target` kwarg from either
+an already-resolved `ObjectDB` (telnet) or a plain int pk; the panel's participant
+picker reads `scene.personas[].character_sheet` (a `CharacterSheet`'s pk equals its
+owning `ObjectDB`'s pk) and sends that id directly as `target`.
+
+**Tabs:**
+- **Call Check** — searches `checks.CheckTypeViewSet` (new, `GET
+  /api/checks/check-types/`, `IsGMOrStaff`), picks a `DifficultyChoice` band, and an
+  optional mutually-exclusive edge/setback reason; dispatches `gm_invoke_check`.
+- **Award** — a kind picker (xp/development/favor_token/stat/technique) plus per-kind
+  fields; `trait_ref`/`org_ref`/`technique_ref` are plain text inputs resolved
+  server-side pk-or-name (mirroring telnet's own `gm award` grammar) rather than
+  catalog pickers — no general `Trait` list endpoint exists, and duplicating one for
+  three free-text fields was judged out of scope for this pass. Dispatches
+  `gm_award_progression`.
+- **Condition** — searches `conditions.ConditionTemplateViewSet`
+  (`/api/conditions/templates/`, pre-existing, reused as-is); dispatches
+  `gm_apply_condition` with the condition's exact name (`condition_ref` — resolved via
+  `ConditionTemplate.get_by_name`, not by pk).
+- **Situation** — a placement-kind toggle between a whole `SituationTemplate`
+  (`mechanics.SituationTemplateViewSet`, pre-existing) and a single
+  `ChallengeTemplate` against a GM-named target object
+  (`mechanics.ChallengeTemplateViewSet`, pre-existing), with the same edge/setback
+  shift as Call Check on the Challenge path. Dispatches `set_situation` or
+  `place_challenge`. Both act on the GM's own room (`target_type=SELF`), so this tab
+  has no participant picker.
+
+**Wire-point:** rendered by `SceneDetailPage.tsx`, gated a second time at the mount
+site (`{scene?.viewer_can_gm && <GMAdjudicationPanel scene={scene} />}`) alongside
+`HighlightReel`.
+
 ---
 
 ## UI Composition — `/game` One Play Surface (#2156)

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -3390,6 +3390,68 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/checks/check-types/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Read-only GM catalog browse for CheckType (#3070) — the web sibling of
+     *     telnet's ``gm check find``, feeding the web GM adjudication panel's Call
+     *     Check picker.
+     *
+     *     Scoped to staff/lore-authored, active rows only: ``owner_sheet__isnull``
+     *     excludes the per-character synthesized magic check
+     *     (``ensure_character_magic_check_type`` mints one row per ``CharacterSheet``;
+     *     a player's own signature check has no place in a general catalog browse,
+     *     mirroring the #2724 export-filter rationale on the model itself).
+     *     Permission mirrors ``InvokeCatalogCheckAction``'s own gate in spirit
+     *     (``IsGMOrStaff`` — the action's ``MinimumGMLevelPrerequisite(GMLevel.SENIOR)``
+     *     is the real enforcement at invocation time; this endpoint only needs to keep
+     *     the catalog out of non-GM hands, not re-derive the exact trust tier).
+     */
+    get: operations['checks_check_types_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/checks/check-types/{id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Read-only GM catalog browse for CheckType (#3070) — the web sibling of
+     *     telnet's ``gm check find``, feeding the web GM adjudication panel's Call
+     *     Check picker.
+     *
+     *     Scoped to staff/lore-authored, active rows only: ``owner_sheet__isnull``
+     *     excludes the per-character synthesized magic check
+     *     (``ensure_character_magic_check_type`` mints one row per ``CharacterSheet``;
+     *     a player's own signature check has no place in a general catalog browse,
+     *     mirroring the #2724 export-filter rationale on the model itself).
+     *     Permission mirrors ``InvokeCatalogCheckAction``'s own gate in spirit
+     *     (``IsGMOrStaff`` — the action's ``MinimumGMLevelPrerequisite(GMLevel.SENIOR)``
+     *     is the real enforcement at invocation time; this endpoint only needs to keep
+     *     the catalog out of non-GM hands, not re-derive the exact trust tier).
+     */
+    get: operations['checks_check_types_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/checks/consequence-outcomes/': {
     parameters: {
       query?: never;
@@ -23223,6 +23285,22 @@ export interface components {
      * @enum {string}
      */
     CharacterVitalsStatusEnum: 'alive' | 'dying' | 'incapacitated' | 'dead';
+    /**
+     * @description Read-only catalog listing for the web GM check-invocation picker (#3070).
+     *
+     *     Mirrors ``InvokeCatalogCheckAction``'s own catalog rendering
+     *     (``_check_type_summary``/``_format_catalog_row`` in
+     *     ``actions/definitions/gm_adjudication.py``) so the web picker shows the same
+     *     stat+skill trait pairing a GM sees via telnet ``gm check find``.
+     */
+    CheckType: {
+      readonly id: number;
+      readonly name: string;
+      readonly category: number;
+      readonly category_name: string;
+      readonly description: string;
+      readonly trait_summary: string;
+    };
     /** @description Minimal read-only representation of a CheckType model instance. */
     CheckTypeMinimal: {
       readonly id: number;
@@ -30029,6 +30107,21 @@ export interface components {
        */
       previous?: string | null;
       results: components['schemas']['CharacterRelationshipList'][];
+    };
+    PaginatedCheckTypeList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['CheckType'][];
     };
     PaginatedCompanionList: {
       /** @example 123 */
@@ -44564,6 +44657,54 @@ export interface operations {
           [name: string]: unknown;
         };
         content?: never;
+      };
+    };
+  };
+  checks_check_types_list: {
+    parameters: {
+      query?: {
+        category?: string;
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        /** @description Number of results to return per page. */
+        page_size?: number;
+        search?: string;
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedCheckTypeList'];
+        };
+      };
+    };
+  };
+  checks_check_types_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this check type. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['CheckType'];
+        };
       };
     };
   };

--- a/frontend/src/gm-adjudication/api.ts
+++ b/frontend/src/gm-adjudication/api.ts
@@ -1,0 +1,52 @@
+/**
+ * REST reads for the GM adjudication toolkit's catalog pickers (#3070).
+ *
+ * Three of the four catalogs already existed for other surfaces
+ * (`ConditionTemplateViewSet`, `SituationTemplateViewSet`,
+ * `ChallengeTemplateViewSet`) — reused as-is. Only `CheckType` needed a new
+ * endpoint (`world/checks/views.py::CheckTypeViewSet`,
+ * `GET /api/checks/check-types/`).
+ */
+
+import { apiFetch } from '@/evennia_replacements/api';
+import type {
+  ChallengeTemplateCatalogEntry,
+  CheckTypeCatalogEntry,
+  ConditionTemplateCatalogEntry,
+  SituationTemplateCatalogEntry,
+} from './types';
+
+async function throwOnBadResponse(res: Response, fallbackMessage: string): Promise<void> {
+  if (res.ok) return;
+  throw new Error(fallbackMessage);
+}
+
+export async function getCheckTypeCatalog(search?: string): Promise<CheckTypeCatalogEntry[]> {
+  const params = new URLSearchParams({ page_size: '50' });
+  if (search) params.set('search', search);
+  const res = await apiFetch(`/api/checks/check-types/?${params.toString()}`);
+  await throwOnBadResponse(res, 'Failed to load check catalog');
+  const data = (await res.json()) as { results?: CheckTypeCatalogEntry[] };
+  return data.results ?? [];
+}
+
+export async function getConditionTemplateCatalog(): Promise<ConditionTemplateCatalogEntry[]> {
+  const res = await apiFetch('/api/conditions/templates/');
+  await throwOnBadResponse(res, 'Failed to load condition catalog');
+  // pagination_class=None on this endpoint — a bare array, not a paginated wrapper.
+  return (await res.json()) as ConditionTemplateCatalogEntry[];
+}
+
+export async function getSituationTemplateCatalog(): Promise<SituationTemplateCatalogEntry[]> {
+  const res = await apiFetch('/api/mechanics/situation-templates/?page_size=100');
+  await throwOnBadResponse(res, 'Failed to load situation catalog');
+  const data = (await res.json()) as { results?: SituationTemplateCatalogEntry[] };
+  return data.results ?? [];
+}
+
+export async function getChallengeTemplateCatalog(): Promise<ChallengeTemplateCatalogEntry[]> {
+  const res = await apiFetch('/api/mechanics/challenge-templates/?page_size=100');
+  await throwOnBadResponse(res, 'Failed to load challenge catalog');
+  const data = (await res.json()) as { results?: ChallengeTemplateCatalogEntry[] };
+  return data.results ?? [];
+}

--- a/frontend/src/gm-adjudication/queries.ts
+++ b/frontend/src/gm-adjudication/queries.ts
@@ -1,0 +1,52 @@
+/**
+ * React Query hooks for the GM adjudication toolkit's catalog pickers (#3070).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+import * as api from './api';
+
+export const gmAdjudicationKeys = {
+  all: ['gm-adjudication'] as const,
+  checkTypes: (search: string) => [...gmAdjudicationKeys.all, 'check-types', search] as const,
+  conditionTemplates: () => [...gmAdjudicationKeys.all, 'condition-templates'] as const,
+  situationTemplates: () => [...gmAdjudicationKeys.all, 'situation-templates'] as const,
+  challengeTemplates: () => [...gmAdjudicationKeys.all, 'challenge-templates'] as const,
+};
+
+/** Enabled only while the picker is open — `enabled` lets the panel defer the
+ *  fetch until a GM actually opens the relevant tab. */
+export function useCheckTypeCatalog(search: string, enabled: boolean) {
+  return useQuery({
+    queryKey: gmAdjudicationKeys.checkTypes(search),
+    queryFn: () => api.getCheckTypeCatalog(search),
+    enabled,
+    staleTime: 30_000,
+  });
+}
+
+export function useConditionTemplateCatalog(enabled: boolean) {
+  return useQuery({
+    queryKey: gmAdjudicationKeys.conditionTemplates(),
+    queryFn: () => api.getConditionTemplateCatalog(),
+    enabled,
+    staleTime: 60_000,
+  });
+}
+
+export function useSituationTemplateCatalog(enabled: boolean) {
+  return useQuery({
+    queryKey: gmAdjudicationKeys.situationTemplates(),
+    queryFn: () => api.getSituationTemplateCatalog(),
+    enabled,
+    staleTime: 60_000,
+  });
+}
+
+export function useChallengeTemplateCatalog(enabled: boolean) {
+  return useQuery({
+    queryKey: gmAdjudicationKeys.challengeTemplates(),
+    queryFn: () => api.getChallengeTemplateCatalog(),
+    enabled,
+    staleTime: 60_000,
+  });
+}

--- a/frontend/src/gm-adjudication/types.ts
+++ b/frontend/src/gm-adjudication/types.ts
@@ -1,0 +1,50 @@
+/**
+ * Types for the GM adjudication toolkit's web panel (#3070).
+ *
+ * The panel dispatches five existing REGISTRY actions
+ * (`gm_invoke_check`, `gm_award_progression`, `gm_apply_condition`,
+ * `set_situation`, `place_challenge` — `src/actions/definitions/gm_adjudication.py`
+ * / `situations.py`) via the generic REST dispatch seam
+ * (`useDispatchPlayerAction` -> `POST /api/actions/characters/{id}/dispatch/`).
+ * None of these actions carry an `ActionTemplate`, so they never appear in
+ * `get_player_actions` — the panel builds its own `ActionRef`s directly,
+ * mirroring `PersonaContextMenu.tsx`'s `challenge`/`identify` dispatches.
+ */
+
+import type { components } from '@/generated/api';
+
+/** GM catalog browse row for the Call Check picker (GET /api/checks/check-types/). */
+export type CheckTypeCatalogEntry = components['schemas']['CheckType'];
+
+/** Condition catalog row (GET /api/conditions/templates/ — bare array, no pagination). */
+export type ConditionTemplateCatalogEntry = components['schemas']['ConditionTemplate'];
+
+/** Situation catalog row (GET /api/mechanics/situation-templates/). */
+export type SituationTemplateCatalogEntry = components['schemas']['SituationTemplateList'];
+
+/** Challenge catalog row (GET /api/mechanics/challenge-templates/). */
+export type ChallengeTemplateCatalogEntry = components['schemas']['ChallengeTemplateList'];
+
+/** Mirrors `world.scenes.action_constants.DifficultyChoice` — the only bands
+ *  `gm_invoke_check` accepts (never a free integer). */
+export const DIFFICULTY_BANDS = [
+  { value: 'trivial', label: 'Trivial' },
+  { value: 'easy', label: 'Easy' },
+  { value: 'normal', label: 'Normal' },
+  { value: 'hard', label: 'Hard' },
+  { value: 'daunting', label: 'Daunting' },
+  { value: 'harrowing', label: 'Harrowing' },
+] as const;
+
+export type DifficultyBand = (typeof DIFFICULTY_BANDS)[number]['value'];
+
+/** Mirrors `GMAwardAction`'s `award_type` dispatch (`_AWARD_TYPES`). */
+export const AWARD_KINDS = [
+  { value: 'xp', label: 'XP' },
+  { value: 'development', label: 'Development Points' },
+  { value: 'favor_token', label: 'Golden Hare (Favor Token)' },
+  { value: 'stat', label: 'Stat Raise' },
+  { value: 'technique', label: 'Technique Grant' },
+] as const;
+
+export type AwardKind = (typeof AWARD_KINDS)[number]['value'];

--- a/frontend/src/scenes/components/GMAdjudicationPanel.test.tsx
+++ b/frontend/src/scenes/components/GMAdjudicationPanel.test.tsx
@@ -1,0 +1,226 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+import type { SceneDetail } from '../types';
+
+// Roster + active-character resolution (mirrors PersonaContextMenu.test.tsx)
+vi.mock('@/roster/queries', () => ({
+  useMyRosterEntriesQuery: vi.fn(() => ({
+    data: [
+      {
+        id: 1,
+        name: 'GMChar',
+        character_id: 42,
+        profile_picture_url: null,
+        primary_persona_id: null,
+        active_persona_id: null,
+      },
+    ],
+  })),
+}));
+
+vi.mock('@/store/hooks', () => ({
+  useAppSelector: vi.fn((selector: (state: unknown) => unknown) =>
+    selector({ game: { active: 'GMChar' }, auth: {} })
+  ),
+}));
+
+interface DispatchBody {
+  ref: { backend: string; registry_key: string };
+  kwargs: Record<string, unknown>;
+}
+
+const mutateAsync = vi.fn((_body: DispatchBody) =>
+  Promise.resolve({ backend: 'registry', deferred: false, success: true, message: 'Done.' })
+);
+vi.mock('@/combat/queries', () => ({
+  useDispatchPlayerAction: vi.fn((_characterId: number) => ({
+    mutateAsync,
+    isPending: false,
+  })),
+}));
+
+vi.mock('@/gm-adjudication/queries', () => ({
+  useCheckTypeCatalog: vi.fn((_search: string, _enabled: boolean) => ({
+    data: [
+      {
+        id: 7,
+        name: 'Power Strike',
+        category: 1,
+        category_name: 'Combat',
+        description: '',
+        trait_summary: 'Strength',
+      },
+    ],
+  })),
+  useConditionTemplateCatalog: vi.fn((_enabled: boolean) => ({
+    data: [{ id: 3, name: 'Winded' }],
+  })),
+  useSituationTemplateCatalog: vi.fn((_enabled: boolean) => ({
+    data: [{ id: 5, name: 'Ambush', category: 1, category_name: 'Combat' }],
+  })),
+  useChallengeTemplateCatalog: vi.fn((_enabled: boolean) => ({
+    data: [{ id: 9, name: 'Locked Gate', category: 1, category_name: 'Exploration' }],
+  })),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { GMAdjudicationPanel } from './GMAdjudicationPanel';
+import { useDispatchPlayerAction } from '@/combat/queries';
+import { toast } from 'sonner';
+
+function makeScene(overrides: Partial<SceneDetail> = {}): SceneDetail {
+  return {
+    id: 1,
+    name: 'Test Scene',
+    description: '',
+    date_started: '2026-01-01T00:00:00Z',
+    location: { id: 10, name: 'Room' },
+    participants: [],
+    is_active: true,
+    is_owner: false,
+    viewer_can_gm: true,
+    personas: [{ id: 100, name: 'Target Persona', persona_type: 'primary', character_sheet: 55 }],
+    positions: [],
+    position_adjacency: [],
+    persona_positions: [],
+    active_round: null,
+    position_nodes: [],
+    position_edges: [],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mutateAsync.mockClear();
+  (toast.success as ReturnType<typeof vi.fn>).mockClear();
+  (toast.error as ReturnType<typeof vi.fn>).mockClear();
+});
+
+test('renders nothing when the viewer cannot GM the scene', () => {
+  const { container } = render(<GMAdjudicationPanel scene={makeScene({ viewer_can_gm: false })} />);
+  expect(container).toBeEmptyDOMElement();
+});
+
+test('renders nothing while scene data has not loaded yet', () => {
+  const { container } = render(<GMAdjudicationPanel scene={undefined} />);
+  expect(container).toBeEmptyDOMElement();
+});
+
+test('renders the panel with all four tabs when the viewer can GM', () => {
+  render(<GMAdjudicationPanel scene={makeScene()} />);
+  expect(screen.getByTestId('gm-adjudication-panel')).toBeInTheDocument();
+  expect(screen.getByTestId('gm-tab-check')).toBeInTheDocument();
+  expect(screen.getByTestId('gm-tab-award')).toBeInTheDocument();
+  expect(screen.getByTestId('gm-tab-condition')).toBeInTheDocument();
+  expect(screen.getByTestId('gm-tab-situation')).toBeInTheDocument();
+});
+
+test('Call Check tab dispatches gm_invoke_check with the picked target and check', async () => {
+  const user = userEvent.setup();
+  render(<GMAdjudicationPanel scene={makeScene()} />);
+
+  await user.selectOptions(screen.getByTestId('gm-adjudication-target-select'), '55');
+  await user.selectOptions(screen.getByTestId('gm-check-type-select'), '7');
+  await user.click(screen.getByTestId('gm-check-submit'));
+
+  await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+  expect(mutateAsync).toHaveBeenCalledWith({
+    ref: { backend: 'registry', registry_key: 'gm_invoke_check' },
+    kwargs: { target: 55, check_type_ref: 7, difficulty: 'normal' },
+  });
+});
+
+test('Award tab dispatches gm_award_progression with the xp payload', async () => {
+  const user = userEvent.setup();
+  render(<GMAdjudicationPanel scene={makeScene()} />);
+
+  await user.selectOptions(screen.getByTestId('gm-adjudication-target-select'), '55');
+  await user.click(screen.getByTestId('gm-tab-award'));
+  await user.type(screen.getByLabelText('Amount'), '10');
+  await user.click(screen.getByTestId('gm-award-submit'));
+
+  await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+  expect(mutateAsync).toHaveBeenCalledWith({
+    ref: { backend: 'registry', registry_key: 'gm_award_progression' },
+    kwargs: { target: 55, award_type: 'xp', description: undefined, amount: 10 },
+  });
+});
+
+test('Condition tab dispatches gm_apply_condition with the condition name', async () => {
+  const user = userEvent.setup();
+  render(<GMAdjudicationPanel scene={makeScene()} />);
+
+  await user.selectOptions(screen.getByTestId('gm-adjudication-target-select'), '55');
+  await user.click(screen.getByTestId('gm-tab-condition'));
+  await user.selectOptions(screen.getByTestId('gm-condition-select'), 'Winded');
+  await user.click(screen.getByTestId('gm-condition-submit'));
+
+  await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+  expect(mutateAsync).toHaveBeenCalledWith({
+    ref: { backend: 'registry', registry_key: 'gm_apply_condition' },
+    kwargs: { target: 55, condition_ref: 'Winded', note: undefined },
+  });
+});
+
+test('Situation tab dispatches set_situation with no target kwarg', async () => {
+  const user = userEvent.setup();
+  render(<GMAdjudicationPanel scene={makeScene()} />);
+
+  await user.click(screen.getByTestId('gm-tab-situation'));
+  await user.selectOptions(screen.getByTestId('gm-situation-select'), '5');
+  await user.click(screen.getByTestId('gm-situation-submit'));
+
+  await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+  expect(mutateAsync).toHaveBeenCalledWith({
+    ref: { backend: 'registry', registry_key: 'set_situation' },
+    kwargs: { situation_template_id: 5 },
+  });
+});
+
+test('Situation tab in Challenge mode dispatches place_challenge with target_object_name', async () => {
+  const user = userEvent.setup();
+  render(<GMAdjudicationPanel scene={makeScene()} />);
+
+  await user.click(screen.getByTestId('gm-tab-situation'));
+  await user.selectOptions(screen.getByLabelText('Placement kind'), 'challenge');
+  await user.selectOptions(screen.getByTestId('gm-challenge-select'), '9');
+  await user.type(screen.getByLabelText('What embodies it'), 'the barred gate');
+  await user.click(screen.getByTestId('gm-situation-submit'));
+
+  await waitFor(() => expect(mutateAsync).toHaveBeenCalled());
+  expect(mutateAsync).toHaveBeenCalledWith({
+    ref: { backend: 'registry', registry_key: 'place_challenge' },
+    kwargs: { challenge_template_id: 9, target_object_name: 'the barred gate' },
+  });
+});
+
+test('a failed dispatch surfaces the refusal message via toast.error', async () => {
+  mutateAsync.mockResolvedValueOnce({
+    backend: 'registry',
+    deferred: false,
+    success: false,
+    message: 'You must hold Senior GM trust or higher.',
+  });
+  const user = userEvent.setup();
+  render(<GMAdjudicationPanel scene={makeScene()} />);
+
+  await user.selectOptions(screen.getByTestId('gm-adjudication-target-select'), '55');
+  await user.selectOptions(screen.getByTestId('gm-check-type-select'), '7');
+  await user.click(screen.getByTestId('gm-check-submit'));
+
+  await waitFor(() =>
+    expect(toast.error).toHaveBeenCalledWith('You must hold Senior GM trust or higher.')
+  );
+});
+
+test('useDispatchPlayerAction is called with the resolved active character id', () => {
+  render(<GMAdjudicationPanel scene={makeScene()} />);
+  expect(useDispatchPlayerAction).toHaveBeenCalledWith(42);
+});

--- a/frontend/src/scenes/components/GMAdjudicationPanel.tsx
+++ b/frontend/src/scenes/components/GMAdjudicationPanel.tsx
@@ -1,0 +1,599 @@
+/**
+ * GMAdjudicationPanel — the web home for the GM adjudication toolkit (#3070).
+ *
+ * Before this panel, the only way to call a check, hand out an award, apply a
+ * condition, or place a situation/challenge from the browser was to type
+ * `gm ...` into the scene composer — which poses it to the room as IC text
+ * instead of running the action. This panel dispatches the SAME five
+ * prerequisite-gated REGISTRY actions telnet's `gm`/`setsituation` commands
+ * already use (`gm_invoke_check`, `gm_award_progression`, `gm_apply_condition`,
+ * `set_situation`, `place_challenge`) directly over the generic REST dispatch
+ * seam (`useDispatchPlayerAction` -> `POST /api/actions/characters/{id}/dispatch/`),
+ * mirroring `PersonaContextMenu.tsx`'s `challenge`/`identify` items — these
+ * actions carry no `ActionTemplate`, so they never appear in the generic
+ * `get_player_actions` listing.
+ *
+ * Visibility is gated on `scene.viewer_can_gm` alone (staff, the scene's own
+ * GM, or its owner) — the same client-readable signal `HighlightReel`'s
+ * `canGm` prop and `RoundSettingsDialog` already gate on. No client-side GM
+ * *trust tier* check exists or should exist: `gm_invoke_check` requires SENIOR,
+ * the rest JUNIOR, but inventing a tier-probe API here was explicitly out of
+ * scope — a below-tier GM simply sees the backend's refusal message surface
+ * via toast, same as any other prerequisite failure.
+ *
+ * Targets are the scene's own participants (`scene.personas`), keyed by
+ * `character_sheet` — a `CharacterSheet`'s pk equals its owning `ObjectDB`'s
+ * pk (shared-pk O2O), so that id is exactly what `gm_invoke_check`/
+ * `gm_award_progression`/`gm_apply_condition`'s `target` kwarg expects
+ * (resolved server-side by `_resolve_gm_target`, `actions/definitions/
+ * gm_adjudication.py`). `set_situation`/`place_challenge` act on the GM's own
+ * room instead (`target_type=SELF`) and so have no target picker.
+ */
+
+import { useMemo, useState } from 'react';
+import { toast } from 'sonner';
+import { useAppSelector } from '@/store/hooks';
+import { useMyRosterEntriesQuery } from '@/roster/queries';
+import { useDispatchPlayerAction } from '@/combat/queries';
+import { isDispatchFailure } from '@/combat/types';
+import type { DispatchResult } from '@/combat/types';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import { Button } from '@/components/ui/button';
+import type { SceneDetail, ScenePersona } from '../types';
+import {
+  useCheckTypeCatalog,
+  useConditionTemplateCatalog,
+  useSituationTemplateCatalog,
+  useChallengeTemplateCatalog,
+} from '@/gm-adjudication/queries';
+import { AWARD_KINDS, DIFFICULTY_BANDS } from '@/gm-adjudication/types';
+import type { AwardKind, DifficultyBand } from '@/gm-adjudication/types';
+
+const SELECT_CLASS =
+  'flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm focus:outline-none focus:ring-1 focus:ring-ring disabled:cursor-not-allowed disabled:opacity-50';
+
+function reportResult(result: DispatchResult, fallbackSuccess: string): void {
+  if (isDispatchFailure(result)) {
+    toast.error(result.message ?? 'The action was refused.');
+    return;
+  }
+  toast.success(result.message ?? fallbackSuccess);
+}
+
+// ---------------------------------------------------------------------------
+// Participant picker — shared by the target-taking tabs (Check/Award/Condition)
+// ---------------------------------------------------------------------------
+
+interface ParticipantPickerProps {
+  personas: ScenePersona[];
+  targetCharacterId: number | null;
+  onChange: (characterId: number | null) => void;
+}
+
+function ParticipantPicker({ personas, targetCharacterId, onChange }: ParticipantPickerProps) {
+  const withCharacter = personas.filter((p) => p.character_sheet != null);
+  return (
+    <div className="space-y-1">
+      <Label htmlFor="gm-adjudication-target">Target</Label>
+      <select
+        id="gm-adjudication-target"
+        className={SELECT_CLASS}
+        value={targetCharacterId ?? ''}
+        onChange={(e) => onChange(e.target.value ? Number(e.target.value) : null)}
+        data-testid="gm-adjudication-target-select"
+      >
+        <option value="">Select a participant…</option>
+        {withCharacter.map((p) => (
+          <option key={p.id} value={p.character_sheet as number}>
+            {p.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Call Check tab
+// ---------------------------------------------------------------------------
+
+interface TabProps {
+  characterId: number;
+  targetCharacterId: number | null;
+}
+
+function CallCheckTab({ characterId, targetCharacterId }: TabProps) {
+  const [search, setSearch] = useState('');
+  const [checkTypeId, setCheckTypeId] = useState<number | null>(null);
+  const [difficulty, setDifficulty] = useState<DifficultyBand>('normal');
+  const [shiftKind, setShiftKind] = useState<'' | 'edge' | 'setback'>('');
+  const [shiftReason, setShiftReason] = useState('');
+  const { data: checkTypes = [] } = useCheckTypeCatalog(search, true);
+  const dispatch = useDispatchPlayerAction(characterId);
+
+  const canSubmit = targetCharacterId !== null && checkTypeId !== null && !dispatch.isPending;
+
+  function handleSubmit() {
+    if (!canSubmit) return;
+    const kwargs: Record<string, unknown> = {
+      target: targetCharacterId,
+      check_type_ref: checkTypeId,
+      difficulty,
+    };
+    if (shiftKind === 'edge') kwargs.edge_reason = shiftReason;
+    if (shiftKind === 'setback') kwargs.setback_reason = shiftReason;
+    dispatch
+      .mutateAsync({ ref: { backend: 'registry', registry_key: 'gm_invoke_check' }, kwargs })
+      .then((result) => reportResult(result, 'Check invoked.'))
+      .catch(() => toast.error('Could not invoke the check.'));
+  }
+
+  return (
+    <div className="space-y-3" data-testid="gm-adjudication-check-tab">
+      <div className="space-y-1">
+        <Label htmlFor="gm-check-search">Check</Label>
+        <Input
+          id="gm-check-search"
+          placeholder="Search the check catalog…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select
+          className={SELECT_CLASS}
+          value={checkTypeId ?? ''}
+          onChange={(e) => setCheckTypeId(e.target.value ? Number(e.target.value) : null)}
+          data-testid="gm-check-type-select"
+        >
+          <option value="">Select a check…</option>
+          {checkTypes.map((ct) => (
+            <option key={ct.id} value={ct.id}>
+              {ct.name}
+              {ct.trait_summary ? ` (${ct.trait_summary})` : ''}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor="gm-check-difficulty">Difficulty</Label>
+        <select
+          id="gm-check-difficulty"
+          className={SELECT_CLASS}
+          value={difficulty}
+          onChange={(e) => setDifficulty(e.target.value as DifficultyBand)}
+        >
+          {DIFFICULTY_BANDS.map((band) => (
+            <option key={band.value} value={band.value}>
+              {band.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor="gm-check-shift">Shift</Label>
+        <select
+          id="gm-check-shift"
+          className={SELECT_CLASS}
+          value={shiftKind}
+          onChange={(e) => setShiftKind(e.target.value as '' | 'edge' | 'setback')}
+        >
+          <option value="">No shift</option>
+          <option value="edge">Edge (one band easier)</option>
+          <option value="setback">Setback (one band harder)</option>
+        </select>
+        {shiftKind !== '' && (
+          <Input
+            placeholder="Why?"
+            value={shiftReason}
+            onChange={(e) => setShiftReason(e.target.value)}
+            data-testid="gm-check-shift-reason"
+          />
+        )}
+      </div>
+      <Button disabled={!canSubmit} onClick={handleSubmit} data-testid="gm-check-submit">
+        {dispatch.isPending ? 'Invoking…' : 'Invoke Check'}
+      </Button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Award tab
+// ---------------------------------------------------------------------------
+
+function AwardTab({ characterId, targetCharacterId }: TabProps) {
+  const [kind, setKind] = useState<AwardKind>('xp');
+  const [amount, setAmount] = useState('');
+  const [description, setDescription] = useState('');
+  const [traitRef, setTraitRef] = useState('');
+  const [orgRef, setOrgRef] = useState('');
+  const [techniqueRef, setTechniqueRef] = useState('');
+  const dispatch = useDispatchPlayerAction(characterId);
+
+  const canSubmit = targetCharacterId !== null && !dispatch.isPending;
+
+  function handleSubmit() {
+    if (!canSubmit) return;
+    const kwargs: Record<string, unknown> = {
+      target: targetCharacterId,
+      award_type: kind,
+      description: description || undefined,
+    };
+    if (kind === 'xp' || kind === 'development') kwargs.amount = Number(amount);
+    if (kind === 'development' || kind === 'stat') kwargs.trait_ref = traitRef;
+    if (kind === 'favor_token') kwargs.org_ref = orgRef;
+    if (kind === 'technique') kwargs.technique_ref = techniqueRef;
+    dispatch
+      .mutateAsync({ ref: { backend: 'registry', registry_key: 'gm_award_progression' }, kwargs })
+      .then((result) => reportResult(result, 'Award granted.'))
+      .catch(() => toast.error('Could not grant the award.'));
+  }
+
+  return (
+    <div className="space-y-3" data-testid="gm-adjudication-award-tab">
+      <div className="space-y-1">
+        <Label htmlFor="gm-award-kind">Award kind</Label>
+        <select
+          id="gm-award-kind"
+          className={SELECT_CLASS}
+          value={kind}
+          onChange={(e) => setKind(e.target.value as AwardKind)}
+        >
+          {AWARD_KINDS.map((k) => (
+            <option key={k.value} value={k.value}>
+              {k.label}
+            </option>
+          ))}
+        </select>
+      </div>
+      {(kind === 'xp' || kind === 'development') && (
+        <div className="space-y-1">
+          <Label htmlFor="gm-award-amount">Amount</Label>
+          <Input
+            id="gm-award-amount"
+            type="number"
+            min={1}
+            value={amount}
+            onChange={(e) => setAmount(e.target.value)}
+          />
+        </div>
+      )}
+      {(kind === 'development' || kind === 'stat') && (
+        <div className="space-y-1">
+          <Label htmlFor="gm-award-trait">Trait</Label>
+          <Input
+            id="gm-award-trait"
+            placeholder="Trait name"
+            value={traitRef}
+            onChange={(e) => setTraitRef(e.target.value)}
+          />
+        </div>
+      )}
+      {kind === 'favor_token' && (
+        <div className="space-y-1">
+          <Label htmlFor="gm-award-org">Organization</Label>
+          <Input
+            id="gm-award-org"
+            placeholder="Organization name"
+            value={orgRef}
+            onChange={(e) => setOrgRef(e.target.value)}
+          />
+        </div>
+      )}
+      {kind === 'technique' && (
+        <div className="space-y-1">
+          <Label htmlFor="gm-award-technique">Technique</Label>
+          <Input
+            id="gm-award-technique"
+            placeholder="Technique name"
+            value={techniqueRef}
+            onChange={(e) => setTechniqueRef(e.target.value)}
+          />
+        </div>
+      )}
+      <div className="space-y-1">
+        <Label htmlFor="gm-award-description">Description</Label>
+        <Input
+          id="gm-award-description"
+          placeholder="Why this award?"
+          value={description}
+          onChange={(e) => setDescription(e.target.value)}
+        />
+      </div>
+      <Button disabled={!canSubmit} onClick={handleSubmit} data-testid="gm-award-submit">
+        {dispatch.isPending ? 'Granting…' : 'Grant Award'}
+      </Button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Condition tab
+// ---------------------------------------------------------------------------
+
+function ConditionTab({ characterId, targetCharacterId }: TabProps) {
+  const [conditionName, setConditionName] = useState('');
+  const [severity, setSeverity] = useState('');
+  const [durationRounds, setDurationRounds] = useState('');
+  const [note, setNote] = useState('');
+  const { data: conditions = [] } = useConditionTemplateCatalog(true);
+  const dispatch = useDispatchPlayerAction(characterId);
+
+  const canSubmit = targetCharacterId !== null && conditionName !== '' && !dispatch.isPending;
+
+  function handleSubmit() {
+    if (!canSubmit) return;
+    const kwargs: Record<string, unknown> = {
+      target: targetCharacterId,
+      condition_ref: conditionName,
+      note: note || undefined,
+    };
+    if (severity) kwargs.severity = Number(severity);
+    if (durationRounds) kwargs.duration_rounds = Number(durationRounds);
+    dispatch
+      .mutateAsync({ ref: { backend: 'registry', registry_key: 'gm_apply_condition' }, kwargs })
+      .then((result) => reportResult(result, 'Condition applied.'))
+      .catch(() => toast.error('Could not apply the condition.'));
+  }
+
+  return (
+    <div className="space-y-3" data-testid="gm-adjudication-condition-tab">
+      <div className="space-y-1">
+        <Label htmlFor="gm-condition-select">Condition</Label>
+        <select
+          id="gm-condition-select"
+          className={SELECT_CLASS}
+          value={conditionName}
+          onChange={(e) => setConditionName(e.target.value)}
+          data-testid="gm-condition-select"
+        >
+          <option value="">Select a condition…</option>
+          {conditions.map((c) => (
+            <option key={c.id} value={c.name}>
+              {c.name}
+            </option>
+          ))}
+        </select>
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor="gm-condition-severity">Severity (optional)</Label>
+        <Input
+          id="gm-condition-severity"
+          type="number"
+          min={1}
+          value={severity}
+          onChange={(e) => setSeverity(e.target.value)}
+        />
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor="gm-condition-duration">Duration in rounds (optional)</Label>
+        <Input
+          id="gm-condition-duration"
+          type="number"
+          min={1}
+          value={durationRounds}
+          onChange={(e) => setDurationRounds(e.target.value)}
+        />
+      </div>
+      <div className="space-y-1">
+        <Label htmlFor="gm-condition-note">Note</Label>
+        <Input
+          id="gm-condition-note"
+          placeholder="Narration only — never a mechanical effect"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+        />
+      </div>
+      <Button disabled={!canSubmit} onClick={handleSubmit} data-testid="gm-condition-submit">
+        {dispatch.isPending ? 'Applying…' : 'Apply Condition'}
+      </Button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Situation / Challenge placement tab — acts on the GM's own room, no target
+// ---------------------------------------------------------------------------
+
+function SituationTab({ characterId }: { characterId: number }) {
+  const [placementKind, setPlacementKind] = useState<'situation' | 'challenge'>('situation');
+  const [situationId, setSituationId] = useState<number | null>(null);
+  const [challengeId, setChallengeId] = useState<number | null>(null);
+  const [targetObjectName, setTargetObjectName] = useState('');
+  const [shiftKind, setShiftKind] = useState<'' | 'edge' | 'setback'>('');
+  const [shiftReason, setShiftReason] = useState('');
+  const { data: situations = [] } = useSituationTemplateCatalog(placementKind === 'situation');
+  const { data: challenges = [] } = useChallengeTemplateCatalog(placementKind === 'challenge');
+  const dispatch = useDispatchPlayerAction(characterId);
+
+  const canSubmit =
+    !dispatch.isPending &&
+    (placementKind === 'situation'
+      ? situationId !== null
+      : challengeId !== null && targetObjectName.trim() !== '');
+
+  function handleSubmit() {
+    if (!canSubmit) return;
+    if (placementKind === 'situation') {
+      dispatch
+        .mutateAsync({
+          ref: { backend: 'registry', registry_key: 'set_situation' },
+          kwargs: { situation_template_id: situationId },
+        })
+        .then((result) => reportResult(result, 'Situation placed.'))
+        .catch(() => toast.error('Could not place the situation.'));
+      return;
+    }
+    const kwargs: Record<string, unknown> = {
+      challenge_template_id: challengeId,
+      target_object_name: targetObjectName.trim(),
+    };
+    if (shiftKind === 'edge') kwargs.edge_reason = shiftReason;
+    if (shiftKind === 'setback') kwargs.setback_reason = shiftReason;
+    dispatch
+      .mutateAsync({ ref: { backend: 'registry', registry_key: 'place_challenge' }, kwargs })
+      .then((result) => reportResult(result, 'Challenge placed.'))
+      .catch(() => toast.error('Could not place the challenge.'));
+  }
+
+  return (
+    <div className="space-y-3" data-testid="gm-adjudication-situation-tab">
+      <div className="space-y-1">
+        <Label htmlFor="gm-placement-kind">Placement kind</Label>
+        <select
+          id="gm-placement-kind"
+          className={SELECT_CLASS}
+          value={placementKind}
+          onChange={(e) => setPlacementKind(e.target.value as 'situation' | 'challenge')}
+        >
+          <option value="situation">Whole Situation</option>
+          <option value="challenge">Single Challenge</option>
+        </select>
+      </div>
+      {placementKind === 'situation' ? (
+        <div className="space-y-1">
+          <Label htmlFor="gm-situation-select">Situation</Label>
+          <select
+            id="gm-situation-select"
+            className={SELECT_CLASS}
+            value={situationId ?? ''}
+            onChange={(e) => setSituationId(e.target.value ? Number(e.target.value) : null)}
+            data-testid="gm-situation-select"
+          >
+            <option value="">Select a situation…</option>
+            {situations.map((s) => (
+              <option key={s.id} value={s.id}>
+                {s.name}
+              </option>
+            ))}
+          </select>
+        </div>
+      ) : (
+        <>
+          <div className="space-y-1">
+            <Label htmlFor="gm-challenge-select">Challenge</Label>
+            <select
+              id="gm-challenge-select"
+              className={SELECT_CLASS}
+              value={challengeId ?? ''}
+              onChange={(e) => setChallengeId(e.target.value ? Number(e.target.value) : null)}
+              data-testid="gm-challenge-select"
+            >
+              <option value="">Select a challenge…</option>
+              {challenges.map((c) => (
+                <option key={c.id} value={c.id}>
+                  {c.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="gm-challenge-target-name">What embodies it</Label>
+            <Input
+              id="gm-challenge-target-name"
+              placeholder="e.g. the barred gate"
+              value={targetObjectName}
+              onChange={(e) => setTargetObjectName(e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label htmlFor="gm-challenge-shift">Shift</Label>
+            <select
+              id="gm-challenge-shift"
+              className={SELECT_CLASS}
+              value={shiftKind}
+              onChange={(e) => setShiftKind(e.target.value as '' | 'edge' | 'setback')}
+            >
+              <option value="">No shift</option>
+              <option value="edge">Edge (one band easier)</option>
+              <option value="setback">Setback (one band harder)</option>
+            </select>
+            {shiftKind !== '' && (
+              <Input
+                placeholder="Why?"
+                value={shiftReason}
+                onChange={(e) => setShiftReason(e.target.value)}
+              />
+            )}
+          </div>
+        </>
+      )}
+      <Button disabled={!canSubmit} onClick={handleSubmit} data-testid="gm-situation-submit">
+        {dispatch.isPending
+          ? 'Placing…'
+          : placementKind === 'situation'
+            ? 'Place Situation'
+            : 'Place Challenge'}
+      </Button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Panel shell
+// ---------------------------------------------------------------------------
+
+interface GMAdjudicationPanelProps {
+  scene: SceneDetail | undefined;
+}
+
+export function GMAdjudicationPanel({ scene }: GMAdjudicationPanelProps) {
+  const activeCharacterName = useAppSelector((state) => state.game.active);
+  const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
+  const characterId = useMemo(
+    () => myRosterEntries.find((e) => e.name === activeCharacterName)?.character_id ?? null,
+    [myRosterEntries, activeCharacterName]
+  );
+  const [targetCharacterId, setTargetCharacterId] = useState<number | null>(null);
+
+  if (!scene?.viewer_can_gm || characterId === null) {
+    return null;
+  }
+
+  const personas = scene.personas ?? [];
+
+  return (
+    <Card data-testid="gm-adjudication-panel">
+      <CardHeader>
+        <CardTitle className="text-base">GM Tools</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <ParticipantPicker
+          personas={personas}
+          targetCharacterId={targetCharacterId}
+          onChange={setTargetCharacterId}
+        />
+        <Tabs defaultValue="check">
+          <TabsList>
+            <TabsTrigger value="check" data-testid="gm-tab-check">
+              Call Check
+            </TabsTrigger>
+            <TabsTrigger value="award" data-testid="gm-tab-award">
+              Award
+            </TabsTrigger>
+            <TabsTrigger value="condition" data-testid="gm-tab-condition">
+              Condition
+            </TabsTrigger>
+            <TabsTrigger value="situation" data-testid="gm-tab-situation">
+              Situation
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="check">
+            <CallCheckTab characterId={characterId} targetCharacterId={targetCharacterId} />
+          </TabsContent>
+          <TabsContent value="award">
+            <AwardTab characterId={characterId} targetCharacterId={targetCharacterId} />
+          </TabsContent>
+          <TabsContent value="condition">
+            <ConditionTab characterId={characterId} targetCharacterId={targetCharacterId} />
+          </TabsContent>
+          <TabsContent value="situation">
+            <SituationTab characterId={characterId} />
+          </TabsContent>
+        </Tabs>
+      </CardContent>
+    </Card>
+  );
+}

--- a/frontend/src/scenes/pages/SceneDetailPage.tsx
+++ b/frontend/src/scenes/pages/SceneDetailPage.tsx
@@ -31,6 +31,7 @@ import { RitualProposedChip } from '@/rituals/components/RitualProposedChip';
 import { useEncounterForScene } from '@/combat/queries';
 import { CombatRail } from '@/combat/components/CombatRail';
 import { LinkedStoriesPanel } from '@/crossover/components/LinkedStoriesPanel';
+import { GMAdjudicationPanel } from '../components/GMAdjudicationPanel';
 
 export function SceneDetailPage() {
   const { id = '' } = useParams();
@@ -211,6 +212,11 @@ export function SceneDetailPage() {
         <SceneTacticalMap sceneId={id} />
         <HighlightReel sceneId={id} canGm={scene?.viewer_can_gm} />
         {scene && <LinkedStoriesPanel sceneId={id} />}
+        {scene?.viewer_can_gm && (
+          <div className="mt-2">
+            <GMAdjudicationPanel scene={scene} />
+          </div>
+        )}
       </div>
 
       {/* Combat rail fold-in (#2197): a two-column C-frame grid (mirroring the

--- a/src/actions/definitions/gm_adjudication.py
+++ b/src/actions/definitions/gm_adjudication.py
@@ -48,6 +48,27 @@ _AWARD_TYPES = (
 )
 
 
+def _resolve_gm_target(kwargs: dict[str, Any]) -> ObjectDB | None:
+    """Resolve the ``target`` kwarg to an ``ObjectDB`` character (#3070).
+
+    Telnet always passes an already-resolved ``ObjectDB``. The web REST dispatch
+    path (``dispatch_player_action`` -> ``_dispatch_registry``) does no ObjectDB
+    resolution of its own -- ``objectdb_target_kwargs`` only helps the *websocket*
+    inputfunc, and only for wire keys ending in ``_id`` (see ``actions/CLAUDE.md``).
+    Resolve a plain int pk here too, mirroring ``identification._resolve_identify_target``.
+    Unlike that resolver, no persona indirection is needed: a ``CharacterSheet``'s pk
+    equals its ``ObjectDB``'s pk (shared-pk O2O), so the web GM panel sends the
+    target character's id directly -- the same id the scene payload's
+    ``personas[].character_sheet`` field already carries.
+    """
+    from evennia.objects.models import ObjectDB  # noqa: PLC0415
+
+    target = kwargs.get("target")
+    if target is None or isinstance(target, ObjectDB):
+        return target
+    return ObjectDB.objects.filter(pk=target).first()
+
+
 def _check_type_summary(check_type: CheckType) -> str:
     """Return the "stat+skill" trait pairing summary for a catalog listing row."""
     names = [
@@ -139,9 +160,11 @@ class InvokeCatalogCheckAction(Action):
         context: ActionContext | None = None,
         **kwargs: Any,
     ) -> ActionResult:
-        target = kwargs.get("target")
-        if target is None:
+        if kwargs.get("target") is None:
             return self._find(kwargs)
+        target = _resolve_gm_target(kwargs)
+        if target is None:
+            return ActionResult(success=False, message="No such target.")
         return self._invoke(target, kwargs)
 
     def _find(self, kwargs: dict[str, Any]) -> ActionResult:
@@ -258,7 +281,7 @@ class GMAwardAction(Action):
         context: ActionContext | None = None,
         **kwargs: Any,
     ) -> ActionResult:
-        target = kwargs.get("target")
+        target = _resolve_gm_target(kwargs)
         if target is None:
             return ActionResult(success=False, message="A target character is required.")
 
@@ -551,7 +574,7 @@ def _resolve_condition_target(kwargs: dict[str, Any]) -> tuple[Any, Any] | Actio
     """
     from world.conditions.models import ConditionTemplate  # noqa: PLC0415
 
-    target = kwargs.get("target")
+    target = _resolve_gm_target(kwargs)
     if target is None:
         return ActionResult(success=False, message="A target character is required.")
 

--- a/src/actions/tests/test_gm_adjudication_actions.py
+++ b/src/actions/tests/test_gm_adjudication_actions.py
@@ -383,6 +383,59 @@ class InvokeCatalogCheckActionFindTests(GMAdjudicationActionsTestBase):
         self.assertFalse(result.success)
 
 
+class RESTTargetResolutionTests(GMAdjudicationActionsTestBase):
+    """The REST dispatch path (``dispatch_player_action`` -> ``_dispatch_registry``)
+    sends a plain int ``target`` -- no ObjectDB resolution happens before
+    ``execute()`` (#3070; see ``actions/CLAUDE.md``'s ``objectdb_target_kwargs``
+    note). Each action must resolve that int itself. A ``CharacterSheet``'s pk
+    equals its owning ``ObjectDB``'s pk, so the frontend sends the target
+    character's plain pk directly -- exactly what these tests pass.
+    """
+
+    def test_invoke_check_resolves_int_target(self) -> None:
+        result = InvokeCatalogCheckAction().run(
+            actor=self.gm_actor,
+            target=self.target.pk,
+            check_type_ref=self.check_type.name,
+            difficulty=DifficultyChoice.NORMAL,
+        )
+        self.assertTrue(result.success, result.message)
+        self.assertIn(self.target.key, result.message)
+
+    def test_invoke_check_int_target_that_does_not_resolve_fails_loud(self) -> None:
+        result = InvokeCatalogCheckAction().run(
+            actor=self.gm_actor,
+            target=999999999,
+            check_type_ref=self.check_type.name,
+            difficulty=DifficultyChoice.NORMAL,
+        )
+        self.assertFalse(result.success)
+
+    def test_award_xp_resolves_int_target(self) -> None:
+        result = GMAwardAction().run(
+            actor=self.gm_actor,
+            target=self.target.pk,
+            award_type="xp",
+            amount=10,
+        )
+        self.assertTrue(result.success, result.message)
+        xp_data = ExperiencePointsData.objects.get(account=self.target_account)
+        self.assertEqual(xp_data.total_earned, 10)
+
+    def test_apply_condition_resolves_int_target(self) -> None:
+        result = GMApplyConditionAction().run(
+            actor=self.gm_actor,
+            target=self.target.pk,
+            condition_ref=self.condition_template.name,
+        )
+        self.assertTrue(result.success, result.message)
+        self.assertTrue(
+            ConditionInstance.objects.filter(
+                target=self.target, condition=self.condition_template
+            ).exists()
+        )
+
+
 class GMAwardActionTests(GMAdjudicationActionsTestBase):
     def test_non_gm_is_refused(self) -> None:
         result = GMAwardAction().run(

--- a/src/schema.json
+++ b/src/schema.json
@@ -5013,6 +5013,90 @@ paths:
       responses:
         '200':
           description: No response body
+  /api/checks/check-types/:
+    get:
+      operationId: checks_check_types_list
+      description: |-
+        Read-only GM catalog browse for CheckType (#3070) — the web sibling of
+        telnet's ``gm check find``, feeding the web GM adjudication panel's Call
+        Check picker.
+
+        Scoped to staff/lore-authored, active rows only: ``owner_sheet__isnull``
+        excludes the per-character synthesized magic check
+        (``ensure_character_magic_check_type`` mints one row per ``CharacterSheet``;
+        a player's own signature check has no place in a general catalog browse,
+        mirroring the #2724 export-filter rationale on the model itself).
+        Permission mirrors ``InvokeCatalogCheckAction``'s own gate in spirit
+        (``IsGMOrStaff`` — the action's ``MinimumGMLevelPrerequisite(GMLevel.SENIOR)``
+        is the real enforcement at invocation time; this endpoint only needs to keep
+        the catalog out of non-GM hands, not re-derive the exact trust tier).
+      parameters:
+      - in: query
+        name: category
+        schema:
+          type: string
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - name: page_size
+        required: false
+        in: query
+        description: Number of results to return per page.
+        schema:
+          type: integer
+      - in: query
+        name: search
+        schema:
+          type: string
+      tags:
+      - checks
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedCheckTypeList'
+          description: ''
+  /api/checks/check-types/{id}/:
+    get:
+      operationId: checks_check_types_retrieve
+      description: |-
+        Read-only GM catalog browse for CheckType (#3070) — the web sibling of
+        telnet's ``gm check find``, feeding the web GM adjudication panel's Call
+        Check picker.
+
+        Scoped to staff/lore-authored, active rows only: ``owner_sheet__isnull``
+        excludes the per-character synthesized magic check
+        (``ensure_character_magic_check_type`` mints one row per ``CharacterSheet``;
+        a player's own signature check has no place in a general catalog browse,
+        mirroring the #2724 export-filter rationale on the model itself).
+        Permission mirrors ``InvokeCatalogCheckAction``'s own gate in spirit
+        (``IsGMOrStaff`` — the action's ``MinimumGMLevelPrerequisite(GMLevel.SENIOR)``
+        is the real enforcement at invocation time; this endpoint only needs to keep
+        the catalog out of non-GM hands, not re-derive the exact trust tier).
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this check type.
+        required: true
+      tags:
+      - checks
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CheckType'
+          description: ''
   /api/checks/consequence-outcomes/:
     get:
       operationId: checks_consequence_outcomes_list
@@ -39278,6 +39362,41 @@ components:
         * `dying` - dying
         * `incapacitated` - incapacitated
         * `dead` - dead
+    CheckType:
+      type: object
+      description: |-
+        Read-only catalog listing for the web GM check-invocation picker (#3070).
+
+        Mirrors ``InvokeCatalogCheckAction``'s own catalog rendering
+        (``_check_type_summary``/``_format_catalog_row`` in
+        ``actions/definitions/gm_adjudication.py``) so the web picker shows the same
+        stat+skill trait pairing a GM sees via telnet ``gm check find``.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        name:
+          type: string
+          readOnly: true
+        category:
+          type: integer
+          readOnly: true
+        category_name:
+          type: string
+          readOnly: true
+        description:
+          type: string
+          readOnly: true
+        trait_summary:
+          type: string
+          readOnly: true
+      required:
+      - category
+      - category_name
+      - description
+      - id
+      - name
+      - trait_summary
     CheckTypeMinimal:
       type: object
       description: Minimal read-only representation of a CheckType model instance.
@@ -53197,6 +53316,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CharacterRelationshipList'
+    PaginatedCheckTypeList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/CheckType'
     PaginatedCompanionList:
       type: object
       required:

--- a/src/world/checks/filters.py
+++ b/src/world/checks/filters.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+from django.db.models import Q, QuerySet
 import django_filters
 
+from world.checks.models import CheckType
 from world.checks.outcome_models import ConsequenceOutcome
 
 
@@ -35,3 +37,30 @@ class ConsequenceOutcomeFilter(django_filters.FilterSet):
     class Meta:
         model = ConsequenceOutcome
         fields = ["character", "pool", "created_after", "created_before", "encounter"]
+
+
+class CheckTypeFilter(django_filters.FilterSet):
+    """Filter for the CheckType catalog browse endpoint (#3070).
+
+    ``search`` mirrors ``InvokeCatalogCheckAction._search_catalog``'s
+    name/description/trait-name matching, so the web picker and telnet
+    ``gm check find`` surface the same rows for the same query.
+    """
+
+    search = django_filters.CharFilter(method="filter_search")
+    category = django_filters.CharFilter(field_name="category__name", lookup_expr="iexact")
+
+    def filter_search(self, queryset: QuerySet[CheckType], name: str, value: str) -> QuerySet:
+        del name
+        value = value.strip()
+        if not value:
+            return queryset
+        return queryset.filter(
+            Q(name__icontains=value)
+            | Q(description__icontains=value)
+            | Q(traits__trait__name__icontains=value)
+        ).distinct()
+
+    class Meta:
+        model = CheckType
+        fields = ["category"]

--- a/src/world/checks/serializers.py
+++ b/src/world/checks/serializers.py
@@ -8,11 +8,40 @@ from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from world.checks.constants import ModifierSourceKind
+from world.checks.models import CheckType
 from world.checks.outcome_models import ConsequenceOutcome, ConsequenceOutcomeModifier
 from world.checks.outcome_utils import build_outcome_display
 
 # Provenance kinds scoped to staff reads.
 _STAFF_ONLY_SOURCE_KINDS = frozenset({ModifierSourceKind.ROLLMOD})
+
+
+class CheckTypeSerializer(serializers.ModelSerializer):
+    """Read-only catalog listing for the web GM check-invocation picker (#3070).
+
+    Mirrors ``InvokeCatalogCheckAction``'s own catalog rendering
+    (``_check_type_summary``/``_format_catalog_row`` in
+    ``actions/definitions/gm_adjudication.py``) so the web picker shows the same
+    stat+skill trait pairing a GM sees via telnet ``gm check find``.
+    """
+
+    category_name = serializers.CharField(source="category.name", read_only=True)
+    trait_summary = serializers.SerializerMethodField()
+
+    class Meta:
+        model = CheckType
+        fields = ["id", "name", "category", "category_name", "description", "trait_summary"]
+        read_only_fields = fields
+
+    def get_trait_summary(self, obj: CheckType) -> str:
+        # Reads the ViewSet's ``to_attr="cached_traits"`` Prefetch when present
+        # (list/retrieve via CheckTypeViewSet); falls back to a live query
+        # otherwise (e.g. a serializer used directly in a test).
+        traits = getattr(obj, "cached_traits", None)  # noqa: GETATTR_LITERAL - Prefetch(to_attr=...) sets this
+        if traits is None:
+            traits = obj.traits.select_related("trait").order_by("-weight")
+        names = [ctt.trait.name for ctt in traits]
+        return " + ".join(names) if names else ""
 
 
 class ConsequenceOutcomeModifierSerializer(serializers.ModelSerializer):

--- a/src/world/checks/tests/test_check_type_api.py
+++ b/src/world/checks/tests/test_check_type_api.py
@@ -1,0 +1,138 @@
+"""Tests for the CheckType catalog read API (#3070).
+
+Covers the GM-only permission gate, active/owner_sheet scoping, and the
+``search``/``category`` filters -- the web sibling of telnet's
+``gm check find``, feeding the GM adjudication panel's Call Check picker.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.test import TestCase
+from rest_framework.test import APIClient
+
+from evennia_extensions.factories import AccountFactory, CharacterFactory
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.factories import CheckCategoryFactory, CheckTypeFactory, CheckTypeTraitFactory
+from world.checks.models import CheckType
+from world.gm.constants import GMLevel
+from world.gm.factories import GMProfileFactory
+from world.traits.constants import TraitCategory, TraitType
+from world.traits.factories import TraitFactory
+
+
+class CheckTypeAPISetupMixin:
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.category = CheckCategoryFactory(name="AdjudicationCombat")
+        cls.check_type = CheckTypeFactory(
+            name="Power Strike",
+            category=cls.category,
+            description="A heavy blow",
+        )
+        cls.trait = TraitFactory(
+            name="adj_api_strength", trait_type=TraitType.STAT, category=TraitCategory.PHYSICAL
+        )
+        CheckTypeTraitFactory(check_type=cls.check_type, trait=cls.trait, weight=Decimal("1.0"))
+        cls.inactive_check_type = CheckTypeFactory(
+            name="Retired Check", category=cls.category, is_active=False
+        )
+
+        cls.owner_char = CharacterFactory()
+        cls.owner_sheet = CharacterSheetFactory(character=cls.owner_char)
+        cls.synthesized_check_type = CheckTypeFactory(
+            name="Signature Magic Check", category=cls.category, owner_sheet=cls.owner_sheet
+        )
+
+        cls.gm_account = AccountFactory()
+        GMProfileFactory(account=cls.gm_account, level=GMLevel.JUNIOR)
+        cls.staff_account = AccountFactory(is_staff=True)
+        cls.player_account = AccountFactory()
+
+
+class CheckTypeAPIPermissionTests(CheckTypeAPISetupMixin, TestCase):
+    def test_anonymous_is_refused(self) -> None:
+        client = APIClient()
+        response = client.get("/api/checks/check-types/")
+        self.assertEqual(response.status_code, 403)
+
+    def test_non_gm_player_is_refused(self) -> None:
+        client = APIClient()
+        client.force_authenticate(user=self.player_account)
+        response = client.get("/api/checks/check-types/")
+        self.assertEqual(response.status_code, 403)
+
+    def test_gm_may_list(self) -> None:
+        client = APIClient()
+        client.force_authenticate(user=self.gm_account)
+        response = client.get("/api/checks/check-types/")
+        self.assertEqual(response.status_code, 200)
+
+    def test_staff_may_list(self) -> None:
+        client = APIClient()
+        client.force_authenticate(user=self.staff_account)
+        response = client.get("/api/checks/check-types/")
+        self.assertEqual(response.status_code, 200)
+
+
+class CheckTypeAPIListTests(CheckTypeAPISetupMixin, TestCase):
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.gm_account)
+
+    def test_active_check_type_is_listed(self) -> None:
+        response = self.client.get("/api/checks/check-types/")
+        self.assertEqual(response.status_code, 200)
+        names = [row["name"] for row in response.json()["results"]]
+        self.assertIn(self.check_type.name, names)
+
+    def test_inactive_check_type_is_excluded(self) -> None:
+        response = self.client.get("/api/checks/check-types/")
+        names = [row["name"] for row in response.json()["results"]]
+        self.assertNotIn(self.inactive_check_type.name, names)
+
+    def test_synthesized_owner_sheet_check_type_is_excluded(self) -> None:
+        """A per-character synthesized magic check never appears in the general
+        catalog browse (#2724 export-filter rationale, mirrored here)."""
+        response = self.client.get("/api/checks/check-types/")
+        names = [row["name"] for row in response.json()["results"]]
+        self.assertNotIn(self.synthesized_check_type.name, names)
+
+    def test_trait_summary_lists_weighted_traits(self) -> None:
+        response = self.client.get("/api/checks/check-types/")
+        row = next(r for r in response.json()["results"] if r["name"] == self.check_type.name)
+        self.assertIn(self.trait.name, row["trait_summary"])
+
+    def test_search_by_name_matches(self) -> None:
+        response = self.client.get("/api/checks/check-types/", {"search": "Power"})
+        names = [row["name"] for row in response.json()["results"]]
+        self.assertIn(self.check_type.name, names)
+
+    def test_search_by_trait_name_matches(self) -> None:
+        response = self.client.get("/api/checks/check-types/", {"search": self.trait.name})
+        names = [row["name"] for row in response.json()["results"]]
+        self.assertIn(self.check_type.name, names)
+
+    def test_search_with_no_matches_returns_empty(self) -> None:
+        response = self.client.get("/api/checks/check-types/", {"search": "zzz_no_such_check"})
+        self.assertEqual(response.json()["results"], [])
+
+    def test_category_filter(self) -> None:
+        other_category = CheckCategoryFactory(name="AdjudicationOther")
+        other_check_type = CheckTypeFactory(name="Other Check", category=other_category)
+        response = self.client.get("/api/checks/check-types/", {"category": other_category.name})
+        names = [row["name"] for row in response.json()["results"]]
+        self.assertIn(other_check_type.name, names)
+        self.assertNotIn(self.check_type.name, names)
+
+
+class CheckTypeAPIQuerysetSanityTests(CheckTypeAPISetupMixin, TestCase):
+    def test_queryset_excludes_synthesized_at_model_level(self) -> None:
+        """Belt-and-suspenders: the ViewSet's own queryset (not just the API
+        response) never includes an owner_sheet row."""
+        from world.checks.views import CheckTypeViewSet
+
+        qs = CheckTypeViewSet.queryset
+        self.assertFalse(qs.filter(pk=self.synthesized_check_type.pk).exists())
+        self.assertTrue(CheckType.objects.filter(pk=self.synthesized_check_type.pk).exists())

--- a/src/world/checks/urls.py
+++ b/src/world/checks/urls.py
@@ -2,9 +2,10 @@
 
 from rest_framework.routers import DefaultRouter
 
-from world.checks.views import ConsequenceOutcomeViewSet
+from world.checks.views import CheckTypeViewSet, ConsequenceOutcomeViewSet
 
 router = DefaultRouter()
+router.register("check-types", CheckTypeViewSet, basename="check-type")
 router.register("consequence-outcomes", ConsequenceOutcomeViewSet, basename="consequence-outcome")
 
 app_name = "checks"

--- a/src/world/checks/views.py
+++ b/src/world/checks/views.py
@@ -8,9 +8,11 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.viewsets import ReadOnlyModelViewSet
 
 from actions.models.consequence_pools import ConsequencePoolEntry
-from world.checks.filters import ConsequenceOutcomeFilter
+from world.checks.filters import CheckTypeFilter, ConsequenceOutcomeFilter
+from world.checks.models import CheckType, CheckTypeTrait
 from world.checks.outcome_models import ConsequenceOutcome, ConsequenceOutcomeModifier
-from world.checks.serializers import ConsequenceOutcomeSerializer
+from world.checks.serializers import CheckTypeSerializer, ConsequenceOutcomeSerializer
+from world.gm.permissions import IsGMOrStaff
 from world.mechanics.models import ApproachConsequence, ChallengeTemplateConsequence
 from world.stories.pagination import StandardResultsSetPagination
 
@@ -39,6 +41,41 @@ _TEMPLATE_CONSEQUENCES_PREFETCH = Prefetch(
     "challenge_record__challenge_instance__template__challenge_consequences",
     queryset=ChallengeTemplateConsequence.objects.select_related("consequence__outcome_tier"),
 )
+
+
+class CheckTypeViewSet(ReadOnlyModelViewSet):
+    """Read-only GM catalog browse for CheckType (#3070) — the web sibling of
+    telnet's ``gm check find``, feeding the web GM adjudication panel's Call
+    Check picker.
+
+    Scoped to staff/lore-authored, active rows only: ``owner_sheet__isnull``
+    excludes the per-character synthesized magic check
+    (``ensure_character_magic_check_type`` mints one row per ``CharacterSheet``;
+    a player's own signature check has no place in a general catalog browse,
+    mirroring the #2724 export-filter rationale on the model itself).
+    Permission mirrors ``InvokeCatalogCheckAction``'s own gate in spirit
+    (``IsGMOrStaff`` — the action's ``MinimumGMLevelPrerequisite(GMLevel.SENIOR)``
+    is the real enforcement at invocation time; this endpoint only needs to keep
+    the catalog out of non-GM hands, not re-derive the exact trust tier).
+    """
+
+    queryset = (
+        CheckType.objects.filter(is_active=True, owner_sheet__isnull=True)
+        .select_related("category")
+        .prefetch_related(
+            Prefetch(
+                "traits",
+                queryset=CheckTypeTrait.objects.select_related("trait").order_by("-weight"),
+                to_attr="cached_traits",
+            )
+        )
+        .order_by("category__display_order", "display_order", "name")
+    )
+    serializer_class = CheckTypeSerializer
+    permission_classes = [IsGMOrStaff]
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = CheckTypeFilter
+    pagination_class = StandardResultsSetPagination
 
 
 class ConsequenceOutcomeViewSet(ReadOnlyModelViewSet):

--- a/tools/noqa_ratchet_baseline.txt
+++ b/tools/noqa_ratchet_baseline.txt
@@ -4,6 +4,6 @@
 # reviewed exception — justify it in the commit message.
 # Plain tokens count '# noqa: <TOKEN>' suppressions; 'pattern:' tokens count
 # the regexes defined in lint_noqa_ratchet.py's PATTERNS map.
-GETATTR_LITERAL 63
+GETATTR_LITERAL 64
 pattern:BARE_OBJECTDB_CREATE 2
 pattern:BROAD_EXCEPT 113


### PR DESCRIPTION
Closes #3070.

## What

A GM can now actually run a session from the browser. New `GMAdjudicationPanel` on the scene page (gated on `scene.viewer_can_gm`), four tabs over the existing prerequisite-gated actions:

- **Call Check** — searchable authored-CheckType picker + difficulty band + edge/setback reason → `gm_invoke_check` (curated-catalog invariant preserved by construction: the UI only offers catalog rows)
- **Award** — all five GMAwardAction kinds (xp / development / Golden Hare / stat / technique, the last two fresh from #3072)
- **Condition** — ConditionTemplate picker + severity/duration/note → `gm_apply_condition`
- **Situation/Challenge** — authored template placement → `set_situation` / `place_challenge`

Dispatch rides the existing REGISTRY REST seam (`useDispatchPlayerAction`), mirroring `PersonaContextMenu`'s pattern — no availability-adapter needed since these actions carry free-form inputs.

## Backend wiring (no new game behavior)

- The REST dispatch path does no ObjectDB resolution, so the three target-taking actions gained the precedented int-resolution fallback (`_resolve_gm_target`, mirroring `identification._resolve_identify_target`); the panel sends plain character ids (CharacterSheet shares ObjectDB's pk). Four new tests call `.run()` with plain ints to prove the wire shape.
- One new read-only catalog endpoint: `GET /api/checks/check-types/` (`IsGMOrStaff`, search/category filters, active non-synthesized rows only). ConditionTemplate/SituationTemplate/ChallengeTemplate ViewSets already existed and are reused.
- Schema + generated api types regenerated and committed.

## Tests

Backend 70 green (57 gm_adjudication incl. int-target shapes; 13 new CheckType API). Frontend: 10 vitest for the panel (GM gate, per-tab payloads); tsc -b, eslint, prettier, vite build all clean.

## Notes

- Trait/org/technique award refs are pk-or-name text inputs matching telnet grammar — no general Trait list endpoint exists and one wasn't worth building for three fields.
- No client-side trust-tier probe: below-tier dispatches surface the backend's own refusal via toast (the prerequisites are the real gate).
- The composer's gm-commands-as-IC-prose trap is mooted by giving GMs a real panel; composer behavior untouched.
- Pre-existing unrelated flake noted: `test_legend_award_handler` stale SQLite schema cache, untouched by this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
