### PR TITLE
Chore: replace duplicated string literals with module constants (SonarCloud S1192 batch)

### DIFF
--- a/src/actions/definitions/gm_adjudication.py
+++ b/src/actions/definitions/gm_adjudication.py
@@ -47,6 +47,11 @@ _AWARD_TYPES = (
     _AWARD_TYPE_TECHNIQUE,
 )
 
+# Failure message repeated across every action here that requires a resolved
+# target character — extracted to satisfy the duplicated-literal SonarCloud
+# smell (python:S1192).
+MSG_TARGET_REQUIRED = "A target character is required."
+
 
 def _resolve_gm_profile(actor: ObjectDB) -> Any | None:
     """Return the acting GM's ``GMProfile``, or ``None`` (staff with no profile, #3071).
@@ -305,7 +310,7 @@ class GMAwardAction(Action):
     ) -> ActionResult:
         target = _resolve_gm_target(kwargs)
         if target is None:
-            return ActionResult(success=False, message="A target character is required.")
+            return ActionResult(success=False, message=MSG_TARGET_REQUIRED)
 
         award_type = str(kwargs.get("award_type") or "").strip().lower()
         description = str(kwargs.get("description") or "").strip()
@@ -598,7 +603,7 @@ def _resolve_condition_target(kwargs: dict[str, Any]) -> tuple[Any, Any] | Actio
 
     target = _resolve_gm_target(kwargs)
     if target is None:
-        return ActionResult(success=False, message="A target character is required.")
+        return ActionResult(success=False, message=MSG_TARGET_REQUIRED)
 
     condition_ref = str(kwargs.get("condition_ref") or "").strip()
     if not condition_ref:
@@ -747,7 +752,7 @@ class SummonPlayerAction(Action):
 
         target = _resolve_gm_target(kwargs)
         if target is None:
-            return ActionResult(success=False, message="A target character is required.")
+            return ActionResult(success=False, message=MSG_TARGET_REQUIRED)
         target_sheet = target.character_sheet
         if target_sheet is None:
             return ActionResult(success=False, message=f"{target.key} has no character sheet.")

--- a/src/commands/showcase.py
+++ b/src/commands/showcase.py
@@ -22,6 +22,10 @@ _SUBVERB_OFF = "off"
 _SUBVERB_OUTFIT = "outfit"
 _SUBVERB_STATUS = "status"
 
+# Lock string shared by every command in this module — extracted to satisfy
+# the duplicated-literal SonarCloud smell (python:S1192).
+LOCK_ALL = "cmd:all()"
+
 
 class CmdShowcase(ArxCommand):
     """Choose what you are showcasing to the fashionable world.
