### PR TITLE
Run deploy-time Django commands through django, not the evennia launcher

### DIFF
--- a/.github/workflows/standup.yml
+++ b/.github/workflows/standup.yml
@@ -35,7 +35,13 @@ jobs:
   standup:
     runs-on: ubuntu-latest
     environment: prod        # gated: required-reviewer approval before run
-    timeout-minutes: 45      # provisioning + converge; refuse to hang forever
+    # Provisioning + converge; refuse to hang forever. 45 minutes could not fit
+    # a first run: provisioning takes ~6 minutes and the initial migration adds
+    # ~80 (143 arxii migrations at ~30-35 s each on a 2-core box), so the guard
+    # fired every time before the database was built. Steady-state converges
+    # apply no migrations and finish well inside 15 minutes; this ceiling only
+    # has to cover the once-per-database first run.
+    timeout-minutes: 150
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       # Shared with rehearse.yml (#2236 review): OpenTofu + Python +

--- a/infra/README.md
+++ b/infra/README.md
@@ -249,10 +249,22 @@ after the box itself is provisioned, the app_deploy role runs (in order):
    bundle. Node/pnpm installation only happens once; the frontend rebuild
    recurs every release. **The first deploy takes noticeably longer** than
    subsequent ones as a result.
-4. **`evennia migrate --noinput`** — apply Django/Evennia migrations.
-   Idempotent: a no-op once everything is applied.
-5. **`evennia collectstatic --noinput`** — gather admin/Evennia static
-   files for Caddy. Idempotent.
+4. **`python -m django migrate --noinput`** — apply Django/Evennia migrations.
+   Idempotent: a no-op once everything is applied. The **first** run on a new
+   database applies 143 `arxii` migrations at roughly 30-35 seconds each, so
+   allow about 80 minutes for it; later deploys apply nothing and return in
+   seconds. The task runs detached (Ansible `async`/`poll`) because a dropped
+   SSH connection during that window would otherwise kill the migration.
+5. **`python -m django collectstatic --noinput`** — gather admin/Evennia
+   static files for Caddy. Idempotent.
+
+   Steps 4, 5 and 7 all call `python -m django`, never the `evennia`
+   launcher. The launcher runs `check_database()` first, which imports
+   `evennia.utils.gametime` and queries `server_serverconfig` at import time,
+   and which prompts interactively to create Account #1 when it is missing.
+   On a fresh box both conditions hold, so the launcher cannot run the very
+   commands that would resolve them. Do not "simplify" these back to
+   `evennia <command>`; `acceptance.sh` fails the build if you do.
 6. **Atomic symlink** `/opt/arxii/current → /opt/arxii/releases/<ref>` — done
    **last** among the release-prep steps, only after the venv, frontend
    build, migrations, and static collection all succeed against the new

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -11,3 +11,11 @@ forks = 10
 
 [ssh_connection]
 pipelining = True
+# Keep long, silent tasks alive. Deploy steps such as `uv sync`, the frontend
+# build and the first-run migration send nothing over the SSH channel for
+# many minutes; an idle-timing-out hop in between then drops the connection,
+# systemd tears down the login session, and every process started under it
+# dies. That is what killed the 2026-08-15 standup mid-migration. Server
+# keepalives hold the channel open, and ControlPersist lets a reconnect reuse
+# it instead of renegotiating.
+ssh_args = -o ControlMaster=auto -o ControlPersist=600s -o ServerAliveInterval=30 -o ServerAliveCountMax=20

--- a/infra/ansible/roles/app_deploy/defaults/main.yml
+++ b/infra/ansible/roles/app_deploy/defaults/main.yml
@@ -8,6 +8,17 @@ app_releases_dir: /opt/arxii/releases
 # settings.py is at app_gamedir/server/conf/settings.py).
 app_current: /opt/arxii/current
 app_gamedir: /opt/arxii/current/src
+# Deploy-time Django commands run through `python -m django`, NOT through the
+# `evennia` launcher, so they need the settings module named explicitly (the
+# launcher is what normally supplies it). Must match the gamedir layout above:
+# server/conf/settings.py under app_gamedir. See the migrate task for why the
+# launcher is bypassed.
+app_django_settings_module: server.conf.settings
+# Ceiling for the detached migrate task, in seconds. A measured first run is
+# ~80 minutes (143 arxii migrations at ~30-35 s each on a 2-core box); this
+# allows more than double that before Ansible gives up. Steady-state deploys
+# apply nothing and return in seconds.
+app_migrate_async_timeout: 10800
 # The org repo, matching this checkout's own origin. It was TehomCD/arxii with
 # a "# confirm" comment nobody ever actioned, and the first real converge hung
 # on it: GitHub answers 404 for a nonexistent-or-private repo, git responds by

