### PR TITLE
Grant CREATE on schema public so migrations can run on PG15+

### DIFF
--- a/infra/ansible/roles/postgres/tasks/main.yml
+++ b/infra/ansible/roles/postgres/tasks/main.yml
@@ -75,3 +75,25 @@
     state: present
   become: true
   become_user: postgres
+
+# Database-level ALL is NOT enough on PostgreSQL 15 and later. PG15 revoked
+# CREATE on schema public from the PUBLIC pseudo-role, so only the database
+# owner can create objects there. Ubuntu 24.04 ships PG16, and the first real
+# converge died on exactly this:
+#   psycopg.errors.InsufficientPrivilege: permission denied for schema public
+#   LINE 1: CREATE TABLE "django_migrations" ...
+# A schema grant rather than making the app role the database owner: ownership
+# would also confer DROP DATABASE, which this role deliberately never wants
+# (see "create-if-absent, NEVER drop" above). CREATE+USAGE is what migrations
+# actually need — the app then owns every table it creates. No migration in
+# this repo needs CREATE EXTENSION or any other superuser-only operation.
+- name: Grant CREATE/USAGE on schema public (PG15+ revoked it from PUBLIC)
+  community.postgresql.postgresql_privs:
+    db: "{{ postgres_db_name }}"
+    role: "{{ postgres_db_user }}"
+    type: schema
+    objs: public
+    privs: CREATE,USAGE
+    state: present
+  become: true
+  become_user: postgres

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -65,6 +65,13 @@ chk   "app runs as non-root user"     "grep -q 'User={{ app_user }}' infra/ansib
 chk   "django: DEBUG = False"         "grep -q 'DEBUG = False' infra/ansible/roles/django_hardening/templates/secret_settings.py.j2"
 chk   "django: TELNET_ENABLED False"  "grep -q 'TELNET_ENABLED = False' infra/ansible/roles/django_hardening/templates/secret_settings.py.j2"
 
+# PG15+ revoked CREATE on schema public from PUBLIC, so a database-level GRANT
+# ALL leaves `evennia migrate` unable to create django_migrations. The schema
+# grant is the fix; without it the very first migrate fails on every fresh
+# cluster (Ubuntu 24.04 ships PG16).
+chk   "postgres role grants CREATE on schema public (PG15+ requirement)" \
+  "grep -q 'type: schema' infra/ansible/roles/postgres/tasks/main.yml && grep -q 'privs: CREATE,USAGE' infra/ansible/roles/postgres/tasks/main.yml"
+
 echo "== first-run setup =="
 chk   "base role installs uv (pinned + sha-verified)" \
   "grep -q 'sha256:{{ base_uv_sha256 }}' infra/ansible/roles/base/tasks/main.yml"


### PR DESCRIPTION
The converge got through `uv sync`, the Node install and the frontend build, then
died at `evennia migrate`:

```
psycopg.errors.InsufficientPrivilege: permission denied for schema public
LINE 1: CREATE TABLE "django_migrations" ("id" bigint NOT NULL PRIMA...
```

PostgreSQL 15 revoked `CREATE` on schema `public` from the `PUBLIC`
pseudo-role. Before that, any role with `CONNECT` could create objects there,
which is why a database-level `GRANT ALL` used to be sufficient. It no longer
is: only the database owner can create in `public` by default. Ubuntu 24.04
ships PG16, so every fresh cluster fails on its first migrate.

## Change

Grant `CREATE,USAGE` on schema `public` to the application role.

The alternative is making that role the database owner, which also works. It is
rejected here because ownership additionally confers `DROP DATABASE`, and this
role goes out of its way to avoid that — its database task is commented
"create-if-absent, NEVER drop". `CREATE`+`USAGE` is exactly what migrations
need, and the application owns every table it subsequently creates.

Checked before choosing the narrow grant: no migration in this repo uses
`CreateExtension` or any other superuser-only operation, so nothing else will
need escalating later.

## Verification

`acceptance.sh` passes with 0 failures, with a new check pinning the schema
grant — the previous database-level grant looked complete and silently was not,
which is the sort of thing worth a regression guard.

The real proof is the next converge getting past migrate into collectstatic and
the superuser creation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
