### PR TITLE
Resend DNS: publish the records Resend actually specifies, not assumed ones

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -72,8 +72,15 @@ file parses as YAML before handing it to Ansible — already a transitive depend
       internet, behind key-only auth + fail2ban). Consciously decide whether to restrict it to a
       known admin CIDR. This is a real decision, not a default to ignore.
 - [ ] Domain nameservers delegated to Cloudflare.
-- [ ] Resend sending domain will be verified automatically via the DNS records this IaC creates
-      (SPF/DKIM/DMARC + Resend verification) once nameservers are delegated.
+- [ ] **Resend sending domain added, and its records copied into `resend_records`.** On the
+      domain's DNS page choose **Manual setup**, not the Cloudflare auto-configure button —
+      auto-configure writes the records into the zone itself and collides with the
+      `cloudflare_dns` module (and grants Resend standing write access to the zone that also
+      points at the game server). Paste every row verbatim, including the return-path SPF TXT
+      and the bounce-feedback MX; only the MX takes `priority`. Do not hand-add them in
+      Cloudflare either. The domain stays **unverified** until the first `tofu apply` publishes
+      them, which cannot happen before the compute instance exists (the module takes the origin
+      IPs from `module.compute`) — that pending state is expected, not a fault.
 - [ ] One-time Terraform remote-state bootstrap run (`terraform/bootstrap/`, see its README).
 
 ## After a successful stand-up — credential hygiene (do this every time)

--- a/infra/terraform/modules/cloudflare_dns/main.tf
+++ b/infra/terraform/modules/cloudflare_dns/main.tf
@@ -2,7 +2,7 @@
 # the TLS-telnet record is DNS-ONLY (grey) so telnet reaches origin directly
 # (Cloudflare free tier does not proxy arbitrary TCP). Resolves the Resend
 # "could only email myself until the domain is verified" chicken-and-egg by
-# authoring the verification + SPF/DKIM/DMARC records as code.
+# authoring the verification + SPF/DKIM records as code.
 #
 # Provider-schema caveat (v4 idiom; CI is the authority — see versions.tf).
 
@@ -42,11 +42,18 @@ resource "cloudflare_record" "telnet_a" {
 }
 
 # --- Email auth -------------------------------------------------------------
