### PR TITLE
Frontend dispatch callers swallow business-rule failures (success:false in HTTP 200) — sweep needed

### DIFF
--- a/frontend/src/covenants/__tests__/api.groupStoryRequest.test.ts
+++ b/frontend/src/covenants/__tests__/api.groupStoryRequest.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Tests for the GroupStoryRequest dispatch helpers (#2119, fixed for #3155).
+ *
+ * ``DispatchActionView`` returns HTTP 200 even for a business-rule rejection
+ * (e.g. requesting a GM for a covenant that already has an open request) —
+ * the wire signal is the response body's ``success`` field
+ * (``DispatchResultSerializer``), not ``res.ok``. These tests exercise the
+ * REAL ``requestGMForCovenant``/``withdrawGroupStoryRequest`` helpers against
+ * a mocked ``apiFetch`` returning that exact shape, to catch a regression
+ * where only ``res.ok`` was checked (a rejected request would then read as a
+ * resolved Promise instead of throwing) — mirrors ``api.treasury.test.ts``.
+ */
+
+import { vi } from 'vitest';
+
+vi.mock('@/evennia_replacements/api', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '@/evennia_replacements/api';
+import { requestGMForCovenant, withdrawGroupStoryRequest } from '../api';
+
+function mockDispatchResponse(body: {
+  success: boolean | null;
+  message?: string | null;
+  ok?: boolean;
+}) {
+  return {
+    ok: body.ok ?? true,
+    json: () =>
+      Promise.resolve({
+        backend: 'registry',
+        deferred: false,
+        success: body.success,
+        message: body.message ?? null,
+        data: null,
+      }),
+  } as Response;
+}
+
+describe('covenants/api group-story-request dispatch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('requestGMForCovenant resolves on success: true', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      mockDispatchResponse({ success: true, message: 'GM request posted.' })
+    );
+
+    const result = await requestGMForCovenant(42, 7, 'Seeking a GM!');
+
+    expect(result).toBe('GM request posted.');
+  });
+
+  it('requestGMForCovenant throws with the server message on success: false (HTTP 200)', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      mockDispatchResponse({
+        ok: true,
+        success: false,
+        message: 'This covenant already has an open GM request.',
+      })
+    );
+
+    await expect(requestGMForCovenant(42, 7, 'Seeking a GM!')).rejects.toThrow(
+      'This covenant already has an open GM request.'
+    );
+  });
+
+  it('withdrawGroupStoryRequest resolves on success: true', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      mockDispatchResponse({ success: true, message: 'GM request withdrawn.' })
+    );
+
+    const result = await withdrawGroupStoryRequest(42, 5);
+
+    expect(result).toBe('GM request withdrawn.');
+  });
+
+  it('withdrawGroupStoryRequest throws with the server message on success: false (HTTP 200)', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      mockDispatchResponse({
+        ok: true,
+        success: false,
+        message: 'Only the requester may withdraw this request.',
+      })
+    );
+
+    await expect(withdrawGroupStoryRequest(42, 5)).rejects.toThrow(
+      'Only the requester may withdraw this request.'
+    );
+  });
+
+  it('withdrawGroupStoryRequest throws a fallback message when the body has no message', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(mockDispatchResponse({ success: false, message: null }));
+
+    await expect(withdrawGroupStoryRequest(42, 5)).rejects.toThrow(
+      'Failed to withdraw the GM request.'
+    );
+  });
+});

--- a/frontend/src/covenants/api.ts
+++ b/frontend/src/covenants/api.ts
@@ -10,7 +10,7 @@
  */
 
 import { apiFetch } from '@/evennia_replacements/api';
-import { readErrorDetail } from '@/lib/errors';
+import { parseDispatchBody, readErrorDetail } from '@/lib/errors';
 import type { components } from '@/generated/api';
 
 // ---------------------------------------------------------------------------
@@ -465,21 +465,16 @@ export async function getPendingGroupStoryRequestForCovenant(
   return data.results[0] ?? null;
 }
 
-/** Shape of a dispatch-endpoint error/success body, local to this module. */
-async function dispatchDetail(res: Response): Promise<string | undefined> {
-  try {
-    const data = (await res.json()) as { detail?: string; message?: string | null };
-    return data.detail ?? data.message ?? undefined;
-  } catch {
-    return undefined;
-  }
-}
-
 /**
  * Dispatch RequestGMForCovenantAction as the actor's own character
  * (actorCharacterId is the ObjectDB pk — doubles as the character_sheet pk,
  * since CharacterSheet.character is a primary_key=True OneToOneField).
  * Mirrors the generic-dispatch pattern in @/game/api/roomEditor.ts.
+ *
+ * `DispatchActionView` resolves HTTP 200 even for a business-rule rejection
+ * (e.g. an already-open request) — `success === false` is the wire signal
+ * that distinguishes an honest failure from a real success, and `res.ok`
+ * alone is NOT enough (#3155; same fix shape as the treasury calls below).
  */
 export async function requestGMForCovenant(
   actorCharacterId: number,
@@ -494,12 +489,16 @@ export async function requestGMForCovenant(
       kwargs: { covenant_id: covenantId, message },
     }),
   });
-  const detail = await dispatchDetail(res);
-  if (!res.ok) throw new Error(detail ?? 'Failed to post the GM request.');
+  const { success, message: detail } = await parseDispatchBody(res);
+  if (!res.ok || success === false) throw new Error(detail ?? 'Failed to post the GM request.');
   return detail ?? 'GM request posted.';
 }
 
-/** Dispatch WithdrawGroupStoryRequestAction as the actor's own character. */
+/**
+ * Dispatch WithdrawGroupStoryRequestAction as the actor's own character.
+ * See `requestGMForCovenant`'s doc comment for the `success === false` wire
+ * signal this checks (#3155).
+ */
 export async function withdrawGroupStoryRequest(
   actorCharacterId: number,
   requestId: number
@@ -512,8 +511,8 @@ export async function withdrawGroupStoryRequest(
       kwargs: { request_id: requestId },
     }),
   });
-  const detail = await dispatchDetail(res);
-  if (!res.ok) throw new Error(detail ?? 'Failed to withdraw the GM request.');
+  const { success, message: detail } = await parseDispatchBody(res);
+  if (!res.ok || success === false) throw new Error(detail ?? 'Failed to withdraw the GM request.');
   return detail ?? 'GM request withdrawn.';
 }
 
