### PR TITLE
Guard Evennia's reload/shutdown lifecycle hooks against bare instances (#3195)

### DIFF
--- a/docs/adr/0217-guard-evennia-lifecycle-hooks-not-patch-the-dependency.md
+++ b/docs/adr/0217-guard-evennia-lifecycle-hooks-not-patch-the-dependency.md
@@ -1,0 +1,25 @@
+# ADR-0217: Guard Evennia's lifecycle hooks in our own code, not by patching the dependency
+
+Context: production reload crashed with `AttributeError: 'AccountDB' object has no attribute
+'at_server_reload'` (#3195). `evennia/server/service.py` `shutdown()` calls `at_server_reload`,
+`at_server_shutdown`, `unpuppet_all`, and `_pause_task` directly on every cached `ObjectDB`,
+`AccountDB`, and `ScriptDB` instance with no guard, assuming every cached instance is running as
+its typeclass. That assumption can be false: `set_class_from_typeclass`
+(`evennia/typeclasses/models.py`) has a fallback ladder that can leave an instance bare, and one
+branch assigns `__dbclass__` instead of `__class__`. A single bare instance in the idmapper cache
+therefore crashes the shutdown Deferred and hangs every reload until systemd kills it. We rejected
+two alternatives: editing the vendored Evennia copy in `site-packages` (forbidden outright — see
+CLAUDE.md's "Never edit dependency code," and a worktree venv edit silently poisons the shared uv
+cache); and waiting for an upstream fix (reload stays broken indefinitely, and every deploy needs a
+full player-disconnecting restart in the meantime). Instead, `evennia_extensions.typeclass_hook_guard`
+patches the three bare model classes from our own code, at Django `AppConfig.ready()` time, adding a
+loudly-logging no-op only for a hook genuinely missing from the bare class — a typeclass's own hook
+sits closer in the MRO and is never touched, so the fix is invisible to every correctly-typeclassed
+instance and only changes behavior for the already-broken bare case. Root cause (how a bare instance
+enters the cache) is tracked separately in #3195 and is not fixed here; the guard makes the symptom
+non-fatal without hiding the condition, since each stub firing logs a warning naming the class and
+instance pk. A related upstream bug found while diagnosing, not patched here:
+`evennia/accounts/models.py:109` sets `AccountDB.__settingsclasspath__` to
+`settings.BASE_SCRIPT_TYPECLASS` instead of `BASE_ACCOUNT_TYPECLASS`.
+
+> Status: accepted · Source: issue #3195 (production reload outage, 2026-08-16) · Related: none

--- a/src/evennia_extensions/CLAUDE.md
+++ b/src/evennia_extensions/CLAUDE.md
@@ -29,6 +29,17 @@ Extends Evennia's functionality with additional models and data handlers while p
 - Adaptation layer between Evennia and Arx II systems
 - Integration utilities for data conversion
 
+### `typeclass_hook_guard.py`
+- Guards Evennia's server reload/shutdown lifecycle hooks (`at_server_reload`,
+  `at_server_shutdown`, `unpuppet_all`, `_pause_task`) against a cached `ObjectDB`,
+  `AccountDB`, or `ScriptDB` instance that is running bare (not as its typeclass) —
+  see issue #3195 and ADR-0217. `install_lifecycle_hook_guards()` runs once from
+  `EvenniaExtensionsConfig.ready()` and adds a loudly-logging no-op only for a hook
+  genuinely missing from the bare model class; a typeclass's own hook is never
+  touched. Never edit `evennia/server/service.py` (site-packages) to "fix" this —
+  the guard is the sanctioned fix location. Does not address how a bare instance
+  enters the idmapper cache; that root cause is still open in #3195.
+
 ## Key Classes
 
 - **`PlayerData`**: Account extensions without replacing core Evennia models

--- a/src/evennia_extensions/apps.py
+++ b/src/evennia_extensions/apps.py
@@ -13,3 +13,16 @@ class EvenniaExtensionsConfig(AppConfig):
     name = "evennia_extensions"
     verbose_name = "Evennia Extensions"
     default_auto_field = "django.db.models.BigAutoField"
+
+    def ready(self) -> None:
+        """Install the reload/shutdown lifecycle hook guard (issue #3195).
+
+        Runs once per process, deterministically, before any request or
+        management command executes -- the same guarantee ``world.apps``
+        relies on for its cross-app registration hooks.
+        """
+        from evennia_extensions.typeclass_hook_guard import (  # noqa: PLC0415
+            install_lifecycle_hook_guards,
+        )
+
+        install_lifecycle_hook_guards()

