### PR TITLE
Deploy from the org repo, and make a bad repo URL fail loudly

### DIFF
--- a/infra/ansible/roles/app_deploy/defaults/main.yml
+++ b/infra/ansible/roles/app_deploy/defaults/main.yml
@@ -8,7 +8,13 @@ app_releases_dir: /opt/arxii/releases
 # settings.py is at app_gamedir/server/conf/settings.py).
 app_current: /opt/arxii/current
 app_gamedir: /opt/arxii/current/src
-app_repo: "https://github.com/TehomCD/arxii.git"  # confirm; no secret (public)
+# The org repo, matching this checkout's own origin. It was TehomCD/arxii with
+# a "# confirm" comment nobody ever actioned, and the first real converge hung
+# on it: GitHub answers 404 for a nonexistent-or-private repo, git responds by
+# prompting for credentials, and with no tty it blocks forever on /dev/tty.
+# Ansible reports that as UNREACHABLE, not as a failed task — see the
+# GIT_TERMINAL_PROMPT guard on the checkout task.
+app_repo: "https://github.com/Arx-Game/arxii.git"  # public; no credential needed
 app_ref: main                            # release tag/ref to deploy
 app_service: arxii
 # Evennia is a forking Twisted daemon; it writes its PID file relative to

--- a/infra/ansible/roles/app_deploy/tasks/main.yml
+++ b/infra/ansible/roles/app_deploy/tasks/main.yml
@@ -15,6 +15,14 @@
     depth: 1
   become: true
   become_user: "{{ app_user }}"
+  # Fail fast instead of hanging. Unauthenticated git against a repo GitHub
+  # will not show you gets a 404, and git's reflex is to ask for a username
+  # and password. With no tty it blocks on /dev/tty producing no output, the
+  # connection eventually dies, and Ansible reports UNREACHABLE rather than a
+  # failed task — which points the operator at the network instead of at the
+  # URL. With prompting disabled, a bad app_repo is a clear, immediate error.
+  environment:
+    GIT_TERMINAL_PROMPT: "0"
   register: app_checkout
 
 # #2236 Phase 5 (Sentry). app_checkout.after is the resolved commit SHA

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -211,6 +211,15 @@ assert_before "app_deploy links the overlay BEFORE evennia migrate reads it" \
   'secret_settings\.py' 'evennia migrate --noinput' \
   infra/ansible/roles/app_deploy/tasks/main.yml
 
+# app_deploy clones from app_repo. A wrong value does not fail cleanly: GitHub
+# 404s an unreachable repo, git prompts for credentials, and with no tty it
+# blocks until the connection dies — reported as UNREACHABLE, which sends the
+# operator hunting a network fault. Pin the org, and pin the prompt guard.
+chk   "app_repo points at this repo's own org (Arx-Game/arxii)" \
+  "grep -q '^app_repo: \"https://github.com/Arx-Game/arxii.git\"' infra/ansible/roles/app_deploy/defaults/main.yml"
+chk   "the checkout disables git's credential prompt (hang -> clear error)" \
+  "grep -q 'GIT_TERMINAL_PROMPT' infra/ansible/roles/app_deploy/tasks/main.yml"
+
 # (d) nftables must never `flush ruleset` (wipes fail2ban's own table too);
 # it must flush only OUR table. nc() strips comments first so the check
 # asserts real code, not the explanatory comment that mentions the banned


### PR DESCRIPTION
The converge went `UNREACHABLE` at the checkout task, with `failed=0`:

```
fatal: [prod]: UNREACHABLE! => "Failed to connect to the host via ssh:
Shared connection to 23.92.20.94 closed."
```

That reads like a network fault. It is not one. The box's journal shows the git
module logging its invocation and then nothing at all:

```
08:26:49 python3.12[33959]: ansible-ansible.builtin.git Invoked with
  repo=https://github.com/TehomCD/arxii.git ...
```

`app_repo` pointed at `TehomCD/arxii`, carrying a `# confirm` comment nobody
ever actioned. GitHub answers 404 for any repo it will not show an
unauthenticated client, and git's reflex to a 404 is to ask for a username and
password. With no tty it blocks on `/dev/tty`, emits no output, and the
connection eventually dies — which Ansible reports as UNREACHABLE rather than a
failed task, pointing the operator at the network instead of at the URL.

Diagnosis was against the live box, not inference: no OOM in `dmesg`, 3.3 GB
memory available, 5% disk, no reboot, and nothing in the sshd log but internet
scanner noise. The only anomaly was the git invocation with no successor line.

## Changes

- `app_repo` becomes `https://github.com/Arx-Game/arxii.git`, matching this
  checkout's own `origin`.
- `GIT_TERMINAL_PROMPT=0` on the checkout task, so a wrong URL is an immediate
  readable error rather than a hang. This is the more valuable half: the
  original failure mode gave no signal at all, and cost a round of diagnosis
  aimed at entirely the wrong layer.

Two acceptance checks pin the org and the prompt guard.

## Verification

`acceptance.sh` passes with 0 failures. The real proof is the next converge
reaching `uv sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