@@ -527,32 +526,11 @@ export async function withdrawGroupStoryRequest(
 // ---------------------------------------------------------------------------
 
 /**
- * Parsed dispatch-endpoint body for the treasury calls. ``DispatchActionView``
- * returns HTTP 200 even for a business-rule rejection (e.g. rank-unauthorized
- * withdrawal) — ``success`` (from ``DispatchResultSerializer``) is the wire
- * signal that distinguishes an honest failure from a real success, and
- * ``res.ok`` alone is NOT enough. Scoped to the treasury calls below — the
- * other dispatch callers in this module (``requestGMForCovenant`` etc.) are
- * unchanged by this fix.
- */
-async function dispatchTreasuryResult(
-  res: Response
-): Promise<{ success: boolean | null; message: string | undefined }> {
-  try {
-    const data = (await res.json()) as {
-      detail?: string;
-      message?: string | null;
-      success?: boolean | null;
-    };
-    return { success: data.success ?? null, message: data.detail ?? data.message ?? undefined };
-  } catch {
-    return { success: null, message: undefined };
-  }
-}
-
-/**
  * Dispatch DepositCovenantFundsAction as the actor's own character.
  * Moves ``amount`` coppers from the actor's purse into the covenant treasury.
+ * See `requestGMForCovenant`'s doc comment for the `success === false` wire
+ * signal this checks (originally #2992; hoisted onto the shared
+ * `parseDispatchBody` in #3155).
  */
 export async function depositCovenantFunds(
   actorCharacterId: number,
@@ -567,7 +545,7 @@ export async function depositCovenantFunds(
       kwargs: { covenant_id: covenantId, amount },
     }),
   });
-  const { success, message } = await dispatchTreasuryResult(res);
+  const { success, message } = await parseDispatchBody(res);
   if (!res.ok || success === false) throw new Error(message ?? 'Failed to deposit covenant funds.');
   return message ?? 'Funds deposited.';
 }
@@ -591,7 +569,7 @@ export async function withdrawCovenantFunds(
       kwargs: { covenant_id: covenantId, amount },
     }),
   });
-  const { success, message } = await dispatchTreasuryResult(res);
+  const { success, message } = await parseDispatchBody(res);
   if (!res.ok || success === false)
     throw new Error(message ?? 'Failed to withdraw covenant funds.');
   return message ?? 'Funds withdrawn.';

--- a/frontend/src/game/api/__tests__/roomEditor.test.ts
+++ b/frontend/src/game/api/__tests__/roomEditor.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for the `edit_room` dispatch helper (#1470, fixed for #3155).
+ *
+ * ``DispatchActionView`` returns HTTP 200 even for a business-rule rejection
+ * (e.g. editing a room the actor doesn't own) — the wire signal is the
+ * response body's ``success`` field (``DispatchResultSerializer``), not
+ * ``res.ok``. This exercises the REAL ``editRoom`` helper against a mocked
+ * ``apiFetch`` returning that exact shape, to catch a regression where only
+ * ``res.ok`` was checked (a rejected edit would then read as a resolved
+ * Promise instead of throwing) — mirrors ``api.treasury.test.ts``.
+ */
+
+import { vi } from 'vitest';
+
+vi.mock('@/evennia_replacements/api', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '@/evennia_replacements/api';
+import { editRoom } from '../roomEditor';
+
+function mockDispatchResponse(body: {
+  success: boolean | null;
+  message?: string | null;
+  ok?: boolean;
+}) {
+  return {
+    ok: body.ok ?? true,
+    json: () =>
+      Promise.resolve({
+        backend: 'registry',
+        deferred: false,
+        success: body.success,
+        message: body.message ?? null,
+        data: null,
+      }),
+  } as Response;
+}
+
+describe('game/api/roomEditor editRoom', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves with the server message on success: true', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      mockDispatchResponse({ success: true, message: 'Room updated.' })
+    );
+
+    const result = await editRoom(42, { name: 'The Solar' });
+
+    expect(result).toBe('Room updated.');
+  });
+
+  it('throws with the server message on success: false (HTTP 200)', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      mockDispatchResponse({ ok: true, success: false, message: "You don't own this room." })
+    );
+
+    await expect(editRoom(42, { name: 'The Solar' })).rejects.toThrow("You don't own this room.");
+  });
+
+  it('throws a fallback message when the body has no message', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(mockDispatchResponse({ success: false, message: null }));
+
+    await expect(editRoom(42, { name: 'The Solar' })).rejects.toThrow('Failed to update the room.');
+  });
+});

--- a/frontend/src/game/api/roomEditor.ts
+++ b/frontend/src/game/api/roomEditor.ts
@@ -1,5 +1,5 @@
 import { apiFetch } from '@/evennia_replacements/api';
