### PR TITLE
Sonar S1192: constants for duplicated model-label literals in mechanics, missions, checks

### DIFF
--- a/src/world/checks/models.py
+++ b/src/world/checks/models.py
@@ -13,6 +13,9 @@ from world.checks.constants import EffectTarget, EffectType, PositionDestination
 from world.checks.outcome_models import ConsequenceOutcome, ConsequenceOutcomeModifier  # noqa: F401
 from world.contributors.models import CreditedContent
 
+_CHECK_TYPE_MODEL = "arxii.CheckType"
+_CHECK_OUTCOME_MODEL = "arxii.CheckOutcome"
+
 
 class OutcomeTierAward(SharedMemoryModel):
     """Shared base: one authored scalar per graded CheckOutcome tier.
@@ -27,7 +30,7 @@ class OutcomeTierAward(SharedMemoryModel):
     """
 
     outcome_tier = models.OneToOneField(
-        "arxii.CheckOutcome",
+        _CHECK_OUTCOME_MODEL,
         on_delete=models.PROTECT,
         related_name="%(app_label)s_%(class)s",
     )
@@ -125,7 +128,7 @@ class CheckTypeTrait(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["check_type", "trait"]
-        dependencies = ["arxii.CheckType", "arxii.Trait"]
+        dependencies = [_CHECK_TYPE_MODEL, "arxii.Trait"]
 
     class Meta:
         unique_together = ["check_type", "trait"]
@@ -162,7 +165,7 @@ class CheckTypeCapabilityModifier(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["check_type", "capability"]
-        dependencies = ["arxii.CheckType", "arxii.CapabilityType"]
+        dependencies = [_CHECK_TYPE_MODEL, "arxii.CapabilityType"]
 
     class Meta:
         unique_together = ["check_type", "capability"]
@@ -195,7 +198,7 @@ class CheckTypeAspect(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["check_type", "aspect"]
-        dependencies = ["arxii.CheckType", "arxii.Aspect"]
+        dependencies = [_CHECK_TYPE_MODEL, "arxii.Aspect"]
 
     class Meta:
         unique_together = ["check_type", "aspect"]
@@ -236,7 +239,7 @@ class CheckTypeSpecialization(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["check_type", "specialization"]
-        dependencies = ["arxii.CheckType", "arxii.Specialization"]
+        dependencies = [_CHECK_TYPE_MODEL, "arxii.Specialization"]
 
     class Meta:
         unique_together = ["check_type", "specialization"]
@@ -277,10 +280,10 @@ class Consequence(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["outcome_tier", "label"]
-        dependencies = ["arxii.CheckOutcome"]
+        dependencies = [_CHECK_OUTCOME_MODEL]
 
     outcome_tier = models.ForeignKey(
-        "arxii.CheckOutcome",
+        _CHECK_OUTCOME_MODEL,
         on_delete=models.CASCADE,
         related_name="consequences",
     )

--- a/src/world/mechanics/models.py
+++ b/src/world/mechanics/models.py
@@ -44,6 +44,10 @@ from world.scenes.action_constants import (
 _DAMAGE_TYPE_MODEL_PATH = "arxii.DamageType"
 _CONSEQUENCE_POOL_MODEL = "arxii.ConsequencePool"
 _CHALLENGE_TEMPLATE_MODEL = "arxii.ChallengeTemplate"
+_TRAIT_MODEL = "arxii.Trait"
+_CAPABILITY_TYPE_MODEL = "arxii.CapabilityType"
+_CHECK_TYPE_MODEL = "arxii.CheckType"
+_CONSEQUENCE_MODEL = "arxii.Consequence"
 
 
 class ModifierCategoryManager(NaturalKeyManager):
@@ -139,7 +143,7 @@ class ModifierTarget(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         ),
     )
     target_trait = models.ForeignKey(
-        "arxii.Trait",
+        _TRAIT_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -165,7 +169,7 @@ class ModifierTarget(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         help_text="The resonance this target represents (resonance category only).",
     )
     target_capability = models.OneToOneField(
-        "arxii.CapabilityType",
+        _CAPABILITY_TYPE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -173,7 +177,7 @@ class ModifierTarget(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         help_text="The capability this target represents (capability category only).",
     )
     target_check_type = models.OneToOneField(
-        "arxii.CheckType",
+        _CHECK_TYPE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -744,7 +748,7 @@ class Application(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
 
     name = models.CharField(max_length=100)
     capability = models.ForeignKey(
-        "arxii.CapabilityType",
+        _CAPABILITY_TYPE_MODEL,
         on_delete=models.CASCADE,
         related_name="applications",
     )
@@ -807,12 +811,12 @@ class TraitCapabilityDerivation(NaturalKeyMixin, SharedMemoryModel):
     """
 
     trait = models.ForeignKey(
-        "arxii.Trait",
+        _TRAIT_MODEL,
         on_delete=models.CASCADE,
         related_name="capability_derivations",
     )
     capability = models.ForeignKey(
-        "arxii.CapabilityType",
+        _CAPABILITY_TYPE_MODEL,
         on_delete=models.CASCADE,
         related_name="trait_derivations",
     )
@@ -835,7 +839,7 @@ class TraitCapabilityDerivation(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["trait", "capability"]
-        dependencies = ["arxii.Trait", "arxii.CapabilityType"]
+        dependencies = [_TRAIT_MODEL, _CAPABILITY_TYPE_MODEL]
 
     def __str__(self) -> str:
         return f"{self.trait.name} → {self.capability.name}"
@@ -909,7 +913,7 @@ class ChallengeTemplate(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         default=ChallengeType.INHIBITOR,
     )
     blocked_capability = models.ForeignKey(
-        "arxii.CapabilityType",
+        _CAPABILITY_TYPE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -921,7 +925,7 @@ class ChallengeTemplate(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         default=DiscoveryType.OBVIOUS,
     )
     consequences = models.ManyToManyField(
-        "arxii.Consequence",
+        _CONSEQUENCE_MODEL,
         through="ChallengeTemplateConsequence",
         related_name="challenge_templates",
         blank=True,
@@ -973,7 +977,7 @@ class ChallengeTemplateConsequence(SharedMemoryModel):
         related_name="challenge_consequences",
     )
     consequence = models.ForeignKey(
-        "arxii.Consequence",
+        _CONSEQUENCE_MODEL,
         on_delete=models.CASCADE,
         related_name="challenge_template_consequences",
     )
@@ -1023,7 +1027,7 @@ class ChallengeApproach(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         related_name="challenge_approaches",
     )
     check_type = models.ForeignKey(
-        "arxii.CheckType",
+        _CHECK_TYPE_MODEL,
         on_delete=models.CASCADE,
         related_name="challenge_approaches",
     )
@@ -1092,7 +1096,7 @@ class ApproachConsequence(SharedMemoryModel):
         related_name="consequences",
     )
     consequence = models.ForeignKey(
-        "arxii.Consequence",
+        _CONSEQUENCE_MODEL,
         on_delete=models.CASCADE,
         related_name="approach_consequences",
     )
@@ -1237,12 +1241,12 @@ class SituationTrapLink(NaturalKeyMixin, SharedMemoryModel):
         related_name="situation_trap_links",
     )
     detect_check_type = models.ForeignKey(
-        "arxii.CheckType",
+        _CHECK_TYPE_MODEL,
         on_delete=models.PROTECT,
         related_name="detect_situation_traps",
     )
     disarm_check_type = models.ForeignKey(
-        "arxii.CheckType",
+        _CHECK_TYPE_MODEL,
         on_delete=models.PROTECT,
         related_name="disarm_situation_traps",
     )
@@ -1415,7 +1419,7 @@ class CharacterChallengeRecord(SharedMemoryModel):
         related_name="challenge_records",
     )
     consequence = models.ForeignKey(
-        "arxii.Consequence",
+        _CONSEQUENCE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1455,7 +1459,7 @@ class ContextConsequencePool(SharedMemoryModel):
         related_name="context_attachments",
     )
     check_type = models.ForeignKey(
-        "arxii.CheckType",
+        _CHECK_TYPE_MODEL,
         on_delete=models.PROTECT,
         null=True,
         blank=True,

--- a/src/world/missions/models.py
+++ b/src/world/missions/models.py
@@ -63,6 +63,9 @@ _CONSEQUENCE_FK = "arxii.Consequence"
 # Lazy model references (Django app_label.ModelName), extracted to satisfy S1192.
 OBJECT_DB_MODEL = "objects.ObjectDB"
 ROOM_PROFILE_MODEL = "arxii.RoomProfile"
+_CHECK_TYPE_MODEL = "arxii.CheckType"
+_CHECK_OUTCOME_MODEL = "arxii.CheckOutcome"
+_NPC_SERVICE_OFFER_MODEL = "arxii.NPCServiceOffer"
 CHARACTER_SHEET_MODEL = "arxii.CharacterSheet"
 
 # #1035 — the durable (non-transient) ExternalAct members. Mirrors
@@ -527,7 +530,7 @@ class MissionOption(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         help_text="Phase 0 predicate tree gating this option's visibility.",
     )
     authored_check_type = models.ForeignKey(
-        "arxii.CheckType",
+        _CHECK_TYPE_MODEL,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -780,7 +783,7 @@ class MissionOptionRoute(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         related_name="routes",
     )
     outcome_tier = models.ForeignKey(
-        "arxii.CheckOutcome",
+        _CHECK_OUTCOME_MODEL,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -1015,7 +1018,7 @@ class MissionOptionRouteReward(NaturalKeyMixin, CreditedContent, SharedMemoryMod
         help_text="Required when sink=ITEM: which ItemTemplate this reward grants.",
     )
     followon_offer = models.ForeignKey(
-        "arxii.NPCServiceOffer",
+        _NPC_SERVICE_OFFER_MODEL,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -1438,7 +1441,7 @@ class MissionInstance(SharedMemoryModel):
     # Used to scope the CharacterSheet.max_active_npc_missions cap to
     # NPC-mediated runs only.
     source_offer = models.ForeignKey(
-        "arxii.NPCServiceOffer",
+        _NPC_SERVICE_OFFER_MODEL,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -1726,7 +1729,7 @@ class MissionDeedRecord(SharedMemoryModel):
         related_name="+",
     )
     outcome = models.ForeignKey(
-        "arxii.CheckOutcome",
+        _CHECK_OUTCOME_MODEL,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -1800,7 +1803,7 @@ class MissionAssistPattern(SharedMemoryModel):
         ),
     )
     check_types = models.ManyToManyField(
-        "arxii.CheckType",
+        _CHECK_TYPE_MODEL,
         blank=True,
         related_name="assist_patterns",
         help_text="Context axis: match when the node has a CHECK option using any of these.",
@@ -1814,7 +1817,7 @@ class MissionAssistPattern(SharedMemoryModel):
         ),
     )
     support_check_type = models.ForeignKey(
-        "arxii.CheckType",
+        _CHECK_TYPE_MODEL,
         on_delete=models.PROTECT,
         related_name="+",
         help_text="The CheckType rolled when a helper declares this support move.",
@@ -1828,7 +1831,7 @@ class MissionAssistPattern(SharedMemoryModel):
         help_text="Bonus added to the resolving check on success (retunable, can be negative).",
     )
     complication_consequence = models.ForeignKey(
-        "arxii.Consequence",
+        _CONSEQUENCE_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1890,7 +1893,7 @@ class MissionNodeSupportOption(SharedMemoryModel):
         help_text="Predicate-tree leg. Empty dict = no predicate gate.",
     )
     support_check_type = models.ForeignKey(
-        "arxii.CheckType",
+        _CHECK_TYPE_MODEL,
         on_delete=models.PROTECT,
         related_name="+",
         help_text="The CheckType rolled when a helper declares this support move.",
@@ -1898,7 +1901,7 @@ class MissionNodeSupportOption(SharedMemoryModel):
     difficulty = models.PositiveSmallIntegerField(default=5)
     easing = models.IntegerField(default=2)
     complication_consequence = models.ForeignKey(
-        "arxii.Consequence",
+        _CONSEQUENCE_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1967,7 +1970,7 @@ class MissionSupportDeclaration(SharedMemoryModel):
         related_name="+",
     )
     outcome = models.ForeignKey(
-        "arxii.CheckOutcome",
+        _CHECK_OUTCOME_MODEL,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -2228,7 +2231,7 @@ class MissionDeedRewardLine(SharedMemoryModel):
         help_text="Required when sink=ITEM: which ItemTemplate this reward grants.",
     )
     followon_offer = models.ForeignKey(
-        "arxii.NPCServiceOffer",
+        _NPC_SERVICE_OFFER_MODEL,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -2348,7 +2351,7 @@ class MissionRiskAcknowledgement(SharedMemoryModel):
     """
 
     offer = models.ForeignKey(
-        "arxii.NPCServiceOffer",
+        _NPC_SERVICE_OFFER_MODEL,
         on_delete=models.CASCADE,
         related_name="mission_risk_acknowledgements",
     )


### PR DESCRIPTION
Closes #3138
Closes #3139
Closes #3140
Closes #3141
Closes #3142
Closes #3143
Closes #3144
Closes #3145
Closes #3098
Closes #3116

## Summary

SonarCloud `python:S1192` cleanup (batch 1 of 4): the duplicated `"arxii.X"` lazy model-reference literals in `world/mechanics/models.py`, `world/missions/models.py` and `world/checks/models.py` now go through module-level `_X_MODEL` constants, the same convention those files (and `justice`, `currency`, `worship`, etc.) already use for their other lazy FK references. `missions/models.py` already had `_CONSEQUENCE_FK`; two uses that had drifted back to the bare literal now use it.

No behavior change: the constants hold the identical strings, so Django resolves the same models and no migration is generated (`Check Django migrations` hook passed).

## Follow-ups filed

(none)

## Notes

- Spec/design phase: skipped (lint-fix issues; no design decisions)
- Tests: `just test-fast world.mechanics world.missions world.checks` - 1622 tests, OK
- Sync-with-main: branched from main tip 953396ad6; no re-sync needed (merge queue re-integrates)

<!-- last-addressed-comment: 0 -->
