### PR TITLE
Move brainstorm port 49200 -> 39200, below Windows dynamic port range

### DIFF
--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -56,8 +56,11 @@ services:
       # Pin the superpowers brainstorm-server port (server.cjs reads
       # BRAINSTORM_PORT, otherwise picks random in 49152-65535). Fixing it
       # to one port lets us forward exactly that one to the Windows host
-      # instead of opening a 16k-port range.
-      BRAINSTORM_PORT: "49200"
+      # instead of opening a 16k-port range. Must stay BELOW 49152: Windows'
+      # dynamic port range starts there, and Hyper-V/WinNAT reserves whole
+      # blocks inside it after reboots (netsh excludedportrange), which makes
+      # the host-side bind fail with "forbidden by its access permissions".
+      BRAINSTORM_PORT: "39200"
       # Relocate Claude Code's config directory inside the named-volume mount
       # so .claude.json (account/onboarding state) persists across
       # dc-down/dc-up. Default location is ~/.claude.json (a sibling of the
@@ -97,7 +100,7 @@ services:
       # keeps its own equivalent setup (shell-extras.sh) for `devcontainer exec`,
       # `bash -lc` and agent tooling.
       SHELL: /bin/zsh
-    # Forward the brainstorm-server port so http://localhost:49200/ in the
+    # Forward the brainstorm-server port so http://localhost:39200/ in the
     # Windows browser reaches the in-container server. The skill's
     # start-server.sh defaults to binding 127.0.0.1; pass --host 0.0.0.0
     # --url-host localhost so it actually listens on the forwarded interface.
@@ -111,7 +114,7 @@ services:
     # Use `arx serve` (which serves the built frontend from Django) if you
     # only want to forward 4001+4002 and skip Vite.
     ports:
-      - "49200:49200"
+      - "39200:39200"
       - "3000:3000"
       - "4001:4001"
       - "4002:4002"

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -468,8 +468,11 @@ mockups in a browser. By default `server.cjs` picks a random port from the IANA
 dynamic range (49152–65535) and binds to `127.0.0.1`. Neither is reachable from
 the Windows host out of the box.
 
-The compose file pins `BRAINSTORM_PORT=49200` and forwards exactly that port to
-the Windows host. The skill's launcher script still defaults to binding the
+The compose file pins `BRAINSTORM_PORT=39200` and forwards exactly that port to
+the Windows host. The port is deliberately below 49152: Windows' dynamic port
+range starts there, and Hyper-V/WinNAT reserves whole blocks inside it after
+reboots (`netsh interface ipv4 show excludedportrange protocol=tcp`), which
+makes the host-side bind fail and the whole devcontainer refuse to start. The skill's launcher script still defaults to binding the
 loopback interface and emitting a `127.0.0.1` URL, so when invoking it inside
 the container pass `--host` and `--url-host` explicitly:
 
@@ -481,7 +484,7 @@ bash ~/.claude/plugins/.../skills/brainstorming/scripts/start-server.sh \
 `--host 0.0.0.0` makes the server listen on the interface Docker forwards;
 `--url-host localhost` ensures the URL printed in the result is something the
 Windows browser can open. Once it's running, open the printed
-`http://localhost:49200/...` URL in your Windows browser.
+`http://localhost:39200/...` URL in your Windows browser.
 
 To change the port (e.g. it collides with something else on Windows), edit
 `BRAINSTORM_PORT` and the `ports:` mapping in `.devcontainer/docker-compose.yml`


### PR DESCRIPTION
## Summary
- Devcontainer startup failed on Windows: compose up died with "ports are not available ... bind: An attempt was made to access a socket in a way forbidden by its access permissions" on 49200.
- Root cause: Hyper-V/WinNAT reserves port blocks inside the Windows dynamic range (49152+) after reboots; netsh showed 49152-49251 excluded, swallowing the pinned brainstorm port 49200.
- Fix: pin BRAINSTORM_PORT and its forward to 39200, below 49152 where Windows never auto-reserves; document the constraint in the compose file and docs/devcontainer-setup.md.

## Testing
- just dc-up on the affected machine: previously failed at compose up; now starts and binds 39200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)