--- a/infra/ansible/roles/app_deploy/tasks/main.yml
+++ b/infra/ansible/roles/app_deploy/tasks/main.yml
@@ -245,6 +245,24 @@
 # EnvironmentFile gives the migration the Postgres password + SECRET_KEY it
 # needs. Runs every deploy by design — the gate against schema-breaking
 # changes lives in the release-safety classifier upstream, not here.
+#
+# Deliberately `python -m django migrate`, NOT `evennia migrate`. Evennia's
+# launcher calls check_database() before it dispatches the command, and that
+# helper imports evennia, whose utils/gametime.py queries server_serverconfig
+# at import time. On a half-migrated database that table does not exist yet,
+# so `evennia migrate` dies with ProgrammingError: the command that creates
+# the table cannot run until the table exists. check_database() also falls
+# through to an interactive create_superuser() prompt when Account #1 is
+# missing, which blocks forever with no tty attached. Django's own entrypoint
+# has neither behaviour. (Diagnosed on the prod standup, 2026-08-15.)
+#
+# async/poll: a first-run migration is ~80 minutes on a 2-core box, and the
+# SSH channel carries no output for any of it. When that connection dropped
+# at 09:23 UTC on 2026-08-15, systemd tore down the login session scope and
+# killed the migrate process with it, stranding the database at migration
+# 0013 while Ansible waited for a reply that was never coming. Running the
+# task detached and polling for its result makes a mid-migration disconnect
+# cost a reconnect instead of the whole run.
 - name: Apply Django/Evennia DB migrations (idempotent on every deploy)
   ansible.builtin.shell: |
     set -a
@@ -252,12 +270,16 @@
     . {{ secrets_env_file | default('/etc/arxii/arxii.env') }}
     set +a
     set -o pipefail
-    {{ base_uv_bin }} run evennia migrate --noinput
+    {{ base_uv_bin }} run python -m django migrate --noinput
   args:
     chdir: "{{ app_release_gamedir }}"
     executable: /bin/bash
+  environment:
+    DJANGO_SETTINGS_MODULE: "{{ app_django_settings_module }}"
   become: true
   become_user: "{{ app_user }}"
+  async: "{{ app_migrate_async_timeout }}"
+  poll: 15
   register: app_migrate
   changed_when: "'Applying' in app_migrate.stdout"
 
@@ -270,6 +292,9 @@
 # collectstatic already ran during THIS release's build (or a prior one,
 # if the frontend didn't need a rebuild either), so there is nothing new
 # to collect and the pass-over-every-static-file cost is pure waste.
+# Uses `python -m django`, not `evennia`, for the reason given on the migrate
+# task: at this point in the play no superuser exists yet, so the launcher's
+# check_database() would stop on an interactive create_superuser() prompt.
 - name: Collect Django static files (idempotent)
   ansible.builtin.shell: |
     set -a
@@ -277,10 +302,12 @@
     . {{ secrets_env_file | default('/etc/arxii/arxii.env') }}
     set +a
     set -o pipefail
-    {{ base_uv_bin }} run evennia collectstatic --noinput
+    {{ base_uv_bin }} run python -m django collectstatic --noinput
   args:
     chdir: "{{ app_release_gamedir }}"
     executable: /bin/bash
+  environment:
+    DJANGO_SETTINGS_MODULE: "{{ app_django_settings_module }}"
   become: true
   become_user: "{{ app_user }}"
   when: app_checkout is changed or app_frontend_build is changed
@@ -301,8 +328,12 @@
 
 # Idempotent superuser bootstrap: if any superuser already exists, skip
 # the create entirely. The credentials come from gated Environment values
-# (username/email = Variables, password = Secret); `evennia
-# createsuperuser --noinput` reads them from DJANGO_SUPERUSER_* env.
+# (username/email = Variables, password = Secret); `django createsuperuser
+# --noinput` reads them from DJANGO_SUPERUSER_* env. Both this task and the
+# guard above it go through `python -m django` rather than the `evennia`
+# launcher: the launcher's own check_database() tries to create a superuser
+# interactively when Account #1 is absent, which is exactly the state these
+# two tasks exist to detect and fix.
 # Runs post-flip (via app_gamedir, which now resolves through `current` to
 # this release) — it needs the running config, same as before; only its
 # position relative to the symlink flip changed.
@@ -313,13 +344,15 @@
     . {{ secrets_env_file | default('/etc/arxii/arxii.env') }}
     set +a
     set -o pipefail
-    {{ base_uv_bin }} run evennia shell <<'PY'
+    {{ base_uv_bin }} run python -m django shell <<'PY'
     from django.contrib.auth import get_user_model
     print('YES' if get_user_model().objects.filter(is_superuser=True).exists() else 'NO')
     PY
   args:
     chdir: "{{ app_gamedir }}"
     executable: /bin/bash
