### PR TITLE
Deliver the DNS-01 token to Caddy, at validate time and at runtime

### DIFF
--- a/infra/ansible/roles/caddy/defaults/main.yml
+++ b/infra/ansible/roles/caddy/defaults/main.yml
@@ -4,6 +4,11 @@
 # different image layout does not need a task edit.
 caddy_bin: /usr/bin/caddy
 caddy_staged_bin: /tmp/caddy-with-cloudflare
+# Caddy's OWN EnvironmentFile, holding only CADDY_CF_DNS_TOKEN. Deliberately
+# not secrets_vault's /etc/arxii/arxii.env: that one is arxii:arxii 0640
+# inside a 0750 dir, unreadable by the caddy user, and it carries every app
+# secret — Caddy has no business seeing the database password.
+caddy_env_file: /etc/caddy/caddy.env
 # Caddy's build service names architectures the Go way; Ansible reports the
 # uname spelling. Only the two we could plausibly run on are mapped, and an
 # unmapped value fails loudly at template time rather than downloading a

--- a/infra/ansible/roles/caddy/handlers/main.yml
+++ b/infra/ansible/roles/caddy/handlers/main.yml
@@ -7,8 +7,10 @@
 # A Caddyfile change only needs a reload, but a BINARY swap does not take
 # effect until the process is replaced — a reload keeps the old image running,
 # so the newly added DNS-01 plugin would appear absent until something else
-# restarted the service.
+# restarted the service. daemon_reload picks up the DNS-01 EnvironmentFile
+# drop-in, which systemd otherwise ignores until its next unit re-read.
 - name: Restart caddy
   ansible.builtin.systemd_service:
     name: caddy
     state: restarted
+    daemon_reload: true

--- a/infra/ansible/roles/caddy/tasks/main.yml
+++ b/infra/ansible/roles/caddy/tasks/main.yml
@@ -118,8 +118,62 @@
     quiet: true
   when: not caddy_rehearsal_mode
 
+# --- DNS-01 token delivery ---------------------------------------------------
+# Caddyfile.j2 reads {env.CADDY_CF_DNS_TOKEN}. secrets_vault renders that key
+# into /etc/arxii/arxii.env — owned arxii:arxii inside a 0750 dir, which the
+# `caddy` user cannot read — and the distro caddy.service carries no
+# EnvironmentFile at all. So the token was in the contract but reached
+# nothing. Give caddy its own single-key file plus a drop-in that loads it.
+- name: Fail-closed — the DNS-01 token must be present outside rehearsal
+  ansible.builtin.assert:
+    that: lookup('env', 'ARXII_CADDY_CF_DNS_TOKEN') | length > 0
+    fail_msg: >-
+      ARXII_CADDY_CF_DNS_TOKEN is empty. Caddyfile.j2's `acme_dns cloudflare`
+      cannot provision without it, so `caddy validate` fails and no
+      certificate is ever issued. Set it as a gated Environment secret.
+    quiet: true
+  when: not caddy_rehearsal_mode
+
+- name: Render caddy's own DNS-01 EnvironmentFile (0640 root:caddy)
+  ansible.builtin.copy:
+    content: "CADDY_CF_DNS_TOKEN={{ lookup('env', 'ARXII_CADDY_CF_DNS_TOKEN') }}\n"
+    dest: "{{ caddy_env_file }}"
+    owner: root
+    group: caddy
+    mode: "0640"
+  no_log: true # the token is the whole content
+  notify: Restart caddy
+  when: not caddy_rehearsal_mode
+
+- name: Ensure the caddy.service drop-in directory exists
+  ansible.builtin.file:
+    path: /etc/systemd/system/caddy.service.d
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: not caddy_rehearsal_mode
+
+- name: Load that file into caddy.service via a drop-in
+  ansible.builtin.copy:
+    content: |
+      [Service]
+      EnvironmentFile={{ caddy_env_file }}
+    dest: /etc/systemd/system/caddy.service.d/10-arxii-dns01-token.conf
+    owner: root
+    group: root
+    mode: "0644"
+  notify: Restart caddy
+  when: not caddy_rehearsal_mode
+
 - name: Deploy Caddyfile (validated before reload)
   ansible.builtin.template:
+    # `caddy validate` PROVISIONS modules, it does not merely parse — the
+    # cloudflare DNS provider rejects an empty token at provision time. This
+    # runs as a bare subprocess with none of the service's environment, so
+    # the token has to be handed to the task explicitly. Separate from the
+    # EnvironmentFile above: that one is for the running service.
+
     # caddy_rehearsal_mode picks the internal-CA template (no DNS-01, no
     # Cloudflare credential needed) — see both templates' "EDIT BOTH" header.
     src: "{{ 'Caddyfile.rehearsal.j2' if caddy_rehearsal_mode else 'Caddyfile.j2' }}"