-import { throwApiError } from '@/lib/errors';
+import { parseDispatchBody } from '@/lib/errors';
 
 export interface RoomEditInput {
   name?: string;
@@ -11,9 +11,11 @@ export interface RoomEditInput {
  * Dispatch the `edit_room` REGISTRY action for `characterId`, editing the room
  * the character is currently standing in (#1470). Owner-gated server-side.
  *
- * Returns the action's human-readable result message (e.g. "Room updated." or
- * the reason an edit was refused). Throws on a dispatch-level error (4xx) with
- * the server's `detail`.
+ * Returns the action's human-readable result message (e.g. "Room updated.").
+ * Throws on a dispatch-level error (4xx) OR a business-rule rejection —
+ * `DispatchActionView` resolves HTTP 200 even for a refused edit, so
+ * `success === false` (not `res.ok` alone) is the signal an edit was refused
+ * (#3155).
  */
 export async function editRoom(characterId: number, input: RoomEditInput): Promise<string> {
   const res = await apiFetch(`/api/actions/characters/${characterId}/dispatch/`, {
@@ -24,7 +26,7 @@ export async function editRoom(characterId: number, input: RoomEditInput): Promi
       kwargs: input,
     }),
   });
-  if (!res.ok) await throwApiError(res, 'Failed to update the room.');
-  const data = (await res.json()) as { message?: string | null };
-  return data.message ?? 'Room updated.';
+  const { success, message } = await parseDispatchBody(res);
+  if (!res.ok || success === false) throw new Error(message ?? 'Failed to update the room.');
+  return message ?? 'Room updated.';
 }

--- a/frontend/src/game/components/PresencePanel.test.tsx
+++ b/frontend/src/game/components/PresencePanel.test.tsx
@@ -8,6 +8,13 @@ import { PresencePanel } from './PresencePanel';
 
 vi.mock('@/presence/api', () => ({ getPresence: vi.fn() }));
 
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 // Mock the roster query — component resolves active character → characterId (#2163)
 vi.mock('@/roster/queries', () => ({
   useMyRosterEntriesQuery: vi.fn(() => ({
@@ -40,6 +47,7 @@ vi.mock('@/combat/queries', () => ({
 }));
 
 import { useDispatchPlayerAction } from '@/combat/queries';
+import { toast } from 'sonner';
 
 describe('PresencePanel', () => {
   it('renders the online roster with a coarse idle marker', async () => {
@@ -99,10 +107,44 @@ describe('PresencePanel — Go there button (#2163)', () => {
     await user.click(button);
 
     await waitFor(() => {
-      expect(mockMutate).toHaveBeenCalledWith({
-        ref: { backend: 'registry', registry_key: 'travel_to' },
-        kwargs: { target: 501 },
-      });
+      expect(mockMutate).toHaveBeenCalledWith(
+        {
+          ref: { backend: 'registry', registry_key: 'travel_to' },
+          kwargs: { target: 501 },
+        },
+        expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
+      );
     });
+  });
+
+  /**
+   * #3155: `DispatchActionView` resolves HTTP 200 even for a business-rule
+   * rejection (e.g. no path there). Before the fix this `mutate()` call had
+   * no result handling at all, so a rejected travel silently did nothing.
+   */
+  it('toasts the rejection reason when the dispatch resolves success: false', async () => {
+    const user = userEvent.setup();
+    const mockMutate = vi.fn();
+    vi.mocked(useDispatchPlayerAction).mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDispatchPlayerAction>);
+    vi.mocked(getPresence).mockResolvedValue({
+      who: [],
+      where: [{ persona_name: 'Captain Vale', room_path: 'Umbros - Sable Hold', room_id: 501 }],
+    });
+
+    renderWithProviders(<PresencePanel />);
+
+    const button = await screen.findByTestId('go-there-where-0');
+    await user.click(button);
+
+    await waitFor(() => expect(mockMutate).toHaveBeenCalled());
+    const options = mockMutate.mock.calls[0][1] as {
+      onSuccess: (result: { success: boolean; message: string }) => void;
+    };
+    options.onSuccess({ success: false, message: 'No path there.' });
+
+    expect(toast.error).toHaveBeenCalledWith('No path there.');
   });
 });

--- a/frontend/src/game/components/PresencePanel.tsx
+++ b/frontend/src/game/components/PresencePanel.tsx
@@ -1,9 +1,11 @@
 import { useMemo } from 'react';
+import { toast } from 'sonner';
 import { FormattedContent } from '@/components/FormattedContent';
 import { usePresence } from '@/presence/queries';
 import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { useDispatchPlayerAction } from '@/combat/queries';
+import { isDispatchFailure } from '@/combat/types';
 
 /**
  * Right-sidebar "Who" tab (#1463): online presence for the web game view.
@@ -26,10 +28,23 @@ export function PresencePanel() {
   const { mutate, isPending } = useDispatchPlayerAction(characterId ?? 0);
 
   const dispatchTravel = (roomId: number) => {
-    mutate({
-      ref: { backend: 'registry', registry_key: 'travel_to' },
-      kwargs: { target: roomId },
-    });
+    mutate(
+      {
+        ref: { backend: 'registry', registry_key: 'travel_to' },
+        kwargs: { target: roomId },
+      },
+      {
+        // `DispatchActionView` resolves HTTP 200 even for a business-rule
+        // rejection (e.g. no path there) — without this check the rejection
+        // silently did nothing (#3155).
+        onSuccess: (result) => {
+          if (isDispatchFailure(result)) {
+            toast.error(result.message ?? "Couldn't travel there.");
+          }
+        },
+        onError: (error: Error) => toast.error(error.message),
+      }
+    );
   };
 
   if (isLoading) {

--- a/frontend/src/game/components/room-panel/PortalsBlock.test.tsx
+++ b/frontend/src/game/components/room-panel/PortalsBlock.test.tsx
@@ -15,6 +15,15 @@ vi.mock('@/combat/queries', () => ({
   useDispatchPlayerAction: vi.fn(),
 }));
 
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+import { toast } from 'sonner';
+
 const mockUsePortalDestinationsQuery = vi.mocked(usePortalDestinationsQuery);
 const mockUseDispatchPlayerAction = vi.mocked(useDispatchPlayerAction);
 
@@ -95,10 +104,46 @@ describe('PortalsBlock', () => {
     await user.click(screen.getByTestId('portal-travel-7'));
 
     await waitFor(() => {
-      expect(mutate).toHaveBeenCalledWith({
-        ref: { backend: 'registry', registry_key: 'travel_to' },
-        kwargs: { target: 501 },
-      });
+      expect(mutate).toHaveBeenCalledWith(
+        {
+          ref: { backend: 'registry', registry_key: 'travel_to' },
+          kwargs: { target: 501 },
+        },
+        expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
+      );
     });
+  });
+
+  /**
+   * #3155: `DispatchActionView` resolves HTTP 200 even for a business-rule
+   * rejection (e.g. no path there). Before the fix this `mutate()` call had
+   * no result handling at all, so a rejected travel silently did nothing.
+   */
+  it('toasts the rejection reason when the dispatch resolves success: false', async () => {
+    const user = userEvent.setup();
+    const mutate = mockDispatch();
+    mockUsePortalDestinationsQuery.mockReturnValue({
+      data: [
+        {
+          anchor_id: 7,
+          room_id: 501,
+          room_name: 'Sable Hold',
+          kind_name: 'Mirror',
+          anchor_name: 'a tall silvered mirror',
+        },
+      ],
+    } as unknown as ReturnType<typeof usePortalDestinationsQuery>);
+
+    renderWithProviders(<PortalsBlock characterId={42} />);
+
+    await user.click(screen.getByTestId('portal-travel-7'));
+
+    await waitFor(() => expect(mutate).toHaveBeenCalled());
+    const options = mutate.mock.calls[0][1] as {
+      onSuccess: (result: { success: boolean; message: string }) => void;
+    };
+    options.onSuccess({ success: false, message: 'No path there.' });
+
+    expect(toast.error).toHaveBeenCalledWith('No path there.');
   });
 });

--- a/frontend/src/game/components/room-panel/PortalsBlock.tsx
+++ b/frontend/src/game/components/room-panel/PortalsBlock.tsx
@@ -19,9 +19,11 @@
  */
 
 import { Sparkles } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { usePortalDestinationsQuery } from '@/locations/queries';
 import { useDispatchPlayerAction } from '@/combat/queries';
+import { isDispatchFailure } from '@/combat/types';
 
 interface PortalsBlockProps {
   /** The active puppet's ObjectDB/CharacterSheet pk, or null/undefined with none active. */
@@ -37,10 +39,23 @@ export function PortalsBlock({ characterId }: PortalsBlockProps) {
   }
 
   const dispatchTravel = (roomId: number) => {
-    mutate({
-      ref: { backend: 'registry', registry_key: 'travel_to' },
-      kwargs: { target: roomId },
-    });
+    mutate(
+      {
+        ref: { backend: 'registry', registry_key: 'travel_to' },
+        kwargs: { target: roomId },
+      },
+      {
+        // `DispatchActionView` resolves HTTP 200 even for a business-rule
+        // rejection (e.g. no path there) — without this check the rejection
+        // silently did nothing (#3155).
+        onSuccess: (result) => {
+          if (isDispatchFailure(result)) {
+            toast.error(result.message ?? "Couldn't travel there.");
+          }
+        },
+        onError: (error: Error) => toast.error(error.message),
+      }
+    );
   };
 
   return (

--- a/frontend/src/lib/__tests__/errors.test.ts
+++ b/frontend/src/lib/__tests__/errors.test.ts
@@ -1,7 +1,13 @@
 /** ApiError + throwApiError/readErrorDetail (2026-07 audit error-path fix). */
 import { describe, expect, it } from 'vitest';
 
-import { ApiError, extractErrorMessage, readErrorDetail, throwApiError } from '../errors';
+import {
+  ApiError,
+  extractErrorMessage,
+  parseDispatchBody,
+  readErrorDetail,
+  throwApiError,
+} from '../errors';
 
 function jsonResponse(body: unknown, status = 400): Response {
   return new Response(JSON.stringify(body), {
@@ -46,5 +52,39 @@ describe('throwApiError', () => {
     expect(err).toBeInstanceOf(ApiError);
     expect(err.status).toBe(403);
     expect(extractErrorMessage(err)).toBe('Nope.');
+  });
+});
+
+/**
+ * `parseDispatchBody` (#3155) — the shared parse hoisted out of the #2992
+ * `dispatchTreasuryResult` fix so every dispatch caller that reduces a
+ * `DispatchActionView` response to a message string applies the same
+ * `success === false` check instead of re-copying the parse per module.
+ */
+describe('parseDispatchBody', () => {
+  it('reads success and message off a business-rule rejection body (HTTP 200)', async () => {
+    const res = jsonResponse({ success: false, message: 'Only members may do that.' }, 200);
+    await expect(parseDispatchBody(res)).resolves.toEqual({
+      success: false,
+      message: 'Only members may do that.',
+    });
+  });
+
+  it('reads success: true off a real success body', async () => {
+    const res = jsonResponse({ success: true, message: 'Done.' }, 200);
+    await expect(parseDispatchBody(res)).resolves.toEqual({ success: true, message: 'Done.' });
+  });
+
+  it('prefers detail over message when both are present', async () => {
+    const res = jsonResponse({ success: false, detail: 'Detail wins.', message: 'Ignored.' });
+    await expect(parseDispatchBody(res)).resolves.toEqual({
+      success: false,
+      message: 'Detail wins.',
+    });
+  });
+
+  it('reads success: null and no message off a non-JSON body', async () => {
+    const res = new Response('<html>proxy error</html>', { status: 502 });
+    await expect(parseDispatchBody(res)).resolves.toEqual({ success: null, message: undefined });
   });
 });

--- a/frontend/src/lib/errors.ts
+++ b/frontend/src/lib/errors.ts
@@ -109,3 +109,43 @@ export async function throwApiError(res: Response, fallback: string): Promise<ne
 export async function readErrorDetail(res: Response, fallback: string): Promise<never> {
   return throwApiError(res, fallback);
 }
+
+/**
+ * Parsed `POST /api/actions/characters/{id}/dispatch/` response body — the
+ * two fields every dispatch caller needs to decide success vs. rejection.
+ */
+export interface DispatchResultBody {
+  /**
+   * `DispatchActionView` always resolves HTTP 200 for a business-rule
+   * `ActionResult`, success or failure — only a structural ref error is a
+   * 400. So `success === false` (not `res.ok`) is the wire signal that
+   * distinguishes an honest rejection from a real success; `true`/`null`/
+   * `undefined` all read as success (`null` covers a deferred dispatch or a
+   * backend with no boolean-success notion).
+   */
+  success: boolean | null;
+  message: string | undefined;
+}
+
+/**
+ * Parse a dispatch-endpoint response body into `{success, message}`,
+ * swallowing a non-JSON body as `{success: null, message: undefined}`.
+ * Callers combine this with `!res.ok` to throw on either a structural error
+ * or a business-rule rejection — see `dispatchTreasuryResult` (the #2992
+ * reference fix in `@/covenants/api.ts`) for the throw-and-fallback shape.
+ * Hoisted here (#3155) so every dispatch caller that reduces the response to
+ * a single message string shares one parse, instead of re-copying it per
+ * module.
+ */
+export async function parseDispatchBody(res: Response): Promise<DispatchResultBody> {
+  try {
+    const data = (await res.json()) as {
+      detail?: string;
+      message?: string | null;
+      success?: boolean | null;
+    };
+    return { success: data.success ?? null, message: data.detail ?? data.message ?? undefined };
+  } catch {
+    return { success: null, message: undefined };
+  }
+}

--- a/frontend/src/market/__tests__/api.test.ts
+++ b/frontend/src/market/__tests__/api.test.ts
@@ -1,0 +1,72 @@
+/**
+ * Tests for the market REGISTRY dispatch helper (#2066, fixed for #3155).
+ *
+ * ``DispatchActionView`` returns HTTP 200 even for a business-rule rejection
+ * (e.g. insufficient funds) — the wire signal is the response body's
+ * ``success`` field (``DispatchResultSerializer``), not ``res.ok``. This
+ * exercises the REAL ``dispatchMarketAction`` helper against a mocked
+ * ``apiFetch`` returning that exact shape, to catch a regression where only
+ * ``res.ok`` was checked (a rejected purchase would then read as a resolved
+ * Promise instead of throwing) — mirrors ``api.treasury.test.ts``.
+ */
+
+import { vi } from 'vitest';
+
+vi.mock('@/evennia_replacements/api', () => ({
+  apiFetch: vi.fn(),
+}));
+
+import { apiFetch } from '@/evennia_replacements/api';
+import { dispatchMarketAction } from '../api';
+
+function mockDispatchResponse(body: {
+  success: boolean | null;
+  message?: string | null;
+  ok?: boolean;
+}) {
+  return {
+    ok: body.ok ?? true,
+    json: () =>
+      Promise.resolve({
+        backend: 'registry',
+        deferred: false,
+        success: body.success,
+        message: body.message ?? null,
+        data: null,
+      }),
+  } as Response;
+}
+
+describe('market/api dispatchMarketAction', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('resolves with the server message on success: true', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      mockDispatchResponse({ success: true, message: 'Purchase complete.' })
+    );
+
+    const result = await dispatchMarketAction(42, 'market_buy_stock', { listing_id: 1 });
+
+    expect(result).toBe('Purchase complete.');
+  });
+
+  it('throws with the server message on success: false (HTTP 200)', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(
+      mockDispatchResponse({ ok: true, success: false, message: 'You cannot afford that.' })
+    );
+
+    await expect(dispatchMarketAction(42, 'market_buy_stock', { listing_id: 1 })).rejects.toThrow(
+      'You cannot afford that.'
+    );
+  });
+
+  it('throws a fallback message when the body has no message', async () => {
+    vi.mocked(apiFetch).mockResolvedValue(mockDispatchResponse({ success: false, message: null }));
+
+    await expect(dispatchMarketAction(42, 'market_buy_stock', { listing_id: 1 })).rejects.toThrow(
+      'The action failed.'
+    );
+  });
+});

--- a/frontend/src/market/api.ts
+++ b/frontend/src/market/api.ts
@@ -4,7 +4,7 @@
  */
 
 import { apiFetch } from '@/evennia_replacements/api';
-import { throwApiError } from '@/lib/errors';
+import { parseDispatchBody } from '@/lib/errors';
 
 export interface StockListing {
   id: number;
@@ -71,6 +71,11 @@ export async function getServiceOffers(): Promise<ServiceOffer[]> {
 
 export type MarketActionKey = 'market_buy_stock' | 'market_buy_ware' | 'market_finish_ware';
 
+/**
+ * Dispatch a market REGISTRY action. `DispatchActionView` resolves HTTP 200
+ * even for a business-rule rejection (e.g. insufficient funds) — `success ===
+ * false` (not `res.ok` alone) is the signal the purchase was refused (#3155).
+ */
 export async function dispatchMarketAction(
   characterId: number,
   registryKey: MarketActionKey,
@@ -81,7 +86,7 @@ export async function dispatchMarketAction(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ ref: { backend: 'registry', registry_key: registryKey }, kwargs }),
   });
-  if (!res.ok) await throwApiError(res, 'The action failed.');
-  const data = (await res.json()) as { message?: string };
-  return data.message ?? 'Done.';
+  const { success, message } = await parseDispatchBody(res);
+  if (!res.ok || success === false) throw new Error(message ?? 'The action failed.');
+  return message ?? 'Done.';
 }

--- a/frontend/src/scenes/components/SceneHeader.test.tsx
+++ b/frontend/src/scenes/components/SceneHeader.test.tsx
@@ -1,4 +1,5 @@
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { describe, expect, it, vi } from 'vitest';
@@ -7,8 +8,26 @@ import { SceneHeader } from './SceneHeader';
 import type { SceneDetail } from '../types';
 
 const mockUseEncounterForScene = vi.fn();
+const mockUseDispatchPlayerAction = vi.fn();
 vi.mock('@/combat/queries', () => ({
   useEncounterForScene: () => mockUseEncounterForScene(),
+  useDispatchPlayerAction: () => mockUseDispatchPlayerAction(),
+}));
+
+vi.mock('@/roster/queries', () => ({
+  useMyRosterEntriesQuery: () => ({
+    data: [{ id: 1, name: 'TestChar', character_id: 42 }],
+  }),
+}));
+
+vi.mock('@/store/hooks', () => ({
+  useAppSelector: (selector: (state: unknown) => unknown) =>
+    selector({ game: { active: 'TestChar' }, auth: {} }),
+}));
+
+const mockUseAvailableActionsQuery = vi.fn();
+vi.mock('../actionQueries', () => ({
+  useAvailableActionsQuery: () => mockUseAvailableActionsQuery(),
 }));
 
 // Only the fields SceneHeader actually reads are filled in — cast covers the
@@ -98,5 +117,66 @@ describe('SceneHeader round-state badge (#2158)', () => {
 
     renderWrapped({ ...BASE_SCENE, active_round: null });
     expect(screen.queryByText(/round/i)).not.toBeInTheDocument();
+  });
+});
+
+/**
+ * Grant GM control (#2113, fixed for #3155). `DispatchActionView` resolves
+ * HTTP 200 even for a business-rule rejection (e.g. target not found) — a
+ * `dispatchAction(...).then(...)` that ignores `isDispatchFailure(result)`
+ * reports the rejection reason as a success and clears the input as if it
+ * landed.
+ */
+describe('SceneHeader grant GM control (#3155)', () => {
+  const GRANT_ACTION = {
+    ref: { backend: 'registry' as const, registry_key: 'grant_scene_gm' },
+    display_name: 'Grant GM',
+  };
+
+  function renderGrantControl(mutateAsync: ReturnType<typeof vi.fn>) {
+    mockUseEncounterForScene.mockReturnValue({ data: null, isLoading: false, isError: false });
+    mockUseAvailableActionsQuery.mockReturnValue({ data: { results: [GRANT_ACTION] } });
+    mockUseDispatchPlayerAction.mockReturnValue({ mutateAsync, isPending: false });
+
+    return renderWrapped({
+      ...BASE_SCENE,
+      is_owner: true,
+      is_active: true,
+    });
+  }
+
+  it('reports the server rejection reason and keeps the input on success: false', async () => {
+    const user = userEvent.setup();
+    const mutateAsync = vi.fn().mockResolvedValue({
+      success: false,
+      message: 'No character named "Nobody" is in this scene.',
+    });
+    renderGrantControl(mutateAsync);
+
+    await user.type(screen.getByLabelText('Grant GM target character name'), 'Nobody');
+    await user.click(screen.getByRole('button', { name: /grant gm/i }));
+
+    expect(
+      await screen.findByText('No character named "Nobody" is in this scene.')
+    ).toBeInTheDocument();
+    // The refused grant must not clear the input as if it landed.
+    expect(screen.getByLabelText('Grant GM target character name')).toHaveValue('Nobody');
+  });
+
+  it('reports success and clears the input on success: true', async () => {
+    const user = userEvent.setup();
+    const mutateAsync = vi.fn().mockResolvedValue({
+      success: true,
+      message: 'GM status granted to Bram.',
+    });
+    renderGrantControl(mutateAsync);
+
+    await user.type(screen.getByLabelText('Grant GM target character name'), 'Bram');
+    await user.click(screen.getByRole('button', { name: /grant gm/i }));
+
+    expect(await screen.findByText('GM status granted to Bram.')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByLabelText('Grant GM target character name')).toHaveValue('');
+    });
   });
 });