--- a/src/evennia_extensions/tests/test_typeclass_hook_guard.py
+++ b/src/evennia_extensions/tests/test_typeclass_hook_guard.py
@@ -1,0 +1,131 @@
+"""Tests for evennia_extensions.typeclass_hook_guard (issue #3195)."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+
+class NoopHookTests(TestCase):
+    """The generated no-op stub logs a warning and behaves like a real pass-bodied hook."""
+
+    def test_noop_logs_warning_with_class_attr_and_pk(self) -> None:
+        from evennia_extensions.typeclass_hook_guard import _make_noop_hook
+
+        stub = _make_noop_hook("AccountDB", "at_server_reload")
+
+        class _FakeBareInstance:
+            pk = 42
+
+        with patch("evennia_extensions.typeclass_hook_guard.logger") as mock_logger:
+            result = stub(_FakeBareInstance())
+
+        self.assertIsNone(result)
+        mock_logger.log_warn.assert_called_once()
+        message = mock_logger.log_warn.call_args[0][0]
+        self.assertIn("AccountDB", message)
+        self.assertIn("at_server_reload", message)
+        self.assertIn("42", message)
+        self.assertIn("3195", message)
+
+    def test_noop_accepts_and_ignores_call_arguments(self) -> None:
+        """Matches upstream's pass-bodied hooks: any call signature is accepted."""
+        from evennia_extensions.typeclass_hook_guard import _make_noop_hook
+
+        stub = _make_noop_hook("ScriptDB", "_pause_task")
+
+        class _FakeBareInstance:
+            pk = 7
+
+        with patch("evennia_extensions.typeclass_hook_guard.logger"):
+            result = stub(_FakeBareInstance(), auto_pause=True)
+
+        self.assertIsNone(result)
+
+
+class InstallLifecycleHookGuardsTests(TestCase):
+    """install_lifecycle_hook_guards() patches only genuinely missing hooks."""
+
+    def test_bare_classes_get_every_hook_the_shutdown_path_calls(self) -> None:
+        """After the guard, every hook evennia/server/service.py's shutdown() calls exists.
+
+        AppConfig.ready() already installed the guard for this process before any test
+        runs, so this asserts the steady-state postcondition rather than a before/after
+        transition.
+        """
+        import evennia
+
+        from evennia_extensions.typeclass_hook_guard import install_lifecycle_hook_guards
+
+        install_lifecycle_hook_guards()
+
+        self.assertTrue(hasattr(evennia.ObjectDB, "at_server_reload"))
+        self.assertTrue(hasattr(evennia.ObjectDB, "at_server_shutdown"))
+        self.assertTrue(hasattr(evennia.AccountDB, "at_server_reload"))
+        self.assertTrue(hasattr(evennia.AccountDB, "at_server_shutdown"))
+        self.assertTrue(hasattr(evennia.AccountDB, "unpuppet_all"))
+        self.assertTrue(hasattr(evennia.ScriptDB, "at_server_reload"))
+        self.assertTrue(hasattr(evennia.ScriptDB, "at_server_shutdown"))
+        self.assertTrue(hasattr(evennia.ScriptDB, "_pause_task"))
+
+    def test_bare_accountdb_hook_is_the_installed_guard_stub(self) -> None:
+        """AccountDB itself has no at_server_reload upstream (issue #3195) -- confirm
+        the attribute the guard adds lives directly on the bare class, not inherited
+        from a typeclass, and that calling it warns instead of raising."""
+        import evennia
+
+        from evennia_extensions.typeclass_hook_guard import install_lifecycle_hook_guards
+
+        install_lifecycle_hook_guards()
+
+        stub = evennia.AccountDB.__dict__["at_server_reload"]
+
+        class _FakeBareAccount:
+            pk = 99
+
+        with patch("evennia_extensions.typeclass_hook_guard.logger") as mock_logger:
+            stub(_FakeBareAccount())
+
+        mock_logger.log_warn.assert_called_once()
+
+    def test_typeclassed_hook_is_never_overridden(self) -> None:
+        """A typeclass's own hook is untouched: the guard only patches the bare class,
+        and MRO means a typeclassed instance never falls through to the stub."""
+        from evennia.accounts.accounts import DefaultAccount
+
+        from evennia_extensions.typeclass_hook_guard import install_lifecycle_hook_guards
+
+        original = DefaultAccount.__dict__["at_server_reload"]
+
+        install_lifecycle_hook_guards()
+
+        self.assertIs(DefaultAccount.__dict__["at_server_reload"], original)
+
+    def test_install_is_idempotent(self) -> None:
+        """Calling install twice does not replace an already-installed stub."""
+        import evennia
+
+        from evennia_extensions.typeclass_hook_guard import install_lifecycle_hook_guards
+
+        install_lifecycle_hook_guards()
+        first_stub = evennia.AccountDB.__dict__["at_server_reload"]
+
+        install_lifecycle_hook_guards()
+        second_stub = evennia.AccountDB.__dict__["at_server_reload"]
+
+        self.assertIs(first_stub, second_stub)
+
+    def test_script_is_active_is_not_guarded(self) -> None:
+        """is_active is a model-field property on bare ScriptDB, not a typeclass hook,
+        so the guard must not replace it with a stub."""
+        import evennia
+
+        from evennia_extensions.typeclass_hook_guard import install_lifecycle_hook_guards
+
+        install_lifecycle_hook_guards()
+
+        # is_active is always present (the idmapper metaclass generates it as a
+        # property wrapper around db_is_active at class-definition time), and
+        # the guard must leave it exactly that: a property, never a guard stub.
+        self.assertIsInstance(evennia.ScriptDB.__dict__["is_active"], property)