@@ -38,7 +42,7 @@ class CmdShowcase(ArxCommand):
     """
 
     key = "showcase"
-    locks = "cmd:all()"
+    locks = LOCK_ALL
 
     def func(self) -> None:
         from actions.definitions.fashion import ShowcaseAction  # noqa: PLC0415
@@ -136,7 +140,7 @@ class CmdReveal(ArxCommand):
 
     key = "reveal"
     aliases = ["show"]
-    locks = "cmd:all()"
+    locks = LOCK_ALL
 
     def func(self) -> None:
         from actions.definitions.fashion import RevealAction  # noqa: PLC0415
@@ -168,7 +172,7 @@ class CmdCover(ArxCommand):
 
     key = "cover"
     aliases = ["conceal"]
-    locks = "cmd:all()"
+    locks = LOCK_ALL
 
     def func(self) -> None:
         from actions.definitions.fashion import CoverUpAction  # noqa: PLC0415

--- a/src/web/admin/content_conflict_views.py
+++ b/src/web/admin/content_conflict_views.py
@@ -27,6 +27,13 @@ from django.shortcuts import render
 from django.urls import reverse
 from django.views.decorators.http import require_GET, require_POST
 
+# Repeated bail-out message across every view below — extracted to satisfy
+# the duplicated-literal SonarCloud smell (python:S1192).
+MSG_CONTENT_REPO_PATH_NOT_SET = (
+    "CONTENT_REPO_PATH is not set. Add it to src/.env pointing at your "
+    "local checkout of the private content repository."
+)
+
 
 def _detail_url(model_label: str, key: str) -> str:
     """Build the conflict-detail URL for one ``(model_label, key)`` pair."""
@@ -197,8 +204,7 @@ def content_conflicts(request: HttpRequest) -> HttpResponse:
     if content_root is None:
         messages.error(
             request,
-            "CONTENT_REPO_PATH is not set. Add it to src/.env pointing at your "
-            "local checkout of the private content repository.",
+            MSG_CONTENT_REPO_PATH_NOT_SET,
         )
         return HttpResponseRedirect(reverse("admin_game_setup"))
 
@@ -232,8 +238,7 @@ def content_conflict_detail(request: HttpRequest) -> HttpResponse:
     if content_root is None:
         messages.error(
             request,
-            "CONTENT_REPO_PATH is not set. Add it to src/.env pointing at your "
-            "local checkout of the private content repository.",
+            MSG_CONTENT_REPO_PATH_NOT_SET,
         )
         return HttpResponseRedirect(reverse("admin_game_setup"))
 
@@ -280,8 +285,7 @@ def content_conflict_resolve(request: HttpRequest) -> HttpResponse:
     if content_root is None:
         messages.error(
             request,
-            "CONTENT_REPO_PATH is not set. Add it to src/.env pointing at your "
-            "local checkout of the private content repository.",
+            MSG_CONTENT_REPO_PATH_NOT_SET,
         )
         return HttpResponseRedirect(reverse("admin_game_setup"))
 

--- a/src/world/buildings/models.py
+++ b/src/world/buildings/models.py
@@ -44,6 +44,7 @@ _PERSONA_FK = "arxii.Persona"
 _CODEX_SUBJECT_FK = "arxii.CodexSubject"
 _ARCHITECTURAL_STYLE_FK = "arxii.ArchitecturalStyle"
 _ROOM_PROFILE_FK = "arxii.RoomProfile"
+_AREA_FK = "arxii.Area"
 
 
 class BuildingKind(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
@@ -112,7 +113,7 @@ class PropertyGrantProfile(NaturalKeyMixin, SharedMemoryModel):
         related_name="property_grant_profiles",
     )
     ward_area = models.ForeignKey(
-        "arxii.Area",
+        _AREA_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -246,7 +247,7 @@ class Building(SharedMemoryModel):
     """
 
     area = models.OneToOneField(
-        "arxii.Area",
+        _AREA_FK,
         on_delete=models.CASCADE,
         related_name="building_profile",
         primary_key=True,
@@ -375,7 +376,7 @@ class Building(SharedMemoryModel):
         ),
     )
     entry_room = models.ForeignKey(
-        "arxii.RoomProfile",
+        _ROOM_PROFILE_FK,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -584,7 +585,7 @@ class BuildingPermitDetails(SharedMemoryModel):
         related_name="permits",
     )
     approved_wards = models.ManyToManyField(
-        "arxii.Area",
+        _AREA_FK,
         related_name="building_permits_valid_in",
         blank=True,
         help_text=(
@@ -967,7 +968,7 @@ class BuildingConstructionDetails(SharedMemoryModel):
         help_text="The (consumed) permit that authorized this construction.",
     )
     ward = models.ForeignKey(
-        "arxii.Area",
+        _AREA_FK,
         on_delete=models.PROTECT,
         related_name="construction_projects",
         help_text="The ward this building will rise in.",
@@ -1109,7 +1110,7 @@ class RoomPolish(SharedMemoryModel):
     """
 
     room = models.ForeignKey(
-        "arxii.RoomProfile",
+        _ROOM_PROFILE_FK,
         on_delete=models.CASCADE,
         related_name="polish_by_category",
     )

--- a/src/world/character_creation/models.py
+++ b/src/world/character_creation/models.py
@@ -48,6 +48,7 @@ from world.items.constants import BodyRegion
 logger = logging.getLogger(__name__)
 
 _SPECIES_MODEL = "arxii.Species"
+_TRADITION_MODEL = "arxii.Tradition"
 
 
 class CGPointBudget(NaturalKeyMixin, SharedMemoryModel):
@@ -296,7 +297,7 @@ class Beginnings(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         help_text="Societies characters gain awareness/membership in during character creation",
     )
     traditions = models.ManyToManyField(
-        "arxii.Tradition",
+        _TRADITION_MODEL,
         through="BeginningTradition",
         blank=True,
         related_name="available_beginnings",
@@ -498,7 +499,7 @@ class BeginningTradition(NaturalKeyMixin, SharedMemoryModel):
         related_name="beginning_traditions",
     )
     tradition = models.ForeignKey(
-        "arxii.Tradition",
+        _TRADITION_MODEL,
         on_delete=models.CASCADE,
         related_name="beginning_traditions",
     )
@@ -828,7 +829,7 @@ class CharacterDraft(SharedMemoryModel):
         help_text="Selected starting path (Prospect stage only)",
     )
     selected_tradition = models.ForeignKey(
-        "arxii.Tradition",
+        _TRADITION_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,

--- a/src/world/checks/models.py
+++ b/src/world/checks/models.py
@@ -13,6 +13,10 @@ from world.checks.constants import EffectTarget, EffectType, PositionDestination
 from world.checks.outcome_models import ConsequenceOutcome, ConsequenceOutcomeModifier  # noqa: F401
 from world.contributors.models import CreditedContent
 
+# Lazy model references (Django app_label.ModelName), extracted to satisfy S1192.
+CHECK_TYPE_MODEL = "arxii.CheckType"
+CHECK_OUTCOME_MODEL = "arxii.CheckOutcome"
+
 
 class OutcomeTierAward(SharedMemoryModel):
     """Shared base: one authored scalar per graded CheckOutcome tier.
@@ -27,7 +31,7 @@ class OutcomeTierAward(SharedMemoryModel):
     """
 
     outcome_tier = models.OneToOneField(
-        "arxii.CheckOutcome",
+        CHECK_OUTCOME_MODEL,
         on_delete=models.PROTECT,
         related_name="%(app_label)s_%(class)s",
     )
@@ -125,7 +129,7 @@ class CheckTypeTrait(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["check_type", "trait"]
-        dependencies = ["arxii.CheckType", "arxii.Trait"]
+        dependencies = [CHECK_TYPE_MODEL, "arxii.Trait"]
 
     class Meta:
         unique_together = ["check_type", "trait"]
@@ -162,7 +166,7 @@ class CheckTypeCapabilityModifier(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["check_type", "capability"]
-        dependencies = ["arxii.CheckType", "arxii.CapabilityType"]
+        dependencies = [CHECK_TYPE_MODEL, "arxii.CapabilityType"]
 
     class Meta:
         unique_together = ["check_type", "capability"]
@@ -195,7 +199,7 @@ class CheckTypeAspect(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["check_type", "aspect"]
-        dependencies = ["arxii.CheckType", "arxii.Aspect"]
+        dependencies = [CHECK_TYPE_MODEL, "arxii.Aspect"]
 
     class Meta:
         unique_together = ["check_type", "aspect"]
@@ -236,7 +240,7 @@ class CheckTypeSpecialization(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["check_type", "specialization"]
-        dependencies = ["arxii.CheckType", "arxii.Specialization"]
+        dependencies = [CHECK_TYPE_MODEL, "arxii.Specialization"]
 
     class Meta:
         unique_together = ["check_type", "specialization"]
@@ -277,10 +281,10 @@ class Consequence(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["outcome_tier", "label"]
-        dependencies = ["arxii.CheckOutcome"]
+        dependencies = [CHECK_OUTCOME_MODEL]
 
     outcome_tier = models.ForeignKey(
-        "arxii.CheckOutcome",
+        CHECK_OUTCOME_MODEL,
         on_delete=models.CASCADE,
         related_name="consequences",
     )

--- a/src/world/codex/models.py
+++ b/src/world/codex/models.py
@@ -18,6 +18,9 @@ from world.consent.models import VisibilityMixin
 from world.contributors.models import CreditedContent
 from world.roster.models import RosterEntry, RosterTenure
 
+# Lazy model reference (Django app_label.ModelName), extracted to satisfy S1192.
+CODEX_ENTRY_MODEL = "arxii.CodexEntry"
+
 
 class CodexCategory(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
     """
@@ -546,7 +549,7 @@ class BeginningsCodexGrant(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["beginnings", "entry"]
-        dependencies = ["arxii.Beginnings", "arxii.CodexEntry"]
+        dependencies = ["arxii.Beginnings", CODEX_ENTRY_MODEL]
 
     class Meta:
         unique_together = ["beginnings", "entry"]
@@ -576,7 +579,7 @@ class PathCodexGrant(NaturalKeyMixin, models.Model):  # noqa: SHARED_MEMORY
 
     class NaturalKeyConfig:
         fields = ["path", "entry"]
-        dependencies = ["arxii.Path", "arxii.CodexEntry"]
+        dependencies = ["arxii.Path", CODEX_ENTRY_MODEL]
 
     class Meta:
         unique_together = ["path", "entry"]
@@ -605,7 +608,7 @@ class DistinctionCodexGrant(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["distinction", "entry"]
-        dependencies = ["arxii.Distinction", "arxii.CodexEntry"]
+        dependencies = ["arxii.Distinction", CODEX_ENTRY_MODEL]
 
     class Meta:
         unique_together = ["distinction", "entry"]
@@ -634,7 +637,7 @@ class TraditionCodexGrant(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["tradition", "entry"]
-        dependencies = ["arxii.Tradition", "arxii.CodexEntry"]
+        dependencies = ["arxii.Tradition", CODEX_ENTRY_MODEL]
 
     class Meta:
         unique_together = ["tradition", "entry"]

--- a/src/world/combat/factories.py
+++ b/src/world/combat/factories.py
@@ -79,6 +79,9 @@ from world.magic.factories import TechniqueFactory
 # SonarCloud smell (python:S1192).
 _CHARACTER_SHEET_FACTORY = "world.character_sheets.factories.CharacterSheetFactory"
 _ROOM_TYPECLASS = "typeclasses.rooms.Room"
+# Lazy model reference (Django app_label.ModelName) used as a factory Meta.model
+# string, extracted to satisfy S1192.
+_TRIGGER_DEFINITION_MODEL = "arxii.TriggerDefinition"
 
 
 class CombatEncounterFactory(factory_django.DjangoModelFactory):
@@ -1663,7 +1666,7 @@ class EscalationSpikeOnIncapacitatedTriggerDefinitionFactory(factory_django.Djan
     """
 
     class Meta:
-        model = "arxii.TriggerDefinition"
+        model = _TRIGGER_DEFINITION_MODEL
         django_get_or_create = ("name",)
 
     name = "escalation_spike_on_incapacitated"
@@ -1677,7 +1680,7 @@ class EscalationSpikeOnKilledTriggerDefinitionFactory(factory_django.DjangoModel
     """TriggerDefinition for the CHARACTER_KILLED escalation spike (#872)."""
 
     class Meta:
-        model = "arxii.TriggerDefinition"
+        model = _TRIGGER_DEFINITION_MODEL
         django_get_or_create = ("name",)
 
     name = "escalation_spike_on_killed"
@@ -1724,7 +1727,7 @@ class EscalationSpikeOnMortalPerilTriggerDefinitionFactory(factory_django.Django
     """
 
     class Meta:
-        model = "arxii.TriggerDefinition"
+        model = _TRIGGER_DEFINITION_MODEL
         django_get_or_create = ("name",)
 
     name = "escalation_spike_on_mortal_peril"
@@ -1775,7 +1778,7 @@ class EncounterBeatTriggerDefinitionFactory(factory_django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.TriggerDefinition"
+        model = _TRIGGER_DEFINITION_MODEL
         django_get_or_create = ("name",)
 
     name = "encounter_completed_beat_wiring"

--- a/src/world/conditions/models.py
+++ b/src/world/conditions/models.py
@@ -42,6 +42,8 @@ _CONDITION_TEMPLATE_FK = "arxii.ConditionTemplate"
 _CONDITION_STAGE_FK = "arxii.ConditionStage"
 CHARACTER_SHEET_MODEL = "arxii.CharacterSheet"
 _POSITION_FK = "arxii.Position"
+_CHECK_TYPE_FK = "arxii.CheckType"
+_DAMAGE_TYPE_FK = "arxii.DamageType"
 
 # =============================================================================
 # Lookup Tables (SharedMemoryModel - cached, rarely change)
@@ -294,7 +296,7 @@ class ConditionTemplate(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         help_text="Can magical dispel effects remove this?",
     )
     cure_check_type = models.ForeignKey(
-        "arxii.CheckType",
+        _CHECK_TYPE_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -306,7 +308,7 @@ class ConditionTemplate(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         help_text="Base difficulty to cure via check",
     )
     resist_check_type = models.ForeignKey(
-        "arxii.CheckType",
+        _CHECK_TYPE_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -331,7 +333,7 @@ class ConditionTemplate(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         ),
     )
     break_free_check_type = models.ForeignKey(
-        "arxii.CheckType",
+        _CHECK_TYPE_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -559,7 +561,7 @@ class ConditionStage(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
 
     # Can a check prevent progression?
     resist_check_type = models.ForeignKey(
-        "arxii.CheckType",
+        _CHECK_TYPE_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -861,7 +863,7 @@ class ConditionCheckModifier(NaturalKeyMixin, ConditionOrStageEffect):
     """
 
     check_type = models.ForeignKey(
-        "arxii.CheckType",
+        _CHECK_TYPE_FK,
         on_delete=models.CASCADE,
         null=True,
         blank=True,
@@ -890,7 +892,7 @@ class ConditionCheckModifier(NaturalKeyMixin, ConditionOrStageEffect):
         dependencies = [
             _CONDITION_TEMPLATE_FK,
             _CONDITION_STAGE_FK,
-            "arxii.CheckType",
+            _CHECK_TYPE_FK,
             "arxii.CheckCategory",
         ]
 
@@ -987,7 +989,7 @@ class ConditionResistanceModifier(NaturalKeyMixin, ConditionOrStageEffect):
         dependencies = [
             _CONDITION_TEMPLATE_FK,
             _CONDITION_STAGE_FK,
-            "arxii.DamageType",
+            _DAMAGE_TYPE_FK,
         ]
 
     class Meta(ConditionOrStageEffect.Meta):
@@ -1069,7 +1071,7 @@ class ConditionDamageOverTime(NaturalKeyMixin, ConditionOrStageEffect):
         dependencies = [
             _CONDITION_TEMPLATE_FK,
             _CONDITION_STAGE_FK,
-            "arxii.DamageType",
+            _DAMAGE_TYPE_FK,
         ]
 
     class Meta(ConditionOrStageEffect.Meta):
@@ -1160,7 +1162,7 @@ class ConditionDamageInteraction(NaturalKeyMixin, CreditedContent, SharedMemoryM
         fields = ["condition", "damage_type"]
         dependencies = [
             _CONDITION_TEMPLATE_FK,
-            "arxii.DamageType",
+            _DAMAGE_TYPE_FK,
         ]
 
     class Meta:
@@ -1509,7 +1511,7 @@ class TreatmentTemplate(SharedMemoryModel):
         choices=TreatmentTargetKind.choices,
     )
 
-    check_type = models.ForeignKey("arxii.CheckType", on_delete=models.PROTECT)
+    check_type = models.ForeignKey(_CHECK_TYPE_FK, on_delete=models.PROTECT)
     target_difficulty = models.PositiveIntegerField(default=0)
     requires_bond = models.BooleanField(default=False)
 

--- a/src/world/covenants/models.py
+++ b/src/world/covenants/models.py
@@ -63,6 +63,7 @@ CHARACTER_SHEET_MODEL = "arxii.CharacterSheet"
 CONDITION_TEMPLATE_MODEL = "arxii.ConditionTemplate"
 GIFT_MODEL = "arxii.Gift"
 VOW_SITUATIONAL_PERK_MODEL = "arxii.VowSituationalPerk"
+MODIFIER_TARGET_MODEL = "arxii.ModifierTarget"
 
 
 class Covenant(SharedMemoryModel):
@@ -919,7 +920,7 @@ class CovenantLevelBonus(SharedMemoryModel):
     """
 
     modifier_target = models.ForeignKey(
-        "arxii.ModifierTarget",
+        MODIFIER_TARGET_MODEL,
         on_delete=models.CASCADE,
         related_name="covenant_level_bonuses",
     )
@@ -970,7 +971,7 @@ class VowStatScaling(NaturalKeyMixin, SharedMemoryModel):
         related_name="vow_stat_scalings",
     )
     modifier_target = models.ForeignKey(
-        "arxii.ModifierTarget",
+        MODIFIER_TARGET_MODEL,
         on_delete=models.CASCADE,
         related_name="vow_stat_scalings",
     )
@@ -994,7 +995,7 @@ class VowStatScaling(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["covenant_role", "modifier_target"]
-        dependencies = [COVENANT_ROLE_MODEL, "arxii.ModifierTarget"]
+        dependencies = [COVENANT_ROLE_MODEL, MODIFIER_TARGET_MODEL]
 
     def __str__(self) -> str:
         return (
@@ -1235,7 +1236,7 @@ class CovenantRoleBonus(NaturalKeyMixin, SharedMemoryModel):
         related_name="role_bonuses",
     )
     modifier_target = models.ForeignKey(
-        "arxii.ModifierTarget",
+        MODIFIER_TARGET_MODEL,
         on_delete=models.CASCADE,
         related_name="covenant_role_bonuses",
     )
@@ -1259,7 +1260,7 @@ class CovenantRoleBonus(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["covenant_role", "modifier_target"]
-        dependencies = [COVENANT_ROLE_MODEL, "arxii.ModifierTarget"]
+        dependencies = [COVENANT_ROLE_MODEL, MODIFIER_TARGET_MODEL]
 
     def __str__(self) -> str:
         return (

--- a/src/world/events/models.py
+++ b/src/world/events/models.py
@@ -7,6 +7,9 @@ from core.mixins import DiscriminatorMixin
 from world.events.constants import EventStatus, InvitationResponse, InvitationTargetType
 from world.game_clock.constants import TimePhase
 
+# Lazy model reference (Django app_label.ModelName), extracted to satisfy S1192.
+PERSONA_MODEL = "arxii.Persona"
+
 
 class Event(SharedMemoryModel):
     """A scheduled RP gathering — ball, meeting, ritual, training session.
@@ -123,7 +126,7 @@ class EventHost(SharedMemoryModel):
         related_name="hosts",
     )
     persona = models.ForeignKey(
-        "arxii.Persona",
+        PERSONA_MODEL,
         null=True,
         on_delete=models.SET_NULL,
         related_name="hosted_events",
@@ -168,7 +171,7 @@ class EventInvitation(DiscriminatorMixin, SharedMemoryModel):
         choices=InvitationTargetType.choices,
     )
     target_persona = models.ForeignKey(
-        "arxii.Persona",
+        PERSONA_MODEL,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -191,7 +194,7 @@ class EventInvitation(DiscriminatorMixin, SharedMemoryModel):
     can_bring_guests = models.BooleanField(default=False)
     invited_at = models.DateTimeField(auto_now_add=True)
     invited_by = models.ForeignKey(
-        "arxii.Persona",
+        PERSONA_MODEL,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -290,7 +293,7 @@ class EventCatering(SharedMemoryModel):
         help_text="CONTAINER (a flagged vessel) or PROVISION (a consumable set out in one).",
     )
     contributed_by = models.ForeignKey(
-        "arxii.Persona",
+        PERSONA_MODEL,
         on_delete=models.PROTECT,
         null=True,
         blank=True,

--- a/src/world/gm/models.py
+++ b/src/world/gm/models.py
@@ -30,6 +30,8 @@ if TYPE_CHECKING:
     from world.game_clock.models import GameWeek
 
 _SITUATION_KIND_MODEL = "arxii.SituationKind"
+GM_PROFILE_MODEL = "arxii.GMProfile"
+ROOM_PROFILE_MODEL = "arxii.RoomProfile"
 
 
 class GMProfile(SharedMemoryModel):
@@ -135,7 +137,7 @@ class GMTable(SharedMemoryModel):
     """A GM's working group — players engaging with a set of stories."""
 
     gm = models.ForeignKey(
-        "arxii.GMProfile",
+        GM_PROFILE_MODEL,
         on_delete=models.PROTECT,
         related_name="tables",
     )
@@ -237,7 +239,7 @@ class GMRosterInvite(SharedMemoryModel):
     )
     code = models.CharField(max_length=64, unique=True, db_index=True)
     created_by = models.ForeignKey(
-        "arxii.GMProfile",
+        GM_PROFILE_MODEL,
         on_delete=models.PROTECT,
         related_name="invites_created",
     )
@@ -346,7 +348,7 @@ class GMLevelChange(SharedMemoryModel):
     """
 
     profile = models.ForeignKey(
-        "arxii.GMProfile",
+        GM_PROFILE_MODEL,
         on_delete=models.CASCADE,
         related_name="level_changes",
     )
@@ -380,7 +382,7 @@ class StoryArea(SharedMemoryModel):
     """
 
     gm = models.ForeignKey(
-        "arxii.GMProfile",
+        GM_PROFILE_MODEL,
         on_delete=models.PROTECT,
         related_name="story_areas",
     )
@@ -410,7 +412,7 @@ class StoryRoomGrant(SharedMemoryModel):
     """
 
     room = models.ForeignKey(
-        "arxii.RoomProfile",
+        ROOM_PROFILE_MODEL,
         on_delete=models.CASCADE,
         related_name="story_grants",
     )
@@ -420,12 +422,12 @@ class StoryRoomGrant(SharedMemoryModel):
         related_name="story_room_grants",
     )
     granted_by = models.ForeignKey(
-        "arxii.GMProfile",
+        GM_PROFILE_MODEL,
         on_delete=models.PROTECT,
         related_name="story_grants_issued",
     )
     return_location = models.ForeignKey(
-        "arxii.RoomProfile",
+        ROOM_PROFILE_MODEL,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -476,7 +478,7 @@ class GMSummonOffer(SharedMemoryModel):
         help_text="The character being invited.",
     )
     invited_by = models.ForeignKey(
-        "arxii.GMProfile",
+        GM_PROFILE_MODEL,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -493,7 +495,7 @@ class GMSummonOffer(SharedMemoryModel):
         ),
     )
     room = models.ForeignKey(
-        "arxii.RoomProfile",
+        ROOM_PROFILE_MODEL,
         on_delete=models.CASCADE,
         related_name="summon_offers",
         help_text="The GM's scene room — destination on accept.",
@@ -843,7 +845,7 @@ class GMWeeklyRewardTracker(SharedMemoryModel):
     """
 
     gm_profile = models.OneToOneField(
-        "arxii.GMProfile",
+        GM_PROFILE_MODEL,
         on_delete=models.CASCADE,
         related_name="weekly_reward_tracker",
     )
@@ -911,7 +913,7 @@ class TableUpdateRequest(SharedMemoryModel):
         help_text="The GM's sign-off/rejection notes.",
     )
     resolved_by = models.ForeignKey(
-        "arxii.GMProfile",
+        GM_PROFILE_MODEL,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,

--- a/src/world/items/models.py
+++ b/src/world/items/models.py
@@ -48,6 +48,9 @@ SOCIETY_MODEL = "arxii.Society"
 CHECK_TYPE_MODEL = "arxii.CheckType"
 FACET_MODEL = "arxii.Facet"
 RESONANCE_MODEL = "arxii.Resonance"
+SILHOUETTE_MODEL = "arxii.Silhouette"
+STYLE_MODEL = "arxii.Style"
+OUTFIT_MODEL = "arxii.Outfit"
 
 
 class QualityTier(NaturalKeyMixin, SharedMemoryModel):
@@ -478,7 +481,7 @@ class ItemTemplate(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         ),
     )
     silhouette = models.ForeignKey(
-        "arxii.Silhouette",
+        SILHOUETTE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -818,7 +821,7 @@ class ItemInstance(SharedMemoryModel):
         related_name="item_instances",
     )
     silhouette = models.ForeignKey(
-        "arxii.Silhouette",
+        SILHOUETTE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1432,7 +1435,7 @@ class RecycleRequest(SharedMemoryModel):
     """
 
     item_instance = models.ForeignKey(
-        "arxii.ItemInstance",
+        _ITEM_INSTANCE_FK,
         on_delete=models.CASCADE,
         related_name="recycle_requests",
     )
@@ -1550,7 +1553,7 @@ class ItemStyle(ItemAttachment):
         related_name="item_styles",
     )
     style = models.ForeignKey(
-        "arxii.Style",
+        STYLE_MODEL,
         on_delete=models.PROTECT,
         related_name="item_attachments",
     )
@@ -1686,7 +1689,7 @@ class FashionPresentation(SharedMemoryModel):
         related_name="fashion_presentations",
     )
     outfit = models.ForeignKey(
-        "arxii.Outfit",
+        OUTFIT_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1809,7 +1812,7 @@ class FashionStyle(NaturalKeyMixin, SharedMemoryModel):
         help_text="Facets that are currently fashionable in this style.",
     )
     in_vogue_styles = models.ManyToManyField(
-        "arxii.Style",
+        STYLE_MODEL,
         related_name="vogue_in",
         blank=True,
         help_text="Aesthetic styles (vocabulary words) that are currently fashionable.",
@@ -1865,14 +1868,14 @@ class ShowcaseState(SharedMemoryModel):
     is_active = models.BooleanField(default=False)
     mode = models.CharField(max_length=20, choices=ShowcaseMode.choices)
     outfit = models.ForeignKey(
-        "arxii.Outfit",
+        OUTFIT_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
         related_name="showcases",
     )
     item = models.ForeignKey(
-        "arxii.ItemInstance",
+        _ITEM_INSTANCE_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1914,28 +1917,28 @@ class FashionShowing(SharedMemoryModel):
     )
     mode = models.CharField(max_length=20, choices=ShowcaseMode.choices)
     statement_item = models.ForeignKey(
-        "arxii.ItemInstance",
+        _ITEM_INSTANCE_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
         related_name="statement_showings",
     )
     statement_outfit = models.ForeignKey(
-        "arxii.Outfit",
+        OUTFIT_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
         related_name="statement_showings",
     )
     statement_style = models.ForeignKey(
-        "arxii.Style",
+        STYLE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
         related_name="statement_showings",
     )
     statement_silhouette = models.ForeignKey(
-        "arxii.Silhouette",
+        SILHOUETTE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1968,7 +1971,7 @@ class SilhouetteVogueMomentum(SharedMemoryModel):
     """
 
     silhouette = models.OneToOneField(
-        "arxii.Silhouette",
+        SILHOUETTE_MODEL,
         on_delete=models.CASCADE,
         primary_key=True,
         related_name="vogue_momentum",
@@ -1987,7 +1990,7 @@ class StyleVogueMomentum(SharedMemoryModel):
     """Accumulating vogue heat for a cultural style register (#2907; global v1)."""
 
     style = models.OneToOneField(
-        "arxii.Style",
+        STYLE_MODEL,
         on_delete=models.CASCADE,
         primary_key=True,
         related_name="vogue_momentum_row",

--- a/src/world/locations/models.py
+++ b/src/world/locations/models.py
@@ -15,6 +15,10 @@ from evennia.utils.idmapper.models import SharedMemoryModel
 from core.mixins import DiscriminatorMixin
 from world.locations.constants import HolderType, KeyType, LocationParentType, StatKey
 
+# Lazy model references (Django app_label.ModelName), extracted to satisfy S1192.
+AREA_MODEL = "arxii.Area"
+ROOM_PROFILE_MODEL = "arxii.RoomProfile"
+
 
 class LocationValueOverride(DiscriminatorMixin, SharedMemoryModel):
     """An absolute claim about a stat or resonance at a specific area or room.
@@ -51,14 +55,14 @@ class LocationValueOverride(DiscriminatorMixin, SharedMemoryModel):
         help_text="Selects which FK (area or room_profile) is active.",
     )
     area = models.ForeignKey(
-        "arxii.Area",
+        AREA_MODEL,
         null=True,
         blank=True,
         on_delete=models.CASCADE,
         related_name="stat_overrides",
     )
     room_profile = models.ForeignKey(
-        "arxii.RoomProfile",
+        ROOM_PROFILE_MODEL,
         null=True,
         blank=True,
         on_delete=models.CASCADE,
@@ -194,14 +198,14 @@ class LocationValueModifier(DiscriminatorMixin, SharedMemoryModel):
         help_text="Selects which FK (area or room_profile) is active.",
     )
     area = models.ForeignKey(
-        "arxii.Area",
+        AREA_MODEL,
         null=True,
         blank=True,
         on_delete=models.CASCADE,
         related_name="stat_modifiers",
     )
     room_profile = models.ForeignKey(
-        "arxii.RoomProfile",
+        ROOM_PROFILE_MODEL,
         null=True,
         blank=True,
         on_delete=models.CASCADE,
@@ -347,14 +351,14 @@ class LocationOwnership(DiscriminatorMixin, SharedMemoryModel):
         help_text="Selects which parent FK (area or room_profile) is active.",
     )
     area = models.ForeignKey(
-        "arxii.Area",
+        AREA_MODEL,
         null=True,
         blank=True,
         on_delete=models.CASCADE,
         related_name="ownership_records",
     )
     room_profile = models.ForeignKey(
-        "arxii.RoomProfile",
+        ROOM_PROFILE_MODEL,
         null=True,
         blank=True,
         on_delete=models.CASCADE,
@@ -466,14 +470,14 @@ class LocationTenancy(DiscriminatorMixin, SharedMemoryModel):
         help_text="Selects which parent FK (area or room_profile) is active.",
     )
     area = models.ForeignKey(
-        "arxii.Area",
+        AREA_MODEL,
         null=True,
         blank=True,
         on_delete=models.CASCADE,
         related_name="tenancy_records",
     )
     room_profile = models.ForeignKey(
-        "arxii.RoomProfile",
+        ROOM_PROFILE_MODEL,
         null=True,
         blank=True,
         on_delete=models.CASCADE,

--- a/src/world/magic/factories.py
+++ b/src/world/magic/factories.py
@@ -126,6 +126,10 @@ _PAYLOAD_PARAM = "@payload"
 _MAGIC_PROGRESSION_PATH = "/magic/progression"
 # SubFactory import paths, extracted to satisfy S1192.
 _DISTINCTION_FACTORY = "world.distinctions.factories.DistinctionFactory"
+# Lazy model references (Django app_label.ModelName) used as factory Meta.model
+# strings, extracted to satisfy S1192.
+_RITUAL_MODEL = "arxii.Ritual"
+_CONDITION_TEMPLATE_MODEL = "arxii.ConditionTemplate"
 
 logger = logging.getLogger(__name__)
 
@@ -2110,7 +2114,7 @@ class CorruptionConditionTemplateFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.ConditionTemplate"
+        model = _CONDITION_TEMPLATE_MODEL
         django_get_or_create = ("corruption_resonance",)
 
     name = factory.LazyAttribute(lambda o: f"Corrupted by {o.corruption_resonance.name}")
@@ -2275,7 +2279,7 @@ class TetherStrainTemplateFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.ConditionTemplate"
+        model = _CONDITION_TEMPLATE_MODEL
         django_get_or_create = ("name",)
 
     name = "Tether Strain"
@@ -2334,7 +2338,7 @@ class SoulTetherActiveTemplateFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.ConditionTemplate"
+        model = _CONDITION_TEMPLATE_MODEL
         django_get_or_create = ("name",)
 
     name = "Soul Tether Active"
@@ -2364,7 +2368,7 @@ class AcceptSoulTetherRitualFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "accept_soul_tether"
@@ -2427,7 +2431,7 @@ class SoulTetherRescueRitualFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "soul_tether_rescue"
@@ -3532,7 +3536,7 @@ class CovenantFormationRitualFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "Covenant Formation"
@@ -3586,7 +3590,7 @@ class CovenantInductionRitualFactory(factory.django.DjangoModelFactory):
     """Factory for the covenant induction ritual."""
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "Covenant Induction"
@@ -3637,7 +3641,7 @@ class OrganizationInductionRitualFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "Organization Induction"
@@ -3666,7 +3670,7 @@ class RenewTheOathRitualFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "Renew the Oath"
@@ -3692,7 +3696,7 @@ class BattleCovenantRiseRitualFactory(factory.django.DjangoModelFactory):
     """Factory for the 'call the banners' battle-covenant rise ritual (Slice E)."""
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "Call the Banners"
@@ -3737,7 +3741,7 @@ class MentorsVowRitualFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "Mentor's Vow"
@@ -4331,7 +4335,7 @@ class RitualOfTheDuranceFactory(factory.django.DjangoModelFactory):
     """
 
     class Meta:
-        model = "arxii.Ritual"
+        model = _RITUAL_MODEL
         django_get_or_create = ("name",)
 
     name = "Ritual of the Durance"

--- a/src/world/magic/models/gifts.py
+++ b/src/world/magic/models/gifts.py
@@ -13,6 +13,9 @@ from world.contributors.models import CreditedContent
 from world.magic.constants import AcquisitionOrigin, GiftKind
 from world.magic.models.affinity import Resonance
 
+# Lazy model reference (Django app_label.ModelName), extracted to satisfy S1192.
+CHARACTER_SHEET_MODEL = "arxii.CharacterSheet"
+
 
 class GiftManager(NaturalKeyManager):
     """Manager for Gift with natural key support."""
@@ -73,7 +76,7 @@ class Gift(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         help_text="Resonances associated with this gift.",
     )
     creator = models.ForeignKey(
-        "arxii.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -195,7 +198,7 @@ class CharacterGift(SharedMemoryModel):
     """
 
     character = models.ForeignKey(
-        "arxii.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="character_gifts",
         help_text="The character who knows this gift.",
@@ -300,7 +303,7 @@ class CharacterTradition(SharedMemoryModel):
     """
 
     character = models.ForeignKey(
-        "arxii.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="character_traditions",
         help_text="The character who belongs to this tradition.",

--- a/src/world/magic/models/grants.py
+++ b/src/world/magic/models/grants.py
@@ -24,6 +24,7 @@ _DISTINCTION_MODEL = "arxii.Distinction"
 _PATH_MODEL = "arxii.Path"
 _GIFT_MODEL = "arxii.Gift"
 _TRADITION_MODEL = "arxii.Tradition"
+_RITUAL_MODEL = "arxii.Ritual"
 
 
 class BeginningsRitualGrant(SharedMemoryModel):
@@ -35,7 +36,7 @@ class BeginningsRitualGrant(SharedMemoryModel):
         related_name="ritual_grants",
     )
     ritual = models.ForeignKey(
-        "arxii.Ritual",
+        _RITUAL_MODEL,
         on_delete=models.CASCADE,
         related_name="+",
     )
@@ -65,7 +66,7 @@ class PathRitualGrant(models.Model):  # noqa: SHARED_MEMORY
         related_name="ritual_grants",
     )
     ritual = models.ForeignKey(
-        "arxii.Ritual",
+        _RITUAL_MODEL,
         on_delete=models.CASCADE,
         related_name="+",
     )
@@ -222,7 +223,7 @@ class DistinctionRitualGrant(SharedMemoryModel):
         related_name="ritual_grants",
     )
     ritual = models.ForeignKey(
-        "arxii.Ritual",
+        _RITUAL_MODEL,
         on_delete=models.CASCADE,
         related_name="+",
     )
@@ -352,7 +353,7 @@ class TraditionRitualGrant(SharedMemoryModel):
         related_name="ritual_grants",
     )
     ritual = models.ForeignKey(
-        "arxii.Ritual",
+        _RITUAL_MODEL,
         on_delete=models.CASCADE,
         related_name="+",
     )
@@ -384,7 +385,7 @@ class CodexEntryRitualGrant(SharedMemoryModel):
         related_name="ritual_grants",
     )
     ritual = models.ForeignKey(
-        "arxii.Ritual",
+        _RITUAL_MODEL,
         on_delete=models.CASCADE,
         related_name="+",
     )

--- a/src/world/magic/models/soul_tether.py
+++ b/src/world/magic/models/soul_tether.py
@@ -5,6 +5,12 @@ from __future__ import annotations
 from django.db import models
 from evennia.utils.idmapper.models import SharedMemoryModel
 
+# Lazy model references (Django app_label.ModelName), extracted to satisfy S1192.
+CHARACTER_SHEET_MODEL = "arxii.CharacterSheet"
+CHARACTER_RELATIONSHIP_MODEL = "arxii.CharacterRelationship"
+SCENE_MODEL = "arxii.Scene"
+RESONANCE_MODEL = "arxii.Resonance"
+
 
 class SineatingPendingOffer(SharedMemoryModel):
     """Pending Sineating offer awaiting Sineater response (Task 1.6).
@@ -25,27 +31,27 @@ class SineatingPendingOffer(SharedMemoryModel):
     """
 
     sinner_sheet = models.ForeignKey(
-        "arxii.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="sineating_offers_sent",
     )
     sineater_sheet = models.ForeignKey(
-        "arxii.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="sineating_offers_received",
     )
     relationship = models.ForeignKey(
-        "arxii.CharacterRelationship",
+        CHARACTER_RELATIONSHIP_MODEL,
         on_delete=models.CASCADE,
         related_name="sineating_pending_offers",
     )
     scene = models.ForeignKey(
-        "arxii.Scene",
+        SCENE_MODEL,
         on_delete=models.CASCADE,
         related_name="sineating_pending_offers",
     )
     resonance = models.ForeignKey(
-        "arxii.Resonance",
+        RESONANCE_MODEL,
         on_delete=models.PROTECT,
         related_name="sineating_pending_offers",
     )
@@ -92,28 +98,28 @@ class PendingStageAdvanceOffer(SharedMemoryModel):
     """
 
     sinner_sheet = models.ForeignKey(
-        "arxii.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="stage_advance_offers_sent",
     )
     sineater_sheet = models.ForeignKey(
-        "arxii.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="stage_advance_offers_received",
     )
     relationship = models.ForeignKey(
-        "arxii.CharacterRelationship",
+        CHARACTER_RELATIONSHIP_MODEL,
         on_delete=models.CASCADE,
         related_name="pending_stage_advance_offers",
     )
     scene = models.ForeignKey(
-        "arxii.Scene",
+        SCENE_MODEL,
         on_delete=models.CASCADE,
         related_name="pending_stage_advance_offers",
         help_text="Active scene at prompt time. Row is only written when a shared scene is found.",
     )
     resonance = models.ForeignKey(
-        "arxii.Resonance",
+        RESONANCE_MODEL,
         on_delete=models.PROTECT,
         related_name="pending_stage_advance_offers",
     )
@@ -154,29 +160,29 @@ class Sineating(SharedMemoryModel):
     """
 
     sinner_sheet = models.ForeignKey(
-        "arxii.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="sineatings_as_sinner",
     )
     sineater_sheet = models.ForeignKey(
-        "arxii.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="sineatings_as_sineater",
     )
     relationship = models.ForeignKey(
-        "arxii.CharacterRelationship",
+        CHARACTER_RELATIONSHIP_MODEL,
         on_delete=models.PROTECT,
         related_name="sineatings",
     )
     scene = models.ForeignKey(
-        "arxii.Scene",
+        SCENE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
         related_name="sineatings",
     )
     resonance = models.ForeignKey(
-        "arxii.Resonance",
+        RESONANCE_MODEL,
         on_delete=models.PROTECT,
         related_name="sineatings",
     )
@@ -206,29 +212,29 @@ class SoulTetherRescue(SharedMemoryModel):
     """Audit row for a stage-3+ rescue ritual (Spec B §9, §14.1)."""
 
     sinner_sheet = models.ForeignKey(
-        "arxii.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="rescues_as_sinner",
     )
     sineater_sheet = models.ForeignKey(
-        "arxii.CharacterSheet",
+        CHARACTER_SHEET_MODEL,
         on_delete=models.CASCADE,
         related_name="rescues_as_sineater",
     )
     relationship = models.ForeignKey(
-        "arxii.CharacterRelationship",
+        CHARACTER_RELATIONSHIP_MODEL,
         on_delete=models.PROTECT,
         related_name="rescues",
     )
     scene = models.ForeignKey(
-        "arxii.Scene",
+        SCENE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
         related_name="rescues",
     )
     resonance = models.ForeignKey(
-        "arxii.Resonance",
+        RESONANCE_MODEL,
         on_delete=models.PROTECT,
         related_name="rescues",
     )

--- a/src/world/mechanics/effect_handlers.py
+++ b/src/world/mechanics/effect_handlers.py
@@ -40,6 +40,7 @@ _ROLE_NAMED_B = "named_b"
 # Skip-reason descriptions repeated across relationship/affection/regard handlers.
 _NO_SHEET_MSG = "Actor or target has no character sheet; skipped."
 _SAME_CHAR_MSG = "Actor and target are the same character; skipped."
+_NO_ROSTER_ENTRY_MSG = "Character has no roster entry"
 
 
 def apply_effect(
@@ -533,9 +534,9 @@ def _grant_codex(
     except RosterEntry.DoesNotExist:
         return AppliedEffect(
             effect_type=EffectType.GRANT_CODEX,
-            description="Character has no roster entry",
+            description=_NO_ROSTER_ENTRY_MSG,
             applied=False,
-            skip_reason="Character has no roster entry",
+            skip_reason=_NO_ROSTER_ENTRY_MSG,
         )
 
     _, created = CharacterCodexKnowledge.objects.get_or_create(
@@ -580,9 +581,9 @@ def _grant_secret(
     except RosterEntry.DoesNotExist:
         return AppliedEffect(
             effect_type=EffectType.GRANT_SECRET,
-            description="Character has no roster entry",
+            description=_NO_ROSTER_ENTRY_MSG,
             applied=False,
-            skip_reason="Character has no roster entry",
+            skip_reason=_NO_ROSTER_ENTRY_MSG,
         )
 
     from world.secrets.services import grant_secret_knowledge  # noqa: PLC0415

--- a/src/world/mechanics/models.py
+++ b/src/world/mechanics/models.py
@@ -45,6 +45,12 @@ _DAMAGE_TYPE_MODEL_PATH = "arxii.DamageType"
 _CONSEQUENCE_POOL_MODEL = "arxii.ConsequencePool"
 _CHALLENGE_TEMPLATE_MODEL = "arxii.ChallengeTemplate"
 
+# Lazy model references (Django app_label.ModelName), extracted to satisfy S1192.
+TRAIT_MODEL = "arxii.Trait"
+CAPABILITY_TYPE_MODEL = "arxii.CapabilityType"
+CHECK_TYPE_MODEL = "arxii.CheckType"
+CONSEQUENCE_MODEL = "arxii.Consequence"
+
 
 class ModifierCategoryManager(NaturalKeyManager):
     """Manager for ModifierCategory with natural key support."""
@@ -139,7 +145,7 @@ class ModifierTarget(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         ),
     )
     target_trait = models.ForeignKey(
-        "arxii.Trait",
+        TRAIT_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -165,7 +171,7 @@ class ModifierTarget(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         help_text="The resonance this target represents (resonance category only).",
     )
     target_capability = models.OneToOneField(
-        "arxii.CapabilityType",
+        CAPABILITY_TYPE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -173,7 +179,7 @@ class ModifierTarget(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         help_text="The capability this target represents (capability category only).",
     )
     target_check_type = models.OneToOneField(
-        "arxii.CheckType",
+        CHECK_TYPE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -744,7 +750,7 @@ class Application(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
 
     name = models.CharField(max_length=100)
     capability = models.ForeignKey(
-        "arxii.CapabilityType",
+        CAPABILITY_TYPE_MODEL,
         on_delete=models.CASCADE,
         related_name="applications",
     )
@@ -807,12 +813,12 @@ class TraitCapabilityDerivation(NaturalKeyMixin, SharedMemoryModel):
     """
 
     trait = models.ForeignKey(
-        "arxii.Trait",
+        TRAIT_MODEL,
         on_delete=models.CASCADE,
         related_name="capability_derivations",
     )
     capability = models.ForeignKey(
-        "arxii.CapabilityType",
+        CAPABILITY_TYPE_MODEL,
         on_delete=models.CASCADE,
         related_name="trait_derivations",
     )
@@ -835,7 +841,7 @@ class TraitCapabilityDerivation(NaturalKeyMixin, SharedMemoryModel):
 
     class NaturalKeyConfig:
         fields = ["trait", "capability"]
-        dependencies = ["arxii.Trait", "arxii.CapabilityType"]
+        dependencies = [TRAIT_MODEL, CAPABILITY_TYPE_MODEL]
 
     def __str__(self) -> str:
         return f"{self.trait.name} → {self.capability.name}"
@@ -909,7 +915,7 @@ class ChallengeTemplate(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         default=ChallengeType.INHIBITOR,
     )
     blocked_capability = models.ForeignKey(
-        "arxii.CapabilityType",
+        CAPABILITY_TYPE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -921,7 +927,7 @@ class ChallengeTemplate(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         default=DiscoveryType.OBVIOUS,
     )
     consequences = models.ManyToManyField(
-        "arxii.Consequence",
+        CONSEQUENCE_MODEL,
         through="ChallengeTemplateConsequence",
         related_name="challenge_templates",
         blank=True,
@@ -973,7 +979,7 @@ class ChallengeTemplateConsequence(SharedMemoryModel):
         related_name="challenge_consequences",
     )
     consequence = models.ForeignKey(
-        "arxii.Consequence",
+        CONSEQUENCE_MODEL,
         on_delete=models.CASCADE,
         related_name="challenge_template_consequences",
     )
@@ -1023,7 +1029,7 @@ class ChallengeApproach(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         related_name="challenge_approaches",
     )
     check_type = models.ForeignKey(
-        "arxii.CheckType",
+        CHECK_TYPE_MODEL,
         on_delete=models.CASCADE,
         related_name="challenge_approaches",
     )
@@ -1092,7 +1098,7 @@ class ApproachConsequence(SharedMemoryModel):
         related_name="consequences",
     )
     consequence = models.ForeignKey(
-        "arxii.Consequence",
+        CONSEQUENCE_MODEL,
         on_delete=models.CASCADE,
         related_name="approach_consequences",
     )
@@ -1237,12 +1243,12 @@ class SituationTrapLink(NaturalKeyMixin, SharedMemoryModel):
         related_name="situation_trap_links",
     )
     detect_check_type = models.ForeignKey(
-        "arxii.CheckType",
+        CHECK_TYPE_MODEL,
         on_delete=models.PROTECT,
         related_name="detect_situation_traps",
     )
     disarm_check_type = models.ForeignKey(
-        "arxii.CheckType",
+        CHECK_TYPE_MODEL,
         on_delete=models.PROTECT,
         related_name="disarm_situation_traps",
     )
@@ -1415,7 +1421,7 @@ class CharacterChallengeRecord(SharedMemoryModel):
         related_name="challenge_records",
     )
     consequence = models.ForeignKey(
-        "arxii.Consequence",
+        CONSEQUENCE_MODEL,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1455,7 +1461,7 @@ class ContextConsequencePool(SharedMemoryModel):
         related_name="context_attachments",
     )
     check_type = models.ForeignKey(
-        "arxii.CheckType",
+        CHECK_TYPE_MODEL,
         on_delete=models.PROTECT,
         null=True,
         blank=True,

--- a/src/world/missions/models.py
+++ b/src/world/missions/models.py
@@ -64,6 +64,9 @@ _CONSEQUENCE_FK = "arxii.Consequence"
 OBJECT_DB_MODEL = "objects.ObjectDB"
 ROOM_PROFILE_MODEL = "arxii.RoomProfile"
 CHARACTER_SHEET_MODEL = "arxii.CharacterSheet"
+CHECK_TYPE_MODEL = "arxii.CheckType"
+CHECK_OUTCOME_MODEL = "arxii.CheckOutcome"
+NPC_SERVICE_OFFER_MODEL = "arxii.NPCServiceOffer"
 
 # #1035 — the durable (non-transient) ExternalAct members. Mirrors
 # ``world.missions.services.external_acts._DURABLE_ACTS`` — duplicated here
@@ -527,7 +530,7 @@ class MissionOption(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         help_text="Phase 0 predicate tree gating this option's visibility.",
     )
     authored_check_type = models.ForeignKey(
-        "arxii.CheckType",
+        CHECK_TYPE_MODEL,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -780,7 +783,7 @@ class MissionOptionRoute(NaturalKeyMixin, CreditedContent, SharedMemoryModel):
         related_name="routes",
     )
     outcome_tier = models.ForeignKey(
-        "arxii.CheckOutcome",
+        CHECK_OUTCOME_MODEL,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -1015,7 +1018,7 @@ class MissionOptionRouteReward(NaturalKeyMixin, CreditedContent, SharedMemoryMod
         help_text="Required when sink=ITEM: which ItemTemplate this reward grants.",
     )
     followon_offer = models.ForeignKey(
-        "arxii.NPCServiceOffer",
+        NPC_SERVICE_OFFER_MODEL,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -1438,7 +1441,7 @@ class MissionInstance(SharedMemoryModel):
     # Used to scope the CharacterSheet.max_active_npc_missions cap to
     # NPC-mediated runs only.
     source_offer = models.ForeignKey(
-        "arxii.NPCServiceOffer",
+        NPC_SERVICE_OFFER_MODEL,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -1726,7 +1729,7 @@ class MissionDeedRecord(SharedMemoryModel):
         related_name="+",
     )
     outcome = models.ForeignKey(
-        "arxii.CheckOutcome",
+        CHECK_OUTCOME_MODEL,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -1800,7 +1803,7 @@ class MissionAssistPattern(SharedMemoryModel):
         ),
     )
     check_types = models.ManyToManyField(
-        "arxii.CheckType",
+        CHECK_TYPE_MODEL,
         blank=True,
         related_name="assist_patterns",
         help_text="Context axis: match when the node has a CHECK option using any of these.",
@@ -1814,7 +1817,7 @@ class MissionAssistPattern(SharedMemoryModel):
         ),
     )
     support_check_type = models.ForeignKey(
-        "arxii.CheckType",
+        CHECK_TYPE_MODEL,
         on_delete=models.PROTECT,
         related_name="+",
         help_text="The CheckType rolled when a helper declares this support move.",
@@ -1828,7 +1831,7 @@ class MissionAssistPattern(SharedMemoryModel):
         help_text="Bonus added to the resolving check on success (retunable, can be negative).",
     )
     complication_consequence = models.ForeignKey(
-        "arxii.Consequence",
+        _CONSEQUENCE_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1890,7 +1893,7 @@ class MissionNodeSupportOption(SharedMemoryModel):
         help_text="Predicate-tree leg. Empty dict = no predicate gate.",
     )
     support_check_type = models.ForeignKey(
-        "arxii.CheckType",
+        CHECK_TYPE_MODEL,
         on_delete=models.PROTECT,
         related_name="+",
         help_text="The CheckType rolled when a helper declares this support move.",
@@ -1898,7 +1901,7 @@ class MissionNodeSupportOption(SharedMemoryModel):
     difficulty = models.PositiveSmallIntegerField(default=5)
     easing = models.IntegerField(default=2)
     complication_consequence = models.ForeignKey(
-        "arxii.Consequence",
+        _CONSEQUENCE_FK,
         on_delete=models.SET_NULL,
         null=True,
         blank=True,
@@ -1967,7 +1970,7 @@ class MissionSupportDeclaration(SharedMemoryModel):
         related_name="+",
     )
     outcome = models.ForeignKey(
-        "arxii.CheckOutcome",
+        CHECK_OUTCOME_MODEL,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -2228,7 +2231,7 @@ class MissionDeedRewardLine(SharedMemoryModel):
         help_text="Required when sink=ITEM: which ItemTemplate this reward grants.",
     )
     followon_offer = models.ForeignKey(
-        "arxii.NPCServiceOffer",
+        NPC_SERVICE_OFFER_MODEL,
         null=True,
         blank=True,
         on_delete=models.PROTECT,
@@ -2348,7 +2351,7 @@ class MissionRiskAcknowledgement(SharedMemoryModel):
     """
 
     offer = models.ForeignKey(
-        "arxii.NPCServiceOffer",
+        NPC_SERVICE_OFFER_MODEL,
         on_delete=models.CASCADE,
         related_name="mission_risk_acknowledgements",
     )

--- a/src/world/registration/models.py
+++ b/src/world/registration/models.py
@@ -15,6 +15,9 @@ from evennia.utils.idmapper.models import SharedMemoryModel
 from core.managers import ArxSharedMemoryManager
 from world.registration.constants import InviteStatus
 
+# Lazy model reference (Django app_label.ModelName), extracted to satisfy S1192.
+ACCOUNT_DB_MODEL = "accounts.AccountDB"
+
 
 class RegistrationConfig(SharedMemoryModel):
     """Singleton (pk=1) staff-tunable toggle for open account registration."""
@@ -27,7 +30,7 @@ class RegistrationConfig(SharedMemoryModel):
     )
     updated_at = models.DateTimeField(auto_now=True)
     updated_by = models.ForeignKey(
-        "accounts.AccountDB",
+        ACCOUNT_DB_MODEL,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,
@@ -63,7 +66,7 @@ class AccountInvite(SharedMemoryModel):
     email = models.EmailField(db_index=True)
     token = models.CharField(max_length=64, unique=True, db_index=True)
     invited_by = models.ForeignKey(
-        "accounts.AccountDB",
+        ACCOUNT_DB_MODEL,
         on_delete=models.PROTECT,
         related_name="issued_account_invites",
     )
@@ -71,7 +74,7 @@ class AccountInvite(SharedMemoryModel):
     expires_at = models.DateTimeField(help_text="Invite cannot be redeemed after this time.")
     redeemed_at = models.DateTimeField(null=True, blank=True)
     redeemed_by = models.ForeignKey(
-        "accounts.AccountDB",
+        ACCOUNT_DB_MODEL,
         null=True,
         blank=True,
         on_delete=models.SET_NULL,


### PR DESCRIPTION
## Summary

Batch fix for the 40 open SonarCloud `python:S1192` issues (duplicated string literals). Each affected file gains module-level constants for its repeated lazy Django model-reference strings (`"arxii.<Model>"`), lock strings, and error messages; every code occurrence is replaced with the constant. Values are byte-identical to the literals they replace: zero behavior change. Comments and docstrings are untouched.

The ~9 open `python:S3776` cognitive-complexity issues are deliberately NOT in this PR: those are real refactors (prose_report, fashion, reference, communication, YourTurn.tsx) and should not ride a mechanical batch.

Verification: `ruff check` + `ruff format` clean on all 22 changed files; `arx manage check` reports 0 errors (catches any broken lazy model reference at import time); per-file pre-commit hooks passed at commit. CI is the regression gate.

Closes #3097
Closes #3098
Closes #3099
Closes #3100
Closes #3101
Closes #3108
Closes #3110
Closes #3113
Closes #3114
Closes #3115
Closes #3116
Closes #3117
Closes #3118
Closes #3119
Closes #3120
Closes #3121
Closes #3122
Closes #3123
Closes #3124
Closes #3125
Closes #3126
Closes #3127
Closes #3128
Closes #3129
Closes #3130
Closes #3131
Closes #3132
Closes #3133
Closes #3134
Closes #3135
Closes #3136
Closes #3137
Closes #3138
Closes #3139
Closes #3140
Closes #3141
Closes #3142
Closes #3143
Closes #3144
Closes #3145

🤖 Generated with [Claude Code](https://claude.com/claude-code)
