### PR TITLE
Sonar S3776: cognitive-complexity refactors across the ten flagged functions

### DIFF
--- a/frontend/src/combat/sections/YourTurn.tsx
+++ b/frontend/src/combat/sections/YourTurn.tsx
@@ -504,6 +504,46 @@ function ClashContributionRow({
   );
 }
 
+/**
+ * Resolve the ally name attached to a declared maneuver (cover/interpose), or
+ * null when a different maneuver is declared or no ally target is set (a null
+ * focused_ally_target on interpose means "guard whoever is hit", #2207).
+ */
+function maneuverAllyName(
+  expectedManeuver: string,
+  declaredManeuver: string | null,
+  ownRoundAction: RoundActionTyped | null,
+  participants: Participant[]
+): string | null {
+  if (declaredManeuver !== expectedManeuver || ownRoundAction?.focused_ally_target == null) {
+    return null;
+  }
+  const ally = participants.find((p) => p.id === ownRoundAction.focused_ally_target);
+  return ally?.character_name ?? `participant #${ownRoundAction.focused_ally_target}`;
+}
+
+/**
+ * The reason the submit button must refuse, or null when clear to dispatch —
+ * mirrors the required-declaration gating (#1543/#2206).
+ */
+function submitBlockReason(args: {
+  soulfrayWarning: SoulfrayWarningData | null;
+  soulfrayAccepted: boolean;
+  furyOverCap: boolean;
+  positionRequirementMet: boolean;
+}): string | null {
+  if (args.soulfrayWarning !== null && !args.soulfrayAccepted) {
+    return 'Accept the Soulfray risk to proceed.';
+  }
+  if (args.furyOverCap) {
+    return 'Chosen fury tier exceeds your bond with the anchor.';
+  }
+  if (!args.positionRequirementMet) {
+    return 'Select a position target for this technique.';
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // YourTurn
 // ---------------------------------------------------------------------------
@@ -742,25 +782,22 @@ export function YourTurn({
     })),
   ];
 
+  // The selected focused technique's action descriptor — one lookup shared by
+  // the reach constraint (#532), the position-targeting shape (#2206), and the
+  // soulfray/fury descriptor (#1543) below.
+  const focusedCastDescriptor =
+    focusedContext.techniqueId === undefined
+      ? null
+      : (availableActions.find((a) => a.ref.technique_id === focusedContext.techniqueId) ?? null);
+
   // Reach constraint for the currently selected focused technique (#532).
-  const focusedTechniqueReach: string | null = (() => {
-    if (focusedContext.techniqueId === undefined) return null;
-    const selected = availableActions.find(
-      (a) => a.ref.technique_id === focusedContext.techniqueId
-    );
-    return selected?.reach ?? null;
-  })();
+  const focusedTechniqueReach: string | null = focusedCastDescriptor?.reach ?? null;
 
   // Cast-time position-targeting shape for the currently selected focused
   // technique (#2206). Positions/edges data is the same source
   // CombatTacticalMap uses — EncounterDetail.position_nodes.
-  const focusedTechniquePositionShape: PositionTargetShape = (() => {
-    if (focusedContext.techniqueId === undefined) return 'none';
-    const selected = availableActions.find(
-      (a) => a.ref.technique_id === focusedContext.techniqueId
-    );
-    return selected?.position_target_shape ?? 'none';
-  })();
+  const focusedTechniquePositionShape: PositionTargetShape =
+    focusedCastDescriptor?.position_target_shape ?? 'none';
   const focusedPositions: PositionNode[] = encounter?.position_nodes ?? [];
 
   // Report the current shape to the caller (#2206) — lets the tactical-map tab
