### PR TITLE
Send mail via Resend's HTTPS API, not SMTP

### DIFF
--- a/docs/adr/0216-resend-mail-rides-the-https-api-not-smtp.md
+++ b/docs/adr/0216-resend-mail-rides-the-https-api-not-smtp.md
@@ -1,0 +1,20 @@
+# ADR-0216: Outbound mail rides Resend's HTTPS API, not SMTP
+
+Context: production could not send any mail. Django's SMTP backend connected to
+`smtp.resend.com:587`, and the host's upstream provider blocks outbound SMTP (587 and
+465 both time out, to `smtp.resend.com` AND `smtp.gmail.com` alike) as a standard
+outbound-SMTP policy outside our control. Because allauth sends a verification email
+inline with account creation, the socket timeout surfaced as an HTTP 500 on the
+signup endpoint, with an account already committed and no working delivery. Asking
+the host to unblock SMTP was rejected: it is a blanket provider policy, not a
+per-account setting we can flip, and it leaves a future move to a different host with
+the identical outage. Port 443 to `api.resend.com` was already open and verified
+working, and Resend already offers delivery over its own HTTPS API, so
+`ResendAPIEmailBackend` (`world.roster.email_backend`) replaces the SMTP backend for
+`EMAIL_BACKEND` in production, sending a short-timeout `POST
+https://api.resend.com/emails` instead of opening an SMTP connection. This closes a
+whole class of failure (provider-blocked outbound ports) rather than working around
+one instance of it.
+
+> Status: accepted · Source: production outage, signup 500s on every registration ·
+> Related: none (no prior ADR recorded the SMTP transport choice)

--- a/docs/integrations/email.md
+++ b/docs/integrations/email.md
@@ -1,26 +1,32 @@
 # Email Integration
 
