### PR TITLE
needs-design: perception-override primitive — one 'who perceives what is real' seam for dreams, illusions, disguise

### DIFF
--- a/AGENT_GLOSSARY_MAP.md
+++ b/AGENT_GLOSSARY_MAP.md
@@ -439,6 +439,38 @@ rewards, or fire the stories reactivity hook. Enforced by the single `can_earn_a
 predicate inside `grant_achievement`, so every caller inherits it (#3024, ADR-0202).
 _Avoid_: ceremony eligible (the narrower pre-#3024 term), tenured sheet (staff tenures are still ineligible).
 
+## Perception (#2997)
+
+**Perception Axis**:
+One of three genuinely different answers to "who perceives what is real" — room-
+broadcast membership (Axis 1), per-viewer content shape/tiering on a recorded event
+(Axis 2, split further by ADR-0170 snapshot vs ADR-0214 live recompute), and
+downstream read-time feed filtering (Axis 3). Deliberately NOT unified behind one
+interface — each axis keeps its own canonical seam. Full taxonomy:
+`docs/systems/scenes.md`'s "Perception & altered reality" section; per-app framing in
+[scenes AGENT_GLOSSARY](src/world/scenes/AGENT_GLOSSARY.md). _Avoid_: perception
+layer, visibility mode (too broad — always name the axis).
+
+**Broadcast Exclusion**:
+Axis-1 registration: `register_broadcast_exclusion(resolver)` /
+`resolve_broadcast_exclusions(location)` (`flows/service_functions
+/perception_registry.py`) — a mechanism registers a resolver naming which occupants
+of a location should NOT receive a room broadcast; `message_location` unions every
+registered resolver instead of importing one mechanism by name. Dependency-free by
+design (ADR-0010) — mirrors `commands.offer_registry.register_offer_handler`.
+_Avoid_: perception filter, visibility gate (too broad — this is specifically the
+room-broadcast-membership registry).
+
+**Perception Check**:
+The single canonical roll for "does this character notice something is off" —
+`resolve_perception_check(observer_sheet, *, difficulty, specialization=None)`
+(`world/checks/perception_services.py`), resolved on the seeded stat-only
+"Perception" `CheckType`. ADR-0033 boundary: may reveal wrongness, never identity —
+identification stays clue-driven (PERSONA_LINK), never an automatic roll. Full
+entry: [checks AGENT_GLOSSARY](src/world/checks/AGENT_GLOSSARY.md). _Avoid_:
+awareness roll, spot check, notice check (Perception Check is the one canonical
+name).
+
 ## Public-event vectors
 
 **Scene**:

--- a/docs/roadmap/planned-systems.md
+++ b/docs/roadmap/planned-systems.md
@@ -30,11 +30,22 @@ PLANNED-UNBUILT tier here. Where a planned system *does* already have an issue/m
   live trigger (Sunlight Exposure); **#1714** routed vehicle-hazard drowning/falling through it;
   **#1744** (ADR-0069) shipped the companion/location mitigation layer. Species-specific triggers
   beyond sunlight and the vehicle-hazard pair are still unbuilt.
-- **Perception-override / altered-reality primitive** — "who perceives what is real." The two intended
-  consumers each shipped as *separate mechanisms*: dreams as a room layer (`world/dreams` — sleep/wake/
-  dreamwalk, peril branching) and illusion/disguise as form overlays (`DisguiseKind`,
-  `ConcealmentLevel`, pierce contest). The shared seam — a scene where different participants perceive
-  different realities — is still unbuilt, and `SceneRound` has no mode/variety axis. `intent` — **#2997**.
+- ✅ **Perception taxonomy + broadcast-exclusion registry + canonical perception-check seam** —
+  DONE (#2997). Verified the "who perceives what is real" question against the seven shipped
+  per-observer mechanisms rather than building a fourth: they split into three genuinely
+  different axes (room-broadcast membership, per-viewer content shape/tiering — ADR-0170 snapshot
+  vs ADR-0214 live recompute, deliberately not unified — and downstream read-time feed filtering),
+  documented in `docs/systems/scenes.md`'s "Perception & altered reality" section. The one real
+  gap (Axis 1 had a repeat-offender risk — `_dreamside_occupants` was already hand-rolled into
+  `message_location`) is closed by `register_broadcast_exclusion`/`resolve_broadcast_exclusions`
+  (`flows/service_functions/perception_registry.py`). Also shipped: the canonical single
+  AD&D-style perception-check seam, `resolve_perception_check` (`world/checks
+  /perception_services.py`), the ONE roll every perceive-the-real mechanic should resolve
+  through going forward (ADR-0033 boundary: reveals wrongness, never identity). **Still
+  `intent`, deliberately deferred pending a real consumer:** a `SceneRound` mode/variety axis for
+  "different participants perceive different realities in one recorded round" — no live
+  consumer yet (no haunting/vision/glamour system in flight); file its own issue when one queues,
+  building on the Axis-1 registry + Axis-2 tiered-audience shape rather than new machinery.
 
 ## Scenes & RP
 
@@ -49,8 +60,9 @@ PLANNED-UNBUILT tier here. Where a planned system *does* already have an issue/m
 - **GM-run-table as a live scene variety** — today `GMTable` is only a membership grouping, not a live
   scene mode a player-GM runs. `intent`.
 - **Dreamstate / illusionary scene varieties** — superseded in part: dreams shipped as a room layer and
-  disguise as form overlays (see the perception-override entry above). What remains is the scene-level
-  shared-altered-reality mode — **#2997**. Dreams also have **zero web surface** — **#3003**.
+  disguise as form overlays (see the perception-taxonomy entry above). What remains is the scene-level
+  shared-altered-reality mode (the deferred `SceneRound` perception-split — see that entry; no issue
+  filed yet, no live consumer). Dreams also have **zero web surface** — **#3003**.
 - **Community pose-of-the-scene voting / award** — `partial`: `WeeklyVote`/`VoteButton` are built but
   unwired (#2161).
 - ✅ **New-player onboarding tutorial** — DONE (#1035; T1–T7 mission chain + e2e journey). Still

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2513,6 +2513,17 @@ action consent flow, and a three-mode non-combat round framework.
   `mute_services.account_muted`/`muted_player_ids_for`; `Friendship`/`Rivalry` are the positive
   connection primitives (`friend_services.py`) feeding the `FRIENDS_WHITELIST`/`RIVALS` consent
   modes. See `world/scenes/CLAUDE.md`'s Block/Mute entries and ADR-0204 for the full seam table.
+- **Perception & altered reality (#2997):** three axes for "who perceives what is
+  real" — room-broadcast membership exclusion (Axis 1, `register_broadcast_exclusion`/
+  `resolve_broadcast_exclusions` in `flows/service_functions/perception_registry.py`),
+  per-viewer content shape/tiering on a recorded event (Axis 2, ADR-0170 snapshot vs
+  ADR-0214 live recompute — deliberately not unified), and downstream read-time
+  feed filtering (Axis 3, mute/block/`visible_to`). Orthogonal canonical check seam:
+  `resolve_perception_check(observer_sheet, *, difficulty, specialization=None)`
+  (`world/checks/perception_services.py`) — the one AD&D-style roll every
+  perceive-the-real mechanic resolves through; ADR-0033 boundary: reveals wrongness,
+  never identity. See [scenes.md](scenes.md) §"Perception & altered reality" for the
+  full taxonomy and decision checklist.
 - **Integrates with:** roster (characters), stories (EpisodeScene join), instances (preservation check),
   flows (auto-logging via message_location), combat (encounter read gate + participation convergence via
   `Scene.objects.viewable_by` / `ensure_scene_participation`),

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -1050,12 +1050,26 @@ send time, never persisted (a room broadcast has no receiver-row ledger the way
 
 **Seam:** `register_broadcast_exclusion(resolver)` /
 `resolve_broadcast_exclusions(location) -> set[ObjectDB]`
-(`flows/service_functions/perception_registry.py`), consumed by
-`message_location` (`flows/service_functions/communication.py`). A mechanism
-registers a resolver — `resolver(location) -> Iterable[ObjectDB]`, the objects to
-exclude — once, at import/`ready()` time; `message_location` unions every
-registered resolver's excluded set. The registry itself stays dependency-free
-(ADR-0010): it never imports a specific mechanism.
+(`flows/service_functions/perception_registry.py`). A mechanism registers a
+resolver — `resolver(location) -> Iterable[ObjectDB]`, the objects to exclude —
+once, at import/`ready()` time; every room-broadcast call site unions every
+registered resolver's excluded set instead of importing one mechanism by name.
+The registry itself stays dependency-free (ADR-0010): it never imports a
+specific mechanism.
+
+**Every live room-broadcast call site routes through this seam**, not just
+`message_location` — a second registered resolver has to apply everywhere a
+room broadcast is hand-rolled, or the registry silently fails to close the gap
+it exists for:
+
+- `message_location` (`flows/service_functions/communication.py`) — the
+  general broadcast path.
+- The language-aware `say` action's per-recipient delivery loop
+  (`actions/definitions/communication.py`) — hand-rolls per-listener room
+  delivery instead of calling `message_location`, so it calls the registry
+  directly.
+- `_broadcast_waking` (`world/vitals/carry_services.py`) — the pick-up/set-down
+  carry room emits.
 
 **Current consumer:** `_dreamside_occupants` (`communication.py`, #2287) — occupants
 whose perception has relocated dreamside (Unconscious or Sleeping) miss waking-room

--- a/docs/systems/scenes.md
+++ b/docs/systems/scenes.md
@@ -1030,6 +1030,117 @@ perceive.
 
 ---
 
+## Perception & altered reality (#2997)
+
+"Who perceives what is real" is not one shared primitive — it is **three genuinely
+different axes** with incompatible timing contracts (write-time snapshot vs read-time
+live recompute) and incompatible return shapes (boolean exclude, tiered audience,
+rewritten text, read-time query filter). Forcing one interface onto all three would
+either violate an axis's own recorded ADR or produce an interface so abstract it
+carries no behavior. Each axis has ONE canonical seam; a new perceive-the-real
+mechanic (a haunting, a vision, a glamour) picks the axis that matches what it needs
+and plugs into that seam — it does not mint a fourth axis or a parallel mechanism on
+an existing one.
+
+### Axis 1 — room-broadcast membership
+
+"Does this observer receive a room broadcast at all." Boolean exclude, computed at
+send time, never persisted (a room broadcast has no receiver-row ledger the way
+`Interaction` does).
+
+**Seam:** `register_broadcast_exclusion(resolver)` /
+`resolve_broadcast_exclusions(location) -> set[ObjectDB]`
+(`flows/service_functions/perception_registry.py`), consumed by
+`message_location` (`flows/service_functions/communication.py`). A mechanism
+registers a resolver — `resolver(location) -> Iterable[ObjectDB]`, the objects to
+exclude — once, at import/`ready()` time; `message_location` unions every
+registered resolver's excluded set. The registry itself stays dependency-free
+(ADR-0010): it never imports a specific mechanism.
+
+**Current consumer:** `_dreamside_occupants` (`communication.py`, #2287) — occupants
+whose perception has relocated dreamside (Unconscious or Sleeping) miss waking-room
+chatter; the dead are NOT excluded (a ghost still watches and hears the waking room).
+Self-registers at the bottom of `communication.py`, its long-standing home.
+
+### Axis 2 — per-viewer content shape/tiering on a recorded event
+
+"What does this observer's copy of a recorded event look like / how much do they get
+to attribute." Two consumers, **deliberately opposite** persistence policy — this is
+not an oversight to unify:
+
+- **Snapshot at write time (ADR-0170).** Cast concealment
+  (`world/magic/services/cast_observation.py`'s `resolve_cast_audience`) resolves a
+  three-tier attribution ladder (full / vague / effect-only) once per observer at
+  pose time and materializes it as `InteractionReceiver` rows under
+  `InteractionVisibility.PERCEIVED_ONLY`. Recomputing at read time would let a
+  bystander who *later* gains a detection capability retroactively "see" a cast their
+  character genuinely missed — a leak ADR-0170 rejects by name.
+- **Live recompute at read time (ADR-0214).** Language comprehension
+  (`world/species/language_services.py`'s `render_speech`/`garble_text`), persona
+  display resolution (`world/scenes/persona_display.py`'s `resolve_display_for_viewer`),
+  disguise/fake-overlay form presentation (`world/forms/services/__init__.py`'s
+  `_form_to_present`, backing `CharacterFormState.active_fake_overlay`,
+  `DisguiseKind`/`ConcealmentLevel`), and body-marking visibility
+  (`world/forms/services/markings.py`'s `visible_markings_for`, layered on the same
+  presented-form resolution) all recompute on every render (telnet delivery, WS push,
+  scene-log reads) instead of snapshotting. For language, the opposite failure mode
+  holds: a character who learns a tongue after the fact SHOULD reread old logs in the
+  clear, and the deterministic seed (`speech_seed`) keeps the recompute stable across
+  delivery paths.
+
+`flows/object_states/character_state.py`'s `CharacterState.return_appearance` is the
+existing per-observer composition seam for the look/examine call site — it takes a
+`looker`/observer and delegates to `resolve_display_for_viewer`,
+`visible_worn_items_for`, and `visible_markings_for`, each of the above. It already IS
+Axis 2's home at that call site; no further extraction is proposed on top of it.
+
+**No extraction proposed for this axis.** Unifying write-time-materialize with
+read-time-recompute behind one call shape would be the false consolidation both ADRs
+already ruled out by picking opposite policies on purpose.
+
+### Axis 3 — downstream read-time filtering of who-already-has-access
+
+"Who among people with raw access actually sees it in their own feed/list." Mute
+(`world/scenes/mute_services.py`'s `muted_persona_ids_for_viewer` — per-account,
+one-way), `InteractionQuerySet.visible_to` (`world/scenes/managers.py` — staff /
+anonymous / authenticated-participant / GM read-visibility tiers), and Block are
+account/privacy-scoped, not character-perception-scoped — a muted persona's poses
+still *happened*; the viewer just filters their own feed. A different domain from
+Axes 1/2, each with its own canonical seam already. No extraction proposed.
+
+### The canonical perception CHECK (ratified, supersedes any per-mechanism roll)
+
+Orthogonal to the three axes above: **when a mechanic needs to ask "does this
+character notice something is off," there is exactly one check to roll.**
+`resolve_perception_check(observer_sheet, *, difficulty, specialization=None)`
+(`world/checks/perception_services.py`) resolves the seeded, stat-only "Perception"
+`CheckType` through `perform_check` — one AD&D-style roll, not a bespoke mechanism per
+consumer. PLACEHOLDER difficulty constants (`world/checks/perception_constants.py`:
+EASY/STANDARD/HARD) are sized against the seeded `CheckRank` ladder and await
+calibration by a real consumer.
+
+**ADR-0033 boundary:** a passed perception check may reveal that something is
+amiss — a tell, a wrongness — **never WHO is behind it.** Identification stays
+clue-driven (PERSONA_LINK), never an automatic roll. The pierce *contest* in
+`world/forms/services/identification.py` is a separate substrate; when it wires up
+its own "something's off" half, it should call this seam rather than folding
+identity resolution into it.
+
+### Decision checklist for the next perceive-the-real mechanic
+
+1. **Snapshot or live?** If a viewer's later capability change could retroactively
+   alter what they perceived in the past, that's a snapshot-at-write leak — follow
+   ADR-0170. If old logs should reflect what a viewer can perceive *now* (e.g. a
+   later-learned skill), follow ADR-0214.
+2. **Which axis?** Excluding an observer from a room broadcast entirely → Axis 1
+   (register a resolver). Shaping/tiering a recorded event per viewer → Axis 2 (own
+   service function, own seam, no shared interface). Filtering an already-visible
+   event out of one viewer's own feed → Axis 3 (existing seams already cover this).
+3. **Does it need a roll?** Any "does the character notice" moment calls
+   `resolve_perception_check` — never mint a new check or a flat probability.
+
+---
+
 ## Permissions
 
 | Permission Class | Used For | Rule |

--- a/src/actions/definitions/communication.py
+++ b/src/actions/definitions/communication.py
@@ -227,16 +227,21 @@ class SayAction(Action):
             speaker_band = fluency_band(fluency_value(actor.sheet_data, language))
             location = actor.location
             if location is not None:
-                # #2287 parity (C2 final-review fix): the per-recipient loop below
+                # #2287 parity (C2 final-review fix), routed through the Axis-1
+                # broadcast-exclusion registry (#2997): the per-recipient loop below
                 # hand-rolls room delivery instead of going through
                 # message_location()/msg_contents, so it must apply the same
-                # dreamside-occupant exclusion by hand or a dreamside-perceiving
-                # character illegitimately hears waking-room language-tagged says.
-                from flows.service_functions.communication import (  # noqa: PLC0415
-                    _dreamside_occupants,
+                # room-broadcast exclusions by hand or a dreamside-perceiving (or any
+                # other registered-exclusion) character illegitimately hears
+                # waking-room language-tagged says. Calling the registry union
+                # (not `_dreamside_occupants` by name) means a second registered
+                # resolver (a haunting/vision/glamour) is honored here too, not
+                # just at `message_location`'s call site.
+                from flows.service_functions.perception_registry import (  # noqa: PLC0415
+                    resolve_broadcast_exclusions,
                 )
 
-                excluded_ids = {obj.pk for obj in _dreamside_occupants(location)}
+                excluded_ids = {obj.pk for obj in resolve_broadcast_exclusions(location)}
                 for obj in location.contents:
                     if not hasattr(obj, "msg"):
                         continue

--- a/src/actions/tests/test_language_speech.py
+++ b/src/actions/tests/test_language_speech.py
@@ -128,15 +128,24 @@ class SayActionLanguageTests(LanguageSpeechTestCase):
         payload (a kwarg-only ``msg(interaction=...)`` call from the pre-existing,
         out-of-scope ``push_interaction``/``_broadcast_to_location`` path) is not
         this fix's concern.
+
+        Post-#2997: the say path routes through the broadcast-exclusion registry
+        (``resolve_broadcast_exclusions``), which calls the real, still-registered
+        ``_dreamside_occupants`` resolver by object reference -- patching the name
+        in ``communication.py`` no longer intercepts it, so this patches
+        ``perceives_dreamside`` (what ``_dreamside_occupants`` itself calls) instead.
         """
         room = _make_room()
         speaker, _ = self._sheeted_character(room, key="Speaker", fluency=100)
-        dreamer, _ = self._sheeted_character(room, key="Dreamer", fluency=100)
+        dreamer, dreamer_sheet = self._sheeted_character(room, key="Dreamer", fluency=100)
+
+        def _fake_perceives_dreamside(sheet):
+            return sheet is not None and sheet.pk == dreamer_sheet.pk
 
         with (
             patch(
-                "flows.service_functions.communication._dreamside_occupants",
-                return_value=[dreamer],
+                "world.vitals.services.perceives_dreamside",
+                side_effect=_fake_perceives_dreamside,
             ),
             patch.object(dreamer, "msg") as mock_msg,
         ):
@@ -145,6 +154,34 @@ class SayActionLanguageTests(LanguageSpeechTestCase):
         assert result.success is True
         text_calls = [c for c in mock_msg.call_args_list if c.args]
         assert not text_calls, f"dreamer received telnet text delivery: {text_calls}"
+
+    def test_second_registered_resolver_honored_by_language_say(self) -> None:
+        """M1 (#2997 review fix): the language-say path must honor EVERY registered
+        broadcast-exclusion resolver, not just the built-in dreamside one -- it calls
+        ``resolve_broadcast_exclusions`` (the registry union), not
+        ``_dreamside_occupants`` by name, so a second resolver (a future haunting/
+        vision/glamour mechanism) is excluded here too.
+        """
+        from flows.service_functions import perception_registry
+
+        room = _make_room()
+        speaker, _ = self._sheeted_character(room, key="Speaker", fluency=100)
+        haunted, _ = self._sheeted_character(room, key="Haunted", fluency=100)
+
+        def _fake_resolver(location):
+            return [haunted] if location == room else []
+
+        original_resolvers = list(perception_registry._RESOLVERS)
+        perception_registry.register_broadcast_exclusion(_fake_resolver)
+        try:
+            with patch.object(haunted, "msg") as mock_msg:
+                result = SayAction().run(speaker, text=self.TEXT, language_id=self.language.pk)
+        finally:
+            perception_registry._RESOLVERS[:] = original_resolvers
+
+        assert result.success is True
+        text_calls = [c for c in mock_msg.call_args_list if c.args]
+        assert not text_calls, f"haunted listener received telnet text delivery: {text_calls}"
 
     def test_language_id_kwarg_beats_current_language(self) -> None:
         room = _make_room()

--- a/src/flows/CLAUDE.md
+++ b/src/flows/CLAUDE.md
@@ -19,6 +19,11 @@ Database-driven workflow engine that replaces hardcoded command logic. All game 
 - **`communication.py`**: message sending, pose formatting, channels
 - **`movement.py`**: room traversal, following, arrival/departure messages
 - **`perception.py`**: looking, searching, inventory, object examination
+- **`perception_registry.py`** (#2997): broadcast-exclusion registry —
+  `register_broadcast_exclusion`/`resolve_broadcast_exclusions`, the Axis-1 seam
+  `communication.py`'s `message_location` calls instead of importing one
+  mechanism (e.g. dreamside) by name. See `docs/systems/scenes.md`'s "Perception
+  & altered reality" section.
 - **`packages.py`**: package imports and behavior attachment
 
 ### `service_functions/serializers/`

--- a/src/flows/service_functions/communication.py
+++ b/src/flows/service_functions/communication.py
@@ -6,6 +6,10 @@ from evennia.utils import funcparser
 
 from flows.object_states.base_state import BaseState
 from flows.scene_data_manager import SceneDataManager
+from flows.service_functions.perception_registry import (
+    register_broadcast_exclusion,
+    resolve_broadcast_exclusions,
+)
 from flows.service_functions.serializers.room_state import build_room_state_payload
 
 if TYPE_CHECKING:
@@ -102,7 +106,7 @@ def message_location(
         text,
         from_obj=caller.obj,
         mapping=resolved_mapping,
-        exclude=_dreamside_occupants(location) or None,
+        exclude=resolve_broadcast_exclusions(location) or None,
     )
 
 
@@ -112,6 +116,17 @@ def _dreamside_occupants(location: "ObjectDB") -> list["ObjectDB"]:
     Dead characters are NOT excluded: a ghost still watches and hears the
     waking room. Direct ``character.msg`` (system/vitals messages) is
     unaffected — only room broadcasts are gated.
+
+    Registered onto the broadcast-exclusion registry (#2997, Axis 1 — see
+    ``perception_registry.py``) at the bottom of this module. Self-registers
+    here rather than through an owning app's ``ready()`` hook because this
+    resolver's home always was ``communication.py`` itself (it only reaches
+    into ``world.vitals.services`` lazily to avoid an import cycle) — routing
+    its own registration through Django app-loading machinery for a function
+    that already lives beside its one caller would be the more-magic option,
+    not the less-magic one. A future mechanism (haunting/vision/glamour) that
+    lives in its own app SHOULD register via that app's ``ready()``, mirroring
+    ``commands.offer_registry.register_offer_handler``'s callers.
     """
     from django.core.exceptions import ObjectDoesNotExist  # noqa: PLC0415
 
@@ -126,6 +141,9 @@ def _dreamside_occupants(location: "ObjectDB") -> list["ObjectDB"]:
         if perceives_dreamside(sheet):
             excluded.append(obj)
     return excluded
+
+
+register_broadcast_exclusion(_dreamside_occupants)
 
 
 def send_room_state(

--- a/src/flows/service_functions/perception_registry.py
+++ b/src/flows/service_functions/perception_registry.py
@@ -1,0 +1,58 @@
+"""Broadcast-exclusion registry — Axis 1 of the perception taxonomy (#2997).
+
+Axis 1 answers "does this observer receive a room broadcast at all." It is the
+one perception axis that already had a repeat-offender risk baked in: before
+this module existed, ``_dreamside_occupants`` (``communication.py``) was
+hand-rolled directly into ``message_location``'s ``exclude=`` kwarg. A second
+consumer (a haunting: "characters without the Sight are excluded from this
+pose") would otherwise hand-roll a second ``_xyz_occupants`` function and a
+second edit to ``communication.py`` — this registry closes that gap by making
+``message_location`` union every *registered* resolver's excluded set instead
+of importing one mechanism by name.
+
+Dependency-free by design (ADR-0010, specific-general FK direction generalized
+to imports): this module must never import a specific mechanism (dreams, a
+future haunting/vision/glamour system). Each mechanism registers its own
+resolver against this registry instead — mirrors the existing
+``commands.offer_registry.register_offer_handler`` plugin-registers-itself
+shape, the closest precedent in this codebase for "an app hands the primitive
+a callback rather than the primitive importing the app."
+
+See ``docs/systems/scenes.md``'s "Perception & altered reality" section for
+the full three-axis taxonomy this is Axis 1 of.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from evennia.objects.models import ObjectDB
+
+BroadcastExclusionResolver = Callable[["ObjectDB"], Iterable["ObjectDB"]]
+
+_RESOLVERS: list[BroadcastExclusionResolver] = []
+
+
+def register_broadcast_exclusion(resolver: BroadcastExclusionResolver) -> None:
+    """Register a room-broadcast exclusion resolver.
+
+    ``resolver(location) -> iterable of ObjectDB`` — objects in ``location``
+    that should NOT receive a room broadcast (e.g. dreamside occupants missing
+    waking-room chatter). Call once per mechanism, at import/``ready()`` time —
+    never per-message.
+    """
+    _RESOLVERS.append(resolver)
+
+
+def resolve_broadcast_exclusions(location: ObjectDB) -> set[ObjectDB]:
+    """Union every registered resolver's excluded set for ``location``.
+
+    Empty when no resolver is registered — byte-identical to the pre-registry
+    ``exclude=None`` fallback with zero mechanisms wired up.
+    """
+    excluded: set[ObjectDB] = set()
+    for resolver in _RESOLVERS:
+        excluded.update(resolver(location))
+    return excluded

--- a/src/flows/service_functions/perception_registry.py
+++ b/src/flows/service_functions/perception_registry.py
@@ -7,8 +7,20 @@ hand-rolled directly into ``message_location``'s ``exclude=`` kwarg. A second
 consumer (a haunting: "characters without the Sight are excluded from this
 pose") would otherwise hand-roll a second ``_xyz_occupants`` function and a
 second edit to ``communication.py`` — this registry closes that gap by making
-``message_location`` union every *registered* resolver's excluded set instead
-of importing one mechanism by name.
+every room-broadcast call site union every *registered* resolver's excluded
+set instead of importing one mechanism by name.
+
+**Every live room-broadcast call site routes through
+``resolve_broadcast_exclusions``, not just ``message_location``** — a second
+registered resolver must apply everywhere a room broadcast is hand-rolled, or
+the registry silently fails to close the gap it exists for. Current callers:
+``flows.service_functions.communication.message_location`` (the general
+broadcast path), ``actions.definitions.communication`` 's language-aware
+``say`` per-recipient delivery loop (hand-rolls room delivery instead of
+calling ``message_location``), and
+``world.vitals.carry_services._broadcast_waking`` (carry/set-down room
+emits). A new hand-rolled ``location.msg_contents(...)`` call site MUST call
+this seam too, not add a fourth direct ``_dreamside_occupants``-style import.
 
 Dependency-free by design (ADR-0010, specific-general FK direction generalized
 to imports): this module must never import a specific mechanism (dreams, a
@@ -42,6 +54,12 @@ def register_broadcast_exclusion(resolver: BroadcastExclusionResolver) -> None:
     that should NOT receive a room broadcast (e.g. dreamside occupants missing
     waking-room chatter). Call once per mechanism, at import/``ready()`` time —
     never per-message.
+
+    A registered resolver must not raise: ``resolve_broadcast_exclusions`` below
+    runs every resolver in an unguarded loop (no per-resolver try/except, mirroring
+    ``commands.offer_registry.get_all_pending``'s handler loop), so an exception in
+    one resolver propagates out and breaks room-broadcast delivery for every
+    location, not just the mechanism that owns the buggy resolver.
     """
     _RESOLVERS.append(resolver)
 
@@ -50,7 +68,8 @@ def resolve_broadcast_exclusions(location: ObjectDB) -> set[ObjectDB]:
     """Union every registered resolver's excluded set for ``location``.
 
     Empty when no resolver is registered — byte-identical to the pre-registry
-    ``exclude=None`` fallback with zero mechanisms wired up.
+    ``exclude=None`` fallback with zero mechanisms wired up. No per-resolver
+    exception isolation — see ``register_broadcast_exclusion``'s docstring.
     """
     excluded: set[ObjectDB] = set()
     for resolver in _RESOLVERS:

--- a/src/flows/tests/test_perception_registry.py
+++ b/src/flows/tests/test_perception_registry.py
@@ -1,0 +1,71 @@
+"""Tests for the broadcast-exclusion registry — Axis 1 of the perception taxonomy (#2997)."""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from evennia_extensions.factories import ObjectDBFactory
+from flows.scene_data_manager import SceneDataManager
+from flows.service_functions import perception_registry
+from flows.service_functions.communication import _dreamside_occupants, message_location
+
+
+class ResolveBroadcastExclusionsTests(TestCase):
+    def setUp(self):
+        # Isolate the module-level registry per test — production code only
+        # ever appends at import time, but a test that registers a fake
+        # resolver must not leak it into other tests.
+        self._original_resolvers = list(perception_registry._RESOLVERS)
+        self.addCleanup(self._restore_resolvers)
+
+    def _restore_resolvers(self):
+        perception_registry._RESOLVERS[:] = self._original_resolvers
+
+    def test_empty_registry_returns_empty_set(self):
+        """No registered resolvers -> empty set, byte-identical to the old ``or None`` path."""
+        perception_registry._RESOLVERS.clear()
+        room = ObjectDBFactory(db_typeclass_path="typeclasses.rooms.Room")
+
+        assert perception_registry.resolve_broadcast_exclusions(room) == set()
+
+    def test_dreamside_is_registered_by_default(self):
+        """``_dreamside_occupants`` self-registers at import time (communication.py)."""
+        assert _dreamside_occupants in perception_registry._RESOLVERS
+
+    def test_second_resolver_composes_with_dreamside(self):
+        """A second registered resolver's exclusions UNION with dreamside's, not replace them."""
+        room = ObjectDBFactory(db_typeclass_path="typeclasses.rooms.Room")
+        haunted_watcher = ObjectDBFactory(
+            db_typeclass_path="typeclasses.characters.Character", location=room
+        )
+
+        def fake_resolver(location):
+            return [haunted_watcher] if location == room else []
+
+        perception_registry.register_broadcast_exclusion(fake_resolver)
+
+        excluded = perception_registry.resolve_broadcast_exclusions(room)
+        assert haunted_watcher in excluded
+
+    def test_message_location_calls_registry_not_dreamside_directly(self):
+        """``message_location`` routes through the registry union, not ``_dreamside_occupants``."""
+        room = ObjectDBFactory(db_typeclass_path="typeclasses.rooms.Room")
+        caller = ObjectDBFactory(
+            db_typeclass_path="typeclasses.characters.Character", location=room
+        )
+
+        sdm = SceneDataManager()
+        caller_state = sdm.initialize_state_for_object(caller)
+        room_state = sdm.initialize_state_for_object(room)
+
+        with (
+            patch.object(room, "msg_contents") as mock_msg_contents,
+            patch(
+                "flows.service_functions.communication.resolve_broadcast_exclusions"
+            ) as mock_resolve,
+        ):
+            mock_resolve.return_value = {caller}
+            message_location(caller_state, "waves.", location_state=room_state)
+
+        mock_resolve.assert_called_once_with(room)
+        assert mock_msg_contents.call_args.kwargs["exclude"] == {caller}

--- a/src/world/checks/AGENT_GLOSSARY.md
+++ b/src/world/checks/AGENT_GLOSSARY.md
@@ -64,6 +64,23 @@ _Avoid_: resistance rating (use "resist increment" for this specific helper's re
 value), Composure score (the CheckType is Composure; the increment is its rating plus
 effort, not a raw trait value)
 
+**Perception Check** (#2997):
+The single canonical roll for "does this character notice something is off" —
+`resolve_perception_check(observer_sheet, *, difficulty, specialization=None)`
+(`perception_services.py`), resolving the seeded stat-only "Perception" `CheckType`
+(PERCEPTION primary stat) through `perform_check`. Every perception-gated mechanic
+(dreamside noticing, an illusion tell, a disguise tell) calls this one seam rather
+than minting its own roll or a flat probability. **ADR-0033 boundary:** a passed
+check may reveal that something is amiss, never identity — identification stays
+clue-driven (PERSONA_LINK), never an automatic roll. Distinct from Search (stat +
+Investigation skill, the deliberate-investigation action's own check) and
+Identification (intellect + Investigation, the "recognize who's under the mask"
+check, `world/seeds/investigation_checks.py`) — both keep their own compositions.
+PLACEHOLDER difficulty magnitudes: `perception_constants.py`'s
+EASY/STANDARD/HARD. Root cross-app framing: root `AGENT_GLOSSARY_MAP.md`'s
+"Perception" section.
+_Avoid_: awareness roll, spot check, notice check.
+
 **CheckTypeCapabilityModifier** (#2505):
 A curated, staff-authored `(check_type, capability, weight)` row — the only path by which a
 character's `conditions.CapabilityType` value reaches a check's point total. No row means the

--- a/src/world/checks/perception_constants.py
+++ b/src/world/checks/perception_constants.py
@@ -1,0 +1,27 @@
+"""PLACEHOLDER constants for the canonical perception-check seam (#2997).
+
+``resolve_perception_check`` (``world.checks.perception_services``) is the ONE
+perception check every perceive-the-real mechanic resolves through — see
+``docs/systems/scenes.md``'s "Perception & altered reality" section. The
+difficulty magnitudes below are unturned placeholders, sized against the
+seeded ``CheckRank`` ladder (``world/seeds/checks.py``'s ``_CHECK_RANKS``:
+0 / 10 / 25 / 50 / 80 / ...) so they land on real rank rungs (Novice /
+Competent / Expert), not arbitrary numbers. The first real consumer
+(dreamside noticing, an illusion tell, a disguise tell) should retune these
+against actual play, not treat them as final.
+"""
+
+PERCEPTION_CHECK_TYPE_NAME = "Perception"
+"""Name of the seeded, stat-only CheckType ``resolve_perception_check`` rolls.
+
+Seeded (PERCEPTION stat, weight 1.0, no skill leg — the AD&D-style "one
+passive perception roll" the ratified spec calls for, deliberately simpler
+than the stat+skill Search/Identification checks) by
+``world.seeds.investigation_checks.ensure_perception_check``.
+"""
+
+PERCEPTION_DIFFICULTY_EASY = 10
+
+PERCEPTION_DIFFICULTY_STANDARD = 25
+
+PERCEPTION_DIFFICULTY_HARD = 50

--- a/src/world/checks/perception_services.py
+++ b/src/world/checks/perception_services.py
@@ -1,0 +1,80 @@
+"""The canonical perception-check seam (#2997, ratified amendment).
+
+``resolve_perception_check`` is the ONE perception check every
+perceive-the-real mechanic resolves through — noticing an illusion is off,
+sensing a dreamside presence, spotting the concealed. AD&D-style: a single
+roll, on the PERCEPTION primary stat, through the standard ``perform_check``
+pipeline. No elaborate override framework beyond it — mirrors
+``resolve_security_check`` (this package's ``security_services.py``), the
+existing thin kind-to-CheckType wrapper this one is modeled on.
+
+**ADR-0033 boundary (preserved, not renegotiated here):** a passed check may
+reveal that something is amiss — a tell, a wrongness — never WHO is behind
+a mask. Identification stays clue-driven (PERSONA_LINK), never an automatic
+roll. The pierce *contest* in ``world.forms.services.identification`` is a
+separate substrate (TehomCD's) — when it wires up, it should call this seam
+for its "something's off" half, never fold identity resolution into it.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from world.checks.perception_constants import PERCEPTION_CHECK_TYPE_NAME
+from world.checks.services import perform_check
+
+if TYPE_CHECKING:
+    from world.character_sheets.models import CharacterSheet
+    from world.checks.types import CheckResult
+    from world.skills.models import Specialization
+
+
+def resolve_perception_check(
+    observer_sheet: CharacterSheet,
+    *,
+    difficulty: int,
+    specialization: Specialization | None = None,
+) -> CheckResult:
+    """Resolve the canonical perception check for ``observer_sheet``.
+
+    The single AD&D-style perception check (#2997 ratified amendment): every
+    perception-gated mechanic (noticing an illusion is off, sensing a
+    dreamside presence, spotting the concealed) calls THIS seam rather than
+    minting its own roll. Rolls the seeded, stat-only "Perception" CheckType
+    (PERCEPTION primary stat) through ``perform_check``, passing ``difficulty``
+    straight through as ``target_difficulty`` and ``specialization`` unchanged.
+
+    **ADR-0033 boundary:** a passed check may reveal that something is amiss —
+    a tell, a wrongness — never identity. Identification stays clue-driven
+    (PERSONA_LINK), never an automatic roll.
+
+    Args:
+        observer_sheet: The perceiving character's CharacterSheet.
+        difficulty: Target difficulty in points — see
+            ``world.checks.perception_constants`` for PLACEHOLDER
+            EASY/STANDARD/HARD magnitudes callers may use until a real
+            consumer calibrates its own.
+        specialization: Optional owned specialization to fold into the roll
+            (e.g. a Perception specialization in "spotting the uncanny").
+
+    Returns:
+        CheckResult from ``perform_check``.
+
+    Raises:
+        ValueError: If the "Perception" CheckType is not seeded/active.
+    """
+    from world.checks.models import CheckType  # noqa: PLC0415
+
+    check_type = CheckType.objects.filter(name=PERCEPTION_CHECK_TYPE_NAME, is_active=True).first()
+    if check_type is None:
+        msg = (
+            f"Perception CheckType '{PERCEPTION_CHECK_TYPE_NAME}' is not seeded or "
+            "not active. Run the 'investigation' seed cluster."
+        )
+        raise ValueError(msg)
+    return perform_check(
+        observer_sheet.character,
+        check_type,
+        target_difficulty=difficulty,
+        specialization=specialization,
+    )

--- a/src/world/checks/tests/test_perception_services.py
+++ b/src/world/checks/tests/test_perception_services.py
@@ -1,0 +1,77 @@
+"""Tests for resolve_perception_check — the canonical perception-check seam (#2997)."""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from world.character_sheets.factories import CharacterSheetFactory
+from world.checks.factories import CheckTypeFactory
+from world.checks.perception_constants import (
+    PERCEPTION_CHECK_TYPE_NAME,
+    PERCEPTION_DIFFICULTY_EASY,
+    PERCEPTION_DIFFICULTY_HARD,
+    PERCEPTION_DIFFICULTY_STANDARD,
+)
+from world.checks.perception_services import resolve_perception_check
+from world.skills.factories import SpecializationFactory
+
+
+class ResolvePerceptionCheckTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.sheet = CharacterSheetFactory()
+        cls.check_type = CheckTypeFactory(name=PERCEPTION_CHECK_TYPE_NAME)
+
+    def test_passes_character_check_type_and_difficulty_to_perform_check(self):
+        """The seam resolves the seeded Perception CheckType and forwards difficulty."""
+        with patch("world.checks.perception_services.perform_check") as mock_perform:
+            resolve_perception_check(self.sheet, difficulty=PERCEPTION_DIFFICULTY_STANDARD)
+
+        mock_perform.assert_called_once_with(
+            self.sheet.character,
+            self.check_type,
+            target_difficulty=PERCEPTION_DIFFICULTY_STANDARD,
+            specialization=None,
+        )
+
+    def test_passes_specialization_through_unchanged(self):
+        """An owned specialization is forwarded, not swallowed or re-derived."""
+        specialization = SpecializationFactory()
+
+        with patch("world.checks.perception_services.perform_check") as mock_perform:
+            resolve_perception_check(
+                self.sheet,
+                difficulty=PERCEPTION_DIFFICULTY_EASY,
+                specialization=specialization,
+            )
+
+        mock_perform.assert_called_once_with(
+            self.sheet.character,
+            self.check_type,
+            target_difficulty=PERCEPTION_DIFFICULTY_EASY,
+            specialization=specialization,
+        )
+
+    def test_returns_perform_check_result(self):
+        """The seam is a pure delegation — its return value IS perform_check's."""
+        with patch("world.checks.perception_services.perform_check") as mock_perform:
+            mock_perform.return_value = "sentinel-result"
+            result = resolve_perception_check(self.sheet, difficulty=PERCEPTION_DIFFICULTY_HARD)
+
+        assert result == "sentinel-result"
+
+    def test_missing_check_type_raises_value_error(self):
+        """If the 'Perception' CheckType is not seeded/active, fail loudly."""
+        self.check_type.is_active = False
+        self.check_type.save()
+
+        with self.assertRaises(ValueError) as ctx:
+            resolve_perception_check(self.sheet, difficulty=PERCEPTION_DIFFICULTY_STANDARD)
+        assert PERCEPTION_CHECK_TYPE_NAME in str(ctx.exception)
+
+
+class PerceptionDifficultyConstantsTests(TestCase):
+    def test_constants_exist_and_are_ordered(self):
+        """EASY < STANDARD < HARD — placeholder magnitudes, but internally consistent."""
+        assert PERCEPTION_DIFFICULTY_EASY < PERCEPTION_DIFFICULTY_STANDARD
+        assert PERCEPTION_DIFFICULTY_STANDARD < PERCEPTION_DIFFICULTY_HARD

--- a/src/world/scenes/AGENT_GLOSSARY.md
+++ b/src/world/scenes/AGENT_GLOSSARY.md
@@ -74,3 +74,15 @@ _Avoid_: retroactive consent, backfill approval
 **Precapture truncation**:
 The scene starter's (or staff's) "start scene from here" cutoff control — detaches (`scene=None`, never deletes) every pre-scene-captured pose before a chosen one. Distinguishes captured poses from live ones purely by `timestamp < scene.date_started`; no separate flag exists, and a live in-scene pose can never be truncated.
 _Avoid_: trim, prune, delete (truncation only detaches; the interaction row survives)
+
+**Perception Axis** (#2997):
+One of three genuinely different answers to "who perceives what is real" — see
+`docs/systems/scenes.md`'s "Perception & altered reality" section for the full
+taxonomy. Room-broadcast membership exclusion (Axis 1 — `_dreamside_occupants` is
+this app's only current consumer, registered from `flows/service_functions
+/communication.py`) is deliberately kept separate from per-viewer content
+shape/tiering on a recorded event (Axis 2 — cast concealment's ADR-0170 snapshot,
+language/persona-display's ADR-0214 live recompute) and downstream read-time feed
+filtering (Axis 3 — this app's own Mute/`InteractionQuerySet.visible_to`/Block).
+Root cross-app entry: root `AGENT_GLOSSARY_MAP.md`'s "Perception" section.
+_Avoid_: perception layer, visibility mode.

--- a/src/world/seeds/investigation_checks.py
+++ b/src/world/seeds/investigation_checks.py
@@ -194,8 +194,46 @@ def ensure_lockpicking_check():
     return check_type
 
 
+def ensure_perception_check():
+    """Look up (or sample) the **Perception** ``CheckType`` (#2997).
+
+    Stat-only — deliberately no skill leg, unlike Search (which shares the
+    same PERCEPTION stat but adds the Investigation skill). This is the
+    canonical AD&D-style "one passive perception roll"
+    ``world.checks.perception_services.resolve_perception_check`` rolls;
+    Search stays the deliberate-investigation action's own check. Shares the
+    perception stat trait row with Search via ``_ensure_perception_stat``.
+
+    ``checks.CheckCategory``/``CheckType``/``CheckTypeTrait`` are content-repo-owned
+    (#2698) — looked up rather than invented unless ``SEED_SAMPLE_CONTENT`` is
+    on. No longer wipes and rewrites the composition on each run (#2698 Part 1).
+    """
+    from world.checks.models import CheckType, CheckTypeTrait  # noqa: PLC0415
+    from world.checks.perception_constants import PERCEPTION_CHECK_TYPE_NAME  # noqa: PLC0415
+    from world.seeds.sample_content import authored_or_sample  # noqa: PLC0415
+
+    stat_trait = _ensure_perception_stat()
+    category = _ensure_exploration_category()
+    if category is None:
+        return None
+    check_type = authored_or_sample(
+        CheckType,
+        {"is_active": True},
+        name=PERCEPTION_CHECK_TYPE_NAME,
+        category=category,
+    )
+    if check_type is None:
+        return None
+    if stat_trait is not None:
+        weight = Decimal("1.0")  # PLACEHOLDER magnitude
+        authored_or_sample(
+            CheckTypeTrait, {"weight": weight}, check_type=check_type, trait=stat_trait
+        )
+    return check_type
+
+
 def seed_investigation_check_content() -> None:
-    """Cluster entry — seed the Investigation skill + the Search + Identification checks."""
+    """Cluster entry — seed the Investigation skill + Search/Identification/Perception."""
     from world.checks.models import CheckType, CheckTypeTrait  # noqa: PLC0415
     from world.clues.constants import SEARCH_CHECK_TYPE_NAME  # noqa: PLC0415
     from world.seeds.sample_content import authored_or_sample  # noqa: PLC0415
@@ -222,3 +260,4 @@ def seed_investigation_check_content() -> None:
                 )
     ensure_identification_check()
     ensure_lockpicking_check()
+    ensure_perception_check()

--- a/src/world/vitals/carry_services.py
+++ b/src/world/vitals/carry_services.py
@@ -93,17 +93,20 @@ def set_down_body(carrier: ObjectDB) -> None:
 
 
 def _broadcast_waking(carrier: ObjectDB, text: str) -> None:
-    """Room emit that honors dreamside perception (#2287) — the carried body
-    is unconscious and dreaming; they must not hear the waking room handle
-    them (the same exclusion every routed room broadcast applies)."""
-    from flows.service_functions.communication import _dreamside_occupants  # noqa: PLC0415
+    """Room emit routed through the broadcast-exclusion registry (#2997) — the
+    carried body may be unconscious and dreaming (#2287) and must not hear the
+    waking room handle them, the same exclusion every routed room broadcast
+    applies. Uses the registry union (not `_dreamside_occupants` by name) so a
+    second registered resolver (a haunting/vision/glamour) is honored here too."""
+    from flows.service_functions.perception_registry import (  # noqa: PLC0415
+        resolve_broadcast_exclusions,
+    )
 
     location = carrier.location
     if location is None:
         return
-    excluded = _dreamside_occupants(location)
-    if carrier not in excluded:
-        excluded.append(carrier)
+    excluded = resolve_broadcast_exclusions(location)
+    excluded.add(carrier)
     location.msg_contents(text, exclude=excluded)
 
 


### PR DESCRIPTION
Closes #2997

## Summary

Perception primitive (#2997): the ratified minimal shape - (1) broadcast-exclusion registry (flows/service_functions/perception_registry.py): message_location, the language-say per-recipient loop, and vitals' _broadcast_waking all union EVERY registered exclusion resolver (dreamside migrated onto it; a second resolver now composes everywhere, proven by test); (2) resolve_perception_check - the canonical AD&D-style perception check seam on the PERCEPTION primary stat via perform_check (seeded stat-only CheckType through the seeds mechanism, ADR-0013-clean), with the ADR-0033 boundary in its docstring: consumers may reveal wrongness, never identity; (3) the seven per-observer mechanisms documented as a three-axis taxonomy in docs/systems/scenes.md. No models, no migration. One review fix round: two pre-existing hand-rolled exclusion call sites routed onto the registry.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #2997 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Up to date with main; no migrations on this branch.

<!-- last-addressed-comment: 0 -->