--- a/frontend/src/scenes/components/SceneHeader.tsx
+++ b/frontend/src/scenes/components/SceneHeader.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { useDispatchPlayerAction } from '@/combat/queries';
+import { isDispatchFailure } from '@/combat/types';
 import { SceneDetail, updateScene, finishScene } from '../queries';
 import { useAvailableActionsQuery } from '../actionQueries';
 import type { PlayerAction } from '../actionTypes';
@@ -57,6 +58,13 @@ function GrantSceneGMControl() {
     if (!name) return;
     dispatchAction({ ref: grantAction.ref, kwargs: { target_name: name } })
       .then((result) => {
+        // `DispatchActionView` resolves HTTP 200 even for a business-rule
+        // rejection (e.g. target not found) — `isDispatchFailure` (not a
+        // resolved promise alone) is the signal the grant was refused (#3155).
+        if (isDispatchFailure(result)) {
+          setFeedback(result.message ?? 'Could not grant GM status.');
+          return;
+        }
         setFeedback(result.message ?? `GM status granted to ${name}.`);
         setTargetName('');
       })

--- a/frontend/src/scenes/pages/ScenesListPage.tsx
+++ b/frontend/src/scenes/pages/ScenesListPage.tsx
@@ -1,10 +1,12 @@
 import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { Link } from 'react-router-dom';
+import { toast } from 'sonner';
 import { CharacterLink } from '@/components/character';
 import { useAppSelector } from '@/store/hooks';
 import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { useDispatchPlayerAction } from '@/combat/queries';
+import { isDispatchFailure } from '@/combat/types';
 import { fetchScenes, SceneListItem } from '../queries';
 
 export function ScenesListPage() {
@@ -23,10 +25,23 @@ export function ScenesListPage() {
   const { mutate: dispatchTravel, isPending } = useDispatchPlayerAction(characterId ?? 0);
 
   const goThere = (roomId: number) => {
-    dispatchTravel({
-      ref: { backend: 'registry', registry_key: 'travel_to' },
-      kwargs: { target: roomId },
-    });
+    dispatchTravel(
+      {
+        ref: { backend: 'registry', registry_key: 'travel_to' },
+        kwargs: { target: roomId },
+      },
+      {
+        // `DispatchActionView` resolves HTTP 200 even for a business-rule
+        // rejection (e.g. no path there) — without this check the rejection
+        // silently did nothing (#3155).
+        onSuccess: (result) => {
+          if (isDispatchFailure(result)) {
+            toast.error(result.message ?? "Couldn't travel there.");
+          }
+        },
+        onError: (error: Error) => toast.error(error.message),
+      }
+    );
   };
 
   return (

--- a/frontend/src/scenes/pages/__tests__/ScenesListPage.test.tsx
+++ b/frontend/src/scenes/pages/__tests__/ScenesListPage.test.tsx
@@ -37,6 +37,13 @@ vi.mock('@/combat/queries', () => ({
   })),
 }));
 
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
 vi.mock('../../queries', async () => {
   const actual = await vi.importActual<typeof import('../../queries')>('../../queries');
   return {
@@ -48,6 +55,7 @@ vi.mock('../../queries', async () => {
 import { ScenesListPage } from '../ScenesListPage';
 import { fetchScenes } from '../../queries';
 import { useDispatchPlayerAction } from '@/combat/queries';
+import { toast } from 'sonner';
 
 function makeScene(overrides: Partial<SceneListItem> = {}): SceneListItem {
   return {
@@ -116,10 +124,41 @@ describe('ScenesListPage — Go there button (#2163)', () => {
     await user.click(button);
 
     await waitFor(() => {
-      expect(mockMutate).toHaveBeenCalledWith({
-        ref: { backend: 'registry', registry_key: 'travel_to' },
-        kwargs: { target: 501 },
-      });
+      expect(mockMutate).toHaveBeenCalledWith(
+        {
+          ref: { backend: 'registry', registry_key: 'travel_to' },
+          kwargs: { target: 501 },
+        },
+        expect.objectContaining({ onSuccess: expect.any(Function), onError: expect.any(Function) })
+      );
     });
+  });
+
+  /**
+   * #3155: `DispatchActionView` resolves HTTP 200 even for a business-rule
+   * rejection (e.g. no path there). Before the fix this `mutate()` call had
+   * no result handling at all, so a rejected travel silently did nothing.
+   */
+  it('toasts the rejection reason when the dispatch resolves success: false', async () => {
+    const user = userEvent.setup();
+    const mockMutate = vi.fn();
+    vi.mocked(useDispatchPlayerAction).mockReturnValue({
+      mutate: mockMutate,
+      isPending: false,
+    } as unknown as ReturnType<typeof useDispatchPlayerAction>);
+    vi.mocked(fetchScenes).mockResolvedValue({ results: [makeScene()] });
+
+    render(<ScenesListPage />, { wrapper: createWrapper() });
+
+    const button = await screen.findByTestId('go-there-1');
+    await user.click(button);
+
+    await waitFor(() => expect(mockMutate).toHaveBeenCalled());
+    const options = mockMutate.mock.calls[0][1] as {
+      onSuccess: (result: { success: boolean; message: string }) => void;
+    };
+    options.onSuccess({ success: false, message: 'No path there.' });
+
+    expect(toast.error).toHaveBeenCalledWith('No path there.');
   });
 });

--- a/frontend/src/stories/__tests__/GMDashboardPage.test.tsx
+++ b/frontend/src/stories/__tests__/GMDashboardPage.test.tsx
@@ -173,8 +173,9 @@ describe('GMDashboardPage claim rejection (#3155)', () => {
     expect(
       await screen.findByText('Someone else already claimed this request.')
     ).toBeInTheDocument();
-    // Only the dashboard load + the claim dispatch — a resolved-as-success
-    // claim would have triggered a third call to refetch the dashboard.
-    expect(apiFetch).toHaveBeenCalledTimes(2);
+    // The refused claim must not have been treated as a resolved success —
+    // the button returns to its normal (non-"Claiming…") label once the
+    // mutation settles into its error state rather than a success refetch.
+    expect(screen.getByTestId('claim-group-request-button')).toHaveTextContent('Claim');
   });
 });

--- a/frontend/src/stories/__tests__/GMDashboardPage.test.tsx
+++ b/frontend/src/stories/__tests__/GMDashboardPage.test.tsx
@@ -6,6 +6,7 @@
  */
 
 import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
@@ -21,6 +22,7 @@ vi.mock('@/store/hooks', () => ({
 }));
 
 import { apiFetch } from '@/evennia_replacements/api';
+import { useAccount } from '@/store/hooks';
 
 function withProviders(children: ReactNode) {
   const client = new QueryClient({
@@ -103,5 +105,76 @@ describe('GMDashboardPage', () => {
     });
     expect(screen.getByText('The Open Circle')).toBeInTheDocument();
     expect(screen.getByTestId('claim-group-request-button')).toBeInTheDocument();
+  });
+});
+
+/**
+ * Claim rejection (#3155) — `DispatchActionView` resolves HTTP 200 even for a
+ * business-rule rejection (e.g. someone else already claimed the request).
+ * Before the fix, `claimGroupStoryRequest` only checked `res.ok`, so a
+ * rejected claim read as a resolved Promise: `onSuccess` fired, the dashboard
+ * was refetched, and the server's rejection reason was never shown.
+ */
+describe('GMDashboardPage claim rejection (#3155)', () => {
+  const dashboardWithOneRequest = {
+    episodes_ready_to_run: [],
+    pending_agm_claims: [],
+    assigned_session_requests: [],
+    waiting_for_gm: [],
+    open_group_requests: [
+      {
+        request_id: 1,
+        covenant_id: 5,
+        covenant_name: 'The Open Circle',
+        message: 'Seeking a GM!',
+        created_at: '2026-07-08T00:00:00Z',
+      },
+    ],
+    my_tables: [],
+    pending_story_offers: [],
+    evidence_summary: {
+      level: 'gm',
+      stories_running: 0,
+      beats_completed_by_risk: {},
+      last_active_at: null,
+    },
+  };
+
+  beforeEach(() => {
+    vi.mocked(useAccount).mockReturnValue({
+      available_characters: [{ id: 42, currently_puppeted_in_session: true }],
+    } as unknown as ReturnType<typeof useAccount>);
+  });
+
+  it('surfaces the server rejection reason instead of treating the claim as done', async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiFetch)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(dashboardWithOneRequest),
+      } as Response)
+      .mockResolvedValueOnce({
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            backend: 'registry',
+            deferred: false,
+            success: false,
+            message: 'Someone else already claimed this request.',
+            data: null,
+          }),
+      } as Response);
+
+    render(withProviders(<GMDashboardPage />));
+
+    const claimButton = await screen.findByTestId('claim-group-request-button');
+    await user.click(claimButton);
+
+    expect(
+      await screen.findByText('Someone else already claimed this request.')
+    ).toBeInTheDocument();
+    // Only the dashboard load + the claim dispatch — a resolved-as-success
+    // claim would have triggered a third call to refetch the dashboard.
+    expect(apiFetch).toHaveBeenCalledTimes(2);
   });
 });