-Arx II uses [SendGrid](https://sendgrid.com/) for transactional email delivery, handling roster application notifications and password resets.
+Arx II uses [Resend](https://resend.com/) for transactional email delivery, handling
+roster application notifications, registration invites, character-creation review
+notices, and allauth's own verification / password-reset mail.
 
 ## Overview
 
-SendGrid provides reliable email delivery services. We use it for:
+Resend provides transactional email delivery. We use it for:
 
 - Roster application confirmations and notifications
 - Application approval/denial emails to players
 - Staff notifications for new applications
-- Password reset emails with secure tokens
-- Automated workflow communications
+- Account invites and password reset emails
+- allauth's account-verification mail
 
 ## Configuration
 
 Required environment variables in `src/.env`:
 
 ```env
-SENDGRID_API_KEY=your_sendgrid_api_key
-DEFAULT_FROM_EMAIL=noreply@yoursite.org
-SITE_DOMAIN=yoursite.org
+RESEND_API_KEY=re_your-resend-api-key
+DEFAULT_FROM_EMAIL=noreply@arx2.com
+SITE_URL=https://arx2.com
 ```
+
+`DEFAULT_FROM_EMAIL` must be an address on a domain Resend has verified for sending —
+Resend rejects a send whose From domain it does not recognize. `arx2.com` is the
+verified sending domain in production.
 
 Optional staff notification settings:
 ```env
@@ -29,18 +35,41 @@ STAFF_NOTIFICATION_EMAILS=admin1@yoursite.org,admin2@yoursite.org
 
 ## Implementation Details
 
+### Transport: Resend's HTTPS API, not SMTP
+
+`world.roster.email_backend.ResendAPIEmailBackend` sends mail with a
+`POST https://api.resend.com/emails` HTTPS call (short, explicit timeout), not an
+SMTP connection. `settings.py` wires it in as `EMAIL_BACKEND` whenever
+`RESEND_API_KEY` is set and `DEBUG` is off:
+
+```python
+EMAIL_BACKEND = "world.roster.email_backend.ResendAPIEmailBackend"
+```
+
+Production's outbound SMTP (ports 587 and 465) is blocked at the provider level,
+which used to turn every signup into an HTTP 500 (the SMTP socket connect timed
+out mid-request). Port 443 to `api.resend.com` is open, so the HTTPS API call
+never hits that block. See ADR-0216 for the full rationale.
+
+The backend does not send attachments — it raises
+`ResendAttachmentsNotSupportedError` rather than silently dropping a file, since no
+caller in this codebase sends one today.
+
 ### Service Layer
 - **Location**: `src/world/roster/email_service.py`
-- **Class**: `RosterEmailService`
-- **Key Methods**:
-  - `send_application_confirmation()` - Player receives application confirmation
-  - `send_application_approved()` - Approval notification with character details
-  - `send_application_denied()` - Denial notification with optional reason
-  - `send_staff_application_notification()` - Alert staff to new applications
-  - `send_password_reset_email()` - Secure password reset with Django tokens
+- **Class**: `EmailServiceBase` (shared `_send_email`/`_get_staff_emails`
+  primitives), subclassed by `RosterEmailService`
+  (`send_application_confirmation()`, `send_application_approved()`,
+  `send_application_denied()`, `send_staff_application_notification()`,
+  `send_password_reset_email()`)
+- **Sibling domain services**: `world.registration.email_service.RegistrationEmailService`
+  (account invites) and `world.character_creation.email_service.CGEmailService`
+  (application review) both subclass `EmailServiceBase` directly rather than
+  `RosterEmailService`, to avoid inheriting its roster-specific method signatures.
 
 ### Django Integration
-- **Backend**: `django-sendgrid-v5` configured in `settings.py`
+- **Backend**: `world.roster.email_backend.ResendAPIEmailBackend`, configured in
+  `settings.py`
 - **Templates**: HTML and plain text versions in `templates/roster/email/`
 - **Security**: Uses Django's built-in token system for password resets
 
@@ -48,12 +77,15 @@ STAFF_NOTIFICATION_EMAILS=admin1@yoursite.org,admin2@yoursite.org
 Templates are located in `src/templates/roster/email/`:
 - `application_confirmation.html` - Application receipt confirmation
 - `application_approved.html` - Approval notification
-- `application_denied.html` - Rejection notification  
+- `application_denied.html` - Rejection notification
 - `staff_notification.html` - Staff alert for new applications
 - `password_reset.html` - Secure password reset link
 
+Registration invites use `src/templates/registration/email/account_invite.html`.
+
 ### Automatic Triggers
-Emails are automatically sent via Django signals:
+Emails are sent via explicit service-function calls (never Django signals — see
+ADR-0009):
 - **Application Created**: Confirmation to player, notification to staff
 - **Application Approved**: Success notification to player
 - **Application Denied**: Update notification to player
@@ -61,7 +93,6 @@ Emails are automatically sent via Django signals:
 ## Security Features
 
 - **Token-based Password Resets**: Uses Django's secure token generator
-- **Rate Limiting**: SendGrid provides built-in rate limiting
 - **Template Escaping**: All user content is properly escaped
 - **Error Handling**: Failed emails don't block application processing
 - **Privacy Protection**: No sensitive game data in email content
@@ -80,19 +111,29 @@ Staff members receive notifications containing:
 The email service implements graceful degradation:
 - Email failures are logged but don't block game operations
 - Applications can be processed even if notifications fail
-- Retry logic for transient failures
 - Fallback to admin email list if staff emails not configured
+
+Note: this graceful degradation is a domain-service-level choice
+(`EmailServiceBase._send_email` catches and logs). It does not apply to allauth's own
+signup flow, which is unrelated code and still surfaces a failed verification send as
+an error to the caller — see ADR-0216 for the transport fix; whether that failure
+should still fail the whole signup request is a separate, open design question.
 
 ## Testing and Development
 
 For development environments:
-- Set `EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'` in settings
-- Emails will be printed to console instead of sent
-- Test with small staff email lists to avoid spam during development
+- `EMAIL_BACKEND` is always `django.core.mail.backends.console.EmailBackend` in
+  `DEBUG` mode (`src/server/conf/dev_settings.py`), regardless of `RESEND_API_KEY` —
+  no real mail is ever sent from a dev box.
+- Tests use `django.core.mail.backends.locmem.EmailBackend`
+  (`src/server/conf/test_settings.py`); assert against `django.core.mail.outbox`.
+- Unit tests for `ResendAPIEmailBackend` itself mock the HTTP call — see
+  `src/world/roster/tests/test_email_backend.py`. Never make a real network call in a
+  test.
 
 ## Monitoring and Maintenance
 
-- Monitor SendGrid dashboard for delivery rates and bounces
+- Monitor the Resend dashboard for delivery rates and bounces
 - Review email logs for failed deliveries
 - Update email templates as game features evolve
 - Maintain staff notification email lists

--- a/docs/systems/registration.md
+++ b/docs/systems/registration.md
@@ -146,10 +146,11 @@ The link is built server-side from `settings.SITE_URL`
 own `inviteLink()` helper builds the same URL from `window.location.origin`, which
 is correct in the browser but unavailable when sending mail.
 
-Delivery rides the existing Resend SMTP backend: `settings.py` switches
-`EMAIL_BACKEND` to `smtp.resend.com` whenever `RESEND_API_KEY` is present and
-`DEBUG` is off, which is the same path allauth's verification and password-reset
-mail already uses. No separate mail configuration exists for invites.
+Delivery rides the existing Resend HTTPS API backend: `settings.py` switches
+`EMAIL_BACKEND` to `world.roster.email_backend.ResendAPIEmailBackend` whenever
+`RESEND_API_KEY` is present and `DEBUG` is off, which is the same path allauth's
+verification and password-reset mail already uses. No separate mail configuration
+exists for invites. See ADR-0216 for why this is an HTTPS API call and not SMTP.
 
 ---
 

--- a/infra/ansible/group_vars/secrets.env.example
+++ b/infra/ansible/group_vars/secrets.env.example
@@ -89,10 +89,13 @@
 #
 # NOT an ARXII_* var at all — DERIVED on-box, not operator-supplied: the
 # secrets_vault EnvironmentFile also renders DATABASE_URL (from
-# ARXII_PG_PASSWORD, urlencode-filtered) and FRONTEND_URL/SITE_URL (from the
-# dh_web_fqdn group_var, itself from the tofu web_fqdn output). settings.py
-# reads all three via env() at its normal (non-overlay) import time — see
-# roles/secrets_vault/templates/arxii.env.j2 for the exact computation.
+# ARXII_PG_PASSWORD, urlencode-filtered), FRONTEND_URL/SITE_URL (from the
+# dh_web_fqdn group_var, itself from the tofu web_fqdn output), and
+# DEFAULT_FROM_EMAIL (from the vault_default_from_email group_var, default
+# "noreply@arx2.com" — the Resend-verified sending domain, see ADR-0216).
+# settings.py reads all four via env() at its normal (non-overlay) import
+# time — see roles/secrets_vault/templates/arxii.env.j2 for the exact
+# computation.
 #
 # #2236 Phase 3 P1 (dress rehearsal, gated `stage` Environment, NOT `prod`):
 # rehearse.sh generates ARXII_PG_PASSWORD/ARXII_DJANGO_SECRET_KEY/

--- a/infra/ansible/roles/django_hardening/defaults/main.yml
+++ b/infra/ansible/roles/django_hardening/defaults/main.yml
@@ -19,5 +19,4 @@ dh_service_group: arxii
 dh_allowed_hosts: []                 # = [web_fqdn, telnet_fqdn] (tofu outputs)
 dh_web_fqdn: "play.example"          # = tofu output web_fqdn; feeds WEBSOCKET_CLIENT_URL
 dh_tls_telnet_port: 4003             # = tofu output tls_telnet_port; feeds SSL_PORTS
-dh_default_from_email: "Arx II <noreply@example>"
 dh_forbidden_mta_packages: [postfix, sendmail, exim4, exim4-base]

--- a/infra/ansible/roles/django_hardening/templates/secret_settings.py.j2
+++ b/infra/ansible/roles/django_hardening/templates/secret_settings.py.j2
@@ -4,14 +4,14 @@
 # end) — this is
 # the prod hardening overlay for values env() alone can't express (booleans,
 # lists, cookie/proxy toggles). SECRET_KEY, DATABASE_URL, the Cloudinary
-# trio, RESEND_API_KEY, FRONTEND_URL, and SITE_URL are all handled by
-# settings.py's own env() reads against the secrets_vault EnvironmentFile —
-# deliberately NOT re-set here (re-setting FRONTEND_URL here, in particular,
-# would be too late: settings.py already derived allauth/CSRF values from it
-# by the time this overlay imports). NO secret VALUES in this file at all —
-# it needs no os.environ access whatsoever now that the settings it used to
-# read directly (SECRET_KEY, POSTGRES_PASSWORD, RESEND_API_KEY) all moved to
-# settings.py's own env() reads.
+# trio, RESEND_API_KEY, DEFAULT_FROM_EMAIL, FRONTEND_URL, and SITE_URL are
+# all handled by settings.py's own env() reads against the secrets_vault
+# EnvironmentFile — deliberately NOT re-set here (re-setting FRONTEND_URL
+# here, in particular, would be too late: settings.py already derived
+# allauth/CSRF values from it by the time this overlay imports). NO secret
+# VALUES in this file at all — it needs no os.environ access whatsoever now
+# that the settings it used to read directly (SECRET_KEY, POSTGRES_PASSWORD,
+# RESEND_API_KEY) all moved to settings.py's own env() reads.
 
 DEBUG = False
 ALLOWED_HOSTS = {{ dh_allowed_hosts | to_json }}
@@ -55,11 +55,12 @@ LOCKDOWN_MODE = False
 # overlay involvement needed.
 
 # Email: settings.py's own `if env("RESEND_API_KEY", default=""):` block
-# switches EMAIL_BACKEND to the Resend SMTP relay automatically once
-# RESEND_API_KEY is present in the EnvironmentFile (secrets_vault) — no
-# overlay involvement needed. Only the FROM address needs a prod-specific
-# value here.
-DEFAULT_FROM_EMAIL = "{{ dh_default_from_email }}"
+# switches EMAIL_BACKEND to ResendAPIEmailBackend (Resend's HTTPS API, see
+# ADR-0216) automatically once RESEND_API_KEY is present in the
+# EnvironmentFile (secrets_vault). DEFAULT_FROM_EMAIL is also read there
+# (settings.py's own `env("DEFAULT_FROM_EMAIL", ...)`, sourced from
+# secrets_vault's arxii.env.j2 -- see `vault_default_from_email`) — no
+# overlay involvement needed for either.
 
 # App-layer rate limiting (abuse / credential-stuffing on login & account
 # creation). Cloudflare handles the web edge; these are the Evennia-side

--- a/infra/ansible/roles/secrets_vault/defaults/main.yml
+++ b/infra/ansible/roles/secrets_vault/defaults/main.yml
@@ -83,3 +83,14 @@ vault_allow_empty: []
 # ever set there) are never mistaken for real prod traffic in the Sentry
 # project.
 vault_sentry_environment: production
+
+# Resend HTTPS API fix (ADR-0216). DEFAULT_FROM_EMAIL is not a secret, so it
+# is rendered here directly (like FRONTEND_URL/SITE_URL/CONTENT_REPO_PATH
+# below in arxii.env.j2), not routed through secrets_map's lookup('env', ...)
+# pattern. settings.py reads it via its own `env("DEFAULT_FROM_EMAIL", ...)`.
+# The default is the Resend-verified sending domain; Resend rejects a send
+# whose From address is not on a domain it has verified, so this must never
+# point at a domain Resend does not know about. standup.sh overrides this to
+# "noreply@${TF_VAR_domain}" for a real prod converge; rehearse.sh overrides
+# it to "noreply@rehearsal.invalid".
+vault_default_from_email: "noreply@arx2.com"

--- a/infra/ansible/roles/secrets_vault/templates/arxii.env.j2
+++ b/infra/ansible/roles/secrets_vault/templates/arxii.env.j2
@@ -51,6 +51,15 @@ DATABASE_URL=postgres://arxii:{{ lookup('env', 'ARXII_PG_PASSWORD') | urlencode 
 FRONTEND_URL=https://{{ dh_web_fqdn }}
 SITE_URL=https://{{ dh_web_fqdn }}
 
+# DEFAULT_FROM_EMAIL: settings.py reads this via its own `env(
+# "DEFAULT_FROM_EMAIL", default="noreply@arx2.com")` at normal (pre-overlay)
+# import time -- same treatment as FRONTEND_URL/SITE_URL above, and for the
+# same reason (no overlay involvement needed). Resend rejects a send whose
+# From address is not on a domain it has verified, so vault_default_from_email
+# (secrets_vault/defaults/main.yml) must always be an address on the
+# Resend-verified sending domain. See ADR-0216.
+DEFAULT_FROM_EMAIL={{ vault_default_from_email }}
+
 # CONTENT_REPO_PATH: consumed by src/core_management/content_repo.py's
 # resolve_content_root(). Static/derived (not operator-supplied, not
 # secret) — content_repo_path is content_repo role's own default

--- a/infra/scripts/rehearse.sh
+++ b/infra/scripts/rehearse.sh
@@ -283,9 +283,11 @@ ttc_web_fqdn: "${REHEARSAL_FQDN}"
 # django_hardening (roles/django_hardening/defaults/main.yml)
 dh_allowed_hosts: ["${REHEARSAL_FQDN}"]
 dh_web_fqdn: "${REHEARSAL_FQDN}"
-dh_default_from_email: "noreply@rehearsal.invalid"
 # Same single-sourcing as hostfw_tls_telnet_port above — see that comment.
 dh_tls_telnet_port: ${TLS_TELNET_PORT}
+
+# secrets_vault (roles/secrets_vault/defaults/main.yml)
+vault_default_from_email: "noreply@rehearsal.invalid"
 
 # backups (roles/backups/defaults/main.yml) — the REAL stage bucket
 # (terraform/ephemeral-stage's object_storage_ephemeral module) with

--- a/infra/scripts/standup.sh
+++ b/infra/scripts/standup.sh
@@ -280,7 +280,9 @@ ttc_web_fqdn: "${web_fqdn}"
 dh_allowed_hosts: ["${web_fqdn}", "${telnet_fqdn}"]
 dh_web_fqdn: "${web_fqdn}"
 dh_tls_telnet_port: ${tls_telnet_port}
-dh_default_from_email: "noreply@${TF_VAR_domain}"
+
+# secrets_vault (roles/secrets_vault/defaults/main.yml)
+vault_default_from_email: "noreply@${TF_VAR_domain}"
 
 # backups (roles/backups/defaults/main.yml)
 backups_bucket: "${backups_bucket}"

--- a/src/server/conf/settings.py
+++ b/src/server/conf/settings.py
@@ -130,22 +130,33 @@ cloudinary.config(
 )
 
 # Email configuration
-if env("RESEND_API_KEY", default="") and not DEBUG:
-    # Use Resend for email delivery in production only.
-    # In DEBUG mode, always use the console backend so registration / email
-    # verification flows work without outbound SMTP (e.g. in the devcontainer,
-    # which blocks smtp.resend.com:587). The verification key prints to the
-    # server log, where it can be extracted for manual or automated testing.
-    EMAIL_BACKEND = "django.core.mail.backends.smtp.EmailBackend"
-    EMAIL_HOST = "smtp.resend.com"
-    EMAIL_PORT = 587
-    EMAIL_USE_TLS = True
-    EMAIL_HOST_USER = "resend"
-    EMAIL_HOST_PASSWORD = env("RESEND_API_KEY")
+#
+# RESEND_API_KEY is always read into a real setting: ResendAPIEmailBackend
+# reads it from `settings.RESEND_API_KEY` at send time, not from `env()`
+# directly (the backend has no import-time access to this file's `env`
+# object).
+RESEND_API_KEY = env("RESEND_API_KEY", default="")
+
+if RESEND_API_KEY and not DEBUG:
+    # Use Resend's HTTPS API for email delivery in production only.
+    #
+    # This used to be Django's SMTP backend against smtp.resend.com:587, but
+    # the production host's upstream provider blocks outbound SMTP (587 and
+    # 465, both timing out on smtp.resend.com AND smtp.gmail.com -- a
+    # provider-level policy, not something in our control). That timeout
+    # surfaced as an HTTP 500 on the signup endpoint, because allauth sends a
+    # verification email inline with account creation. Port 443 to
+    # api.resend.com is open, so ResendAPIEmailBackend sends over Resend's
+    # HTTPS API instead. See ADR-0216.
+    #
+    # In DEBUG mode, always use the console backend instead, so no real mail
+    # is sent in development -- the verification key prints to the server
+    # log, where it can be extracted for manual or automated testing.
+    EMAIL_BACKEND = "world.roster.email_backend.ResendAPIEmailBackend"
 else:
     # Use console backend for testing when no email service configured
     EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
-DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="noreply@arxmush.org")
+DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="noreply@arx2.com")
 SITE_URL = env("SITE_URL", default="https://arxmush.org")
 
 # Sample world content in the dev seeders (#2698). OFF by default.

