### PR TITLE
Render the hardening overlay outside releases, symlink it into the one being deployed

### DIFF
--- a/infra/ansible/roles/app_deploy/defaults/main.yml
+++ b/infra/ansible/roles/app_deploy/defaults/main.yml
@@ -27,6 +27,11 @@ app_portal_pidfile: /opt/arxii/current/src/server/portal.pid
 # `current`-scoped).
 app_release_dir: "{{ app_releases_dir }}/{{ app_ref }}"
 app_release_gamedir: "{{ app_releases_dir }}/{{ app_ref }}/src"
+# Where django_hardening rendered the production settings overlay. MUST equal
+# roles/django_hardening/defaults/main.yml's dh_settings_path — the tasks here
+# only symlink it into the release being built, they never render it.
+# acceptance.sh pins the two values equal.
+app_secret_settings_src: /etc/arxii/secret_settings.py
 
 # Frontend build (Task D). The box has no Node preinstalled — installed here
 # via the NodeSource apt repo, pinned to the Node 20.x line to match CI

--- a/infra/ansible/roles/app_deploy/tasks/main.yml
+++ b/infra/ansible/roles/app_deploy/tasks/main.yml
@@ -47,6 +47,24 @@
 # (whatever `current` still points at) untouched, instead of stranding a
 # half-deployed `current` with no rollback.
 
+# Which is exactly why the hardening overlay is symlinked in here rather than
+# written to a release path by django_hardening: `current` does not exist at
+# all on a first converge, and points at the PREVIOUS release on every later
+# one, so the release being migrated below would never see the overlay.
+# django_hardening renders the file itself (earlier in site.yml's role order)
+# at dh_settings_path — app_secret_settings_src MUST equal that value; both
+# defaults carry the pairing note and acceptance.sh pins them equal.
+# `secret_settings.py` is gitignored, so the checkout above never places a
+# real file at this path for the link to fight with.
+- name: Link the hardening overlay into this release (BEFORE migrate reads it)
+  ansible.builtin.file:
+    src: "{{ app_secret_settings_src }}"
+    dest: "{{ app_release_gamedir }}/server/conf/secret_settings.py"
+    state: link
+    owner: "{{ app_user }}"
+    group: "{{ app_group }}"
+    follow: false
+
 # Build the project venv from uv.lock so the `evennia` entrypoint exists
 # under the service user. --frozen ensures we install EXACTLY what the
 # lockfile says (no implicit resolution drift); --no-dev skips dev deps.

--- a/infra/ansible/roles/django_hardening/defaults/main.yml
+++ b/infra/ansible/roles/django_hardening/defaults/main.yml
@@ -6,7 +6,14 @@
 # tls_telnet_cert's ttc_game_dir (#2236 review). Get this wrong and the
 # overlay deploys to a path settings.py's sibling import never reaches.
 dh_game_dir: /opt/arxii/current/src
-dh_settings_path: "{{ dh_game_dir }}/server/conf/secret_settings.py"
+# The overlay is rendered OUTSIDE any release, and app_deploy symlinks it into
+# the release it is building (app_secret_settings_src there must equal this).
+# It cannot live at dh_game_dir directly: app_deploy flips `current` LAST, on
+# purpose, so that path does not exist on a first converge and points at the
+# PREVIOUS release on every later one — the release actually being migrated
+# would never receive the overlay. Config outlives releases, so it belongs
+# beside the EnvironmentFile, and a rollback keeps working.
+dh_settings_path: /etc/arxii/secret_settings.py
 dh_service_user: arxii
 dh_service_group: arxii
 dh_allowed_hosts: []                 # = [web_fqdn, telnet_fqdn] (tofu outputs)

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -198,6 +198,19 @@ chk   "caddy role loads that file into caddy.service via a drop-in" \
 chk   "Caddyfile validate gets the DNS-01 token in its environment" \
   "grep -q 'CADDY_CF_DNS_TOKEN: ' infra/ansible/roles/caddy/tasks/main.yml"
 
+# (c2) The hardening overlay is rendered by one role and consumed by another.
+# app_deploy flips `current` LAST, so the overlay must NOT live under a
+# release path: on a first converge `current` does not exist, and on later
+# ones it points at the PREVIOUS release, so the release being migrated would
+# never get it. Pin the two paths equal, and pin the link before migrate.
+chk   "django_hardening's overlay path is not under a release/current path" \
+  "sed -n 's/^dh_settings_path: //p' infra/ansible/roles/django_hardening/defaults/main.yml | grep -qv '/opt/arxii'"
+chk   "dh_settings_path == app_deploy's app_secret_settings_src" \
+  "[ \"\$(sed -n 's/^dh_settings_path: //p' infra/ansible/roles/django_hardening/defaults/main.yml)\" = \"\$(sed -n 's/^app_secret_settings_src: //p' infra/ansible/roles/app_deploy/defaults/main.yml)\" ]"
+assert_before "app_deploy links the overlay BEFORE evennia migrate reads it" \
+  'secret_settings\.py' 'evennia migrate --noinput' \
+  infra/ansible/roles/app_deploy/tasks/main.yml
+
 # (d) nftables must never `flush ruleset` (wipes fail2ban's own table too);
 # it must flush only OUR table. nc() strips comments first so the check
 # asserts real code, not the explanatory comment that mentions the banned


### PR DESCRIPTION
The converge reached `django_hardening` and failed:

```
Destination directory /opt/arxii/current/src/server/conf does not exist
```

`django_hardening` renders `secret_settings.py` under `app_current`. `app_deploy`
flips that symlink LAST, deliberately, so a failed deploy cannot strand a broken
`current` with no rollback.

## The missing directory is only the first-run symptom

On every LATER converge the path exists — and points at the **previous** release.
Meanwhile `uv sync`, the frontend build, `migrate` and `collectstatic` all run
against the new release directory. So the release being migrated would never
receive the overlay, and would run on Evennia's defaults instead of `DEBUG=False`,
the real `ALLOWED_HOSTS`, `SECURE_PROXY_SSL_HEADER` and the `wss://` client URL.

Reordering the roles cannot fix it. The overlay must exist before `migrate` reads
it, and the release must exist before the overlay can be written into it.

## Change

The overlay stops living inside a release.

- `django_hardening` renders it to `/etc/arxii/secret_settings.py`, beside the
  EnvironmentFile, owned `arxii:arxii` at `0640`.
- `app_deploy` symlinks it into `{{ app_release_gamedir }}/server/conf/` right
  after checkout and well before `migrate`.

Configuration outlives releases, which is the property that was missing: a
rollback to an older release now keeps a working config instead of finding an
overlay written for a directory that no longer exists.

`secret_settings.py` is gitignored (`.gitignore:42`), so the checkout never
leaves a real file for the symlink to fight with.

`dh_game_dir` stays as-is — the role's handler still uses it as a `chdir`.

## Verification

`acceptance.sh` passes with 0 failures, including three new cross-file checks:
the overlay path is not under a release/`current` path, `dh_settings_path` equals
`app_secret_settings_src`, and the symlink task precedes `evennia migrate`. That
last one matters because the ordering is the whole bug, and it is invisible to
any single-file grep.

Not verifiable locally: ansible-lint does not run on Windows, and the roles can
only be proven by the next converge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
