### PR TITLE
Caddy DNS-01 plugin: fetch the rebuilt binary directly, not via add-package

### DIFF
--- a/infra/ansible/roles/caddy/defaults/main.yml
+++ b/infra/ansible/roles/caddy/defaults/main.yml
@@ -1,4 +1,14 @@
 ---
+# Where apt installs the binary, and where the plugin-carrying rebuild is
+# staged before it is renamed over that path. Both are overridable so a
+# different image layout does not need a task edit.
+caddy_bin: /usr/bin/caddy
+caddy_staged_bin: /tmp/caddy-with-cloudflare
+# Caddy's build service names architectures the Go way; Ansible reports the
+# uname spelling. Only the two we could plausibly run on are mapped, and an
+# unmapped value fails loudly at template time rather than downloading a
+# binary for the wrong architecture.
+caddy_download_arch: "{{ {'x86_64': 'amd64', 'aarch64': 'arm64'}[ansible_architecture] }}"
 caddy_web_fqdn: "play.example"          # = tofu output web_fqdn
 caddy_backend: "127.0.0.1:4001"         # localhost-bound Django/web app backend
 # Evennia portal websocket, localhost-bound. Templated into the Caddyfile's
@@ -18,13 +28,14 @@ caddy_ws_backend: "127.0.0.1:4002"
 caddy_static_root: "/opt/arxii/current/src/server/.static"
 # ACME behind Cloudflare proxy needs DNS-01 (HTTP-01 is intercepted by the
 # orange-cloud). DNS-01 requires Caddy BUILT WITH the caddy-dns/cloudflare
-# plugin (added idempotently by tasks/main.yml via `caddy add-package`) and a
+# plugin (added idempotently by tasks/main.yml, which fetches the matching
+# Caddy version rebuilt with that module from Caddy's build service) and a
 # DNS-edit-scoped Cloudflare token supplied via env (CADDY_CF_DNS_TOKEN),
 # which is a NEW on-box secret to add to the gated-Environment contract.
 caddy_acme_email: "ops@example"
 # #2236 Phase 3 P1 (dress rehearsal). When true: deploy Caddyfile.rehearsal.j2
 # (local_certs, no DNS-01) instead of Caddyfile.j2, and skip the
-# caddy-dns/cloudflare add-package steps below (not needed without acme_dns —
+# caddy-dns/cloudflare plugin steps below (not needed without acme_dns —
 # and the ephemeral-stage root has no Cloudflare credential to fail with
 # anyway, by the isolation doctrine). Set by the rehearsal group_vars
 # rehearse.sh generates; standup.sh never sets it, so prod always gets the

--- a/infra/ansible/roles/caddy/handlers/main.yml
+++ b/infra/ansible/roles/caddy/handlers/main.yml
@@ -3,3 +3,12 @@
   ansible.builtin.systemd_service:
     name: caddy
     state: reloaded
+
+# A Caddyfile change only needs a reload, but a BINARY swap does not take
+# effect until the process is replaced — a reload keeps the old image running,
+# so the newly added DNS-01 plugin would appear absent until something else
+# restarted the service.
+- name: Restart caddy
+  ansible.builtin.systemd_service:
+    name: caddy
+    state: restarted

--- a/infra/ansible/roles/caddy/tasks/main.yml
+++ b/infra/ansible/roles/caddy/tasks/main.yml
@@ -4,9 +4,16 @@
 # `caddy validate`/`caddy adapt` on the stock binary fails. Rather than a
 # custom xcaddy build (which forfeits the apt package's systemd unit/user/
 # upgrade scaffolding), install stock apt caddy, then swap the binary in
-# place for the SAME Caddy version WITH the plugin via `caddy add-package`
-# (Caddy's official build service). Idempotent — guarded by `caddy
-# list-modules`.
+# place for the SAME Caddy version WITH the plugin. Idempotent — guarded by
+# `caddy list-modules`.
+#
+# This used to call `caddy add-package`. That subcommand does not exist in
+# Ubuntu's packaged binary — the first real prod converge died on
+# `unknown command "add-package"`. It is a self-update mechanism, and a
+# distro package manages its own binary, so the distro build omits it.
+# `add-package` is only a convenience wrapper around Caddy's public build
+# service, so the tasks below call that service directly and swap the binary
+# themselves, which is what the original comment intended all along.
 - name: Install Caddy (base apt package; DNS-01 plugin added below)
   ansible.builtin.apt:
     name: caddy
@@ -28,24 +35,73 @@
   register: caddy_modules_before
   when: not caddy_rehearsal_mode
 