+  environment:
+    DJANGO_SETTINGS_MODULE: "{{ app_django_settings_module }}"
   become: true
   become_user: "{{ app_user }}"
   register: app_su_check
@@ -332,11 +365,12 @@
     . {{ secrets_env_file | default('/etc/arxii/arxii.env') }}
     set +a
     set -o pipefail
-    {{ base_uv_bin }} run evennia createsuperuser --noinput
+    {{ base_uv_bin }} run python -m django createsuperuser --noinput
   args:
     chdir: "{{ app_gamedir }}"
     executable: /bin/bash
   environment:
+    DJANGO_SETTINGS_MODULE: "{{ app_django_settings_module }}"
     DJANGO_SUPERUSER_USERNAME: "{{ app_superuser_username }}"
     DJANGO_SUPERUSER_EMAIL: "{{ app_superuser_email }}"
   become: true

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -66,7 +66,7 @@ chk   "django: DEBUG = False"         "grep -q 'DEBUG = False' infra/ansible/rol
 chk   "django: TELNET_ENABLED False"  "grep -q 'TELNET_ENABLED = False' infra/ansible/roles/django_hardening/templates/secret_settings.py.j2"
 
 # PG15+ revoked CREATE on schema public from PUBLIC, so a database-level GRANT
-# ALL leaves `evennia migrate` unable to create django_migrations. The schema
+# ALL leaves the migration unable to create django_migrations. The schema
 # grant is the fix; without it the very first migrate fails on every fresh
 # cluster (Ubuntu 24.04 ships PG16).
 chk   "postgres role grants CREATE on schema public (PG15+ requirement)" \
@@ -79,10 +79,21 @@ chk   "base role pins uv version + sha256"           \
   "grep -qE '^base_uv_version: ' infra/ansible/roles/base/defaults/main.yml && grep -qE '^base_uv_sha256: ' infra/ansible/roles/base/defaults/main.yml"
 chk   "app_deploy runs uv sync --frozen --no-dev"    \
   "grep -q 'sync --frozen --no-dev' infra/ansible/roles/app_deploy/tasks/main.yml"
-chk   "app_deploy runs evennia migrate --noinput"    \
-  "grep -q 'evennia migrate --noinput' infra/ansible/roles/app_deploy/tasks/main.yml"
-chk   "app_deploy runs evennia collectstatic --noinput" \
-  "grep -q 'evennia collectstatic --noinput' infra/ansible/roles/app_deploy/tasks/main.yml"
+chk   "app_deploy runs django migrate --noinput"     \
+  "grep -q 'python -m django migrate --noinput' infra/ansible/roles/app_deploy/tasks/main.yml"
+chk   "app_deploy runs django collectstatic --noinput" \
+  "grep -q 'python -m django collectstatic --noinput' infra/ansible/roles/app_deploy/tasks/main.yml"
+# Regression guard. Every deploy-time Django command must use `python -m
+# django`, never the `evennia` launcher: the launcher's check_database() both
+# queries server_serverconfig at import time (fatal on a half-migrated
+# database) and prompts interactively to create Account #1 (blocks with no
+# tty). Either one strands a first-run standup. See the migrate task comment.
+chk   "app_deploy never shells out to the evennia launcher" \
+  "! grep -qE '(^|[^-])\\brun evennia ' infra/ansible/roles/app_deploy/tasks/main.yml"
+chk   "app_deploy migrate runs detached (survives an SSH drop)" \
+  "grep -q 'async: \"{{ app_migrate_async_timeout }}\"' infra/ansible/roles/app_deploy/tasks/main.yml"
+chk   "ansible.cfg sets SSH keepalives for long silent tasks" \
+  "grep -q 'ServerAliveInterval=30' infra/ansible/ansible.cfg"
 chk   "app_deploy guards superuser create with an exists-check (idempotent)" \
   "grep -q 'is_superuser=True' infra/ansible/roles/app_deploy/tasks/main.yml && grep -q \"'YES' not in\" infra/ansible/roles/app_deploy/tasks/main.yml"
 chk   "secrets_vault maps ARXII_DJANGO_SUPERUSER_PASSWORD -> DJANGO_SUPERUSER_PASSWORD" \
@@ -214,8 +225,8 @@ chk   "django_hardening's overlay path is not under a release/current path" \
   "sed -n 's/^dh_settings_path: //p' infra/ansible/roles/django_hardening/defaults/main.yml | grep -qv '/opt/arxii'"
 chk   "dh_settings_path == app_deploy's app_secret_settings_src" \
   "[ \"\$(sed -n 's/^dh_settings_path: //p' infra/ansible/roles/django_hardening/defaults/main.yml)\" = \"\$(sed -n 's/^app_secret_settings_src: //p' infra/ansible/roles/app_deploy/defaults/main.yml)\" ]"