-resource "cloudflare_record" "spf" {
-  zone_id = cloudflare_zone.this.id
-  name    = "@"
-  type    = "TXT"
-  content = "v=spf1 include:${var.resend_spf_include} ~all"
+# SPF is NOT declared here. Resend fronts Amazon SES and puts both the SPF TXT
+# and the bounce-feedback MX on a return-path subdomain (send.<domain>), not on
+# the apex — and the include host is SES's, not Resend's own. An apex SPF
+# hardcoded here would sit where nothing checks it while the record that
+# verification actually requires went missing. Every Resend-authored row,
+# SPF included, therefore flows through var.resend_records verbatim.
+
+locals {
+  # rua is optional: aggregate reports need a mailbox whose domain authorises
+  # this one to report to it, which a plain third-party inbox does not. Omit
+  # rather than publish an address whose reports get refused.
+  dmarc_reporting = var.dmarc_rua == "" ? "" : " rua=${var.dmarc_rua}; fo=1;"
 }
 
 resource "cloudflare_record" "dmarc" {
@@ -54,16 +61,18 @@ resource "cloudflare_record" "dmarc" {
   name    = "_dmarc"
   type    = "TXT"
   # p starts none/quarantine (validated in variables.tf) — tighten later.
-  content = "v=DMARC1; p=${var.dmarc_policy}; rua=${var.dmarc_rua}; fo=1"
+  content = "v=DMARC1; p=${var.dmarc_policy};${local.dmarc_reporting}"
 }
 
-# Resend domain-verification + DKIM (PUBLIC record only; key is Resend-managed)
-# — exactly as Resend's dashboard provides them for this sending domain.
+# Resend domain-verification, DKIM and SPF (DKIM here is the PUBLIC record
+# only; the private key is Resend-managed) — exactly as Resend's dashboard
+# provides them for this sending domain. priority is null except on the MX.
 resource "cloudflare_record" "resend" {
   for_each = { for r in var.resend_records : "${r.type}:${r.name}" => r }
 
-  zone_id = cloudflare_zone.this.id
-  name    = each.value.name
-  type    = each.value.type
-  content = each.value.value
+  zone_id  = cloudflare_zone.this.id
+  name     = each.value.name
+  type     = each.value.type
+  content  = each.value.value
+  priority = each.value.priority
 }

--- a/infra/terraform/modules/cloudflare_dns/variables.tf
+++ b/infra/terraform/modules/cloudflare_dns/variables.tf
@@ -33,7 +33,7 @@ variable "origin_ipv6" {
 variable "dmarc_policy" {
   type        = string
   default     = "none"
-  description = "Initial DMARC policy for a FRESH sending domain. Start 'none' (or 'quarantine') with rua reporting, then tighten. NEVER 'reject' initially (blackholes legit mail before traffic is observed)."
+  description = "Initial DMARC policy for a FRESH sending domain. Start 'none' (or 'quarantine'), then tighten. NEVER 'reject' initially (blackholes legit mail before traffic is observed)."
   validation {
     condition     = contains(["none", "quarantine"], var.dmarc_policy)
     error_message = "dmarc_policy must start at 'none' or 'quarantine' — not 'reject' on a fresh domain (tighten later, deliberately)."
@@ -42,21 +42,17 @@ variable "dmarc_policy" {
 
 variable "dmarc_rua" {
   type        = string
-  description = "DMARC aggregate-report mailbox, e.g. mailto:dmarc@arxii.example."
-}
-
-variable "resend_spf_include" {
-  type        = string
-  default     = "_spf.resend.com"
-  description = "SPF include host for Resend. CONFIRM the exact value against Resend's domain-setup page for this sending domain (do not assume)."
+  default     = ""
+  description = "DMARC aggregate-report mailbox, e.g. mailto:dmarc@arxii.example. Empty omits rua entirely. Cross-domain reporting requires the RECEIVING domain to publish a <this-domain>._report._dmarc authorisation record, so a plain third-party inbox (gmail.com and friends) does not work — use an address on this domain or a reporting service that publishes its own authorisation."
 }
 
 variable "resend_records" {
   type = list(object({
-    type  = string
-    name  = string
-    value = string
+    type     = string
+    name     = string
+    value    = string
+    priority = optional(number)
   }))
   default     = []
-  description = "Resend domain-verification + DKIM records EXACTLY as Resend's dashboard shows them for this sending domain (DKIM here is the PUBLIC record only; the private key is Resend-managed). Operator pastes these; kept generic so the provider/account specifics aren't guessed."
+  description = "EVERY DNS row Resend's dashboard shows for this sending domain, verbatim — verification/DKIM TXT, the return-path SPF TXT, and the bounce-feedback MX (priority set only on the MX). DKIM here is the PUBLIC record only; the private key is Resend-managed. Operator pastes these from the dashboard's MANUAL SETUP view; do not use Cloudflare auto-configure, which writes records this module then collides with."
 }

--- a/infra/terraform/prod/main.tf
+++ b/infra/terraform/prod/main.tf
@@ -27,17 +27,16 @@ module "firewall" {
 }
 
 module "dns" {
-  source             = "../modules/cloudflare_dns"
-  account_id         = var.cloudflare_account_id
-  domain             = var.domain
-  web_hostname       = var.web_hostname
-  telnet_hostname    = var.telnet_hostname
-  origin_ipv4        = module.compute.ipv4
-  origin_ipv6        = module.compute.ipv6
-  dmarc_policy       = var.dmarc_policy
-  dmarc_rua          = var.dmarc_rua
-  resend_spf_include = var.resend_spf_include
-  resend_records     = var.resend_records
+  source          = "../modules/cloudflare_dns"
+  account_id      = var.cloudflare_account_id
+  domain          = var.domain
+  web_hostname    = var.web_hostname
+  telnet_hostname = var.telnet_hostname
+  origin_ipv4     = module.compute.ipv4
+  origin_ipv6     = module.compute.ipv6
+  dmarc_policy    = var.dmarc_policy
+  dmarc_rua       = var.dmarc_rua
+  resend_records  = var.resend_records
 }
 
 module "object_storage" {

--- a/infra/terraform/prod/terraform.tfvars.example
+++ b/infra/terraform/prod/terraform.tfvars.example
@@ -5,6 +5,17 @@ domain                = "arxii.example"
 authorized_keys       = ["ssh-ed25519 AAAA... you@host"]
 state_bucket_label    = "arxii-backups-REPLACE-unique"
 r2_bucket_name        = "arxii-offsite-REPLACE-unique"
-dmarc_rua             = "mailto:dmarc@arxii.example"
 # ssh_admin_cidrs    = ["203.0.113.10/32"]  # OPERATOR DECISION — narrow this
-# resend_records     = [{ type="TXT", name="...", value="..." }]  # from Resend dashboard
+# dmarc_rua          = "mailto:dmarc@arxii.example"  # optional; omit to publish no rua
+
+# Every row from the Resend domain page's MANUAL SETUP view, verbatim — do NOT
+# use its Cloudflare auto-configure button (it writes these records itself and
+# collides with this module). Names are zone-relative, as Cloudflare's API wants.
+# Shape below is Resend-over-SES: DKIM on resend._domainkey, and SPF + bounce
+# feedback on the send.* return-path subdomain. Re-viewable in the dashboard
+# any time, so nothing here needs archiving.
+# resend_records = [
+#   { type = "TXT", name = "resend._domainkey", value = "p=MIGfMA0GCSq..." },
+#   { type = "TXT", name = "send", value = "v=spf1 include:amazonses.com ~all" },
+#   { type = "MX", name = "send", value = "feedback-smtp.us-east-1.amazonses.com", priority = 10 },
+# ]

--- a/infra/terraform/prod/variables.tf
+++ b/infra/terraform/prod/variables.tf
@@ -64,17 +64,15 @@ variable "dmarc_policy" {
   default = "none"
 }
 variable "dmarc_rua" {
-  type = string
-}
-variable "resend_spf_include" {
   type    = string
-  default = "_spf.resend.com"
+  default = ""
 }
 variable "resend_records" {
   type = list(object({
-    type  = string
-    name  = string
-    value = string
+    type     = string
+    name     = string
+    value    = string
+    priority = optional(number)
   }))
   default = []
 }


### PR DESCRIPTION
Standing up Resend for the alpha (#2236) surfaced that `modules/cloudflare_dns`
could never have verified a sending domain. Comparing the module against the real
Resend dashboard for the live domain:

- **The SPF include was guessed wrong.** `resend_spf_include` defaulted to
  `_spf.resend.com`; Resend fronts Amazon SES and specifies
  `include:amazonses.com`. The variable's own description already said to confirm
  rather than assume.
- **SPF was authored at the wrong name.** The module hardcoded `name = "@"`.
  Resend puts both the SPF TXT and the bounce-feedback MX on the `send.*`
  return-path subdomain, which is what receivers actually check SPF against. As
  written we would publish an apex SPF nobody consults while omitting the record
  verification requires - the domain would sit unverified indefinitely.
- **The MX was inexpressible.** `resend_records` was typed without `priority`,
  which `cloudflare_record` requires for MX. Dropping that row doesn't block
  verification but does silently discard bounce and complaint feedback, which is
  how a sending reputation rots without anyone noticing.

## Changes

Delete the hardcoded apex SPF resource and `resend_spf_include` entirely. Every
Resend-authored row - verification/DKIM TXT, return-path SPF TXT, feedback MX -
now flows through `resend_records` verbatim, with `priority = optional(number)`.
Nothing about the provider's record shape is inferred any more, which is what the
original comment was trying to achieve.

`dmarc_rua` becomes optional (default empty omits `rua`/`fo`, yielding
`v=DMARC1; p=none;`). Cross-domain aggregate reporting requires the *receiving*
domain to publish a `<sender>._report._dmarc` authorisation record, so pointing
`rua` at an ordinary third-party inbox gets the reports refused by conformant
reporters. Omitting is honest; an address can be added when the policy tightens
past `none`, which is the point at which reports become useful. `standup.yml`
passes `TF_VAR_dmarc_rua` from an unset repo Variable, so this makes the button
work rather than fail.

`infra/README.md` records two operational facts the checklist got wrong: use
Resend's **manual setup** view rather than its Cloudflare auto-configure button
(auto-configure writes the records itself, colliding with this module, and grants
Resend standing write access to the zone that also points at the game server),
and the domain necessarily stays unverified until the first apply, because the
module takes origin IPs from `module.compute`. That pending state is expected,
not a fault to work around by hand-adding records.

## Verification

`tofu fmt` clean; `tofu validate` passes against the pinned cloudflare 4.52.7 /
linode 2.41.2 providers (only the pre-existing `linode_instance.ip_address`
deprecation warning). No plan run - that needs live credentials and a compute
instance that does not exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