-- name: Add the caddy-dns/cloudflare plugin (needs outbound HTTPS)
-  ansible.builtin.command: caddy add-package github.com/caddy-dns/cloudflare
+- name: Read the installed Caddy version (so the rebuild matches it exactly)
+  ansible.builtin.command: caddy version
+  changed_when: false
+  register: caddy_version_raw
   when:
     - not caddy_rehearsal_mode
     - "'dns.providers.cloudflare' not in caddy_modules_before.stdout"
-  changed_when: true # gated by the `when` above: if it runs, it swapped the binary
-  # TRAP: a later plain `apt upgrade` of the `caddy` package replaces this
-  # binary with the plugin-less stock one, silently dropping DNS-01 — the
-  # next converge re-runs this task (guarded by the `when` above) and
-  # re-adds it. unattended-upgrades (roles/unattended_upgrades) only
-  # auto-installs the security pocket, and caddy isn't normally served from
-  # there, so this is an edge case in practice, not a routine occurrence.
-  # Until the next converge, the offbox heartbeat's cert-issuer check
-  # (roles/tls_telnet_cert) catches the fallout — DNS-01 renewal failing
-  # means Caddy falls back to a self-signed/expired cert, which that check
-  # flags.
 
-- name: Re-check installed Caddy modules (verify plugin state after add-package)
+# `caddy version` prints "v2.7.6 h1:<hash>" — the first token is the tag the
+# build service expects. Pinning it keeps the swapped binary on the SAME
+# version apt installed, so the package's unit file and config stay matched.
+#
+# TRAP: a later plain `apt upgrade` of the `caddy` package replaces this
+# binary with the plugin-less stock one, silently dropping DNS-01 — the next
+# converge re-runs these tasks (guarded by the `when` conditions) and re-adds
+# it. unattended-upgrades (roles/unattended_upgrades) only auto-installs the
+# security pocket, and caddy isn't normally served from there, so this is an
+# edge case in practice, not a routine occurrence. Until the next converge,
+# the offbox heartbeat's cert-issuer check (roles/tls_telnet_cert) catches
+# the fallout — DNS-01 renewal failing means Caddy falls back to a
+# self-signed/expired cert, which that check flags.
+- name: Fetch the same Caddy version rebuilt with caddy-dns/cloudflare
+  ansible.builtin.get_url:
+    url: >-
+      https://caddyserver.com/api/download?p=github.com/caddy-dns/cloudflare&os=linux&arch={{
+      caddy_download_arch }}&version={{ caddy_version_raw.stdout.split() | first }}
+    dest: "{{ caddy_staged_bin }}"
+    mode: "0755"
+    force: true
+  when:
+    - not caddy_rehearsal_mode
+    - "'dns.providers.cloudflare' not in caddy_modules_before.stdout"
+
+# Prove the download before it replaces a working binary. A build-service
+# error page saved to disk would otherwise be installed as /usr/bin/caddy and
+# only fail later, at Caddyfile validation, with a far less obvious message.
+- name: Verify the staged binary actually carries the plugin
+  ansible.builtin.command: "{{ caddy_staged_bin }} list-modules"
+  changed_when: false
+  register: caddy_staged_modules
+  failed_when: "'dns.providers.cloudflare' not in caddy_staged_modules.stdout"
+  when:
+    - not caddy_rehearsal_mode
+    - "'dns.providers.cloudflare' not in caddy_modules_before.stdout"
+
+# `copy` renames into place rather than writing through the existing inode,
+# so this does not hit ETXTBSY against the running caddy process.
+- name: Swap the staged binary into place
+  ansible.builtin.copy:
+    src: "{{ caddy_staged_bin }}"
+    dest: "{{ caddy_bin }}"
+    remote_src: true
+    owner: root
+    group: root
+    mode: "0755"
+  notify: Restart caddy
+  when:
+    - not caddy_rehearsal_mode
+    - "'dns.providers.cloudflare' not in caddy_modules_before.stdout"
+
+- name: Remove the staged binary
+  ansible.builtin.file:
+    path: "{{ caddy_staged_bin }}"
+    state: absent
+  when: not caddy_rehearsal_mode
+
+- name: Re-check installed Caddy modules (verify plugin state after the swap)
   ansible.builtin.command: caddy list-modules
   changed_when: false
   register: caddy_modules_after
@@ -55,7 +111,7 @@
   ansible.builtin.assert:
     that: "'dns.providers.cloudflare' in caddy_modules_after.stdout"
     fail_msg: >-
