### PR TITLE
Sonar S1192: constants for duplicated model-label literals in magic, combat, covenants

### DIFF
--- a/src/world/combat/factories.py
+++ b/src/world/combat/factories.py
@@ -79,6 +79,7 @@ from world.magic.factories import TechniqueFactory
 # SonarCloud smell (python:S1192).
 _CHARACTER_SHEET_FACTORY = "world.character_sheets.factories.CharacterSheetFactory"
 _ROOM_TYPECLASS = "typeclasses.rooms.Room"
+_TRIGGER_DEFINITION_MODEL = "arxii.TriggerDefinition"
 
 
 class CombatEncounterFactory(factory_django.DjangoModelFactory):
@@ -1663,7 +1664,7 @@ class EscalationSpikeOnIncapacitatedTriggerDefinitionFactory(factory_django.Djan
     """
 
     class Meta:
-        model = "arxii.TriggerDefinition"
+        model = _TRIGGER_DEFINITION_MODEL
         django_get_or_create = ("name",)
 
     name = "escalation_spike_on_incapacitated"
@@ -1677,7 +1678,7 @@ class EscalationSpikeOnKilledTriggerDefinitionFactory(factory_django.DjangoModel
     """TriggerDefinition for the CHARACTER_KILLED escalation spike (#872)."""
 
     class Meta:
-        model = "arxii.TriggerDefinition"
+        model = _TRIGGER_DEFINITION_MODEL
         django_get_or_create = ("name",)
 
     name = "escalation_spike_on_killed"
@@ -1724,7 +1725,7 @@ class EscalationSpikeOnMortalPerilTriggerDefinitionFactory(factory_django.Django
     """
 
     class Meta:
-        model = "arxii.TriggerDefinition"
+        model = _TRIGGER_DEFINITION_MODEL
         django_get_or_create = ("name",)
 
     name = "escalation_spike_on_mortal_peril"
@@ -1775,7 +1776,7 @@ class EncounterBeatTriggerDefinitionFactory(factory_django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.TriggerDefinition"
+        model = _TRIGGER_DEFINITION_MODEL
         django_get_or_create = ("name",)
 
     name = "encounter_completed_beat_wiring"

--- a/src/world/covenants/models.py
+++ b/src/world/covenants/models.py
@@ -61,6 +61,7 @@ COVENANT_MODEL = "arxii.Covenant"
 COVENANT_ROLE_MODEL = "arxii.CovenantRole"
 CHARACTER_SHEET_MODEL = "arxii.CharacterSheet"
 CONDITION_TEMPLATE_MODEL = "arxii.ConditionTemplate"
+MODIFIER_TARGET_MODEL = "arxii.ModifierTarget"
 GIFT_MODEL = "arxii.Gift"
 VOW_SITUATIONAL_PERK_MODEL = "arxii.VowSituationalPerk"
 
@@ -140,7 +141,7 @@ class Covenant(SharedMemoryModel):
         ),
     )
     leader = models.ForeignKey(
-        "arxii.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -919,7 +920,7 @@ class CovenantLevelBonus(SharedMemoryModel):
     """
 
     modifier_target = models.ForeignKey(
-        "arxii.ModifierTarget",
+        MODIFIER_TARGET_MODEL,
         on_delete=models.CASCADE,
         related_name="covenant_level_bonuses",
     )
@@ -970,7 +971,7 @@ class VowStatScaling(NaturalKeyMixin, SharedMemoryModel):
         related_name="vow_stat_scalings",
     )
     modifier_target = models.ForeignKey(
-        "arxii.ModifierTarget",
+        MODIFIER_TARGET_MODEL,
         on_delete=models.CASCADE,
         related_name="vow_stat_scalings",
     )
@@ -994,7 +995,7 @@ class VowStatScaling(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["covenant_role", "modifier_target"]
-        dependencies = [COVENANT_ROLE_MODEL, "arxii.ModifierTarget"]
+        dependencies = [COVENANT_ROLE_MODEL, MODIFIER_TARGET_MODEL]
 
     def __str__(self) -> str:
         return (
@@ -1235,7 +1236,7 @@ class CovenantRoleBonus(NaturalKeyMixin, SharedMemoryModel):
         related_name="role_bonuses",
     )
     modifier_target = models.ForeignKey(
-        "arxii.ModifierTarget",
+        MODIFIER_TARGET_MODEL,
         on_delete=models.CASCADE,
         related_name="covenant_role_bonuses",
     )
@@ -1259,7 +1260,7 @@ class CovenantRoleBonus(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["covenant_role", "modifier_target"]
-        dependencies = [COVENANT_ROLE_MODEL, "arxii.ModifierTarget"]
+        dependencies = [COVENANT_ROLE_MODEL, MODIFIER_TARGET_MODEL]
 
     def __str__(self) -> str:
         return (

--- a/src/world/magic/factories.py
+++ b/src/world/magic/factories.py
@@ -126,6 +126,8 @@ _PAYLOAD_PARAM = "@payload"
 _MAGIC_PROGRESSION_PATH = "/magic/progression"
 # SubFactory import paths, extracted to satisfy S1192.
 _DISTINCTION_FACTORY = "world.distinctions.factories.DistinctionFactory"
+_CONDITION_TEMPLATE_MODEL = "arxii.ConditionTemplate"
+_RITUAL_MODEL = "arxii.Ritual"
 
 logger = logging.getLogger(__name__)
 
@@ -2110,7 +2112,7 @@ class CorruptionConditionTemplateFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.ConditionTemplate"
+        model = _CONDITION_TEMPLATE_MODEL
         django_get_or_create = ("corruption_resonance",)
 
     name = factory.LazyAttribute(lambda o: f"Corrupted by {o.corruption_resonance.name}")
@@ -2275,7 +2277,7 @@ class TetherStrainTemplateFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.ConditionTemplate"
+        model = _CONDITION_TEMPLATE_MODEL
         django_get_or_create = ("name",)
 
     name = "Tether Strain"
@@ -2334,7 +2336,7 @@ class SoulTetherActiveTemplateFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.ConditionTemplate"
+        model = _CONDITION_TEMPLATE_MODEL
         django_get_or_create = ("name",)
 
     name = "Soul Tether Active"
@@ -2364,7 +2366,7 @@ class AcceptSoulTetherRitualFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "accept_soul_tether"
@@ -2427,7 +2429,7 @@ class SoulTetherRescueRitualFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "soul_tether_rescue"
@@ -3532,7 +3534,7 @@ class CovenantFormationRitualFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "Covenant Formation"
@@ -3586,7 +3588,7 @@ class CovenantInductionRitualFactory(factory.django.DjangoModelFactory):
     """Factory for the covenant induction ritual."""
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "Covenant Induction"
@@ -3637,7 +3639,7 @@ class OrganizationInductionRitualFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "Organization Induction"
@@ -3666,7 +3668,7 @@ class RenewTheOathRitualFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "Renew the Oath"
@@ -3692,7 +3694,7 @@ class BattleCovenantRiseRitualFactory(factory.django.DjangoModelFactory):
     """Factory for the 'call the banners' battle-covenant rise ritual (Slice E)."""
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "Call the Banners"
@@ -3737,7 +3739,7 @@ class MentorsVowRitualFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "Mentor's Vow"
@@ -4331,7 +4333,7 @@ class RitualOfTheDuranceFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "Ritual of the Durance"

--- a/src/world/magic/models/gifts.py
+++ b/src/world/magic/models/gifts.py
@@ -13,6 +13,8 @@ from world.contributors.models import CreditedContent
 from world.magic.constants import AcquisitionOrigin, GiftKind
 from world.magic.models.affinity import Resonance
 
+_CHARACTER_SHEET_MODEL = "arxii.CharacterSheet"
+
 
 class GiftManager(NaturalKeyManager):
     """Manager for Gift with natural key support."""
@@ -73,7 +75,7 @@ class Gift(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         help_text="Resonances associated with this gift.",
     )
     creator = models.ForeignKey(
-        "arxii.CharacterSheet",
+        _CHARACTER_SHEET_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -195,7 +197,7 @@ class CharacterGift(SharedMemoryModel):
     """
 
     character = models.ForeignKey(
-        "arxii.CharacterSheet",
+        _CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="character_gifts",
         help_text="The character who knows this gift.",
@@ -300,7 +302,7 @@ class CharacterTradition(SharedMemoryModel):
     """
 
     character = models.ForeignKey(
-        "arxii.CharacterSheet",
+        _CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="character_traditions",
         help_text="The character who belongs to this tradition.",

--- a/src/world/magic/models/grants.py
+++ b/src/world/magic/models/grants.py
@@ -24,6 +24,7 @@ _DISTINCTION_MODEL = "arxii.Distinction"
 _PATH_MODEL = "arxii.Path"
 _GIFT_MODEL = "arxii.Gift"
 _TRADITION_MODEL = "arxii.Tradition"
+_RITUAL_MODEL = "arxii.Ritual"
 
 
 class BeginningsRitualGrant(SharedMemoryModel):
@@ -35,7 +36,7 @@ class BeginningsRitualGrant(SharedMemoryModel):
         related_name="ritual_grants",
     )
     ritual = models.ForeignKey(
-        "arxii.Ritual",
+        _RITUAL_MODEL,
         on_delete=models.CASCADE,
         related_name="+",
     )
@@ -65,7 +66,7 @@ class PathRitualGrant(models.Model):  # noqa: SHARED_MEMORY
         related_name="ritual_grants",
     )
     ritual = models.ForeignKey(
-        "arxii.Ritual",
+        _RITUAL_MODEL,
         on_delete=models.CASCADE,
         related_name="+",
     )
@@ -222,7 +223,7 @@ class DistinctionRitualGrant(SharedMemoryModel):
         related_name="ritual_grants",
     )
     ritual = models.ForeignKey(
-        "arxii.Ritual",
+        _RITUAL_MODEL,
         on_delete=models.CASCADE,
         related_name="+",
     )
@@ -352,7 +353,7 @@ class TraditionRitualGrant(SharedMemoryModel):
         related_name="ritual_grants",
     )
     ritual = models.ForeignKey(
-        "arxii.Ritual",
+        _RITUAL_MODEL,
         on_delete=models.CASCADE,
         related_name="+",
     )
@@ -384,7 +385,7 @@ class CodexEntryRitualGrant(SharedMemoryModel):
         related_name="ritual_grants",
     )
     ritual = models.ForeignKey(
-        "arxii.Ritual",
+        _RITUAL_MODEL,
         on_delete=models.CASCADE,
         related_name="+",
     )

--- a/src/world/magic/models/soul_tether.py
+++ b/src/world/magic/models/soul_tether.py
@@ -5,6 +5,11 @@ from __future__ import annotations
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+_CHARACTER_SHEET_MODEL = "arxii.CharacterSheet"
+_CHARACTER_RELATIONSHIP_MODEL = "arxii.CharacterRelationship"
+_SCENE_MODEL = "arxii.Scene"
+_RESONANCE_MODEL = "arxii.Resonance"
+
 
 class SineatingPendingOffer(SharedMemoryModel):
     """Pending Sineating offer awaiting Sineater response (Task 1.6).
@@ -25,27 +30,27 @@ class SineatingPendingOffer(SharedMemoryModel):
     """
 
     sinner_sheet = models.ForeignKey(
-        "arxii.CharacterSheet",
+        _CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="sineating_offers_sent",
     )
     sineater_sheet = models.ForeignKey(
-        "arxii.CharacterSheet",
+        _CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="sineating_offers_received",
     )
     relationship = models.ForeignKey(
-        "arxii.CharacterRelationship",
+        _CHARACTER_RELATIONSHIP_MODEL,
         on_delete=models.CASCADE,
         related_name="sineating_pending_offers",
     )
     scene = models.ForeignKey(
-        "arxii.Scene",
+        _SCENE_MODEL,
         on_delete=models.CASCADE,
         related_name="sineating_pending_offers",
     )
     resonance = models.ForeignKey(
-        "arxii.Resonance",
+        _RESONANCE_MODEL,
         on_delete=models.PROTECT,
         related_name="sineating_pending_offers",
     )
@@ -92,28 +97,28 @@ class PendingStageAdvanceOffer(SharedMemoryModel):
     """
 
     sinner_sheet = models.ForeignKey(
-        "arxii.CharacterSheet",
+        _CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="stage_advance_offers_sent",
     )
     sineater_sheet = models.ForeignKey(
-        "arxii.CharacterSheet",
+        _CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="stage_advance_offers_received",
     )
     relationship = models.ForeignKey(
-        "arxii.CharacterRelationship",
+        _CHARACTER_RELATIONSHIP_MODEL,
         on_delete=models.CASCADE,
         related_name="pending_stage_advance_offers",
     )
     scene = models.ForeignKey(
-        "arxii.Scene",
+        _SCENE_MODEL,
         on_delete=models.CASCADE,
         related_name="pending_stage_advance_offers",
         help_text="Active scene at prompt time. Row is only written when a shared scene is found.",
     )
     resonance = models.ForeignKey(
-        "arxii.Resonance",
+        _RESONANCE_MODEL,
         on_delete=models.PROTECT,
         related_name="pending_stage_advance_offers",
     )
@@ -154,29 +159,29 @@ class Sineating(SharedMemoryModel):
     """
 
     sinner_sheet = models.ForeignKey(
-        "arxii.CharacterSheet",
+        _CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="sineatings_as_sinner",
     )
     sineater_sheet = models.ForeignKey(
-        "arxii.CharacterSheet",
+        _CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="sineatings_as_sineater",
     )
     relationship = models.ForeignKey(
-        "arxii.CharacterRelationship",
+        _CHARACTER_RELATIONSHIP_MODEL,
         on_delete=models.PROTECT,
         related_name="sineatings",
     )
     scene = models.ForeignKey(
-        "arxii.Scene",
+        _SCENE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
         related_name="sineatings",
     )
     resonance = models.ForeignKey(
-        "arxii.Resonance",
+        _RESONANCE_MODEL,
         on_delete=models.PROTECT,
         related_name="sineatings",
     )
@@ -206,29 +211,29 @@ class SoulTetherRescue(SharedMemoryModel):
     """Audit row for a stage-3+ rescue ritual (Spec B §9, §14.1)."""
 
     sinner_sheet = models.ForeignKey(
-        "arxii.CharacterSheet",
+        _CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="rescues_as_sinner",
     )
     sineater_sheet = models.ForeignKey(
-        "arxii.CharacterSheet",
+        _CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="rescues_as_sineater",
     )
     relationship = models.ForeignKey(
-        "arxii.CharacterRelationship",
+        _CHARACTER_RELATIONSHIP_MODEL,
         on_delete=models.PROTECT,
         related_name="rescues",
     )
     scene = models.ForeignKey(
-        "arxii.Scene",
+        _SCENE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
         related_name="rescues",
     )
     resonance = models.ForeignKey(
-        "arxii.Resonance",
+        _RESONANCE_MODEL,
         on_delete=models.PROTECT,
         related_name="rescues",
     )


### PR DESCRIPTION
Closes #3134
Closes #3135
Closes #3136
Closes #3137
Closes #3132
Closes #3133
Closes #3130
Closes #3131
Closes #3118
Closes #3121

## Summary

SonarCloud `python:S1192` cleanup (batch 2 of 4): the duplicated `"arxii.X"` lazy model-reference literals in `world/magic/models/soul_tether.py`, `gifts.py`, `grants.py`, `world/magic/factories.py`, `world/combat/factories.py` and `world/covenants/models.py` now go through module-level constants, following each file's existing convention (`grants.py` and `covenants/models.py` already had constant blocks). `covenants/models.py` already defined `CHARACTER_SHEET_MODEL`; one bare-literal use that had drifted past it now goes through the constant.

No behavior change: the constants hold the identical strings, so Django/FactoryBoy resolve the same models and no migration is generated (`Check Django migrations` hook passed).

## Follow-ups filed

(none)

## Notes

- Spec/design phase: skipped (lint-fix issues; no design decisions)
- Tests: `just test-fast world.magic world.combat world.covenants` - 6452 tests, OK
- Sync-with-main: branched from main tip 953396ad6; no re-sync needed (merge queue re-integrates)

<!-- last-addressed-comment: 0 -->