--- a/src/world/roster/email_backend.py
+++ b/src/world/roster/email_backend.py
@@ -1,0 +1,134 @@
+"""Resend HTTPS API email backend.
+
+Production blocks outbound SMTP (ports 587 and 465) at the hosting provider
+level -- confirmed against both smtp.resend.com and smtp.gmail.com. Django's
+SMTP backend against smtp.resend.com therefore times out, and that timeout
+surfaces as an HTTP 500 on the signup endpoint (allauth sends a verification
+email inline with account creation). Port 443 to api.resend.com is open and
+verified working, so this backend sends mail over Resend's HTTPS API instead
+of SMTP. See ADR-0216 for the full rationale and the rejected alternative
+(asking the host to unblock SMTP).
+
+Lives beside ``EmailServiceBase`` (``world.roster.email_service``): that class
+is the low-level sender every domain email service in this codebase already
+shares, and this backend is the transport layer underneath it (and underneath
+allauth's own mail, which does not go through EmailServiceBase at all).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+from django.conf import settings
+from django.core.mail.backends.base import BaseEmailBackend
+from django.core.mail.message import EmailMultiAlternatives
+import requests
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from django.core.mail.message import EmailMessage
+
+logger = logging.getLogger(__name__)
+
+RESEND_API_URL = "https://api.resend.com/emails"
+
+# A hung mail provider must never hang the request thread that triggered the
+# send (that was exactly the SMTP failure mode this backend replaces), so the
+# HTTP call always carries a short, explicit timeout.
+RESEND_TIMEOUT_SECONDS = 10
+
+
+class ResendAttachmentsNotSupportedError(Exception):
+    """Raised when a message carries attachments this backend cannot send.
+
+    The Resend HTTPS API does support a base64-encoded ``attachments`` field,
+    but nothing in this codebase sends an attachment today -- every caller of
+    ``EmailServiceBase._send_email`` (roster, registration, character_creation)
+    sends body/html only, and allauth's own mail carries no attachments either.
+    Rather than silently dropping a future attachment, this backend refuses
+    loudly so the gap gets real support instead of a mail that quietly arrives
+    without the file a user was told to expect.
+    """
+
+
+def _html_alternative(message: EmailMessage) -> str | None:
+    """Return the text/html alternative body of ``message``, if any.
+
+    ``EmailMultiAlternatives.attach_alternative(content, mimetype)`` appends to
+    ``message.alternatives`` as a list of ``(content, mimetype)`` tuples. A
+    plain ``EmailMessage`` has no such attribute at all.
+    """
+    if not isinstance(message, EmailMultiAlternatives):
+        return None
+    for content, mimetype in message.alternatives:
+        if mimetype == "text/html":
+            return str(content)
+    return None
+
+
+class ResendAPIEmailBackend(BaseEmailBackend):
+    """Django email backend that sends via Resend's HTTPS API.
+
+    Drop-in replacement for the SMTP backend: honours ``fail_silently`` the
+    same way Django's built-in backends do (swallow and continue when True,
+    raise on the first failure when False), and returns the count of messages
+    actually sent, per the ``BaseEmailBackend.send_messages`` contract.
+    """
+
+    def send_messages(self, email_messages: Sequence[EmailMessage]) -> int:
+        if not email_messages:
+            return 0
+
+        api_key = settings.RESEND_API_KEY
+        sent_count = 0
+        for message in email_messages:
+            try:
+                self._send_one(message, api_key)
+            except (requests.exceptions.RequestException, ResendAttachmentsNotSupportedError):
+                logger.exception(
+                    "Resend API send failed for message %r",
+                    message.subject,
+                )
+                if not self.fail_silently:
+                    raise
+            else:
+                sent_count += 1
+        return sent_count
+
+    def _send_one(self, message: EmailMessage, api_key: str) -> None:
+        if message.attachments:
+            error_message = (
+                f"Message {message.subject!r} has {len(message.attachments)} "
+                "attachment(s); ResendAPIEmailBackend does not send attachments."
+            )
+            raise ResendAttachmentsNotSupportedError(error_message)
+
+        payload: dict[str, object] = {
+            "from": message.from_email,
+            "to": list(message.to),
+            "subject": message.subject,
+            "text": message.body,
+        }
+        if message.cc:
+            payload["cc"] = list(message.cc)
+        if message.bcc:
+            payload["bcc"] = list(message.bcc)
+        if message.reply_to:
+            payload["reply_to"] = list(message.reply_to)
+
+        html_body = _html_alternative(message)
+        if html_body:
+            payload["html"] = html_body
+
+        response = requests.post(
+            RESEND_API_URL,
+            headers={
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            },
+            json=payload,
+            timeout=RESEND_TIMEOUT_SECONDS,
+        )
+        response.raise_for_status()

--- a/src/world/roster/tests/test_email_backend.py
+++ b/src/world/roster/tests/test_email_backend.py
@@ -1,0 +1,179 @@
+"""Tests for the Resend HTTPS API email backend.
+
+Production blocked outbound SMTP (587/465) at the provider level, so the SMTP
+backend against smtp.resend.com timed out and turned every signup into an HTTP
+500 (see ADR-0216). These tests pin ResendAPIEmailBackend's contract: it must
+never make a real network call in a test, so requests.post is mocked
+throughout.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from django.core.mail import EmailMessage, EmailMultiAlternatives
+from django.test import TestCase, override_settings
+import requests
+
+from world.roster.email_backend import (
+    RESEND_API_URL,
+    ResendAPIEmailBackend,
+    ResendAttachmentsNotSupportedError,
+)
+
+TARGET = "world.roster.email_backend.requests.post"
+
+
+def _mock_response() -> MagicMock:
+    response = MagicMock()
+    response.raise_for_status.return_value = None
+    return response
+
+
+@override_settings(RESEND_API_KEY="re_test_key")
+class ResendAPIEmailBackendTests(TestCase):
+    def test_plain_text_message_is_sent(self):
+        message = EmailMessage(
+            subject="Hello",
+            body="Plain body",
+            from_email="noreply@arx2.com",
+            to=["player@example.com"],
+        )
+        backend = ResendAPIEmailBackend()
+
+        with patch(TARGET, return_value=_mock_response()) as post:
+            sent_count = backend.send_messages([message])
+
+        self.assertEqual(sent_count, 1)
+        post.assert_called_once()
+        _args, kwargs = post.call_args
+        self.assertEqual(kwargs["json"]["from"], "noreply@arx2.com")
+        self.assertEqual(kwargs["json"]["to"], ["player@example.com"])
+        self.assertEqual(kwargs["json"]["subject"], "Hello")
+        self.assertEqual(kwargs["json"]["text"], "Plain body")
+        self.assertNotIn("html", kwargs["json"])
+        self.assertEqual(kwargs["headers"]["Authorization"], "Bearer re_test_key")
+        self.assertIn("timeout", kwargs)
+        self.assertEqual(post.call_args.args[0], RESEND_API_URL)
+
+    def test_html_alternative_is_sent_as_html(self):
+        message = EmailMultiAlternatives(
+            subject="Hello HTML",
+            body="Plain fallback",
+            from_email="noreply@arx2.com",
+            to=["player@example.com"],
+        )
+        message.attach_alternative("<p>Hi</p>", "text/html")
+        backend = ResendAPIEmailBackend()
+
+        with patch(TARGET, return_value=_mock_response()) as post:
+            backend.send_messages([message])
+
+        kwargs = post.call_args.kwargs
+        self.assertEqual(kwargs["json"]["text"], "Plain fallback")
+        self.assertEqual(kwargs["json"]["html"], "<p>Hi</p>")
+
+    def test_multiple_recipients_cc_bcc_and_reply_to(self):
+        message = EmailMessage(
+            subject="Multi",
+            body="Body",
+            from_email="noreply@arx2.com",
+            to=["one@example.com", "two@example.com"],
+            cc=["cc@example.com"],
+            bcc=["bcc@example.com"],
+            reply_to=["reply@example.com"],
+        )
+        backend = ResendAPIEmailBackend()
+
+        with patch(TARGET, return_value=_mock_response()) as post:
+            backend.send_messages([message])
+
+        payload = post.call_args.kwargs["json"]
+        self.assertEqual(payload["to"], ["one@example.com", "two@example.com"])
+        self.assertEqual(payload["cc"], ["cc@example.com"])
+        self.assertEqual(payload["bcc"], ["bcc@example.com"])
+        self.assertEqual(payload["reply_to"], ["reply@example.com"])
+
+    def test_fail_silently_true_swallows_provider_error_and_returns_zero(self):
+        message = EmailMessage(
+            subject="Will fail",
+            body="Body",
+            from_email="noreply@arx2.com",
+            to=["player@example.com"],
+        )
+        backend = ResendAPIEmailBackend(fail_silently=True)
+
+        with patch(TARGET, side_effect=requests.exceptions.ConnectTimeout("timed out")):
+            sent_count = backend.send_messages([message])
+
+        self.assertEqual(sent_count, 0)
+
+    def test_fail_silently_false_raises(self):
+        message = EmailMessage(
+            subject="Will fail",
+            body="Body",
+            from_email="noreply@arx2.com",
+            to=["player@example.com"],
+        )
+        backend = ResendAPIEmailBackend(fail_silently=False)
+
+        with patch(TARGET, side_effect=requests.exceptions.ConnectTimeout("timed out")):
+            with self.assertRaises(requests.exceptions.ConnectTimeout):
+                backend.send_messages([message])
+
+    def test_returns_count_of_successfully_sent_messages(self):
+        messages = [
+            EmailMessage(
+                subject=f"Message {i}",
+                body="Body",
+                from_email="noreply@arx2.com",
+                to=["player@example.com"],
+            )
+            for i in range(3)
+        ]
+        backend = ResendAPIEmailBackend()
+
+        with patch(TARGET, return_value=_mock_response()) as post:
+            sent_count = backend.send_messages(messages)
+
+        self.assertEqual(sent_count, 3)
+        self.assertEqual(post.call_count, 3)
+
+    def test_empty_message_list_returns_zero_without_calling_out(self):
+        backend = ResendAPIEmailBackend()
+
+        with patch(TARGET) as post:
+            sent_count = backend.send_messages([])
+
+        self.assertEqual(sent_count, 0)
+        post.assert_not_called()
+
+    def test_attachments_raise_a_typed_error(self):
+        message = EmailMessage(
+            subject="Has attachment",
+            body="Body",
+            from_email="noreply@arx2.com",
+            to=["player@example.com"],
+        )
+        message.attach("notes.txt", "some content", "text/plain")
+        backend = ResendAPIEmailBackend(fail_silently=False)
+
+        with patch(TARGET) as post:
+            with self.assertRaises(ResendAttachmentsNotSupportedError):
+                backend.send_messages([message])
+
+        post.assert_not_called()
+
+    def test_http_error_status_is_treated_as_a_failed_send(self):
+        message = EmailMessage(
+            subject="Rejected",
+            body="Body",
+            from_email="noreply@arx2.com",
+            to=["player@example.com"],
+        )
+        response = MagicMock()
+        response.raise_for_status.side_effect = requests.exceptions.HTTPError("422")
+        backend = ResendAPIEmailBackend(fail_silently=True)
+
+        with patch(TARGET, return_value=response):
+            sent_count = backend.send_messages([message])
+
+        self.assertEqual(sent_count, 0)


