### PR TITLE
Fix CONTENT_REPO_PATH pointing at repo checkout root instead of arx2 corpus root

### DIFF
--- a/docs/systems/content-authoring.md
+++ b/docs/systems/content-authoring.md
@@ -10,12 +10,23 @@ the durable source of truth, and credit stamps are the lock between them.**
 
 ## One-time setup
 
+The private lore repo is a two-game monorepo: one repo, two top-level game
+directories. The Arx II corpus lives in the `arx2/` subdirectory
+(`arx2/fixtures/`, `arx2/content/`, plus the domain directories such as
+`arx2/items/`, `arx2/skills/`). `CONTENT_REPO_PATH` must point at `arx2/`,
+not at the repo checkout root — the checkout root has no `fixtures/` or
+domain directories of its own, so every content lookup at that level
+silently finds nothing.
+
 1. Clone the private content repo somewhere on the machine.
-2. In `src/.env`, set `CONTENT_REPO_PATH` to that checkout. Every surface
-   below resolves the path through the same helper
+2. In `src/.env`, set `CONTENT_REPO_PATH` to the `arx2/` subdirectory of
+   that checkout (not the checkout root). Every surface below resolves the
+   path through the same helper
    (`core_management.content_repo.resolve_content_root()`); if it is unset,
    loading/export surfaces hide themselves and show a setup hint instead of
-   erroring.
+   erroring. A path with neither known domain directories nor a `fixtures/`
+   directory (for example, the checkout root by mistake) now raises a clear
+   error naming the path instead of silently loading zero rows.
 3. If this machine will open session pull requests (see below), make a
    GitHub token available: `GITHUB_ISSUE_TOKEN` in settings, or the
    `GH_TOKEN` env var. Local commits work without it; only the open-PR
@@ -38,8 +49,10 @@ infra" → Run workflow) with the **"Also refresh the private lore-repo
 checkout"** `workflow_dispatch` input checked — this appends
 `--tags all,content_repo` to the converge, running the ordinary deploy as
 usual plus this role. `CONTENT_REPO_PATH` is always set for the app process
-(a fixed path); the checkout itself only exists after the on-demand refresh
-has been run at least once. Expect to use this once during alpha bootstrap and
+(a fixed path, pointing at the `arx2/` subdirectory of the checkout, not the
+checkout root — see `infra/ansible/roles/content_repo/defaults/main.yml`);
+the checkout itself only exists after the on-demand refresh has been run at
+least once. Expect to use this once during alpha bootstrap and
 maybe again after a full alpha rebuild — not as part of routine ongoing
 operation. See `infra/README.md`'s "Content-repo checkout credential"
 section for the one-time credential setup.

--- a/infra/ansible/roles/content_repo/defaults/main.yml
+++ b/infra/ansible/roles/content_repo/defaults/main.yml
@@ -1,10 +1,22 @@
 ---
-# Sibling of app_releases_dir/app_current (roles/app_deploy/defaults/main.yml)
-# — same /opt/arxii root, own subdirectory. Fixed/static (not operator-
-# supplied): the app resolves it via CONTENT_REPO_PATH, which this role's
-# clone task's dest and secrets_vault's arxii.env.j2 template both derive
-# from this single var (see roles/secrets_vault/templates/arxii.env.j2).
-content_repo_path: /opt/arxii/content
+# Two separate variables, on purpose. The lore repo is a two-game monorepo
+# (both games' content in one repo, each game's corpus in its own top-level
+# subdirectory); this role clones the WHOLE repo, but the app only reads ONE
+# subdirectory of it. Conflating the two used to point CONTENT_REPO_PATH at
+# the repo root instead of the corpus subdirectory, so every content lookup
+# silently found nothing (0 created, 0 updated, no error).
+#
+# content_repo_checkout: where the role clones the repo. Sibling of
+# app_releases_dir/app_current (roles/app_deploy/defaults/main.yml) — same
+# /opt/arxii root, own subdirectory. Used by tasks/main.yml's git `dest:`
+# and by every other reference to the checkout itself (rescue message, etc.).
+content_repo_checkout: /opt/arxii/content
+
+# content_repo_path: the app-visible content root — the Arx II corpus
+# subdirectory inside the checkout. This is the value written into
+# CONTENT_REPO_PATH (see roles/secrets_vault/templates/arxii.env.j2). Fixed/
+# static (not operator-supplied).
+content_repo_path: "{{ content_repo_checkout }}/arx2"
 
 # #2236 Phase 3 P1 (dress rehearsal): the ARXII_CONTENT_REPO_TOKEN credential
 # is prod-adjacent (real GitHub PAT with real private-repo read access) —