--- a/src/evennia_extensions/tests/test_typeclass_hook_guard_repro.py
+++ b/src/evennia_extensions/tests/test_typeclass_hook_guard_repro.py
@@ -1,0 +1,49 @@
+"""Root-cause reproduction attempt for issue #3195.
+
+The issue's leading, unproven hypothesis is that Django's auth layer is how a
+bare (non-typeclassed) AccountDB enters the idmapper cache: AUTH_USER_MODEL is
+AccountDB, and every authenticated web request loads a user via
+django.contrib.auth.get_user(), which resolves through
+ModelBackend.get_user() -> UserModel._default_manager.get(pk=...).
+
+This test drives a real authenticated admin request (force_login, then a GET
+that touches request.user) and inspects AccountDB.get_all_cached_instances()
+afterwards for an instance whose exact __class__ is the bare AccountDB model
+rather than a subclassing typeclass.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+from django.urls import reverse
+from evennia.accounts.models import AccountDB
+
+from evennia_extensions.factories import AccountFactory
+
+
+class AuthLayerBareAccountReproductionTests(TestCase):
+    """Does an authenticated request leave a bare AccountDB in the idmapper cache."""
+
+    def test_authenticated_admin_request_does_not_leave_bare_accountdb_cached(self) -> None:
+        account = AccountFactory(is_staff=True)
+        account.is_superuser = True
+        account.save()
+
+        logged_in = self.client.force_login(account)
+        self.assertIsNone(logged_in)  # force_login returns None on success
+
+        response = self.client.get(reverse("admin:index"))
+        self.assertEqual(response.status_code, 200)
+
+        bare_instances = [
+            obj
+            for obj in AccountDB.get_all_cached_instances()
+            if type(obj) is AccountDB  # exact-class check is the point
+        ]
+
+        self.assertEqual(
+            bare_instances,
+            [],
+            "Reproduced #3195: an authenticated admin request left a bare "
+            f"AccountDB in the idmapper cache: pk(s) {[o.pk for o in bare_instances]}.",
+        )

--- a/src/evennia_extensions/typeclass_hook_guard.py
+++ b/src/evennia_extensions/typeclass_hook_guard.py
@@ -1,0 +1,139 @@
+"""Guard Evennia's server lifecycle hooks against bare, non-typeclassed instances.
+
+See issue #3195.
+
+Evennia's ``evennia/server/service.py`` ``shutdown()`` calls lifecycle hooks
+(``at_server_reload``, ``at_server_shutdown``, ``unpuppet_all``, ``_pause_task``)
+directly on every cached ``ObjectDB``, ``AccountDB``, and ``ScriptDB`` instance,
+with no guard. Those hooks are defined on the *typeclasses*
+(``DefaultObject``, ``DefaultAccount``, ``DefaultScript``), not on the bare
+Django model classes. Evennia assumes every cached instance is running as its
+typeclass, because ``TypedObject.__init__`` calls ``set_class_from_typeclass``
+on creation. That assumption can be wrong: ``set_class_from_typeclass``
+(``evennia/typeclasses/models.py``, around lines 267 to 300) has a fallback
+ladder that can leave an instance bare. One branch of that ladder assigns
+``__dbclass__`` instead of ``__class__``, so the instance never actually
+becomes its typeclass.
+
+On production this crashed reload outright::
+
+    builtins.AttributeError: 'AccountDB' object has no attribute 'at_server_reload'
+
+The exception kills the shutdown Deferred. The Server never finishes its half
+of the reload handshake. ``evennia reload`` then blocks on the AMP socket
+until systemd kills it at the 90 second timeout, and every deploy needs a
+full restart, which disconnects players.
+
+How a bare instance enters the idmapper cache is a separate, unresolved
+question (tracked in issue #3195). This module does not address that
+question. It only makes sure a missing hook cannot crash the Server.
+
+Upstream bug found while diagnosing (not patched here; report to Evennia):
+``evennia/accounts/models.py:109`` sets, on ``AccountDB``::
+
+    __settingsclasspath__ = settings.BASE_SCRIPT_TYPECLASS
+
+That is the Script typeclass path, not ``BASE_ACCOUNT_TYPECLASS``. An account
+whose typeclass import fails and falls through to ``__settingsclasspath__``
+therefore falls back to the wrong typeclass family.
+
+Design
+------
+``install_lifecycle_hook_guards()`` patches the three bare model classes
+(``evennia.accounts.models.AccountDB``, ``evennia.objects.models.ObjectDB``,
+``evennia.scripts.models.ScriptDB``) so each carries a working no-op for
+every hook the shutdown path calls, but only for hooks genuinely missing
+from the bare class. A typeclass (e.g.
+``typeclasses.accounts.Account``, via ``DefaultAccount``) defines its own
+``at_server_reload`` closer in the MRO, so a typeclassed instance keeps using
+its real hook untouched; the guard is invisible to it. Only a bare instance,
+which has no such override, falls through to the guard's no-op.
+
+The no-op is not silent. A bare instance means that object is not running as
+its typeclass anywhere, so every custom hook and method defined on its real
+typeclass is silently absent for it too. That is a bigger correctness problem
+than the reload crash. Each time a stub actually fires, it logs a warning
+naming the class and the instance pk, so the underlying condition stays
+visible in the logs instead of being permanently hidden by the guard.
+
+``ScriptDB.is_active`` is not guarded here. It is not a typeclass hook: the
+idmapper metaclass (``evennia.utils.idmapper.models.SharedMemoryModelBase``)
+generates an ``is_active`` property wrapper for the ``db_is_active`` model
+field on the bare ``ScriptDB`` class itself, so it is always present,
+typeclassed or not.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from evennia.accounts.models import AccountDB
+from evennia.objects.models import ObjectDB
+from evennia.scripts.models import ScriptDB
+from evennia.utils import logger
+
+# Imported straight from each app's `models` module rather than via the
+# `evennia.ObjectDB` / `evennia.AccountDB` / `evennia.ScriptDB` top-level
+# lazy attributes: those start as `None` and are only populated by
+# Evennia's own `evennia._init()`, which runs later than Django's app
+# loading. `install_lifecycle_hook_guards()` runs from an AppConfig.ready(),
+# so at that point the lazy attributes are still `None` -- the real model
+# classes, imported directly, are already available because Django
+# populates every app's models before calling any app's ready().
+
+# Hooks the shutdown/reload path in evennia/server/service.py calls directly
+# on cached instances, per class. Enumerated by reading shutdown() line by
+# line (2026-08-16): ObjectDB.at_server_reload/at_server_shutdown,
+# AccountDB.at_server_reload/at_server_shutdown/unpuppet_all,
+# ScriptDB.at_server_reload/at_server_shutdown/_pause_task. The
+# `_SA(p, "is_connected", False)` call uses `object.__setattr__` directly, and
+# `ScriptDB.is_active` is a model-level property (see module docstring), so
+# neither needs a guard.
+_GUARDED_CLASSES = {
+    ObjectDB: ("at_server_reload", "at_server_shutdown"),
+    AccountDB: ("at_server_reload", "at_server_shutdown", "unpuppet_all"),
+    ScriptDB: ("at_server_reload", "at_server_shutdown", "_pause_task"),
+}
+
+
+def _make_noop_hook(class_name: str, attr_name: str) -> Any:
+    """Build a logging no-op to stand in for a missing lifecycle hook.
+
+    Args:
+        class_name: Name of the bare model class the stub is installed on.
+        attr_name: Name of the missing hook/method.
+
+    Returns:
+        A function suitable for use as an unbound method: it accepts and
+        ignores any positional/keyword arguments the real hook would have
+        received, so it matches upstream's no-op (``pass``-bodied) semantics
+        regardless of call signature.
+    """
+
+    def _noop(self: Any, *_args: Any, **_kwargs: Any) -> None:
+        logger.log_warn(
+            f"typeclass_hook_guard: {class_name} pk={self.pk} has no '{attr_name}'. "
+            "This instance is running bare, not as its typeclass -- every custom "
+            "hook and method on its real typeclass is silently absent for it. "
+            "See issue #3195."
+        )
+
+    _noop.__name__ = f"guarded_{attr_name}"
+    _noop.__doc__ = (
+        f"typeclass_hook_guard no-op stand-in for a missing '{attr_name}'. See issue #3195."
+    )
+    return _noop
+
+
+def install_lifecycle_hook_guards() -> None:
+    """Patch bare Evennia model classes with no-ops for missing lifecycle hooks.
+
+    Idempotent and safe to call more than once: only ever adds an attribute
+    that is genuinely absent from the bare class, and never overwrites an
+    attribute that already exists (whether it is a real hook, an inherited
+    typeclass override, or a guard installed by an earlier call).
+    """
+    for cls, attr_names in _GUARDED_CLASSES.items():
+        for attr_name in attr_names:
+            if not hasattr(cls, attr_name):
+                setattr(cls, attr_name, _make_noop_hook(cls.__name__, attr_name))


### PR DESCRIPTION
## Summary

- Guards Evennia's server reload/shutdown lifecycle hooks (`at_server_reload`,
  `at_server_shutdown`, `unpuppet_all`, `_pause_task`) so a bare (non-typeclassed)
  cached `ObjectDB`/`AccountDB`/`ScriptDB` instance cannot crash the shutdown
  Deferred and hang reload, as it did in production.
