### PR TITLE
Declare pyOpenSSL so the Portal can bind the SSL-telnet listener

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -309,6 +309,14 @@ Installed once by the converge, then running unattended on the box:
   `OnFailure=` units that fire an immediate off-box alert on failure; the daily heartbeat
   independently re-flags any backup/offsite unit still in a failed state, in case the
   `OnFailure=` alert itself didn't land.
+- **SSL-telnet needs pyOpenSSL installed.** `django_hardening` sets `SSL_ENABLED = True`
+  with `SSL_PORTS = [4003]` (and `TELNET_ENABLED = False`, so TLS is the only telnet
+  offered). Evennia's Portal imports `OpenSSL` to bind that listener, and it is NOT a
+  base Evennia dependency: upstream keeps it in the `extra` extra, alongside jupyter,
+  scipy and boto3 that a game server has no use for. `pyopenssl` and `service-identity`
+  are therefore declared directly in `pyproject.toml`. Without them the Portal exits with
+  `ImportError: No module named 'OpenSSL'`, never writes `server.pid`, and systemd fails
+  the unit on `protocol` — which is what happened on the first standup that got this far.
 - **Telnet cert renewal** (`arxii-telnet-cert.timer`, daily). Caddy's ACME cert is the
   source of truth; Evennia's SSL-telnet paths are hardcoded and don't reload on `evennia
   reload`, so this timer syncs the cert in and reboots Evennia **only when the cert

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -64,6 +64,13 @@ chkno "pg_hba has no 'trust'"         "nc infra/ansible/roles/postgres/templates
 chk   "app runs as non-root user"     "grep -q 'User={{ app_user }}' infra/ansible/roles/app_deploy/templates/arxii.service.j2"
 chk   "django: DEBUG = False"         "grep -q 'DEBUG = False' infra/ansible/roles/django_hardening/templates/secret_settings.py.j2"
 chk   "django: TELNET_ENABLED False"  "grep -q 'TELNET_ENABLED = False' infra/ansible/roles/django_hardening/templates/secret_settings.py.j2"
+# SSL_ENABLED binds a TLS-telnet listener, and Evennia's Portal imports OpenSSL
+# to do it. pyOpenSSL is NOT a base Evennia dependency (upstream parks it in the
+# `extra` extra with jupyter/scipy/boto3), so it has to be declared here or the
+# Portal dies on ImportError, never writes server.pid, and systemd fails the unit
+# on 'protocol'. That is exactly how the 2026-08-15 standup failed.
+chk   "SSL-telnet's pyOpenSSL dependency is declared" \
+  "grep -qi '^ *\"pyopenssl' pyproject.toml && grep -qi '^ *\"service-identity' pyproject.toml"
 
 # PG15+ revoked CREATE on schema public from PUBLIC, so a database-level GRANT
 # ALL leaves the migration unable to create django_migrations. The schema

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,8 @@ dependencies = [
     "django-linear-migrations>=2.19.0",
     "django-htmx>=1.27.0",
     "sentry-sdk>=2.64.0",
+    "pyopenssl>=19.1",
+    "service-identity>=18.1.0",
 ]
 
 [tool.ruff]

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.13"
 
 [manifest]
