### PR TITLE
Standup button: pass the Resend records and hostnames to tofu

### DIFF
--- a/.github/workflows/standup.yml
+++ b/.github/workflows/standup.yml
@@ -76,6 +76,18 @@ jobs:
           TF_VAR_state_bucket_label: ${{ vars.ARXII_BACKUPS_BUCKET }}
           TF_VAR_r2_bucket_name: ${{ vars.ARXII_R2_BUCKET }}
           TF_VAR_dmarc_rua: ${{ vars.ARXII_DMARC_RUA }}
+          # Resend's DNS rows, verbatim from its domain page's MANUAL SETUP
+          # view, as a JSON array. WITHOUT this the module receives its `[]`
+          # default and publishes NO Resend records, so the sending domain
+          # never verifies and no mail leaves the box. The `|| '[]'` matters:
+          # an unset Variable renders as an empty string, which is not valid
+          # JSON for a list(object) and fails the apply outright.
+          TF_VAR_resend_records: ${{ vars.ARXII_RESEND_RECORDS || '[]' }}
+          # Hostnames. Same empty-string trap as above — an unset Variable
+          # would otherwise override the module default with "", putting the
+          # record at the zone apex.
+          TF_VAR_web_hostname: ${{ vars.ARXII_WEB_HOSTNAME || 'play' }}
+          TF_VAR_telnet_hostname: ${{ vars.ARXII_TELNET_HOSTNAME || 'telnet' }}
           # SSH admin CIDR allowlist — conscious operator decision (JSON
           # list), enforced non-empty by standup.sh's preflight.
           TF_VAR_ssh_admin_cidrs: ${{ vars.ARXII_SSH_ADMIN_CIDRS }}

--- a/infra/README.md
+++ b/infra/README.md
@@ -202,6 +202,23 @@ for prod.
   default to leave unmade.
 - `ARXII_ACME_EMAIL` — optional; Caddy's ACME account email. Defaults to
   `admin@<domain>` if unset.
+- `ARXII_RESEND_RECORDS` — **required for mail to work**, maps to
+  `TF_VAR_resend_records`. A JSON array of every row on Resend's domain page,
+  taken from its **Manual setup** view — never its Cloudflare auto-configure
+  button, which writes the records itself and collides with the
+  `cloudflare_dns` module. `priority` is set on the MX row only:
+  ```
+  [{"type":"TXT","name":"resend._domainkey","value":"p=MIGf..."},
+   {"type":"TXT","name":"send","value":"v=spf1 include:amazonses.com ~all"},
+   {"type":"MX","name":"send","value":"feedback-smtp.us-east-1.amazonses.com","priority":10}]
+  ```
+  Leave it unset and the workflow substitutes `[]`, the apply succeeds, and
+  the sending domain silently never verifies — so no registration or
+  password-reset mail ever leaves the box.
+- `ARXII_WEB_HOSTNAME` / `ARXII_TELNET_HOSTNAME` — optional; default to `play`
+  and `telnet`. Both are substituted in the workflow rather than left to the
+  tofu default, because an unset GitHub Variable renders as an empty string,
+  and an empty hostname would place the record at the zone apex.
 - `ARXII_CONTENT_REPO` — the private lore repo's `owner/repo` slug. Pairs
   with `ARXII_CONTENT_REPO_TOKEN` above; knowing the slug alone grants no
   access without the token, which is what keeps this a Variable rather than

--- a/infra/terraform/modules/cloudflare_dns/variables.tf
+++ b/infra/terraform/modules/cloudflare_dns/variables.tf
@@ -16,7 +16,7 @@ variable "web_hostname" {
 
 variable "telnet_hostname" {
   type        = string
-  default     = "mud"
+  default     = "telnet"
   description = "Subdomain for TLS-telnet. DNS-only (NOT proxied) — telnet bypasses Cloudflare straight to origin."
 }
 

--- a/infra/terraform/prod/variables.tf
+++ b/infra/terraform/prod/variables.tf
@@ -38,7 +38,7 @@ variable "web_hostname" {
 }
 variable "telnet_hostname" {
   type    = string
-  default = "mud"
+  default = "telnet"
 }
 variable "tls_telnet_port" {
   type    = number


### PR DESCRIPTION
PR #3160 made `modules/cloudflare_dns` accept every Resend-authored DNS row through
`resend_records`. Nothing passes that variable.

`standup.yml` has no `TF_VAR_resend_records`, so the module takes its `[]` default and
publishes no Resend records at all. The apply succeeds. The sending domain then never
verifies, and no registration or password-reset mail ever leaves the box. The only symptom
is mail that does not arrive, which is a poor way to find out.

`TF_VAR_web_hostname` and `TF_VAR_telnet_hostname` were unreachable from the Environment for
the same reason.

## Changes

Add all three to the workflow's env block. Each substitutes a literal default rather than
passing the Variable through unguarded:

```yaml
TF_VAR_resend_records: ${{ vars.ARXII_RESEND_RECORDS || '[]' }}
TF_VAR_web_hostname: ${{ vars.ARXII_WEB_HOSTNAME || 'play' }}
TF_VAR_telnet_hostname: ${{ vars.ARXII_TELNET_HOSTNAME || 'telnet' }}
```

The guard is load-bearing. An unset GitHub Variable renders as an empty string, not as an
absent value, so a bare passthrough would hand tofu `TF_VAR_resend_records=""` - invalid JSON
for a `list(object)`, failing the apply - and `TF_VAR_telnet_hostname=""`, which places the
record at the zone apex instead of using the module default.

Change `telnet_hostname` from `mud` to `telnet` in both `variables.tf` files. That matches the
intended infra shape (apex, `play`, `telnet`) and the workflow's substituted default. No other
reference to the old value exists in `infra/`, `docs/` or `.github/`.

`infra/README.md` documents the three new Variables under the non-secret config list, with the
JSON shape for the records, the manual-setup-not-auto-configure rule, and an explicit statement
of what leaving `ARXII_RESEND_RECORDS` unset costs.

## Verification

`tofu fmt -check` clean. `tofu validate` passes against the pinned cloudflare 4.52.7 and linode
2.41.2 providers, with only the pre-existing `linode_instance.ip_address` deprecation warning.
No apply run - that needs live credentials and an instance that does not exist yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