- `evennia_extensions.typeclass_hook_guard.install_lifecycle_hook_guards()` patches
  the three bare model classes once, from `EvenniaExtensionsConfig.ready()`. It only
  adds a hook that is genuinely missing from the bare class, and every stub logs a
  warning naming the class and pk when it fires, so the underlying bare-instance
  condition stays visible rather than being hidden.
- Records the decision in `docs/adr/0217-guard-evennia-lifecycle-hooks-not-patch-the-dependency.md`
  and documents the module in `src/evennia_extensions/CLAUDE.md`.
- Attempted to reproduce the root cause (how a bare instance enters the idmapper
  cache) with an authenticated Django admin request test
  (`test_typeclass_hook_guard_repro.py`). It did **not** reproduce locally: after
  `force_login` + a request that reads `request.user`, `AccountDB.get_all_cached_instances()`
  held no instance whose exact `__class__` was the bare `AccountDB`. This rules out
  the simplest form of the Django-auth-layer hypothesis under SQLite/local dev, but
  does not rule out the hypothesis under production conditions (Postgres, real
  session middleware stack, concurrent requests, idmapper cache eviction timing).
  Root cause stays open in #3195.
- Also records, without patching, the upstream bug found while diagnosing:
  `evennia/accounts/models.py:109` sets `AccountDB.__settingsclasspath__` to
  `settings.BASE_SCRIPT_TYPECLASS` instead of `BASE_ACCOUNT_TYPECLASS`.