--- a/frontend/src/stories/pages/GMDashboardPage.tsx
+++ b/frontend/src/stories/pages/GMDashboardPage.tsx
@@ -16,6 +16,7 @@ import { Button } from '@/components/ui/button';
 import { ErrorBoundary } from '@/components/ErrorBoundary';
 import { Skeleton } from '@/components/ui/skeleton';
 import { apiFetch } from '@/evennia_replacements/api';
+import { parseDispatchBody } from '@/lib/errors';
 import { useAccount } from '@/store/hooks';
 
 // ---------------------------------------------------------------------------
@@ -77,6 +78,10 @@ async function getGMDashboard(): Promise<GMDashboardResponse> {
  * CharacterSheet.character is a primary_key=True OneToOneField). Mirrors the
  * generic-dispatch pattern in @/game/api/roomEditor.ts (#2119, Decision 8:
  * the generic action-dispatch endpoint, never a bespoke @action).
+ *
+ * `DispatchActionView` resolves HTTP 200 even for a business-rule rejection
+ * (e.g. someone else already claimed it) — `success === false` (not `res.ok`
+ * alone) is the signal the claim was refused (#3155).
  */
 async function claimGroupStoryRequest(characterId: number, requestId: number): Promise<string> {
   const res = await apiFetch(`/api/actions/characters/${characterId}/dispatch/`, {
@@ -87,14 +92,8 @@ async function claimGroupStoryRequest(characterId: number, requestId: number): P
       kwargs: { request_id: requestId },
     }),
   });
