### PR TITLE
Install AWS CLI v2 from Amazon's pinned bundle; Ubuntu 24.04 has no awscli

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -296,6 +296,29 @@ What the button **does not** do (deliberately, by-design):
   flip the singleton toggle to open registration for early access, via the
   Django admin's "Registration Config" entry — no deploy required.
 
+## The `aws` CLI is installed from Amazon's bundle, not apt
+
+Ubuntu 24.04 removed the `awscli` package from the archive. Universe is enabled on the box
+and `apt-cache policy awscli` still reports no candidate, so an apt install fails outright:
+that is how the 2026-08-15 standup died at the `backups` role with `No package matching
+'awscli' is available`.
+
+The `base` role therefore installs **AWS CLI v2** from Amazon's official bundle, pinned to a
+version with a `sha256` checksum, using the same `get_url` + verify + install idiom as `uv`
+(`base_awscli_version` / `base_awscli_sha256` / `base_awscli_bin`). It lives in `base`, not
+in `backups` or `offsite_replication`, because both roles need `aws` and neither should own a
+second copy of the install.
+
+Do not "fix" this back to apt, and do not switch to another S3 client casually: `aws` is
+called in 11 places across the backup, offsite and restore paths, `infra/scripts/restore.sh`
+and `pull_prod_db.sh` included. Changing the tool means rewriting the restore path, which is
+the last thing that should acquire untested differences. `acceptance.sh` fails the build if a
+role apt-installs `awscli` again, or if the pin loses its version or checksum.
+
+Bumping the version is deliberate work: change both `base_awscli_version` and
+`base_awscli_sha256` together. The versioned download URL is byte-identical to the floating
+"latest" one, so the pin costs nothing but has to be maintained by hand.
+
 ## Ongoing safety nets (after stand-up)
 
 Installed once by the converge, then running unattended on the box:

--- a/infra/ansible/roles/backups/tasks/main.yml
+++ b/infra/ansible/roles/backups/tasks/main.yml
@@ -1,7 +1,10 @@
 ---
-- name: Install awscli + postgresql-client (pg_dump)
+# `aws` is NOT installed here: Ubuntu 24.04 has no awscli package at all, so
+# the base role installs AWS CLI v2 from Amazon's pinned, sha256-verified
+# bundle. Only postgresql-client (pg_dump) comes from apt.
+- name: Install postgresql-client (pg_dump)
   ansible.builtin.apt:
-    name: [awscli, postgresql-client]
+    name: [postgresql-client]
     state: present
     update_cache: true
     cache_valid_time: 3600

--- a/infra/ansible/roles/base/defaults/main.yml
+++ b/infra/ansible/roles/base/defaults/main.yml
@@ -21,3 +21,16 @@ base_packages:
 base_uv_version: "0.11.15"
 base_uv_sha256: "b03e572f010bea94a4a52d42671ba72981e12894f71576181a1d26ff68546da7"
 base_uv_bin: /usr/local/bin/uv
+# AWS CLI v2, pinned + sha256-verified, same idiom as uv above. Ubuntu 24.04
+# dropped the `awscli` package from the archive entirely (universe included),
+# so apt cannot supply it: `apt-cache policy awscli` reports no candidate even
+# after an update. The backups and offsite_replication roles both need the
+# `aws` command, and it appears in 11 places across those roles' templates and
+# infra/scripts (restore.sh and pull_prod_db.sh included), so switching tools
+# would mean rewriting the restore path. Installed here in base rather than in
+# either role, so there is one pinned copy instead of two.
+# The versioned URL is byte-identical to the floating "latest" one; pin the
+# version so a new upstream release cannot change what we install.
+base_awscli_version: "2.36.24"
+base_awscli_sha256: "18a0807c25cb5b1737c652c554ab40404f6928dac677e1e263bbc19e16acd2fa"
+base_awscli_bin: /usr/local/bin/aws

--- a/infra/ansible/roles/base/tasks/main.yml
+++ b/infra/ansible/roles/base/tasks/main.yml
@@ -112,6 +112,51 @@
         mode: "0755"
         remote_src: true
 
+# AWS CLI v2. Pinned version + SHA verified, same idiom as uv above, and
+# idempotent the same way: if the binary already reports the pinned version,
+# the block is skipped and nothing is downloaded.
+#
+# This lives in base, not in backups/offsite_replication, because both of those
+# roles need the `aws` command and neither should own a second copy of the
+# install. Ubuntu 24.04 removed `awscli` from the archive, so apt cannot supply
+# it at all -- the 2026-08-15 standup failed here with "No package matching
+# 'awscli' is available" after universe was already enabled.
+- name: Check installed AWS CLI version (if present)
+  ansible.builtin.command: "{{ base_awscli_bin }} --version"
+  register: base_awscli_check
+  changed_when: false
+  failed_when: false
+
+- name: Install AWS CLI v2 (pinned + sha256-verified official bundle)
+  when: "base_awscli_version not in (base_awscli_check.stdout | default(''))"
+  block:
+    - name: Ensure unzip is present (AWS ships the installer as a zip)
+      ansible.builtin.apt:
+        name: unzip
+        state: present
+        update_cache: true
+        cache_valid_time: 3600
+        lock_timeout: 600
+
+    - name: Download the AWS CLI v2 bundle
+      ansible.builtin.get_url:
+        url: "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-{{ base_awscli_version }}.zip"
+        dest: "/tmp/awscli-{{ base_awscli_version }}.zip"
+        checksum: "sha256:{{ base_awscli_sha256 }}"
+        mode: "0644"
+
+    - name: Extract the AWS CLI v2 bundle
+      ansible.builtin.unarchive:
+        src: "/tmp/awscli-{{ base_awscli_version }}.zip"
+        dest: /tmp/
+        remote_src: true
+
+    - name: Run AWS's own installer (writes {{ base_awscli_bin }})
+      # --update so a version bump replaces the existing /usr/local/aws-cli
+      # tree in place; without it the installer refuses when one is present.
+      ansible.builtin.command: /tmp/aws/install --update
+      changed_when: true
+
 - name: Create the game cgroup slice (MemoryMax isolates a leak from the box)
   ansible.builtin.copy:
     dest: /etc/systemd/system/arxii.slice

