### PR TITLE
Strip the prefix length from the Linode IPv6 output

### DIFF
--- a/infra/terraform/modules/compute/outputs.tf
+++ b/infra/terraform/modules/compute/outputs.tf
@@ -9,8 +9,14 @@ output "ipv4" {
 }
 
 output "ipv6" {
-  value       = linode_instance.host.ipv6
-  description = "Public IPv6."
+  # Linode returns this as a CIDR ("2600:3c03::.../128"), but every consumer
+  # wants a bare address: Cloudflare rejects an AAAA record whose content
+  # carries a prefix length ("AAAA record must be a valid IPv6 address"),
+  # which failed the first real prod apply after the instance already
+  # existed. Strip the prefix here, at the source, so no consumer has to
+  # remember to.
+  value       = split("/", linode_instance.host.ipv6)[0]
+  description = "Public IPv6, bare (prefix length stripped — see comment)."
 }
 
 output "data_volume_id" {


### PR DESCRIPTION
The first real prod apply failed here:

```
Error: error validating record content of "play": AAAA record must be a valid
IPv6 address, got: "2600:3c03::2000:3aff:fea7:967b/128"

  with module.dns.cloudflare_record.web_aaaa,
  on ../modules/cloudflare_dns/main.tf line 27
```

Linode returns `linode_instance.ipv6` as a CIDR with a `/128` prefix length.
Cloudflare rejects AAAA content that carries one. The compute module passed the
value straight through, so `origin_ipv6` reached the record unusable.

`tofu validate` cannot catch this. The value is `(known after apply)` at plan
time, so the failure only appears once a real instance exists and the provider
validates the record against the API. That is exactly the class of bug the dress
rehearsal exists to catch, and it is untested there too, because the rehearsal
root has no Cloudflare credential and creates no DNS.

## Change

Strip the prefix in the compute module's own output rather than at the consumer:

```hcl
value = split("/", linode_instance.host.ipv6)[0]
```

Fixing it at the source means no future consumer of `module.compute.ipv6` has to
know about the quirk. Only one consumer exists today, so the two placements are
equivalent in effect and differ only in what the next person has to remember.

## State after the failed run

The apply is apply-only and got most of the way through before dying. Already
created and recorded in state: the instance, the data volume, the firewall, both
object-storage buckets, both object-storage keys, the R2 bucket, and three of the
four DNS records (`_dmarc`, `telnet`, `play` A). Only the `play` AAAA record is
missing, and the ansible step never ran.

Nothing needs unpicking. A re-run creates the one missing record and proceeds
into the converge.

## Verification

`tofu fmt -check` clean. `tofu validate` passes against the pinned cloudflare
4.52.7 and linode 2.41.2 providers, with only the pre-existing
`linode_instance.ip_address` deprecation warning, which is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