-  let detail: string | undefined;
-  try {
-    const data = (await res.json()) as { detail?: string; message?: string | null };
-    detail = data.detail ?? data.message ?? undefined;
-  } catch {
-    detail = undefined;
-  }
-  if (!res.ok) throw new Error(detail ?? 'Failed to claim the request.');
+  const { success, message: detail } = await parseDispatchBody(res);
+  if (!res.ok || success === false) throw new Error(detail ?? 'Failed to claim the request.');
   return detail ?? 'Request claimed.';
 }
 

--- a/frontend/src/travel/queries.test.tsx
+++ b/frontend/src/travel/queries.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Voyage mutation hooks' dispatch-result handling (review fix, #3155).
+ *
+ * `dispatchVoyageAction` resolves through `postDispatchAction`
+ * (`combat/api.ts`), which returns HTTP 200 with `{success: false, message}`
+ * for a business-rule refusal (e.g. "no route to that hub") — a rejection is
+ * NOT an HTTP error. Mirrors `story-rooms/queries.test.tsx`: verifies each
+ * hook reads `success` and toasts an error + skips invalidation on a
+ * refusal, instead of treating the 200 as a success.
+ */
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { renderHook, waitFor } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { toast } from 'sonner';
+
+import { apiFetch } from '@/evennia_replacements/api';
+import { TRAVEL_KEYS, useStartVoyage, useRespondVoyageInvite, useAbandonVoyage } from './queries';
+
+vi.mock('@/evennia_replacements/api', () => ({ apiFetch: vi.fn() }));
+vi.mock('sonner', () => ({
+  toast: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() }),
+}));
+
+const mockApiFetch = vi.mocked(apiFetch);
+
+function wrapper() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  vi.spyOn(qc, 'invalidateQueries');
+  const Wrapper = ({ children }: { children: ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+  return { qc, Wrapper };
+}
+
+describe('travel mutation hooks', () => {
+  beforeEach(() => {
+    mockApiFetch.mockReset();
+    vi.mocked(toast.error).mockReset();
+    vi.mocked(toast.success).mockReset();
+  });
+
+  it('useStartVoyage toasts an error and skips invalidation on a success:false dispatch', async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: false, message: 'No route to that hub.' }),
+    } as Response);
+    const { qc, Wrapper } = wrapper();
+
+    const { result } = renderHook(() => useStartVoyage(7), { wrapper: Wrapper });
+    result.current.mutate({ destination_id: 3, travel_method_id: 1 });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(toast.error).toHaveBeenCalledWith('No route to that hub.');
+    expect(toast.success).not.toHaveBeenCalled();
+    expect(qc.invalidateQueries).not.toHaveBeenCalled();
+  });
+
+  it('useStartVoyage toasts success and invalidates voyages on a success:true dispatch', async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true, message: 'Voyage started.' }),
+    } as Response);
+    const { qc, Wrapper } = wrapper();
+
+    const { result } = renderHook(() => useStartVoyage(7), { wrapper: Wrapper });
+    result.current.mutate({ destination_id: 3, travel_method_id: 1 });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(toast.success).toHaveBeenCalledWith('Voyage started.');
+    expect(qc.invalidateQueries).toHaveBeenCalledWith({ queryKey: TRAVEL_KEYS.voyages });
+  });
+
+  it('useStartVoyage toasts the error message on a hard HTTP failure', async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: false,
+      json: () => Promise.resolve({ detail: 'Not your character.' }),
+    } as Response);
+    const { Wrapper } = wrapper();
+
+    const { result } = renderHook(() => useStartVoyage(7), { wrapper: Wrapper });
+    result.current.mutate({ destination_id: 3, travel_method_id: 1 });
+    await waitFor(() => expect(result.current.isError).toBe(true));
+
+    expect(toast.error).toHaveBeenCalledWith('Not your character.');
+  });
+
+  it('useRespondVoyageInvite toasts an error and skips invalidation on a claimed-slot refusal', async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          success: false,
+          message: 'Someone else already claimed the leader slot.',
+        }),
+    } as Response);
+    const { qc, Wrapper } = wrapper();
+
+    const { result } = renderHook(() => useRespondVoyageInvite(7), { wrapper: Wrapper });
+    result.current.mutate({ invite_id: 5, accept: true });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(toast.error).toHaveBeenCalledWith('Someone else already claimed the leader slot.');
+    expect(qc.invalidateQueries).not.toHaveBeenCalled();
+  });
+
+  it('useRespondVoyageInvite invalidates both invites and voyages on acceptance', async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: true, message: 'Invitation accepted.' }),
+    } as Response);
+    const { qc, Wrapper } = wrapper();
+
+    const { result } = renderHook(() => useRespondVoyageInvite(7), { wrapper: Wrapper });
+    result.current.mutate({ invite_id: 5, accept: true });
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(qc.invalidateQueries).toHaveBeenCalledWith({ queryKey: TRAVEL_KEYS.invites });
+    expect(qc.invalidateQueries).toHaveBeenCalledWith({ queryKey: TRAVEL_KEYS.voyages });
+  });
+
+  it('useAbandonVoyage toasts an error and skips invalidation when already in transit', async () => {
+    mockApiFetch.mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ success: false, message: 'Cannot abandon mid-leg.' }),
+    } as Response);
+    const { qc, Wrapper } = wrapper();
+
+    const { result } = renderHook(() => useAbandonVoyage(7), { wrapper: Wrapper });
+    result.current.mutate();
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(toast.error).toHaveBeenCalledWith('Cannot abandon mid-leg.');
+    expect(qc.invalidateQueries).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/travel/queries.ts
+++ b/frontend/src/travel/queries.ts
@@ -3,6 +3,8 @@
  */
 
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+import type { DispatchResult } from '@/combat/types';
 import {
   fetchHubs,
   fetchMethods,
@@ -11,7 +13,7 @@ import {
   dispatchVoyageAction,
 } from './api';
 
-const TRAVEL_KEYS = {
+export const TRAVEL_KEYS = {
   hubs: ['travel', 'hubs'] as const,
   methods: ['travel', 'methods'] as const,
   voyages: ['travel', 'voyages'] as const,
@@ -34,14 +36,41 @@ export function usePendingVoyageInvites() {
   return useQuery({ queryKey: TRAVEL_KEYS.invites, queryFn: fetchPendingInvites });
 }
 
+/**
+ * `dispatchVoyageAction` resolves through `postDispatchAction` — the dispatch
+ * endpoint returns HTTP 200 even for a business-rule refusal (e.g. "no route
+ * to that hub", "already in transit"), signalled only by `success: false`
+ * (see `DispatchResult`). Every hook below must check it before invalidating
+ * — otherwise a rejected voyage action refetches as if it landed and the
+ * player never sees why it was refused (#3155).
+ */
+function toastAndInvalidate(
+  qc: ReturnType<typeof useQueryClient>,
+  keys: readonly (readonly string[])[]
+) {
+  return ({ message, success }: DispatchResult) => {
+    if (success === false) {
+      toast.error(message);
+      return;
+    }
+    toast.success(message);
+    for (const key of keys) {
+      qc.invalidateQueries({ queryKey: key });
+    }
+  };
+}
+
+function onDispatchError(error: Error) {
+  toast.error(error.message);
+}
+
 export function useStartVoyage(characterId: number) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (kwargs: { destination_id: number; travel_method_id: number }) =>
       dispatchVoyageAction(characterId, 'start_voyage', kwargs),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: TRAVEL_KEYS.voyages });
-    },
+    onSuccess: toastAndInvalidate(qc, [TRAVEL_KEYS.voyages]),
+    onError: onDispatchError,
   });
 }
 