--- a/infra/ansible/roles/offsite_replication/tasks/main.yml
+++ b/infra/ansible/roles/offsite_replication/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
-- name: Ensure awscli present (also installed by backups; idempotent)
-  ansible.builtin.apt:
-    name: awscli
-    state: present
-    update_cache: true
-    cache_valid_time: 3600
-    lock_timeout: 600
+# `aws` comes from the base role's pinned, sha256-verified AWS CLI v2 bundle.
+# It used to be apt-installed here and in backups; Ubuntu 24.04 has no awscli
+# package, and one pinned copy beats two installs of a package that no longer
+# exists. Fail early and legibly rather than at 03:30 in a timer.
+- name: Assert the AWS CLI is present (installed by the base role)
+  ansible.builtin.command: "{{ base_awscli_bin | default('/usr/local/bin/aws') }} --version"
+  changed_when: false
 
 - name: Install the offsite-replication script
   ansible.builtin.template:

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -86,6 +86,17 @@ chk   "base role pins uv version + sha256"           \
   "grep -qE '^base_uv_version: ' infra/ansible/roles/base/defaults/main.yml && grep -qE '^base_uv_sha256: ' infra/ansible/roles/base/defaults/main.yml"
 chk   "app_deploy runs uv sync --frozen --no-dev"    \
   "grep -q 'sync --frozen --no-dev' infra/ansible/roles/app_deploy/tasks/main.yml"
+# Ubuntu 24.04 dropped the awscli package from the archive (universe included),
+# so `apt-cache policy awscli` reports no candidate and the apt install fails
+# outright — that is how the 2026-08-15 standup died at the backups role. The
+# `aws` command appears in 11 places across the backup, offsite and restore
+# paths, so it is installed once in base from Amazon's pinned bundle.
+chk   "base role installs AWS CLI v2 (pinned + sha-verified)" \
+  "grep -q 'awscli-exe-linux-x86_64-{{ base_awscli_version }}.zip' infra/ansible/roles/base/tasks/main.yml && grep -q 'sha256:{{ base_awscli_sha256 }}' infra/ansible/roles/base/tasks/main.yml"
+chk   "base role pins AWS CLI version + sha256" \
+  "grep -qE '^base_awscli_version: ' infra/ansible/roles/base/defaults/main.yml && grep -qE '^base_awscli_sha256: ' infra/ansible/roles/base/defaults/main.yml"
+chkno "no role apt-installs awscli (no such package on Ubuntu 24.04)" \
+  "grep -rn 'name: awscli\|\\[awscli' infra/ansible/roles/"
 chk   "app_deploy runs django migrate --noinput"     \
   "grep -q 'python -m django migrate --noinput' infra/ansible/roles/app_deploy/tasks/main.yml"
 chk   "app_deploy runs django collectstatic --noinput" \


### PR DESCRIPTION
## Why

The standup got past the service start (thanks to #3183) and then failed here:

```
TASK [backups : Install awscli + postgresql-client (pg_dump)]
fatal: [prod]: FAILED! => No package matching 'awscli' is available
```

Ubuntu 24.04 removed `awscli` from the archive. On the box, with universe
already enabled and after `apt-get update`:

```
$ apt-cache policy awscli
awscli:
  Installed: (none)
  Candidate: (none)
$ apt-cache search --names-only '^awscli'
(nothing)
```

Both `backups` and `offsite_replication` installed it that way, so neither
could ever converge on this OS.

## Fix

The `base` role installs AWS CLI v2 from Amazon's official bundle, pinned to
**2.36.24** with a sha256, using the same `get_url` + verify + install idiom as
`uv`. Idempotent the same way: if the binary already reports the pinned
version, nothing downloads.

It lives in `base` rather than in either consuming role, because both need
`aws` and neither should own a second copy of the install. `backups` keeps its
apt task for `postgresql-client` alone. `offsite_replication` asserts the
binary is present instead, so a missing CLI fails during converge rather than
at 03:30 inside a timer.

## Why not s3cmd

`s3cmd` 2.4.0 *is* in the Ubuntu repos, and staying apt-managed would be nicer.
It was rejected because `aws` is called in **11 places across 5 files**,
`infra/scripts/restore.sh` and `pull_prod_db.sh` among them. Changing the tool
means rewriting the restore path, which is the last thing that should acquire
untested differences in order to work around a packaging change.

## Verification

- Version and checksum derived on the box, not guessed. The versioned URL was
  downloaded and confirmed **byte-identical** to the floating "latest" one
  (`cmp` reports identical), so the pin is honest:
  `18a0807c25cb5b1737c652c554ab40404f6928dac677e1e263bbc19e16acd2fa`.
- `acceptance.sh` -- exit 0, with three new guards: the pinned download, the
  version+sha pair, and a standing refusal of any apt install of `awscli`.
- `infra/README.md` explains why this is not apt and why the client should not
  be swapped casually.

Bumping the version means changing `base_awscli_version` and
`base_awscli_sha256` together. That is deliberate, and the README says so.