@@ -40,6 +40,7 @@ dependencies = [
     { name = "pyjwt" },
     { name = "pympler" },
     { name = "pyngrok" },
+    { name = "pyopenssl" },
     { name = "pytest" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
@@ -47,6 +48,7 @@ dependencies = [
     { name = "resend" },
     { name = "ruff" },
     { name = "sentry-sdk" },
+    { name = "service-identity" },
     { name = "tblib" },
     { name = "ty" },
     { name = "typer" },
@@ -75,6 +77,7 @@ requires-dist = [
     { name = "pyjwt", specifier = ">=2.12.0" },
     { name = "pympler", specifier = ">=1.1" },
     { name = "pyngrok", specifier = ">=7.0.0" },
+    { name = "pyopenssl", specifier = ">=19.1" },
     { name = "pytest", specifier = ">=9.0.3" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -82,6 +85,7 @@ requires-dist = [
     { name = "resend", specifier = ">=2.13.1" },
     { name = "ruff", specifier = ">=0.8.0" },
     { name = "sentry-sdk", specifier = ">=2.64.0" },
+    { name = "service-identity", specifier = ">=18.1.0" },
     { name = "tblib", specifier = ">=3.2.2" },
     { name = "ty", specifier = ">=0.0.8" },
     { name = "typer", specifier = ">=0.9" },
@@ -1033,6 +1037,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pyopenssl"
+version = "26.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3f/e8/7325d258199b159eb2c03fe32107533e2832e70e63f4fb88a6aa00023201/pyopenssl-26.4.0.tar.gz", hash = "sha256:28dfcce0162b9211413e26dfbfdf1d24317fbeba18fc93c12400a1856b2a0bc7", size = 182046, upload-time = "2026-08-01T19:50:50.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/51/ad/2cf6d3fa2fae5c79e1ed9960c0d42badd0f94d81dd12b50604cdc839e648/pyopenssl-26.4.0-py3-none-any.whl", hash = "sha256:f0eb0cb2d581d3ad2b9c489468485e7f2ab6727d08401bcf9d824c3caddf3c1c", size = 56026, upload-time = "2026-08-01T19:50:48.94Z" },
+]
+
+[[package]]
 name = "pytest"
 version = "9.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1277,6 +1293,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/60/31/b7341f156a5f6f36f0b4845d6f1c28a2ae4799171dba7007f3a1e9b234b4/sentry_sdk-2.64.0.tar.gz", hash = "sha256:68be2c29e14ae310f8a39e1a79916b6d85c6cb41dcce789d14ff05fe293e4c55", size = 921020, upload-time = "2026-06-30T08:13:47.682Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/36/a8/3fb9a4319efa3b26f5be0e90e6d8918df43fa7c7e977d26390f589501d82/sentry_sdk-2.64.0-py3-none-any.whl", hash = "sha256:715ea91ca860a819e8d8a50a7bde3a80d0df3b4ed7b6660a20fb9a2d084188f1", size = 498901, upload-time = "2026-06-30T08:13:45.566Z" },
+]
+
+[[package]]
+name = "service-identity"
+version = "26.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "attrs" },
+    { name = "cryptography" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/61/87/ad52e2c582c0f0e7f0a1b86950494c38d67422dc0f5ed9044a5fb9569a49/service_identity-26.1.0.tar.gz", hash = "sha256:6358c52882c96e66ac4a55eb3a72c7dd4a70763f8cc6fa4e70abde2656f4bf3b", size = 42898, upload-time = "2026-05-30T12:04:55.184Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/eb/2433e1af4ff903499144de4846569fb3300b816179ae99a03c2f011b666a/service_identity-26.1.0-py3-none-any.whl", hash = "sha256:68c32dadbb69135fb951077677e07cd7f6031020f3a8c8f47a28cda8a0742118", size = 11370, upload-time = "2026-05-30T12:04:53.911Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why

The first standup run to reach the service-start step failed there. Every
step #3179 fixed passed: migrate returned `ASYNC OK`, collectstatic ran, the
symlink flipped, and the bootstrap superuser was created. Then:

```
TASK [app_deploy : Ensure the game service is enabled and running]
fatal: [prod]: FAILED! => Unable to start service arxii
```

On the box, the Portal was crash-looping:

```
uv[53553]: An error has occurred: ImportError:
    No module named 'OpenSSL'
    Telnet-SSL requires the PyOpenSSL library and dependencies
systemd: Can't open PID file /opt/arxii/current/src/server/server.pid (yet?)
systemd: arxii.service: Failed with result 'protocol'
```

Evennia runs Server and Portal as two processes. The Portal dies before
writing `server.pid`, so systemd never sees the unit come up and fails it on
`protocol` rather than reporting the import error.

## Cause

`django_hardening` sets `SSL_ENABLED = True` with `SSL_PORTS = [4003]`, and
`TELNET_ENABLED = False`, so TLS is the only telnet offered. That is the
intended posture, and the external port scan on the ACCOUNT-TIME checklist
expects exactly it.

Evennia imports `OpenSSL` to bind that listener, but pyOpenSSL is not a base
Evennia dependency. Upstream parks it in the `extra` extra. `uv sync --frozen
--no-dev` installs only what is locked, so the package was never there. The
config enabled a feature whose dependency nobody had declared.

## Fix

Depending on `evennia[extra]` would resolve the import and also install
jupyter, ipython, scipy, boto3, botocore and gitpython onto a 2-core
production box. So `pyopenssl` and `service-identity` are declared directly.
The lock gains those two packages and nothing else -- cryptography and pyasn1
were already present transitively.

## Verification

- `uv run python -c "import OpenSSL, service_identity; from twisted.internet
  import ssl"` -- resolves, OpenSSL 26.4.0.
- `acceptance.sh` -- exit 0, including a new guard that ties the declaration
  to `SSL_ENABLED` so this cannot silently regress.
- `infra/README.md` records why the dependency is direct rather than an extra,
  so nobody later "simplifies" it to the upstream extra.

The real proof is the next button press reaching a started service.