Closes #3195.

## Hooks guarded and how they were enumerated

Read `evennia/server/service.py`'s `shutdown()` line by line (reload, reset, and
shutdown branches):

- `ObjectDB.at_server_reload`, `ObjectDB.at_server_shutdown`
- `AccountDB.at_server_reload`, `AccountDB.at_server_shutdown`, `AccountDB.unpuppet_all`
- `ScriptDB.at_server_reload`, `ScriptDB.at_server_shutdown`, `ScriptDB._pause_task`

Not guarded, deliberately:
- `_SA(p, "is_connected", False)` uses `object.__setattr__` directly, not a hook call.
- `ScriptDB.is_active` is not a typeclass hook. The idmapper metaclass
  (`SharedMemoryModelBase`) generates it as a property wrapper around the
  `db_is_active` model field on the bare `ScriptDB` class itself at class-definition
  time, so it is always present regardless of typeclass state.

## Test plan

- [x] `uv run ruff check` on all changed Python (clean)
- [x] `tools/lint_objectdb_param.py` / `tools/lint_identifier_dashes.py` on all changed
      Python (clean)
- [x] `arx test --sqlite --exclude-tag postgres` on the new test modules: 8/8 pass
  - Unit tests: a class lacking a hook gets a working no-op; a typeclass's own hook is
    never overridden; the guard is idempotent; the warning fires when a stub is
    called; `ScriptDB.is_active` is confirmed to stay a plain property, never guarded.
  - Reproduction attempt (did not reproduce; see Summary)
- [ ] CI (Postgres parity suite) — pending