--- a/infra/ansible/roles/content_repo/tasks/main.yml
+++ b/infra/ansible/roles/content_repo/tasks/main.yml
@@ -94,7 +94,7 @@
     - name: Clone/update the private lore-repo checkout (credential via env, never the URL or disk)
       ansible.builtin.git:
         repo: "https://github.com/{{ lookup('env', 'ARXII_CONTENT_REPO') }}.git"
-        dest: "{{ content_repo_path }}"
+        dest: "{{ content_repo_checkout }}"
         version: main
       become: true
       become_user: "{{ app_user }}"
@@ -103,13 +103,13 @@
         GIT_CONFIG_KEY_0: "http.https://github.com/.extraheader"
         GIT_CONFIG_VALUE_0: "AUTHORIZATION: basic {{ ('x-access-token:' + lookup('env', 'ARXII_CONTENT_REPO_TOKEN')) | b64encode }}"
       no_log: true
-      register: content_repo_checkout
+      register: content_repo_checkout_result
   rescue:
     - name: Fail with a diagnosable message (the block above is no_log; this is not)
       ansible.builtin.fail:
         msg: >-
           content_repo checkout failed. Likely causes: (1) local
-          modifications exist in {{ content_repo_path }} from prod-admin
+          modifications exist in {{ content_repo_checkout }} from prod-admin
           content authoring (uncommitted export output blocks the next
           refresh) — commit or discard them before the next
           refresh; (2) ARXII_CONTENT_REPO_TOKEN is expired, revoked, or

--- a/infra/ansible/roles/secrets_vault/templates/arxii.env.j2
+++ b/infra/ansible/roles/secrets_vault/templates/arxii.env.j2
@@ -54,9 +54,17 @@ SITE_URL=https://{{ dh_web_fqdn }}
 # CONTENT_REPO_PATH: consumed by src/core_management/content_repo.py's
 # resolve_content_root(). Static/derived (not operator-supplied, not
 # secret) — content_repo_path is content_repo role's own default
-# (/opt/arxii/content), visible here regardless of that role's position in
-# site.yml's role list (Ansible loads all roles' defaults for the whole
-# play up front; only TASK execution is order-sensitive). Unlike
+# (/opt/arxii/content/arx2), visible here regardless of that role's
+# position in site.yml's role list (Ansible loads all roles' defaults for
+# the whole play up front; only TASK execution is order-sensitive). Unlike
 # SENTRY_RELEASE above, this value needs no post-hoc lineinfile stamp —
 # it's known statically, not resolved from a runtime fact.
+#
+# content_repo_path is NOT the same directory the content_repo role clones
+# into (content_repo_checkout, /opt/arxii/content). The lore repo is a
+# two-game monorepo; the app only reads the Arx II corpus, which lives in
+# the arx2/ subdirectory of that checkout. Pointing this at the checkout
+# root instead of arx2/ makes every content lookup miss silently (0
+# created, 0 updated, no error) — see content_repo role's defaults for the
+# full explanation.
 CONTENT_REPO_PATH={{ content_repo_path }}