@@ -781,10 +818,6 @@ export function YourTurn({
       castPosition.pairB !== undefined);
 
   // Soulfray + fury descriptor for the currently selected focused cast (#1543).
-  const focusedCastDescriptor = (() => {
-    if (focusedContext.techniqueId === undefined) return null;
-    return availableActions.find((a) => a.ref.technique_id === focusedContext.techniqueId) ?? null;
-  })();
   const soulfrayWarning = focusedCastDescriptor?.soulfray_warning ?? null;
   const furyTiers = focusedCastDescriptor?.available_fury_tiers ?? [];
   const furyAnchors = focusedCastDescriptor?.eligible_fury_anchors ?? [];
@@ -798,21 +831,16 @@ export function YourTurn({
   const declaredManeuver = ownRoundAction?.maneuver ?? null;
 
   // Resolve covered ally's name from participants list.
-  const coveredAllyName = (() => {
-    if (declaredManeuver !== 'cover' || ownRoundAction?.focused_ally_target == null) return null;
-    const ally = participants.find((p) => p.id === ownRoundAction.focused_ally_target);
-    return ally?.character_name ?? `participant #${ownRoundAction.focused_ally_target}`;
-  })();
+  const coveredAllyName = maneuverAllyName('cover', declaredManeuver, ownRoundAction, participants);
 
   // Resolve guarded ally's name from participants list (#2207). null
   // focused_ally_target on an interpose maneuver means "guard whoever is hit."
-  const guardedAllyName = (() => {
-    if (declaredManeuver !== 'interpose' || ownRoundAction?.focused_ally_target == null) {
-      return null;
-    }
-    const ally = participants.find((p) => p.id === ownRoundAction.focused_ally_target);
-    return ally?.character_name ?? `participant #${ownRoundAction.focused_ally_target}`;
-  })();
+  const guardedAllyName = maneuverAllyName(
+    'interpose',
+    declaredManeuver,
+    ownRoundAction,
+    participants
+  );
 
   // Techniques offered as a Guard's optional protective technique (#2207): any
   // available combat-cast technique whose protective_flavor classifier resolved.
@@ -845,16 +873,14 @@ export function YourTurn({
 
     setSubmitError(null);
 
-    if (soulfrayWarning !== null && !soulfrayAccepted) {
-      setSubmitError('Accept the Soulfray risk to proceed.');
-      return;
-    }
-    if (furyOverCap) {
-      setSubmitError('Chosen fury tier exceeds your bond with the anchor.');
-      return;
-    }
-    if (!positionRequirementMet) {
-      setSubmitError('Select a position target for this technique.');
+    const blockReason = submitBlockReason({
+      soulfrayWarning,
+      soulfrayAccepted,
+      furyOverCap,
+      positionRequirementMet,
+    });
+    if (blockReason !== null) {
+      setSubmitError(blockReason);
       return;
     }
 

--- a/src/actions/definitions/fashion.py
+++ b/src/actions/definitions/fashion.py
@@ -440,22 +440,30 @@ def _equipped_rows(sheet: Any) -> list:
 def _blockers_above(rows: list, mine: list, *, opened_only: bool = False) -> list:
     """Rows above any of ``mine``'s slots that block (or, for conceal, are open)."""
     from world.items.services.appearance import LAYER_RANK  # noqa: PLC0415
-    from world.items.services.visibility import is_see_through  # noqa: PLC0415
 
     blockers = []
     for target_row in mine:
         rank = LAYER_RANK.get(target_row.equipment_layer, 99)
         for row in rows:
-            if row.body_region != target_row.body_region or row.pk == target_row.pk:
-                continue
-            if LAYER_RANK.get(row.equipment_layer, 99) <= rank:
-                continue
-            if opened_only:
-                if row.opened_at is not None and row not in blockers:
-                    blockers.append(row)
-            elif not is_see_through(row) and row not in blockers:
+            if _blocks_target(row, target_row, rank, opened_only=opened_only) and (
+                row not in blockers
+            ):
                 blockers.append(row)
     return blockers
+
+
+def _blocks_target(row: Any, target_row: Any, rank: int, *, opened_only: bool) -> bool:
+    """Whether ``row`` sits above ``target_row``'s layer and blocks (or, for conceal, is open)."""
+    from world.items.services.appearance import LAYER_RANK  # noqa: PLC0415
+    from world.items.services.visibility import is_see_through  # noqa: PLC0415
+
+    if row.body_region != target_row.body_region or row.pk == target_row.pk:
+        return False
+    if LAYER_RANK.get(row.equipment_layer, 99) <= rank:
+        return False
+    if opened_only:
+        return row.opened_at is not None
+    return not is_see_through(row)
 
 
 def _open_rows(rows: list) -> None:

--- a/src/commands/evennia_overrides/communication.py
+++ b/src/commands/evennia_overrides/communication.py
@@ -157,7 +157,57 @@ class CmdPage(FrontendMetadataMixin, Command):  # ty: ignore[invalid-base]
     locks = "cmd:all()"
     help_category = "Account"
 
-    def func(self) -> None:  # noqa: PLR0911 — sequential guard clauses for a dispatcher
+    def _resolve_target(self, charname: str) -> Any | None:
+        """Resolve *charname* to a rostered character, messaging the caller on any miss."""
+        characters = search.object_search(charname, exact=True)
+        if not characters:
+            self.caller.msg(f"Could not find character '{charname}'.")
+            return None
+        if len(characters) > 1:
+            self.caller.msg(f"Multiple characters found matching '{charname}'.")
+            return None
+        character = characters[0]
+        try:
+            _ = character.sheet_data.roster_entry
+        except ObjectDoesNotExist:
+            self.caller.msg(f"Character '{charname}' is not on the roster.")
+            return None
+        return character
+
+    def _quiet_mode_refusal(
+        self, sender_char: object | None, character: Any, account: Any, charname: str
+    ) -> str | None:
+        """Quiet-mode (#1463) reach gating, both directions, keyed off the account↔account
+        allowlist. CmdPage is an AccountCmdSet command, so self.caller is the sender's
+        account; the per-character hidden flag is read on the sender's session puppet and
+        on the resolved target.
+        """
+        from world.scenes.presence import (  # noqa: PLC0415
+            account_on_allowlist,
+            character_appears_offline,
+        )
+
+        # (a) A hidden character can only page people on their own allowlist — so they never
+        #     strand a non-whitelisted friend who then can't reply (the friend would just see
+        #     "offline"). Self-explaining refusal, since the sender may have forgotten.
+        if (
+            sender_char is not None
+            and character_appears_offline(sender_char)
+            and not account_on_allowlist(owner_account=self.caller, viewer_account=account)
+        ):
+            return (
+                "You're hidden (appearing offline), so you can only page people on your "
+                "allowlist. Use 'unhide' to come back online first."
+            )
+        # (b) A hidden target is unreachable to anyone off their allowlist — the SAME message
+        #     as if they were simply offline, so quiet mode never leaks.
+        if character_appears_offline(character) and not account_on_allowlist(
+            owner_account=account, viewer_account=self.caller
+        ):
+            return f"Character '{charname}' is not online."
+        return None
+
+    def func(self) -> None:
         """Execute the page command."""
         if not self.args or "=" not in self.args:
             self.caller.msg("Usage: page <character>=<message>")
@@ -168,19 +218,8 @@ class CmdPage(FrontendMetadataMixin, Command):  # ty: ignore[invalid-base]
             self.caller.msg("Usage: page <character>=<message>")
             return
 
-        characters = search.object_search(charname, exact=True)
-        if not characters:
-            self.caller.msg(f"Could not find character '{charname}'.")
-            return
-        if len(characters) > 1:
-            self.caller.msg(f"Multiple characters found matching '{charname}'.")
-            return
-
-        character = characters[0]
-        try:
-            _ = character.sheet_data.roster_entry
-        except ObjectDoesNotExist:
-            self.caller.msg(f"Character '{charname}' is not on the roster.")
+        character = self._resolve_target(charname)
+        if character is None:
             return
 
         account = character.active_account
@@ -188,37 +227,12 @@ class CmdPage(FrontendMetadataMixin, Command):  # ty: ignore[invalid-base]
             self.caller.msg(f"Character '{charname}' has no active player.")
             return
 
-        # Quiet-mode (#1463) reach gating, both directions, keyed off the account↔account
-        # allowlist. CmdPage is an AccountCmdSet command, so self.caller is the sender's
-        # account; the per-character hidden flag is read on the sender's session puppet and
-        # on the resolved target.
-        from world.scenes.presence import (  # noqa: PLC0415
-            account_on_allowlist,
-            character_appears_offline,
-        )
-
         # Suppression justified: Evennia cmdhandler sets .session at runtime.
         session = getattr(self, "session", None)  # noqa: GETATTR_LITERAL
         sender_char = session.puppet if session is not None else None
-        # (a) A hidden character can only page people on their own allowlist — so they never
-        #     strand a non-whitelisted friend who then can't reply (the friend would just see
-        #     "offline"). Self-explaining refusal, since the sender may have forgotten.
-        if (
-            sender_char is not None
-            and character_appears_offline(sender_char)
-            and not account_on_allowlist(owner_account=self.caller, viewer_account=account)
-        ):
-            self.caller.msg(
-                "You're hidden (appearing offline), so you can only page people on your "
-                "allowlist. Use 'unhide' to come back online first."
-            )
-            return
-        # (b) A hidden target is unreachable to anyone off their allowlist — the SAME message
-        #     as if they were simply offline, so quiet mode never leaks.
-        if character_appears_offline(character) and not account_on_allowlist(
-            owner_account=account, viewer_account=self.caller
-        ):
-            self.caller.msg(f"Character '{charname}' is not online.")
+        refusal = self._quiet_mode_refusal(sender_char, character, account, charname)
+        if refusal is not None:
+            self.caller.msg(refusal)
             return
 
         # #2996 Decision 2 — an account-level block upgrades page delivery from flag-only to

--- a/src/core_management/prose_report.py
+++ b/src/core_management/prose_report.py
@@ -107,6 +107,15 @@ def _count(report: ProseReport, domain: str, fields: dict, extra_words: int = 0)
         row.reviewed += 1
 
 
+def _fixture_records(path: Path) -> list:
+    """One fixture file's record list; [] when unreadable or not a list."""
+    try:
+        records = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return []
+    return records if isinstance(records, list) else []
+
+
 def _scan_fixture_json(content_root: Path, report: ProseReport) -> None:
     """Count prose rows in ``fixtures/<domain>/<model>.json``."""
     fixtures_dir = content_root / "fixtures"
@@ -116,17 +125,32 @@ def _scan_fixture_json(content_root: Path, report: ProseReport) -> None:
     for path in sorted(fixtures_dir.rglob("*.json")):
         if path.is_relative_to(grid_dir):
             continue
-        try:
-            records = json.loads(path.read_text(encoding="utf-8"))
-        except (OSError, ValueError):
-            continue
-        if not isinstance(records, list):
-            continue
         domain = path.relative_to(fixtures_dir).parts[0]
-        for record in records:
+        for record in _fixture_records(path):
             fields = record.get("fields") if isinstance(record, dict) else None
             if isinstance(fields, dict):
                 _count(report, domain, fields)
+
+
+def _parse_markdown_entry(path: Path) -> tuple[dict, int] | None:
+    """One entry's frontmatter dict + body word count; None when malformed."""
+    lines = path.read_text(encoding="utf-8").splitlines()
+    if not lines or lines[0].strip() != FRONTMATTER_DELIMITER:
+        return None
+    end = next(
+        (i for i in range(1, len(lines)) if lines[i].strip() == FRONTMATTER_DELIMITER),
+        None,
+    )
+    if end is None:
+        return None
+    try:
+        meta = yaml.safe_load("\n".join(lines[1:end])) or {}
+    except yaml.YAMLError:
+        return None
+    if not isinstance(meta, dict):
+        return None
+    body = "\n".join(lines[end + 1 :]).strip()
+    return meta, len(body.split())
 
 
 def _scan_markdown(content_root: Path, report: ProseReport) -> None:
@@ -136,23 +160,11 @@ def _scan_markdown(content_root: Path, report: ProseReport) -> None:
         if not domain_dir.is_dir():
             continue
         for path in sorted(domain_dir.rglob("*.md")):
-            lines = path.read_text(encoding="utf-8").splitlines()
-            if not lines or lines[0].strip() != FRONTMATTER_DELIMITER:
+            parsed = _parse_markdown_entry(path)
+            if parsed is None:
                 continue
-            end = next(
-                (i for i in range(1, len(lines)) if lines[i].strip() == FRONTMATTER_DELIMITER),
-                None,
-            )
-            if end is None:
-                continue
-            try:
-                meta = yaml.safe_load("\n".join(lines[1:end])) or {}
-            except yaml.YAMLError:
-                continue
-            if not isinstance(meta, dict):
-                continue
-            body = "\n".join(lines[end + 1 :]).strip()
-            _count(report, domain, meta, extra_words=len(body.split()))
+            meta, body_words = parsed
+            _count(report, domain, meta, extra_words=body_words)
 
 
 def scan_corpus(content_root: Path) -> ProseReport:

--- a/src/web/admin/authoring/contributors.py
+++ b/src/web/admin/authoring/contributors.py
@@ -87,32 +87,9 @@ def link_contributor(
             player_data, _created = PlayerData.objects.get_or_create(account=user)
 
             if existing_pk is not None:
-                try:
-                    contributor = ContentContributor.objects.get(pk=existing_pk)
-                except (
-                    ContentContributor.DoesNotExist,
-                    ValueError,
-                    OverflowError,
-                    DataError,
-                ) as exc:
-                    msg = "That contributor no longer exists."
-                    raise ValueError(msg) from exc
-                _refuse_if_linked_elsewhere(contributor, player_data)
+                contributor = _pick_existing(existing_pk, player_data)
             else:
-                stripped_name = name.strip()
-                if not stripped_name:
-                    msg = "Enter a name to write under."
-                    raise ValueError(msg)
-                if any(char in stripped_name for char in _DASH_CHARACTERS):
-                    raise ValueError(_DASH_NAME_MESSAGE)
-                if len(stripped_name) > _MAX_NAME_LENGTH:
-                    raise ValueError(_LONG_NAME_MESSAGE)
-
-                contributor = ContentContributor.objects.filter(name=stripped_name).first()
-                if contributor is not None:
-                    _refuse_if_linked_elsewhere(contributor, player_data)
-                else:
-                    contributor = ContentContributor.objects.create(name=stripped_name)
+                contributor = _create_or_pick_by_name(name, player_data)
 
             player_data.contributor = contributor
             player_data.save()
@@ -122,3 +99,38 @@ def link_contributor(
         if raced_contributor is not None:
             return raced_contributor
         raise ValueError(_RACE_MESSAGE) from exc
+
+
+def _pick_existing(existing_pk: int, player_data: PlayerData) -> ContentContributor:
+    """The pick-from-the-list path: an existing, not-otherwise-linked contributor."""
+    try:
+        contributor = ContentContributor.objects.get(pk=existing_pk)
+    except (
+        ContentContributor.DoesNotExist,
+        ValueError,
+        OverflowError,
+        DataError,
+    ) as exc:
+        msg = "That contributor no longer exists."
+        raise ValueError(msg) from exc
+    _refuse_if_linked_elsewhere(contributor, player_data)
+    return contributor
+
+
+def _create_or_pick_by_name(name: str, player_data: PlayerData) -> ContentContributor:
+    """The typed-name path: validate, then pick an unlinked exact match or create."""
+    stripped_name = name.strip()
+    if not stripped_name:
+        msg = "Enter a name to write under."
+        raise ValueError(msg)
+    if any(char in stripped_name for char in _DASH_CHARACTERS):
+        raise ValueError(_DASH_NAME_MESSAGE)
+    if len(stripped_name) > _MAX_NAME_LENGTH:
+        raise ValueError(_LONG_NAME_MESSAGE)
+
+    contributor = ContentContributor.objects.filter(name=stripped_name).first()
+    if contributor is not None:
+        _refuse_if_linked_elsewhere(contributor, player_data)
+    else:
+        contributor = ContentContributor.objects.create(name=stripped_name)
+    return contributor

--- a/src/web/admin/authoring/reference.py
+++ b/src/web/admin/authoring/reference.py
@@ -162,18 +162,24 @@ def _iter_text_files(root: Path, deadline: float):
         for name in names:
             if time.monotonic() > deadline:
                 return
-            candidate = Path(base) / name
-            if candidate.suffix not in _TEXT_SUFFIXES:
-                continue
-            try:
-                if candidate.stat().st_size > _MAX_FILE_BYTES:
-                    continue
-            except OSError:
-                continue
-            resolved = candidate.resolve()
-            if not resolved.is_relative_to(root):
-                continue
-            yield resolved
+            resolved = _eligible_file(Path(base) / name, root)
+            if resolved is not None:
+                yield resolved
+
+
+def _eligible_file(candidate: Path, root: Path) -> Path | None:
+    """Resolve one walk candidate; None when filtered by suffix, size, or escape."""
+    if candidate.suffix not in _TEXT_SUFFIXES:
+        return None
+    try:
+        if candidate.stat().st_size > _MAX_FILE_BYTES:
+            return None
+    except OSError:
+        return None
+    resolved = candidate.resolve()
+    if not resolved.is_relative_to(root):
+        return None
+    return resolved
 
 
 def file_search(
@@ -208,30 +214,43 @@ def file_search(
     deadline = time.monotonic() + budget_seconds
     for raw_root in roots:
         root = raw_root.resolve()
-        root_label = root.name
         for path in _iter_text_files(root, deadline):
             if len(hits) >= cap or time.monotonic() > deadline:
                 return hits
-            try:
-                text = path.read_text(encoding="utf-8", errors="replace")
-            except OSError:
-                continue
-            for line_no, line in enumerate(text.splitlines(), start=1):
-                if time.monotonic() > deadline:
-                    return hits
-                if needle not in line.casefold():
-                    continue
-                hits.append(
-                    FileSearchHit(
-                        root_label=root_label,
-                        path=str(path.relative_to(root)),
-                        line=line_no,
-                        text=line.strip()[:200],
-                    )
-                )
-                if len(hits) >= cap:
-                    return hits
+            file_hits, budget_ok = _scan_file_lines(
+                path, root, needle, limit=cap - len(hits), deadline=deadline
+            )
+            hits.extend(file_hits)
+            if not budget_ok:
+                return hits
     return hits
+
+
+def _scan_file_lines(
+    path: Path, root: Path, needle: str, *, limit: int, deadline: float
+) -> tuple[list[FileSearchHit], bool]:
+    """One file's matching lines, at most *limit*; False when the budget halted mid-file."""
+    file_hits: list[FileSearchHit] = []
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return file_hits, True
+    for line_no, line in enumerate(text.splitlines(), start=1):
+        if time.monotonic() > deadline:
+            return file_hits, False
+        if needle not in line.casefold():
+            continue
+        file_hits.append(
+            FileSearchHit(
+                root_label=root.name,
+                path=str(path.relative_to(root)),
+                line=line_no,
+                text=line.strip()[:200],
+            )
+        )
+        if len(file_hits) >= limit:
+            return file_hits, True
+    return file_hits, True
 
 
 def reference_roots(*, staff_docs: bool, arx1: bool) -> list[Path]:

--- a/src/world/societies/houses/stature_services.py
+++ b/src/world/societies/houses/stature_services.py
@@ -198,6 +198,27 @@ def _union_membership(
     return members_by_union, kin_by_id
 
 
+@dataclass(frozen=True)
+class _UnionRoster:
+    """Union membership context: who belongs to which union, and who is house-side."""
+
+    members_by_union: dict[int, list[int]]
+    kin_by_id: dict[int, Kinsperson]
+    house_ids: set[int]
+
+    def insiders(self, union: Union) -> list[Kinsperson]:
+        member_ids = self.members_by_union.get(union.pk, [])
+        return [
+            self.kin_by_id[m] for m in member_ids if m in self.house_ids and m in self.kin_by_id
+        ]
+
+    def outsiders(self, union: Union) -> list[Kinsperson]:
+        member_ids = self.members_by_union.get(union.pk, [])
+        return [
+            self.kin_by_id[m] for m in member_ids if m not in self.house_ids and m in self.kin_by_id
+        ]
+
+
 def _union_partner_scores(
     house_kin: list[Kinsperson],
     seen_kin_ids: set[int],
@@ -221,12 +242,12 @@ def _union_partner_scores(
         .distinct()
     )
     members_by_union, kin_by_id = _union_membership(unions, house_ids, house_kin)
+    roster = _UnionRoster(members_by_union, kin_by_id, house_ids)
     total = 0
     consorts_per_senior: dict[int, list[Union]] = {}
     for union in unions:
-        member_ids = members_by_union.get(union.pk, [])
-        inside = [kin_by_id[m] for m in member_ids if m in house_ids and m in kin_by_id]
-        outside = [kin_by_id[m] for m in member_ids if m not in house_ids and m in kin_by_id]
+        inside = roster.insiders(union)
+        outside = roster.outsiders(union)
         if not inside or not outside:
             continue
         kind = union.kind
@@ -241,20 +262,31 @@ def _union_partner_scores(
                 partner, kind.stature_share_pct, seen_kin_ids, seen_sheet_ids, legend_reader
             )
     for unions_for_senior in consorts_per_senior.values():
-        ordered = sorted(
-            unions_for_senior, key=lambda u: (u.started_at is None, u.started_at, u.pk)
+        total += _consort_scores(
+            unions_for_senior, roster, seen_kin_ids, seen_sheet_ids, legend_reader
         )
-        for union in _capped(ordered):
-            for kin_id in members_by_union.get(union.pk, []):
-                if kin_id in house_ids or kin_id not in kin_by_id:
-                    continue
-                total += _partner_contribution(
-                    kin_by_id[kin_id],
-                    union.kind.stature_share_pct,
-                    seen_kin_ids,
-                    seen_sheet_ids,
-                    legend_reader,
-                )
+    return total
+
+
+def _consort_scores(
+    unions_for_senior: list[Union],
+    roster: _UnionRoster,
+    seen_kin_ids: set[int],
+    seen_sheet_ids: set[int],
+    legend_reader: LegendReader,
+) -> int:
+    """One senior's consort-class unions: earliest first, capped at max_concurrent."""
+    ordered = sorted(unions_for_senior, key=lambda u: (u.started_at is None, u.started_at, u.pk))
+    total = 0
+    for union in _capped(ordered):
+        for partner in roster.outsiders(union):
+            total += _partner_contribution(
+                partner,
+                union.kind.stature_share_pct,
+                seen_kin_ids,
+                seen_sheet_ids,
+                legend_reader,
+            )
     return total
 
 


### PR DESCRIPTION
Closes #3096
Closes #3102
Closes #3103
Closes #3104
Closes #3105
Closes #3106
Closes #3107
Closes #3109
Closes #3111
Closes #3112

## Summary

SonarCloud `S3776` cognitive-complexity batch: every flagged function is brought under the 15 threshold by extracting the deepest-nested block into a small named helper, with no behavior change. Complements PR #3148, which took the 40 `S1192` duplicated-literal issues; together they retire the whole `sonarcloud`-labeled backlog. Locations were re-verified against SonarCloud's live API before refactoring (the issue bodies' line numbers had drifted; e.g. #3096's function is `_union_partner_scores` at line 201, complexity 24).

- `world/societies/houses/stature_services.py` — `_union_partner_scores` (24): the consort-cap tail moves to `_consort_scores`, with a small `_UnionRoster` dataclass carrying the membership context (also dedupes the inside/outside comprehensions).
- `core_management/prose_report.py` — `_scan_fixture_json` (16) and `_scan_markdown` (19): per-file parsing extracted to `_fixture_records` / `_parse_markdown_entry`.
- `commands/evennia_overrides/communication.py` — `CmdPage.func` (18): target resolution moves to `_resolve_target`, the two quiet-mode gates to `_quiet_mode_refusal` (comments preserved).
- `web/admin/authoring/contributors.py` — `link_contributor` (16): the pick-vs-create branches move to `_pick_existing` / `_create_or_pick_by_name`; the atomic/IntegrityError race handling stays in the caller unchanged.
- `web/admin/authoring/reference.py` — `_iter_text_files` (20) and `file_search` (26): candidate filtering moves to `_eligible_file`; the per-line scan to `_scan_file_lines`, which returns its own hits + a budget flag (same cap/deadline contract, re-documented).
- `actions/definitions/fashion.py` — `_blockers_above` (20): the per-row layer/see-through/opened predicate moves to `_blocks_target`.
- `frontend/src/combat/sections/YourTurn.tsx` — the component (17) and `handleSubmit` (16): three identical `availableActions.find` IIFEs collapse into one shared `focusedCastDescriptor` lookup, the covered/guarded ally-name IIFEs into a module-level `maneuverAllyName`, and `handleSubmit`'s guard chain into `submitBlockReason`.

## Follow-ups filed

(none)

## Notes

- Spec/design phase: skipped (lint-fix issues; no design decisions)
- Backend tests: narrow modules for every touched file (`test_stature`, `test_prose_report`, `test_cmd_page`, `test_fashion_actions`, `test_authoring_reference`, `test_authoring_setup`), SQLite tier
- Frontend: `pnpm typecheck`, ESLint, Prettier, `pnpm build`, and the `YourTurn` + `YourTurnReach` vitest suites (63 tests) all pass
- Sync-with-main: branched from main tip 953396ad6; no re-sync needed (merge queue re-integrates)

<!-- last-addressed-comment: 0 -->
