### PR TITLE
Let Caddy traverse to /static: app root and releases dir become 0751

### DIFF
--- a/infra/ansible/roles/app_deploy/tasks/main.yml
+++ b/infra/ansible/roles/app_deploy/tasks/main.yml
@@ -1,11 +1,16 @@
 ---
-- name: Ensure releases dir exists
+# 0751 for the same reason as the app root in roles/base: Caddy serves
+# /static/* from <releases>/<ref>/src/server/.static and must traverse to reach
+# it. Execute-for-other permits traversal only — no listing, and file modes are
+# untouched, so the 0640 secret_settings.py inside each release stays
+# unreadable to the web server.
+- name: Ensure releases dir exists (0751 so Caddy can traverse to /static)
   ansible.builtin.file:
     path: "{{ app_releases_dir }}"
     state: directory
     owner: "{{ app_user }}"
     group: "{{ app_group }}"
-    mode: "0750"
+    mode: "0751"
 
 - name: Check out the release at its ref (idempotent; no secrets — public repo)
   ansible.builtin.git:

--- a/infra/ansible/roles/base/tasks/main.yml
+++ b/infra/ansible/roles/base/tasks/main.yml
@@ -54,13 +54,27 @@
     home: "{{ base_app_root }}"
     create_home: true
 
-- name: Lock down the app root
+# 0751, not 0750: Caddy runs as its own `caddy` user and serves /static/* off
+# disk from under this tree, so it needs to *traverse* here. The execute bit
+# for "other" grants exactly that and nothing else — the directory still cannot
+# be listed, and every file keeps its own mode. The static assets Caddy serves
+# are already world-readable (0644); the secrets under here are not
+# (secret_settings.py is 0640 arxii:arxii, the EnvironmentFile 0600), so they
+# stay unreadable to Caddy.
+#
+# The alternative — adding `caddy` to the `arxii` group — was rejected: group
+# membership would make that 0640 secret_settings.py readable by the web
+# server, handing it SECRET_KEY, the database password and the Resend key.
+# Traversal is the smaller grant. Without it the frontend serves a blank page,
+# because index.html comes from Django through the reverse proxy while every
+# dist/assets bundle 403s from Caddy's file_server.
+- name: Lock down the app root (0751 so Caddy can traverse to /static)
   ansible.builtin.file:
     path: "{{ base_app_root }}"
     state: directory
     owner: "{{ base_service_user }}"
     group: "{{ base_service_group }}"
-    mode: "0750"
+    mode: "0751"
 
 # Waits out first-boot provisioning so the apt lock isn't held by
 # apt-daily/apt-daily-upgrade on a fresh image; tolerated if cloud-init

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -62,6 +62,20 @@ echo "== postgres / app hardening =="
 chk   "postgres binds localhost only" "grep -q \"listen_addresses = 'localhost'\" infra/ansible/roles/postgres/templates/10-arxii.conf.j2"
 chkno "pg_hba has no 'trust'"         "nc infra/ansible/roles/postgres/templates/pg_hba.conf.j2 | grep -w trust"
 chk   "app runs as non-root user"     "grep -q 'User={{ app_user }}' infra/ansible/roles/app_deploy/templates/arxii.service.j2"
+# Caddy runs as its own user and serves /static/* off disk from under
+# /opt/arxii, so both parent dirs need the execute bit for "other" or every
+# asset 403s and the frontend renders a blank page. Traversal only: the dirs
+# still cannot be listed and file modes are untouched, so secret_settings.py
+# (0640) and the EnvironmentFile (0600) stay unreadable to the web server.
+chk   "app root is 0751 (Caddy can traverse, not list)" \
+  "grep -q 'mode: \"0751\"' infra/ansible/roles/base/tasks/main.yml"
+chk   "releases dir is 0751 (Caddy can traverse, not list)" \
+  "grep -q 'mode: \"0751\"' infra/ansible/roles/app_deploy/tasks/main.yml"
+# The tempting shortcut. Group membership would make the 0640 secret_settings.py
+# readable by Caddy — SECRET_KEY, DB password, Resend key. Traversal is the
+# smaller grant; never widen it to group membership.
+chkno "caddy is never added to the app group" \
+  "grep -rnE 'name: *caddy' infra/ansible/roles/*/tasks/main.yml | grep -iE 'group|append'"
 chk   "django: DEBUG = False"         "grep -q 'DEBUG = False' infra/ansible/roles/django_hardening/templates/secret_settings.py.j2"
 chk   "django: TELNET_ENABLED False"  "grep -q 'TELNET_ENABLED = False' infra/ansible/roles/django_hardening/templates/secret_settings.py.j2"
 # SSL_ENABLED binds a TLS-telnet listener, and Evennia's Portal imports OpenSSL


### PR DESCRIPTION
## Why

The site came up and served a **blank page**. `index.html` was fine (Django,
through the reverse proxy) but every `dist/assets` bundle returned 403 from
Caddy's `file_server`, as did `/static/admin/css/base.css`.

The files were never the problem — they are 0644 inside a 0775 directory. The
parents were:

```
/opt/arxii            drwxr-x---  arxii arxii
/opt/arxii/releases   drwxr-x---  arxii arxii
```

Caddy runs as its own `caddy` user (`uid=997 groups=caddy,www-data`), so it
could not traverse into the tree at all.

## Fix

Both directories become **0751**. The execute bit for "other" grants traversal
and nothing else: the directories still cannot be listed, and no file mode
changes.

**Adding `caddy` to the `arxii` group was rejected.** Group membership would
make `secret_settings.py` (0640 arxii:arxii) readable by the web server —
`SECRET_KEY`, the Postgres password and the Resend key. Traversal is the
smaller grant, and `acceptance.sh` now refuses the group shortcut outright.

## Verified on the box before committing

Running as the `caddy` user:

```
cat /etc/arxii/secret_settings.py  -> denied  (correct)
cat /etc/arxii/arxii.env           -> denied  (correct)
read .static/admin/css/base.css    -> allowed (correct)
```

Over HTTPS, both previously-403 paths now return 200:

```
GET /static/admin/css/base.css             -> 200
GET /static/dist/assets/index-BwLADimF.js  -> 200
```

The change is already applied by hand on prod, so the site works now; this PR
makes it survive the next converge. `acceptance.sh` passes at exit 0 with three
new guards: both modes, and the standing refusal to add caddy to the app group.
