### PR TITLE
Stop the app-checkout secret scan failing on dependency and runtime files

### DIFF
--- a/infra/ansible/roles/secrets_perms/defaults/main.yml
+++ b/infra/ansible/roles/secrets_perms/defaults/main.yml
@@ -1,0 +1,23 @@
+---
+# Paths the "no secret-shaped files in the app checkout" scan must ignore.
+# Both are legitimate and appear on every healthy box, so without these the
+# guard fails every converge — and a check that always fails gets switched
+# off, which is how a real leak eventually gets through.
+
+# 1. The virtualenv is dependency code. `uv sync` recreates it on every
+#    deploy and we never audit or edit it (see CLAUDE.md: site-packages is
+#    read-only). certifi ships a CA bundle at certifi/cacert.pem, and Twisted
+#    ships TLS test fixtures under a directory literally named `fake_CAs`.
+secrets_scan_exclude_venv_re: '/\.venv/'
+
+# 2. Evennia's SSL-telnet material. With SSL_ENABLED the Portal generates a
+#    self-signed pair on first start, and tls_telnet_cert then syncs Caddy's
+#    real cert over it — its defaults call these paths out as HARDCODED in
+#    Evennia, not settings-driven. Runtime state, not committed secrets.
+#    Excluded from the scan and then positively checked below, so the posture
+#    is asserted rather than merely ignored.
+secrets_ssl_telnet_dir: "{{ app_gamedir | default('/opt/arxii/current/src') }}/server"
+secrets_ssl_telnet_files:
+  - "{{ secrets_ssl_telnet_dir }}/ssl.cert"
+  - "{{ secrets_ssl_telnet_dir }}/ssl.key"
+  - "{{ secrets_ssl_telnet_dir }}/ssl-public.key"

--- a/infra/ansible/roles/secrets_perms/tasks/main.yml
+++ b/infra/ansible/roles/secrets_perms/tasks/main.yml
@@ -39,8 +39,45 @@
     hidden: true
   register: leaked
 
+# The raw scan always matches two legitimate sets of files on a healthy box:
+# the virtualenv's vendored CA bundle and TLS test fixtures, and Evennia's own
+# SSL-telnet cert/key. See this role's defaults for why each is expected. Both
+# are dropped here so the assertion below only fires on something genuinely
+# unexpected — a stray key an operator copied in, a committed .env, a tfstate.
+- name: Reduce the scan to genuinely unexpected secret-shaped files
+  ansible.builtin.set_fact:
+    leaked_unexpected: >-
+      {{ leaked.files
+         | map(attribute='path')
+         | reject('search', secrets_scan_exclude_venv_re)
+         | reject('in', secrets_ssl_telnet_files)
+         | list }}
+
 - name: Fail if any secret-shaped file is committed in the app checkout
   ansible.builtin.assert:
     quiet: true
-    that: "leaked.files | length == 0"
-    fail_msg: "Secret-shaped files found in the app checkout: {{ leaked.files | map(attribute='path') | list }}"
+    that: "leaked_unexpected | length == 0"
+    fail_msg: "Secret-shaped files found in the app checkout: {{ leaked_unexpected }}"
+
+# The SSL-telnet key is excluded from the scan above, so assert its posture
+# directly rather than leaving it unchecked. A world-readable telnet private
+# key is exactly the kind of thing this role exists to catch.
+- name: Stat the SSL-telnet key material
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop: "{{ secrets_ssl_telnet_files }}"
+  register: secrets_ssl_stat
+
+- name: SSL-telnet key material must be 0600 and service-user-owned
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - "not item.stat.exists or item.stat.mode == '0600'"
+      - "not item.stat.exists or item.stat.pw_name == (secrets_owner | default('arxii'))"
+    fail_msg: >-
+      {{ item.item }} is not 0600/service-user-owned
+      (mode={{ item.stat.mode | default('absent') }},
+      owner={{ item.stat.pw_name | default('absent') }}).
+  loop: "{{ secrets_ssl_stat.results }}"
+  loop_control:
+    label: "{{ item.item }}"

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -129,6 +129,16 @@ chkno "no tracked .env"               "git ls-files | grep -E '(^|/)\\.env$'"
 chkno "no ansible-vault ciphertext committed" "git grep -lE '^\\\$ANSIBLE_VAULT;1' -- ."
 chkno "no --vault-password-file in real config" "grep -rn --include='*.sh' --include='*.cfg' --include='*.yml' -- 'vault[_-]password[_-]file' infra/ .github/ | grep -v 'infra/scripts/acceptance.sh' | grep -vE '#'"
 chk   "secrets_vault uses lookup('env')"      "grep -q \"lookup('env'\" infra/ansible/roles/secrets_vault/tasks/main.yml"