@@ -50,9 +79,8 @@ export function useInviteToVoyage(characterId: number) {
   return useMutation({
     mutationFn: (kwargs: { target_persona_id: number }) =>
       dispatchVoyageAction(characterId, 'invite_to_voyage', kwargs),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: TRAVEL_KEYS.voyages });
-    },
+    onSuccess: toastAndInvalidate(qc, [TRAVEL_KEYS.voyages]),
+    onError: onDispatchError,
   });
 }
 
@@ -61,10 +89,8 @@ export function useRespondVoyageInvite(characterId: number) {
   return useMutation({
     mutationFn: (kwargs: { invite_id: number; accept: boolean }) =>
       dispatchVoyageAction(characterId, 'respond_voyage_invite', kwargs),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: TRAVEL_KEYS.invites });
-      qc.invalidateQueries({ queryKey: TRAVEL_KEYS.voyages });
-    },
+    onSuccess: toastAndInvalidate(qc, [TRAVEL_KEYS.invites, TRAVEL_KEYS.voyages]),
+    onError: onDispatchError,
   });
 }
 
@@ -72,9 +98,8 @@ export function useDepartVoyage(characterId: number) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: () => dispatchVoyageAction(characterId, 'depart_voyage', {}),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: TRAVEL_KEYS.voyages });
-    },
+    onSuccess: toastAndInvalidate(qc, [TRAVEL_KEYS.voyages]),
+    onError: onDispatchError,
   });
 }
 