### PR DESCRIPTION
## Summary

Production could not send any mail. Every registration returned HTTP 500.

- The SMTP backend connected to smtp.resend.com:587. The production host's provider blocks outbound SMTP (587 and 465, confirmed against smtp.resend.com and smtp.gmail.com alike). The connection timed out. Allauth sends a verification email inline with signup, so the timeout surfaced as an HTTP 500 on the signup endpoint, after the account row already committed.
- DEFAULT_FROM_EMAIL was not set on the production box. It fell back to an unverified domain. Resend rejects a send whose From domain it has not verified.

This PR fixes both.

- Add `ResendAPIEmailBackend` (`src/world/roster/email_backend.py`). It sends mail with a short-timeout HTTPS POST to `api.resend.com` instead of an SMTP connection. Handles plain text, HTML alternatives, multiple recipients, cc, bcc, and reply-to. Refuses attachments with a typed error (`ResendAttachmentsNotSupportedError`) instead of silently dropping them; no caller sends one today.
- Wire it into `settings.py` as `EMAIL_BACKEND` in production. Keep the console backend in DEBUG.
- Add `DEFAULT_FROM_EMAIL` to the secrets_vault env template (`arxii.env.j2`), driven by `vault_default_from_email` (default `noreply@arx2.com`, the Resend-verified domain). Remove the old `django_hardening` overlay override of the same setting, since it imported last and would have won over the new env value; now there is exactly one source of truth.
- Update `docs/integrations/email.md` (was still describing SendGrid) and `docs/systems/registration.md`.
- Add ADR-0216 recording the HTTPS-API decision and the rejected alternative (asking the host to unblock SMTP).

## Test plan

- [x] `uv run ruff check` on all changed Python files
- [x] `arx test --sqlite --exclude-tag postgres world.roster.tests.test_email_backend` (9/9 pass; HTTP call mocked throughout, no real network calls)
- [x] `arx test --sqlite --exclude-tag postgres world.registration.tests.test_email_service` (9/9 pass, unaffected)
- [ ] CI (Postgres parity suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