@@ -128,6 +182,8 @@
     group: caddy
     mode: "0640"
     validate: "caddy validate --adapter caddyfile --config %s"
+  environment:
+    CADDY_CF_DNS_TOKEN: "{{ lookup('env', 'ARXII_CADDY_CF_DNS_TOKEN') }}"
   notify: Reload caddy
 
 - name: Ensure caddy is enabled and running

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -186,6 +186,17 @@ chk   "caddy role verifies the staged binary before swapping it in" \
   "grep -q 'caddy_staged_modules' infra/ansible/roles/caddy/tasks/main.yml"
 chk   "Caddyfile.j2 still uses DNS-01 via cloudflare (paired with the plugin fetch above)" \
   "grep -q 'acme_dns cloudflare' infra/ansible/roles/caddy/templates/Caddyfile.j2"
+# Caddyfile.j2's {env.CADDY_CF_DNS_TOKEN} is only as good as whatever puts
+# that key in caddy's environment. secrets_vault renders it into the APP's
+# EnvironmentFile, which the caddy user cannot read — so the role must give
+# caddy its own file AND a drop-in that loads it, or DNS-01 silently gets an
+# empty token (validate fails; worse, a runtime miss issues no cert).
+chk   "caddy role renders caddy's own DNS-01 EnvironmentFile" \
+  "grep -q 'CADDY_CF_DNS_TOKEN={{ lookup' infra/ansible/roles/caddy/tasks/main.yml"
+chk   "caddy role loads that file into caddy.service via a drop-in" \
+  "grep -q 'caddy.service.d' infra/ansible/roles/caddy/tasks/main.yml"
+chk   "Caddyfile validate gets the DNS-01 token in its environment" \
+  "grep -q 'CADDY_CF_DNS_TOKEN: ' infra/ansible/roles/caddy/tasks/main.yml"
 
 # (d) nftables must never `flush ruleset` (wipes fail2ban's own table too);
 # it must flush only OUR table. nc() strips comments first so the check


### PR DESCRIPTION
Follows #3167, which got the DNS-01 plugin into the binary. The next converge
reached the Caddyfile and failed there:

```
Error: ... loading module 'cloudflare': provision dns.providers.cloudflare:
API token '' appears invalid; ensure it's correctly entered and not wrapped
in braces nor quotes
```

`caddy validate` PROVISIONS modules rather than only parsing, so the cloudflare
DNS provider loads its token. Ansible's `validate:` runs as a bare subprocess
with none of the service's environment, so it saw an empty string.

## The larger half

Investigating that surfaced the real gap: **the token never reached Caddy at
all.**

`secrets_vault` maps `ARXII_CADDY_CF_DNS_TOKEN` to `CADDY_CF_DNS_TOKEN` in
`/etc/arxii/arxii.env` — owned `arxii:arxii` inside a `0750` directory, which the
`caddy` user cannot read. And the distro `caddy.service` carries no
`EnvironmentFile` at all. The key was in the gated-Environment contract and
plumbed to nothing.

Validation is only where it surfaced first. Had `validate` passed, the running
Caddy would have had an empty token, DNS-01 renewal would have failed, and no
certificate would ever have been issued — a much quieter failure.

## Changes

- Render `/etc/caddy/caddy.env`, `0640 root:caddy`, containing only
  `CADDY_CF_DNS_TOKEN`. A single-key file rather than reusing the app's: Caddy
  has no business reading the database password or the Cloudinary secret.
- Add a `caddy.service.d` drop-in that loads it, so the running service has the
  token.
- Pass the same value through the template task's `environment:` so `validate`
  can provision. Distinct from the file above, which serves the daemon.
- `daemon_reload: true` on the Restart handler, since systemd ignores a new
  drop-in until it re-reads units.
- Fail-closed assert outside rehearsal mode, so an empty token stops the
  converge with a clear message rather than at Caddy's own error.
- `no_log: true` on the render, whose entire content is the secret.

Rehearsal mode skips all of it: `Caddyfile.rehearsal.j2` uses `local_certs` and
needs no token, and the isolated ephemeral-stage root has none to give.

## Verification

`acceptance.sh` passes with 0 failures, including three new cross-file checks:
the role renders caddy's own EnvironmentFile, loads it via a drop-in, and hands
the token to validate. That pairing is exactly the kind of two-file contract the
#2236 audit noted single-file greps cannot see — `Caddyfile.j2` referencing
`{env.CADDY_CF_DNS_TOKEN}` is worth nothing on its own.

Not verifiable locally: ansible-lint does not run on Windows, and the role can
only be proven by the next converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