+# The app-checkout secret scan matches the venv's vendored CA bundle/TLS test
+# fixtures and Evennia's own SSL-telnet cert+key on every healthy box. Those
+# exclusions must stay, or the guard fails every converge and gets disabled —
+# which is how a real leak eventually gets through. The SSL-telnet material is
+# excluded from the scan and then positively checked, so it is never simply
+# ignored.
+chk   "secret scan excludes the venv and Evennia's SSL-telnet material" \
+  "grep -q 'secrets_scan_exclude_venv_re' infra/ansible/roles/secrets_perms/tasks/main.yml && grep -q 'secrets_ssl_telnet_files' infra/ansible/roles/secrets_perms/tasks/main.yml"
+chk   "SSL-telnet key material has its own 0600/owner assertion" \
+  "grep -q 'SSL-telnet key material must be 0600' infra/ansible/roles/secrets_perms/tasks/main.yml"
 chk   "forbidden-env guard uses REAL token names (not a dead ARXII_ guard)" \
   "grep -A4 secrets_forbidden_env infra/ansible/roles/secrets_vault/defaults/main.yml | grep -q '^[[:space:]]*- LINODE_TOKEN$'"
 chkno "standup.sh never passes secrets via --extra-vars" "nc infra/scripts/standup.sh | grep -- '--extra-vars'"


### PR DESCRIPTION
## Why

The standup cleared backups and offsite replication (111 tasks ok) and then
failed on the final safety check:

```
TASK [secrets_perms : Fail if any secret-shaped file is committed in the app checkout]
fatal: Secret-shaped files found in the app checkout: [
  ".venv/lib/python3.13/site-packages/certifi/cacert.pem",
  ".venv/lib/python3.13/site-packages/twisted/internet/test/fake_CAs/thing1.pem",
  ".venv/lib/python3.13/site-packages/twisted/internet/test/fake_CAs/thing2.pem",
  ".venv/lib/python3.13/site-packages/twisted/internet/test/fake_CAs/chain.pem",
  ".venv/lib/python3.13/site-packages/twisted/test/server.pem",
  "src/server/ssl-public.key", "src/server/ssl.key" ]
```

None of these is a leaked secret.

**The venv is dependency code.** `uv sync` recreates it on every deploy and we
never audit it. certifi ships a CA bundle; Twisted ships TLS fixtures in a
directory literally named `fake_CAs`.

**`src/server/ssl.*` is Evennia's SSL-telnet material.** With `SSL_ENABLED` the
Portal generates a self-signed pair on first start, and `tls_telnet_cert` then
syncs Caddy's real cert over it — that role's own defaults describe these paths
as HARDCODED in Evennia, not settings-driven. On the box they are already
`0600`, `arxii`-owned, created at 18:50 when the Portal first came up.

They surfaced only now because every earlier run failed before this task, when
neither the `current` symlink nor the venv existed yet.

## What changed

Both sets are excluded, so the assertion fires only on something genuinely
unexpected: a stray key copied in by hand, a committed `.env`, a `tfstate`.

The SSL-telnet material is excluded **and then positively checked** rather than
merely ignored — a new assertion requires each file to be `0600` and
service-user-owned when present. A world-readable telnet private key is
precisely what this role exists to catch, so dropping it from the scan without
replacing the check would have been a real regression.

The alternative was leaving the guard failing on every converge. A check that
always fails gets switched off, and that is how a real leak eventually gets
through.

## Verification

- `acceptance.sh` — exit 0, with two new guards: the exclusions must stay, and
  the SSL-telnet posture assertion must exist.
- Both role files parse as YAML.
- Semantics are proven by the next button press; `validate.yml` runs
  ansible-lint over the changed role in the meantime.