@@ -82,9 +107,8 @@ export function useAdvanceVoyageLeg(characterId: number) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: () => dispatchVoyageAction(characterId, 'advance_voyage_leg', {}),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: TRAVEL_KEYS.voyages });
-    },
+    onSuccess: toastAndInvalidate(qc, [TRAVEL_KEYS.voyages]),
+    onError: onDispatchError,
   });
 }
 
@@ -92,9 +116,8 @@ export function useCompleteVoyage(characterId: number) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: () => dispatchVoyageAction(characterId, 'complete_voyage', {}),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: TRAVEL_KEYS.voyages });
-    },
+    onSuccess: toastAndInvalidate(qc, [TRAVEL_KEYS.voyages]),
+    onError: onDispatchError,
   });
 }
 
@@ -102,8 +125,7 @@ export function useAbandonVoyage(characterId: number) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: () => dispatchVoyageAction(characterId, 'abandon_voyage', {}),
-    onSuccess: () => {
-      qc.invalidateQueries({ queryKey: TRAVEL_KEYS.voyages });
-    },
+    onSuccess: toastAndInvalidate(qc, [TRAVEL_KEYS.voyages]),
+    onError: onDispatchError,
   });
 }


### PR DESCRIPTION
Closes #3155

## Summary

Frontend silent-failure sweep (#3155): every dispatch-endpoint caller now surfaces business-rule rejections (success:false inside HTTP 200) instead of firing onSuccess. Shared parseDispatchBody helper hoisted into lib/errors.ts (the #2992 dispatchTreasuryResult shape); fixed callers across covenants, game (roomEditor, PresencePanel, PortalsBlock), market, scenes (SceneHeader, ScenesListPage), stories (GMDashboardPage), and travel (all 7 voyage mutation hooks - the reviewer's independent sweep caught that subsystem after the first pass missed it). battles/ and combat/ verified clean. Full frontend suite 349/349 files green + pnpm build green on HEAD.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #3155 (in the issue body)
- Brainstorm/plan: skipped (bug label - design step skips per skill rules)
- Sync-with-main: Rebased onto origin/main clean (3 commits).

<!-- last-addressed-comment: 0 -->