### PR TITLE
Batch-aware stat-check achievement grants: encounter completion and relationship reciprocation award per-sheet, splitting group discoveries

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2817,7 +2817,9 @@ gains a discoverable content item for the first time.
   COVENANT_ROLE_ENGAGED / COVENANT_ROLE_DISENGAGED / CHARACTER_CREATION / PATH_ADVANCEMENT /
   GIFT_ACQUISITION / TECHNIQUE_GRANT / ACADEMY_TRAINING / CODEX_LEARNING)
 - **Handlers:** `character_sheet.stats` (`StatHandler`) — `get(stat_def) -> int`,
-  `increment(stat_def, n) -> int` (atomic F() expression; checks requirement thresholds after increment)
+  `increment(stat_def, n, *, check_achievements=True) -> int` (atomic F() expression; checks
+  requirement thresholds after increment unless `check_achievements=False`, used by the batch
+  seam below, #3075)
 - **Key Services (`world/achievements/services.py`):** `grant_achievement(achievement,
   sheets) -> AchievementGrantResult` (`world/achievements/types.py` — frozen dataclass with
   `character_achievements: list[CharacterAchievement]` and `created_discovery: Discovery |
@@ -2832,7 +2834,8 @@ gains a discoverable content item for the first time.
   current tenure, #3055),
   `can_earn_achievements(character_sheet) -> bool` (current, non-staff `RosterTenure`; #3024,
   ADR-0202), `apply_achievement_rewards(sheet, achievement)`,
-  `get_stat(sheet, stat_def) -> int`, `increment_stat(sheet, stat_def, n) -> int`
+  `get_stat(sheet, stat_def) -> int`, `increment_stat(sheet, stat_def, n) -> int`,
+  `increment_stat_for_group(sheets, stat_def, n=1) -> None` (#3075, batch stat-check seam below)
 - **Display rule (#3063):** `DiscoverySerializer.shared` (`world/achievements/serializers.py`)
   is `True` iff `shared_with_tenures` is non-empty — the primary `discovered_by_tenure` FK is
   pure bookkeeping in the group case (it has to point somewhere) and must never be read as a
@@ -2843,11 +2846,19 @@ gains a discoverable content item for the first time.
   `CharacterAchievement` but never land in `shared_with_tenures`. `fire_combo_discovery`
   (`world/combat/combo_discovery.py`) is the reference implementation: it grants the whole combo
   participant group in one call rather than routing through the single-sheet
-  `execute_ceremony_beat` helper (see that module's docstring). Two other group-earning
-  moments — combat encounter completion and relationship reciprocation — currently reach
-  `grant_achievement` only through the single-sheet `StatHandler.increment` →
-  `_check_achievements` indirection and are NOT yet batched; a follow-up is needed before they
-  can claim shared credit.
+  `execute_ceremony_beat` helper (see that module's docstring).
+- **Batch stat-check seam (#3075):** `increment_stat_for_group(sheets, stat, amount=1)`
+  increments every sheet's tracker with the per-sheet achievement check deferred
+  (`StatHandler.increment(..., check_achievements=False)`), then runs ONE group evaluation
+  (`_check_achievements_for_group`, the same evaluator `_check_achievements` delegates into for
+  the single-sheet case) — per candidate achievement, the crossing set is every sheet (caller
+  order) that meets the requirements now and doesn't already hold it, and `grant_achievement` is
+  called once per achievement with that set, so the first crossing sheet takes the primary
+  Discovery slot and the rest share it. A sheet that doesn't cross this increment earns the
+  achievement solo, non-shared, later. Wired callers: combat encounter completion
+  (`world/combat/services.py::_increment_completion_counters`, bucketed by outcome via
+  `world/combat/achievement_counters.py::increment_combat_counter_for_group`) and relationship
+  reciprocation (`world/relationships/services.py::create_first_impression`).
 - **Access-change + discovery surface (`world/achievements/discovery.py` — ADR-0061):**
   - `announce_access_change(character_sheet, *, gained, lost, source)` — sends an ABILITY
     `NarrativeMessage` to the character listing what techniques/capabilities changed, then for

--- a/src/world/achievements/CLAUDE.md
+++ b/src/world/achievements/CLAUDE.md
@@ -86,11 +86,29 @@ never lands in `shared_with_tenures`, so a party discovery looks solo to everyon
 first sheet. Pass the whole eligible group to a single `grant_achievement(achievement,
 sheets)` call instead (`world/combat/combo_discovery.py::fire_combo_discovery` is the
 reference implementation — see its module docstring for why it bypasses
-`execute_ceremony_beat`'s per-sheet shape). Two other group-earning moments — combat
-encounter completion (`world/combat/services.py`) and relationship reciprocation
-(`world/relationships/services.py`) — currently reach `grant_achievement` only through the
-single-sheet `StatHandler.increment` → `_check_achievements` indirection and are NOT yet
-batched; fixing them needs a batch stat-check seam, tracked as a follow-up, not fixed here.
+`execute_ceremony_beat`'s per-sheet shape).
+
+**Batch stat-check seam (#3075).** A stat-driven achievement has the same group-Discovery
+problem when several sheets cross a threshold on a genuinely simultaneous increment (a
+party winning an encounter, both halves of a reciprocated relationship): the single-sheet
+`StatHandler.increment` → `_check_achievements` path grants per sheet, one at a time.
+`services.increment_stat_for_group(character_sheets, stat, amount=1)` is the batch entry
+point — it increments every sheet's tracker (with the per-sheet achievement check deferred
+via `StatHandler.increment(stat, amount, check_achievements=False)`), then runs ONE group
+evaluation (`_check_achievements_for_group`) for the whole set. The evaluator computes, per
+candidate achievement, the crossing set of sheets (in caller order) that meet the
+requirements now and don't already hold the achievement, and calls `grant_achievement` once
+per achievement with that crossing set — so the first eligible crossing sheet takes the
+primary Discovery slot and the rest land in `shared_with_tenures`, while a sheet that
+doesn't cross this increment (e.g. one party member one win short) simply isn't in the set
+and earns the achievement solo later. `_check_achievements` (single-sheet) is now a thin
+wrapper into this same evaluator with a one-element list — there is only one evaluator, no
+parallel single-sheet copy of the requirement/prerequisite/convergence logic. Wired callers:
+combat encounter completion (`world/combat/services.py::_increment_completion_counters`,
+bucketed by outcome — won / lost / fled, or winner / loser / fled for a DUEL — via
+`world/combat/achievement_counters.py::increment_combat_counter_for_group`) and relationship
+reciprocation (`world/relationships/services.py::create_first_impression`'s reciprocation
+block, `increment_stat_for_group([source, target], stat_def)`).
 
 ### CharacterAchievement
 Records when a character earned an achievement.

--- a/src/world/achievements/handlers.py
+++ b/src/world/achievements/handlers.py
@@ -48,12 +48,21 @@ class StatHandler:
         self._load()
         return self._cache.get(stat.pk, 0)  # type: ignore[union-attr]
 
-    def increment(self, stat: StatDefinition, amount: int = 1) -> int:
+    def increment(
+        self, stat: StatDefinition, amount: int = 1, *, check_achievements: bool = True
+    ) -> int:
         """
         Increment a stat (create if needed) and check for achievements.
 
         Uses F() for atomic DB increment, then updates the local cache.
         Returns the new value.
+
+        ``check_achievements=False`` skips the achievement-requirement check
+        after the increment -- used by batch callers (see
+        ``services.increment_stat_for_group``) that increment several sheets
+        for the same simultaneous moment and want ONE group evaluation
+        afterward instead of N single-sheet checks. The default path (True)
+        is byte-for-byte the same behavior as before this flag existed.
         """
         model = _get_stat_tracker_model()
 
@@ -71,9 +80,10 @@ class StatHandler:
         self._load()
         self._cache[stat.pk] = tracker.value  # type: ignore[index]
 
-        # Check for newly met achievement requirements
-        from world.achievements.services import _check_achievements  # noqa: PLC0415
+        if check_achievements:
+            # Check for newly met achievement requirements
+            from world.achievements.services import _check_achievements  # noqa: PLC0415
 
-        _check_achievements(self._character_sheet, stat)
+            _check_achievements(self._character_sheet, stat)
 
         return tracker.value

--- a/src/world/achievements/services.py
+++ b/src/world/achievements/services.py
@@ -49,6 +49,29 @@ def increment_stat(character_sheet: CharacterSheet, stat: StatDefinition, amount
     return character_sheet.stats.increment(stat, amount)
 
 
+def increment_stat_for_group(
+    character_sheets: list[CharacterSheet], stat: StatDefinition, amount: int = 1
+) -> None:
+    """
+    Increment a stat for several sheets as one simultaneous group moment.
+
+    A party winning an encounter or both halves of a reciprocated
+    relationship are genuinely simultaneous: each sheet's tracker updates
+    atomically (mirrors ``increment_stat``'s F() + cache update), with the
+    per-sheet achievement check deferred, then ONE group evaluation runs for
+    ``(character_sheets, stat)``. Any achievement that multiple sheets cross
+    on this increment grants with all crossing sheets in a single
+    ``grant_achievement`` call, so a first-ever Discovery is shared instead
+    of going solely to whichever sheet a per-sheet loop happened to process
+    first. A sheet that does not cross this increment (e.g. one party member
+    one win short of the threshold) is simply not in the crossing set --
+    it earns the achievement solo, non-shared, on a later increment.
+    """
+    for sheet in character_sheets:
+        sheet.stats.increment(stat, amount, check_achievements=False)
+    _check_achievements_for_group(character_sheets, stat)
+
+
 def can_earn_achievements(character_sheet: CharacterSheet) -> bool:
     """Whether ``character_sheet`` may earn achievements at all (#3024).
 
@@ -141,67 +164,150 @@ def grant_achievement(
 def _check_achievements(character_sheet: CharacterSheet, stat: StatDefinition) -> None:
     """
     Find active, unearned achievements with requirements on the given stat
-    and grant any whose requirements are fully met.
+    and grant any whose requirements are fully met for this one sheet.
+
+    Thin wrapper into the group evaluator (see ``_check_achievements_for_group``)
+    with a one-element sheet list -- there is only one evaluator, no parallel
+    single-sheet copy of the requirement/prerequisite/convergence logic.
     """
-    if not can_earn_achievements(character_sheet):
+    _check_achievements_for_group([character_sheet], stat)
+
+
+def _check_achievements_for_group(
+    character_sheets: list[CharacterSheet], stat: StatDefinition
+) -> None:
+    """
+    Group achievement evaluator for a stat increment shared by one or more sheets.
+
+    Filters to sheets that pass ``can_earn_achievements``, then batch-fetches
+    every eligible sheet's earned-achievement id set and stat-value dict with
+    two ``character_sheet__in`` queries (no per-sheet queries in a loop).
+    Candidates are active achievements with a requirement on ``stat``. For
+    each candidate, the crossing set is every sheet (in caller order) whose
+    requirements are met now AND who does not already hold the achievement;
+    ``grant_achievement`` is called ONCE per achievement with that crossing
+    set, so the first eligible crossing sheet takes the primary Discovery
+    slot exactly as ``grant_achievement`` documents.
+
+    A convergence loop re-passes for prerequisite chains: if tier2's
+    prerequisite is tier1 and a sheet crosses tier1 on this pass, the
+    in-memory earned set updates so tier2's prerequisite check sees tier1 as
+    earned on the next pass -- regardless of the candidate queryset's
+    iteration order.
+    """
+    eligible_sheets = [s for s in character_sheets if can_earn_achievements(s)]
+    if not eligible_sheets:
         return
 
-    earned_ids = CharacterAchievement.objects.filter(character_sheet=character_sheet).values_list(
-        "achievement_id", flat=True
+    candidates = list(
+        Achievement.objects.filter(is_active=True, requirements__stat=stat).distinct()
     )
-
-    candidates = (
-        Achievement.objects.filter(
-            is_active=True,
-            requirements__stat=stat,
-        )
-        .exclude(id__in=earned_ids)
-        .distinct()
-    )
-
     if not candidates:
         return
 
-    # Batch-fetch all stat values for this character, keyed by stat_id
-    stats_dict: dict[int, int] = dict(
-        StatTracker.objects.filter(character_sheet=character_sheet).values_list("stat_id", "value")
-    )
+    earned_by_sheet = _batch_fetch_earned_ids(eligible_sheets)
+    stats_by_sheet = _batch_fetch_stat_values(eligible_sheets)
+    requirements_by_achievement = _batch_fetch_requirements(candidates)
 
     # Iterate until no more grants happen. A single pass is order-dependent for
     # chained achievements: if tier2 (prerequisite=tier1) is iterated before
     # tier1 in the same call, tier2's prereq check sees no tier1 yet and skips.
     # The convergence loop guarantees the full chain grants regardless of the
-    # queryset's iteration order.
-    pending = list(candidates)
+    # queryset's iteration order, updating earned_by_sheet in memory between
+    # passes so a sheet that crosses tier1 this pass can cross tier2 next pass.
+    pending = candidates
     while pending:
         granted_this_pass = []
         for achievement in pending:
-            if _achievement_requirements_met(achievement, stats_dict, character_sheet):
-                grant_achievement(achievement, [character_sheet])
+            crossing_sheets = _crossing_sheets(
+                achievement,
+                eligible_sheets,
+                earned_by_sheet,
+                stats_by_sheet,
+                requirements_by_achievement[achievement.pk],
+            )
+            if crossing_sheets:
+                grant_achievement(achievement, crossing_sheets)
                 granted_this_pass.append(achievement)
+                for sheet in crossing_sheets:
+                    earned_by_sheet[sheet.pk].add(achievement.pk)
         if not granted_this_pass:
             break
         pending = [a for a in pending if a not in granted_this_pass]
 
 
+def _batch_fetch_earned_ids(sheets: list[CharacterSheet]) -> dict[int, set[int]]:
+    """Per-sheet earned-achievement id sets for ``sheets``, one query, no loop."""
+    earned_by_sheet: dict[int, set[int]] = {s.pk: set() for s in sheets}
+    for sheet_id, achievement_id in CharacterAchievement.objects.filter(
+        character_sheet__in=sheets
+    ).values_list("character_sheet_id", "achievement_id"):
+        earned_by_sheet[sheet_id].add(achievement_id)
+    return earned_by_sheet
+
+
+def _batch_fetch_stat_values(sheets: list[CharacterSheet]) -> dict[int, dict[int, int]]:
+    """Per-sheet stat-value dicts (sheet_id -> {stat_id: value}) for ``sheets``, one query."""
+    stats_by_sheet: dict[int, dict[int, int]] = {s.pk: {} for s in sheets}
+    for sheet_id, stat_id, value in StatTracker.objects.filter(
+        character_sheet__in=sheets
+    ).values_list("character_sheet_id", "stat_id", "value"):
+        stats_by_sheet[sheet_id][stat_id] = value
+    return stats_by_sheet
+
+
+def _batch_fetch_requirements(
+    achievements: list[Achievement],
+) -> dict[int, list[AchievementStatRequirement]]:
+    """Per-achievement requirement rows for ``achievements``, one query, no loop."""
+    requirements_by_achievement: dict[int, list[AchievementStatRequirement]] = {
+        a.pk: [] for a in achievements
+    }
+    for req in AchievementStatRequirement.objects.filter(achievement__in=achievements):
+        requirements_by_achievement[req.achievement_id].append(req)
+    return requirements_by_achievement
+
+
+def _crossing_sheets(
+    achievement: Achievement,
+    eligible_sheets: list[CharacterSheet],
+    earned_by_sheet: dict[int, set[int]],
+    stats_by_sheet: dict[int, dict[int, int]],
+    requirements: list[AchievementStatRequirement],
+) -> list[CharacterSheet]:
+    """Sheets (in caller order) that cross ``achievement`` on this evaluation.
+
+    A sheet crosses when it does not already hold the achievement and its
+    requirements are met against its own stat values.
+    """
+    return [
+        sheet
+        for sheet in eligible_sheets
+        if achievement.pk not in earned_by_sheet[sheet.pk]
+        and _achievement_requirements_met(
+            achievement, stats_by_sheet[sheet.pk], earned_by_sheet[sheet.pk], requirements
+        )
+    ]
+
+
 def _achievement_requirements_met(
-    achievement: Achievement, stats_dict: dict[int, int], character_sheet: CharacterSheet
+    achievement: Achievement,
+    stats_dict: dict[int, int],
+    earned_ids: set[int],
+    requirements: list[AchievementStatRequirement],
 ) -> bool:
     """
-    Check prerequisite chain and all requirements against stats dict.
+    Check prerequisite chain and all requirements against a stat dict.
 
-    stats_dict is keyed by stat_id (int) to value (int).
+    ``stats_dict`` is keyed by stat_id (int) to value (int); ``earned_ids`` is
+    the sheet's already-earned achievement id set, used for the prerequisite
+    chain check instead of issuing a query here; ``requirements`` is the
+    achievement's prefetched AchievementStatRequirement rows.
     Returns False if no requirements exist (never auto-grant empty achievements).
     """
     # Check prerequisite chain
-    if achievement.prerequisite_id is not None:
-        if not CharacterAchievement.objects.filter(
-            character_sheet=character_sheet,
-            achievement_id=achievement.prerequisite_id,
-        ).exists():
-            return False
-
-    requirements = list(AchievementStatRequirement.objects.filter(achievement=achievement))
+    if achievement.prerequisite_id is not None and achievement.prerequisite_id not in earned_ids:
+        return False
 
     if not requirements:
         return False

--- a/src/world/achievements/tests/test_services.py
+++ b/src/world/achievements/tests/test_services.py
@@ -9,7 +9,12 @@ from world.achievements.factories import (
     StatTrackerFactory,
 )
 from world.achievements.models import CharacterAchievement, Discovery, StatTracker
-from world.achievements.services import get_stat, grant_achievement, increment_stat
+from world.achievements.services import (
+    get_stat,
+    grant_achievement,
+    increment_stat,
+    increment_stat_for_group,
+)
 from world.character_sheets.factories import CharacterSheetFactory
 from world.roster.factories import grant_test_tenure
 
@@ -137,6 +142,130 @@ class IncrementStatTest(TestCase):
                 character_sheet=self.sheet, achievement=achievement
             ).exists()
         )
+
+
+class IncrementStatForGroupTest(TestCase):
+    """#3075: the batch stat-check seam shares a Discovery across the crossing set."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.stat = StatDefinitionFactory(key="group_stat", name="Group Stat")
+        cls.sheet1 = CharacterSheetFactory()
+        cls.tenure1 = grant_test_tenure(cls.sheet1)
+        cls.sheet2 = CharacterSheetFactory()
+        cls.tenure2 = grant_test_tenure(cls.sheet2)
+        cls.sheet3 = CharacterSheetFactory()
+        cls.tenure3 = grant_test_tenure(cls.sheet3)
+
+    def test_increments_every_sheet_tracker(self) -> None:
+        increment_stat_for_group([self.sheet1, self.sheet2], self.stat, amount=3)
+
+        self.assertEqual(get_stat(self.sheet1, self.stat), 3)
+        self.assertEqual(get_stat(self.sheet2, self.stat), 3)
+
+    def test_group_crossing_shares_one_discovery(self) -> None:
+        """Every sheet that crosses on the same increment lands in one Discovery:
+        the first crossing sheet primary, the rest shared_with_tenures."""
+        achievement = AchievementFactory(name="Group First", slug="group-first")
+        AchievementStatRequirementFactory(achievement=achievement, stat=self.stat, threshold=1)
+
+        increment_stat_for_group([self.sheet1, self.sheet2], self.stat, amount=1)
+
+        self.assertEqual(Discovery.objects.filter(achievement=achievement).count(), 1)
+        discovery = Discovery.objects.get(achievement=achievement)
+        self.assertEqual(discovery.discovered_by_tenure_id, self.tenure1.pk)
+        self.assertEqual(
+            list(discovery.shared_with_tenures.values_list("pk", flat=True)),
+            [self.tenure2.pk],
+        )
+        self.assertTrue(
+            CharacterAchievement.objects.filter(
+                character_sheet=self.sheet1, achievement=achievement
+            ).exists()
+        )
+        self.assertTrue(
+            CharacterAchievement.objects.filter(
+                character_sheet=self.sheet2, achievement=achievement
+            ).exists()
+        )
+
+    def test_partial_crossing_excludes_sheet_below_threshold(self) -> None:
+        """A sheet one short of the threshold is not swept into the group's
+        Discovery -- it earns the achievement solo, non-shared, later."""
+        achievement = AchievementFactory(name="Partial Cross", slug="partial-cross")
+        AchievementStatRequirementFactory(achievement=achievement, stat=self.stat, threshold=10)
+
+        StatTrackerFactory(character_sheet=self.sheet1, stat=self.stat, value=9)
+        StatTrackerFactory(character_sheet=self.sheet2, stat=self.stat, value=8)
+
+        # Both sheets increment by 1 in the same group moment: sheet1 crosses
+        # (9 -> 10), sheet2 does not (8 -> 9).
+        increment_stat_for_group([self.sheet1, self.sheet2], self.stat, amount=1)
+
+        discovery = Discovery.objects.get(achievement=achievement)
+        self.assertEqual(discovery.discovered_by_tenure_id, self.tenure1.pk)
+        self.assertEqual(discovery.shared_with_tenures.count(), 0)
+        self.assertTrue(
+            CharacterAchievement.objects.filter(
+                character_sheet=self.sheet1, achievement=achievement
+            ).exists()
+        )
+        self.assertFalse(
+            CharacterAchievement.objects.filter(
+                character_sheet=self.sheet2, achievement=achievement
+            ).exists()
+        )
+
+        # sheet2 later crosses the threshold solo -- earns it non-shared.
+        increment_stat_for_group([self.sheet2], self.stat, amount=1)
+        self.assertTrue(
+            CharacterAchievement.objects.filter(
+                character_sheet=self.sheet2, achievement=achievement
+            ).exists()
+        )
+        discovery.refresh_from_db()
+        self.assertEqual(discovery.shared_with_tenures.count(), 0)
+
+    def test_chained_prerequisite_convergence_in_group_shape(self) -> None:
+        """A group increment that crosses a whole prerequisite chain grants
+        both tiers to the crossing sheets in the same call (convergence loop)."""
+        tier1 = AchievementFactory(slug="group-tier1")
+        AchievementStatRequirementFactory(achievement=tier1, stat=self.stat, threshold=10)
+
+        tier2 = AchievementFactory(slug="group-tier2", prerequisite=tier1)
+        AchievementStatRequirementFactory(achievement=tier2, stat=self.stat, threshold=10)
+
+        StatTrackerFactory(character_sheet=self.sheet1, stat=self.stat, value=9)
+        StatTrackerFactory(character_sheet=self.sheet2, stat=self.stat, value=9)
+
+        increment_stat_for_group([self.sheet1, self.sheet2], self.stat, amount=1)
+
+        for sheet in (self.sheet1, self.sheet2):
+            self.assertTrue(
+                CharacterAchievement.objects.filter(
+                    character_sheet=sheet, achievement=tier1
+                ).exists()
+            )
+            self.assertTrue(
+                CharacterAchievement.objects.filter(
+                    character_sheet=sheet, achievement=tier2
+                ).exists()
+            )
+        tier1_discovery = Discovery.objects.get(achievement=tier1)
+        tier2_discovery = Discovery.objects.get(achievement=tier2)
+        self.assertEqual(tier1_discovery.shared_with_tenures.count(), 1)
+        self.assertEqual(tier2_discovery.shared_with_tenures.count(), 1)
+
+    def test_single_sheet_call_unaffected(self) -> None:
+        """A one-element group call behaves like the existing single-sheet path."""
+        achievement = AchievementFactory(name="Solo via Group", slug="solo-via-group")
+        AchievementStatRequirementFactory(achievement=achievement, stat=self.stat, threshold=1)
+
+        increment_stat_for_group([self.sheet1], self.stat, amount=1)
+
+        discovery = Discovery.objects.get(achievement=achievement)
+        self.assertEqual(discovery.discovered_by_tenure_id, self.tenure1.pk)
+        self.assertEqual(discovery.shared_with_tenures.count(), 0)
 
 
 class GrantAchievementTest(TestCase):

--- a/src/world/combat/achievement_counters.py
+++ b/src/world/combat/achievement_counters.py
@@ -116,3 +116,26 @@ def increment_combat_counter(
         return character_sheet.stats.get(_get_or_create_stat_def(key))
     stat_def = _get_or_create_stat_def(key)
     return character_sheet.stats.increment(stat_def, amount)
+
+
+def increment_combat_counter_for_group(
+    character_sheets: list[CharacterSheet],
+    key: str,
+    amount: int = 1,
+) -> None:
+    """Increment a combat counter for several sheets as one simultaneous moment.
+
+    Keeps the lazy ``StatDefinition`` get_or_create in this one place (mirrors
+    ``increment_combat_counter``) but batches the achievement check via
+    ``increment_stat_for_group`` so a moment shared by a whole bucket of
+    participants (everyone who won, everyone who fled) grants a
+    threshold-crossing achievement to every sheet that crosses on this
+    increment in ONE ``grant_achievement`` call. Skips amount<=0 like the
+    single-sheet version (no tracker mutation, no achievement check).
+    """
+    if amount <= 0 or not character_sheets:
+        return
+    from world.achievements.services import increment_stat_for_group  # noqa: PLC0415
+
+    stat_def = _get_or_create_stat_def(key)
+    increment_stat_for_group(character_sheets, stat_def, amount)

--- a/src/world/combat/services.py
+++ b/src/world/combat/services.py
@@ -9121,12 +9121,19 @@ def _increment_completion_counters(encounter: CombatEncounter, outcome: Encounte
     DUEL the win is credited solely to ``encounter.duel_winner`` and the loss to
     the other duelist; an abandoned duel (no ``duel_winner``) credits neither
     (#1182).
+
+    Buckets participants by outcome and makes ONE group counter call per bucket
+    (#3075) — everyone who fled, everyone who won, everyone who lost is a
+    genuinely simultaneous moment, so a first-ever threshold achievement shares
+    its Discovery across the whole bucket instead of going solely to whichever
+    participant a per-sheet loop happened to process first. Buckets never share
+    a stat, so no cross-bucket moment exists.
     """
     from world.combat.achievement_counters import (  # noqa: PLC0415
         STAT_KEY_ENCOUNTERS_FLED,
         STAT_KEY_ENCOUNTERS_LOST,
         STAT_KEY_ENCOUNTERS_WON,
-        increment_combat_counter,
+        increment_combat_counter_for_group,
     )
 
     participants = CombatParticipant.objects.filter(encounter=encounter).select_related(
@@ -9135,15 +9142,21 @@ def _increment_completion_counters(encounter: CombatEncounter, outcome: Encounte
 
     if encounter.encounter_type == EncounterType.DUEL:
         winner_sheet_id = encounter.duel_winner_id
+        fled_sheets = []
+        winner_sheets = []
+        loser_sheets = []
         for participant in participants:
             if participant.status == ParticipantStatus.FLED:
-                increment_combat_counter(participant.character_sheet, STAT_KEY_ENCOUNTERS_FLED)
+                fled_sheets.append(participant.character_sheet)
             elif winner_sheet_id is None:
                 continue  # Abandoned / mutual stop — no victor; credit neither.
             elif participant.character_sheet_id == winner_sheet_id:
-                increment_combat_counter(participant.character_sheet, STAT_KEY_ENCOUNTERS_WON)
+                winner_sheets.append(participant.character_sheet)
             else:
-                increment_combat_counter(participant.character_sheet, STAT_KEY_ENCOUNTERS_LOST)
+                loser_sheets.append(participant.character_sheet)
+        increment_combat_counter_for_group(fled_sheets, STAT_KEY_ENCOUNTERS_FLED)
+        increment_combat_counter_for_group(winner_sheets, STAT_KEY_ENCOUNTERS_WON)
+        increment_combat_counter_for_group(loser_sheets, STAT_KEY_ENCOUNTERS_LOST)
         return
 
     outcome_key = {
@@ -9151,11 +9164,16 @@ def _increment_completion_counters(encounter: CombatEncounter, outcome: Encounte
         EncounterOutcome.DEFEAT: STAT_KEY_ENCOUNTERS_LOST,
     }.get(outcome)
 
+    fled_sheets = []
+    outcome_sheets = []
     for participant in participants:
         if participant.status == ParticipantStatus.FLED:
-            increment_combat_counter(participant.character_sheet, STAT_KEY_ENCOUNTERS_FLED)
+            fled_sheets.append(participant.character_sheet)
         elif participant.status == ParticipantStatus.ACTIVE and outcome_key is not None:
-            increment_combat_counter(participant.character_sheet, outcome_key)
+            outcome_sheets.append(participant.character_sheet)
+    increment_combat_counter_for_group(fled_sheets, STAT_KEY_ENCOUNTERS_FLED)
+    if outcome_key is not None:
+        increment_combat_counter_for_group(outcome_sheets, outcome_key)
 
 
 def _emit_encounter_completed(encounter: CombatEncounter, outcome: EncounterOutcome) -> None:

--- a/src/world/combat/tests/test_encounter_aftermath.py
+++ b/src/world/combat/tests/test_encounter_aftermath.py
@@ -14,7 +14,12 @@ from actions.factories import (
 )
 from evennia_extensions.factories import AccountFactory, CharacterFactory, ObjectDBFactory
 from flows.constants import EventName
-from world.achievements.models import StatDefinition
+from world.achievements.factories import (
+    AchievementFactory,
+    AchievementStatRequirementFactory,
+    StatDefinitionFactory,
+)
+from world.achievements.models import CharacterAchievement, Discovery, StatDefinition
 from world.character_sheets.factories import CharacterSheetFactory
 from world.checks.factories import CheckTypeFactory, ConsequenceFactory
 from world.checks.outcome_models import ConsequenceOutcome
@@ -52,7 +57,7 @@ from world.magic.factories import (
     TechniqueFactory,
 )
 from world.mechanics.factories import CharacterEngagementFactory
-from world.roster.factories import RosterTenureFactory
+from world.roster.factories import RosterTenureFactory, grant_test_tenure
 from world.scenes.constants import InteractionMode, RoundStatus
 from world.scenes.factories import SceneFactory, SceneParticipationFactory
 from world.scenes.models import Interaction
@@ -429,6 +434,55 @@ class CompleteEncounterTests(_CompletionSeamTestBase):
             complete_encounter(encounter, outcome=EncounterOutcome.VICTORY)
 
         mock_emit.assert_not_called()
+
+
+class CompletionCounterGroupAchievementTests(_CompletionSeamTestBase):
+    """#3075: completion counters batch the achievement grant per outcome bucket.
+
+    A party win is a genuinely simultaneous moment for everyone who stayed and
+    won -- a first-ever threshold achievement should share one Discovery
+    across the whole winning bucket, not go solely to whichever participant
+    ``_increment_completion_counters`` happened to process first. A party
+    member who fled instead is a different bucket entirely and must not be
+    swept into the winners' Discovery.
+    """
+
+    def test_mixed_won_fled_party_shares_discovery_among_winners_only(self) -> None:
+        won_stat = StatDefinitionFactory(key=STAT_KEY_ENCOUNTERS_WON, name="Encounters Won")
+        achievement = AchievementFactory(name="First Victory", slug="first-victory")
+        AchievementStatRequirementFactory(achievement=achievement, stat=won_stat, threshold=1)
+
+        encounter = self._make_encounter()
+        winner_one = self._add_pc(encounter)
+        winner_two = self._add_pc(encounter)
+        fled = self._add_pc(encounter, status=ParticipantStatus.FLED)
+        tenure_one = grant_test_tenure(winner_one.character_sheet)
+        tenure_two = grant_test_tenure(winner_two.character_sheet)
+        grant_test_tenure(fled.character_sheet)
+
+        complete_encounter(encounter, outcome=EncounterOutcome.VICTORY)
+
+        discovery = Discovery.objects.get(achievement=achievement)
+        self.assertEqual(discovery.discovered_by_tenure_id, tenure_one.pk)
+        self.assertEqual(
+            list(discovery.shared_with_tenures.values_list("pk", flat=True)),
+            [tenure_two.pk],
+        )
+        self.assertTrue(
+            CharacterAchievement.objects.filter(
+                character_sheet=winner_one.character_sheet, achievement=achievement
+            ).exists()
+        )
+        self.assertTrue(
+            CharacterAchievement.objects.filter(
+                character_sheet=winner_two.character_sheet, achievement=achievement
+            ).exists()
+        )
+        self.assertFalse(
+            CharacterAchievement.objects.filter(
+                character_sheet=fled.character_sheet, achievement=achievement
+            ).exists()
+        )
 
 
 class ResolveRoundCompletionTests(TestCase):

--- a/src/world/relationships/services.py
+++ b/src/world/relationships/services.py
@@ -12,7 +12,7 @@ from django.db.models import Q
 from django.utils import timezone
 
 from world.achievements.models import StatDefinition
-from world.achievements.services import increment_stat
+from world.achievements.services import increment_stat_for_group
 from world.progression.constants import FIRST_IMPRESSION_AUTHOR_XP, FIRST_IMPRESSION_TARGET_XP
 from world.progression.models import KudosSourceCategory
 from world.progression.services.awards import award_xp
@@ -151,8 +151,7 @@ def create_first_impression(  # noqa: PLR0913
                 relationship.save(update_fields=["is_pending"])
 
                 stat_def = StatDefinition.objects.get(key="relationships.total_established")
-                increment_stat(source, stat_def)
-                increment_stat(target, stat_def)
+                increment_stat_for_group([source, target], stat_def)
         except CharacterRelationship.DoesNotExist:
             pass
 

--- a/src/world/relationships/tests/test_services.py
+++ b/src/world/relationships/tests/test_services.py
@@ -3,8 +3,12 @@
 from django.core.exceptions import ValidationError
 from django.test import TestCase
 
-from world.achievements.factories import StatDefinitionFactory
-from world.achievements.models import StatTracker
+from world.achievements.factories import (
+    AchievementFactory,
+    AchievementStatRequirementFactory,
+    StatDefinitionFactory,
+)
+from world.achievements.models import CharacterAchievement, Discovery, StatTracker
 from world.character_sheets.factories import CharacterSheetFactory
 from world.progression.models import ExperiencePointsData
 from world.relationships.constants import (
@@ -31,7 +35,7 @@ from world.relationships.services import (
     create_first_impression,
     redistribute_points,
 )
-from world.roster.factories import RosterTenureFactory
+from world.roster.factories import RosterTenureFactory, grant_test_tenure
 
 
 class CreateFirstImpressionTest(TestCase):
@@ -135,6 +139,67 @@ class CreateFirstImpressionTest(TestCase):
         target_xp = ExperiencePointsData.objects.get(account=target_account)
         self.assertEqual(source_xp.total_earned, 3)
         self.assertEqual(target_xp.total_earned, 5)
+
+
+class ReciprocationAchievementSharingTest(TestCase):
+    """#3075: reciprocation's stat increment is batched, so a first-ever
+    threshold achievement shares its Discovery between both parties instead
+    of going solely to whichever of source/target the old per-sheet loop
+    processed first."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.source = CharacterSheetFactory()
+        cls.source_tenure = grant_test_tenure(cls.source)
+        cls.target = CharacterSheetFactory()
+        cls.target_tenure = grant_test_tenure(cls.target)
+        cls.rel_stat = StatDefinitionFactory(
+            key="relationships.total_established", name="Relationships Established"
+        )
+        cls.achievement = AchievementFactory(name="Bonded", slug="bonded")
+        AchievementStatRequirementFactory(
+            achievement=cls.achievement, stat=cls.rel_stat, threshold=1
+        )
+
+    def _first_impression(self, *, source, target, track):
+        return create_first_impression(
+            source=source,
+            target=target,
+            title="A Meeting",
+            writeup="We crossed paths.",
+            track=track,
+            points=5,
+            coloring=FirstImpressionColoring.POSITIVE,
+            visibility=UpdateVisibility.SHARED,
+        )
+
+    def test_reciprocation_shares_discovery_between_both_parties(self):
+        track_ab = RelationshipTrackFactory(name="Kinship", sign=TrackSign.POSITIVE)
+        self._first_impression(source=self.source, target=self.target, track=track_ab)
+
+        track_ba = RelationshipTrackFactory(name="Loyalty", sign=TrackSign.POSITIVE)
+        # This second call is the one whose reciprocation branch fires the
+        # group increment; its own (source, target) params -- self.target,
+        # self.source -- are the caller order passed to
+        # increment_stat_for_group, so self.target's tenure is primary.
+        self._first_impression(source=self.target, target=self.source, track=track_ba)
+
+        discovery = Discovery.objects.get(achievement=self.achievement)
+        self.assertEqual(discovery.discovered_by_tenure_id, self.target_tenure.pk)
+        self.assertEqual(
+            list(discovery.shared_with_tenures.values_list("pk", flat=True)),
+            [self.source_tenure.pk],
+        )
+        self.assertTrue(
+            CharacterAchievement.objects.filter(
+                character_sheet=self.source, achievement=self.achievement
+            ).exists()
+        )
+        self.assertTrue(
+            CharacterAchievement.objects.filter(
+                character_sheet=self.target, achievement=self.achievement
+            ).exists()
+        )
 
 
 class RedistributePointsTest(TestCase):


### PR DESCRIPTION
Closes #3075

## Summary

Batch-aware stat-check achievement grants: new increment_stat_for_group seam evaluates threshold crossings per sheet and makes ONE grant_achievement call per achievement with all crossing sheets, so simultaneous group moments (combat encounter completion, relationship reciprocation) share Discovery credit instead of splitting it to whichever sheet processed first. Single-sheet path is a thin wrapper into the same evaluator; no models, no migrations.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #3075 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto origin/main cleanly (no conflicts).

<!-- last-addressed-comment: 0 -->