-assert_before "app_deploy links the overlay BEFORE evennia migrate reads it" \
-  'secret_settings\.py' 'evennia migrate --noinput' \
+assert_before "app_deploy links the overlay BEFORE the migration reads it" \
+  'secret_settings\.py' 'django migrate --noinput' \
   infra/ansible/roles/app_deploy/tasks/main.yml
 
 # app_deploy clones from app_repo. A wrong value does not fail cleanly: GitHub


### PR DESCRIPTION
## Why

The first production standup never built its database. The run showed only
`Error: The operation was canceled`, which is what GitHub prints when a job
hits `timeout-minutes`. The real failure was earlier and quieter. Evidence
came from the box, not from the workflow log.

Applied migrations stopped at `arxii.0013_initial_part_13`, at 09:23:37 UTC.
The twelve migrations before it averaged 28 seconds each. The Postgres log
then recorded this at 09:23:55:

```
[41540] arxii@arxii LOG:  could not receive data from client: Connection reset by peer
[41540] arxii@arxii LOG:  unexpected EOF on client connection with an open transaction
```

The system journal gives the cause:

```
09:23:55 sshd[39357]: pam_unix(sshd:session): session closed for user arxadmin
09:23:55 systemd-logind: Session 65 logged out. Waiting for processes to exit.
09:23:55 session-65.scope: Deactivated. Consumed 8min 6.169s CPU time
```

The Ansible SSH connection dropped. systemd removed the login session scope
and killed the migration with it. Ansible then waited for a reply that never
arrived, until the 45 minute guard stopped the job 37 minutes later.

A retry could not recover, because a second and independent fault blocks
every rerun.

## The three causes

**1. The evennia launcher cannot run on a fresh box.**

Each deploy-time Django command ran as `evennia <command>`. The launcher
calls `check_database()` before it dispatches the command. That helper
imports evennia, and `evennia/utils/gametime.py` queries `server_serverconfig`
at import time. On a half-migrated database that table does not exist:

```
django.db.utils.ProgrammingError: relation "server_serverconfig" does not exist
  evennia_launcher.py -> check_database() -> evennia._init()
  -> utils/gametime.py:30 -> ServerConfig.objects.conf("gametime_offset")
```

The command that creates the table cannot start until the table exists.

The same helper ends with an interactive prompt when Account #1 is missing:

```python
else:
    create_superuser()          # interactive; blocks with no tty
    check_database(...)
```

Four tasks were exposed: `migrate`, `collectstatic`, the superuser guard, and
`createsuperuser`. The last two are circular, because the launcher tries to
create a superuser before it runs the command that creates the superuser.
`collectstatic` was the next step due to run after migrate, so this would
have stopped the standup again immediately.

An empty database hides all of this, which is why `nightly-migration-replay`
never caught it. That workflow starts from nothing, and `check_database()`
takes a different path when no tables exist at all.

All four tasks now call `python -m django`, which has neither behaviour.
`DJANGO_SETTINGS_MODULE` comes from a new `app_django_settings_module`
default, since the launcher is what used to supply it.

**2. A dropped connection killed the migration.**

The migrate task now runs detached through Ansible `async`/`poll`. A
disconnect costs a reconnect instead of the run. `ansible.cfg` also sets
`ServerAliveInterval` and `ControlPersist`, which hold the channel open
during any long and silent task. The on-box sshd is not at fault here: it has
`clientaliveinterval 0` and `tcpkeepalive yes`, and fail2ban banned no runner
address.

**3. The job budget could not fit a first run.**

Provisioning takes about 6 minutes. The first migration adds about 80, which
is 143 `arxii` migrations at 30 to 35 seconds each on a 2-core box. The 45
minute guard could never cover that. It is now 150 minutes. Steady-state
converges apply no migrations and finish well inside 15 minutes.

## Verification

The migration is running on the production box now, started by hand with
`python -m django migrate`, which is the exact command this PR moves the role
to. It resumed at `0014_initial_part_14` and is applying cleanly, so migration
0014 was never the problem. Applied migrations are durable, because Postgres
commits each one in its own transaction.

`acceptance.sh` passes with 131 checks and exit 0, and gains three guards:
deploy tasks must not call the evennia launcher, the migrate task must stay
detached, and `ansible.cfg` must keep its keepalives. An ordering check that
matched the old command string is updated. A stale pattern there is not
harmless: it aborts the whole script under `set -e`, which is how it first
appeared.

**Not yet proven:** the `async`/`poll` change cannot be exercised without a
real converge, because tofu and ansible do not run locally on Windows. If it
misbehaves it fails loudly at task start, rather than hanging, so the next
button press is a safe place to find out.