-      caddy-dns/cloudflare module missing after `caddy add-package` — the
+      caddy-dns/cloudflare module missing after the binary swap — the
       Caddyfile's `acme_dns cloudflare` directive (DNS-01) will fail to
       validate/adapt. Check outbound HTTPS to Caddy's build service
       (caddyserver.com) from this host and re-run the converge.

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -180,9 +180,11 @@ assert_before "standup.sh unsets LINODE_TOKEN/CLOUDFLARE_API_TOKEN before invoki
 
 # (c) The caddy DNS-01 plugin install and the Caddyfile directive that
 # needs it are paired — if either half disappears the other is stale.
-chk   "caddy role installs the caddy-dns/cloudflare plugin (add-package)" \
-  "grep -q 'caddy add-package github.com/caddy-dns/cloudflare' infra/ansible/roles/caddy/tasks/main.yml"
-chk   "Caddyfile.j2 still uses DNS-01 via cloudflare (paired with add-package above)" \
+chk   "caddy role fetches the caddy-dns/cloudflare plugin build" \
+  "grep -q 'p=github.com/caddy-dns/cloudflare' infra/ansible/roles/caddy/tasks/main.yml"
+chk   "caddy role verifies the staged binary before swapping it in" \
+  "grep -q 'caddy_staged_modules' infra/ansible/roles/caddy/tasks/main.yml"
+chk   "Caddyfile.j2 still uses DNS-01 via cloudflare (paired with the plugin fetch above)" \
   "grep -q 'acme_dns cloudflare' infra/ansible/roles/caddy/templates/Caddyfile.j2"
 
 # (d) nftables must never `flush ruleset` (wipes fail2ban's own table too);
@@ -316,7 +318,7 @@ chkno "Caddyfile.rehearsal.j2 never uses acme_dns (would need a credential rehea
 # (e) caddy role: rehearsal must skip the DNS-01 plugin install (a
 # guaranteed failure without a Cloudflare credential) and select the
 # rehearsal template by caddy_rehearsal_mode.
-chk   "caddy role skips the add-package plugin steps when caddy_rehearsal_mode" \
+chk   "caddy role skips the DNS-01 plugin steps when caddy_rehearsal_mode" \
   "grep -q 'not caddy_rehearsal_mode' infra/ansible/roles/caddy/tasks/main.yml"
 chk   "caddy role selects Caddyfile.rehearsal.j2 via caddy_rehearsal_mode" \
   "grep -q \"Caddyfile.rehearsal.j2' if caddy_rehearsal_mode\" infra/ansible/roles/caddy/tasks/main.yml"


### PR DESCRIPTION
The first real prod converge died in the caddy role:

```
Error: unknown command "add-package" for "caddy"
```

`caddy add-package` is Caddy's self-update mechanism. Ubuntu's packaged binary
omits it, because a distro package manages its own binary. So the command does
not exist at all - this is not a permissions or network failure.

The role's header already described the right intent: install stock apt caddy,
then swap in the SAME version WITH the caddy-dns/cloudflare plugin, rather than
an xcaddy build that forfeits the package's systemd unit and user. `add-package`
is only a convenience wrapper around Caddy's public build service, so the role
now calls that service directly and does the swap itself.

## Change

1. Read the installed version. `caddy version` prints `v2.7.6 h1:<hash>`; the
   first token pins the download, so the swapped binary stays on the version apt
   installed and the package's unit file and config stay matched.
2. Download that version rebuilt with the plugin, from
   `caddyserver.com/api/download`.
3. **Verify the staged binary before it replaces anything.** It must list
   `dns.providers.cloudflare` or the task fails. Without this, a build-service
   error page saved to disk would be installed as `/usr/bin/caddy` and only
   surface later, at Caddyfile validation, with a much less obvious message.
4. Rename it into place. `copy` renames rather than writing through the existing
   inode, so this does not hit `ETXTBSY` against the running caddy process.
5. Remove the staged file.

Adds a `Restart caddy` handler. The existing `Reload` is right for a Caddyfile
change but leaves the old process image running, so a binary swap would appear
to have done nothing until something else restarted the service.

Every existing guard is unchanged. The block is still skipped entirely under
`caddy_rehearsal_mode`, and still gated on `dns.providers.cloudflare` being
absent from `caddy list-modules`, so it stays idempotent across converges. The
post-swap re-check and its assert are untouched. The apt-upgrade TRAP comment
moves to the fetch task, where it now applies.

## Verification

`acceptance.sh` passes with 0 failures. Its two `add-package` greps are
retargeted at the new mechanism, and a third check asserts the staged binary is
verified before the swap - the pairing those checks exist to protect (plugin
install vs. the Caddyfile's `acme_dns cloudflare` directive) is preserved.

Not verifiable locally: ansible-lint does not run on Windows, and the role
itself can only be proven by the next converge. CI runs both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