--- a/src/core_management/content_fixtures.py
+++ b/src/core_management/content_fixtures.py
@@ -850,13 +850,26 @@ def build_all(content_root: Path) -> BuildResult:
     (the lore repo's primary content format). Unknown directories are
     reference canon — ignored by design. Raises ``ContentError`` (with every
     failing file listed) when validation fails.
+
+    Also raises ``ContentError`` when ``content_root`` contains NEITHER any
+    known domain directory NOR a ``fixtures/`` directory — this is not a
+    legitimately empty corpus, it is a path that names nothing that looks
+    like a content corpus at all. The likely cause is ``CONTENT_REPO_PATH``
+    pointing at a parent of the actual corpus root (e.g. a repo checkout
+    root) rather than the corpus root itself: every domain lookup would
+    then silently miss, and a load would report "0 created, 0 updated"
+    with no error. An empty-but-present corpus (a ``fixtures/`` directory
+    with no JSON files, or a domain directory with no entries) does NOT
+    raise — that is a legitimately empty load.
     """
     result = BuildResult()
     errors: list[str] = []
+    found_any_domain_dir = False
     for domain, config in DOMAIN_BUILDERS.items():
         domain_dir = content_root / domain
         if not domain_dir.is_dir():
             continue
+        found_any_domain_dir = True
         objects: list[dict] = []
         paths: list[Path] = []
         for path in sorted(domain_dir.rglob("*.md")):
@@ -872,6 +885,15 @@ def build_all(content_root: Path) -> BuildResult:
         if objects:
             result.fixtures[config["output"]] = objects
             result.source_paths[config["output"]] = paths
+    if not found_any_domain_dir and not (content_root / "fixtures").is_dir():
+        msg = (
+            f"{content_root}: no known content domain directories and no "
+            "fixtures/ directory found. This path does not look like a "
+            "content corpus root. Likely cause: CONTENT_REPO_PATH points "
+            "at a parent of the actual corpus root instead of the corpus "
+            "root itself."
+        )
+        raise ContentError(msg)
     # Raw fixture JSON from the lore repo's fixtures/ directory.
     try:
         build_fixture_json(content_root, result)

--- a/src/core_management/tests/test_content_fixtures.py
+++ b/src/core_management/tests/test_content_fixtures.py
@@ -112,6 +112,22 @@ class ParseAndValidateTests(TestCase):
         assert "world/traits/fixtures/content_skills.json" in outputs
         assert "world/traits/fixtures/content_stats.json" in outputs
 
+    def test_empty_content_root_raises_content_error_naming_the_path(self) -> None:
+        # No domain dirs, no fixtures/ dir. This is the shape of the #944
+        # production bug: CONTENT_REPO_PATH pointed at the repo checkout root
+        # instead of the arx2/ corpus subdirectory, so every lookup silently
+        # missed and the load reported "0 created, 0 updated" with no error.
+        with self.assertRaises(ContentError) as ctx:
+            build_all(self.root)
+        assert str(self.root) in str(ctx.exception)
+
+    def test_fixtures_dir_present_but_empty_does_not_raise(self) -> None:
+        # A legitimately empty corpus: fixtures/ exists but has no JSON files.
+        (self.root / "fixtures").mkdir()
+        result = build_all(self.root)
+        assert result.entries == []
+        assert result.fixtures == {}
+
     def test_bad_category_collects_error(self) -> None:
         _write(
             self.root,

--- a/src/web/admin/tests/test_content_conflict_views.py
+++ b/src/web/admin/tests/test_content_conflict_views.py
@@ -109,6 +109,11 @@ class TestContentConflictConfigured(TestCase):
         self.content = tempfile.TemporaryDirectory()
         self.addCleanup(self.content.cleanup)
         self.root = Path(self.content.name)
+        # A real checkout always carries fixtures/, even when a given test seeds
+        # no entries into it. build_all() rejects a root holding neither domain
+        # directories nor fixtures/ as "not a corpus root at all", so create the
+        # directory here: an empty corpus is legitimate and must still load.
+        (self.root / "fixtures").mkdir(exist_ok=True)
 
     def _seed_conflict(self) -> None:
         from core_management.content_fixtures import build_all, load_entries


### PR DESCRIPTION
## Root cause

The private lore repo is a two-game monorepo. Its root holds `arx1/`, `arx2/`,
and `README.md`. The Arx II content corpus lives in `arx2/`
(`arx2/fixtures/`, `arx2/content/`, plus domain directories like
`arx2/items/`, `arx2/skills/`).

On the production box, `infra/ansible/roles/content_repo/` cloned the repo to
`/opt/arxii/content` and `roles/secrets_vault/templates/arxii.env.j2` wrote
`CONTENT_REPO_PATH=/opt/arxii/content`, the repo root, one directory too high.
`core_management.content_fixtures.build_all()` walks `content_root/<domain>`
and `build_fixture_json()` scans `content_root/fixtures/`; at the repo root
neither exists. Every lookup silently missed, and the admin "Load private
content repo" button reported "0 created, 0 updated" with no error.

## Changes

**1. Split the ansible clone destination from the app-visible content root**
(`infra/ansible/roles/content_repo/defaults/main.yml`):

- `content_repo_checkout: /opt/arxii/content` - the git clone destination.
- `content_repo_path: "{{ content_repo_checkout }}/arx2"` - the app-visible
  content root, written into `CONTENT_REPO_PATH`.

`tasks/main.yml`'s git `dest:` and rescue-message text now use
`content_repo_checkout`. Also fixed a variable-name collision the split would
otherwise hit silently: the git task's `register:` used the name
`content_repo_checkout`, which would have clobbered the new path variable on
every run (the rescue message on failure would have read a git-result dict
instead of a path string). Renamed the register target to
`content_repo_checkout_result`.

Updated `roles/secrets_vault/templates/arxii.env.j2`'s comment to describe the
two-variable arrangement.

**2. Make a zero-content load fail loudly**
(`src/core_management/content_fixtures.py`):

`build_all(content_root)` now raises `ContentError` when the content root has
NEITHER any known domain directory NOR a `fixtures/` directory - naming the
path and the likely cause (`CONTENT_REPO_PATH` pointing at a parent of the
actual corpus root). A legitimately empty corpus (a present-but-empty
`fixtures/` directory, or an empty domain directory) does NOT raise.

`src/web/admin/content_load_views.py` and
`tools/build_content_fixtures.py` already catch `ContentError` and surface it
cleanly, so no view/CLI change was needed there - verified by reading both.

**3. Docs** - `docs/systems/content-authoring.md`'s one-time setup section now
says `CONTENT_REPO_PATH` must point at the `arx2/` subdirectory of the
checkout, not the checkout root, and mentions the new loud-failure behavior.

**4. Tests** - two new tests in
`src/core_management/tests/test_content_fixtures.py::ParseAndValidateTests`:
a content root with neither domain dirs nor `fixtures/` raises `ContentError`
naming the path; a content root with a present-but-empty `fixtures/`
directory does not raise.

## How to verify

- `uv run ruff check src/core_management/content_fixtures.py
  src/core_management/tests/test_content_fixtures.py` - passes.
- `just test-fast core_management` - 349 tests, same 6 pre-existing
  Windows-local failures as on `main` before this change (unrelated to this
  fix - `test_pk_is_stripped_at_load_time`,
  `test_defer_unresolved_returns_deferred_entries`,
  `test_fixture_json_loaded_into_result`,
  `test_combined_frontmatter_and_fixture_json`,
  `test_row_is_addition_at_head_folds_case`,
  `test_row_is_addition_at_head_json_key_present_is_not_addition`); no new
  failures.
- Point `CONTENT_REPO_PATH` at a directory with neither domain dirs nor
  `fixtures/` and run `uv run python tools/build_content_fixtures.py --check`;
  it now fails with a message naming the path instead of reporting 0 results.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
