### PR TITLE
Assert 0600 on the SSL-telnet key only, not on the public cert

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -349,7 +349,10 @@ Installed once by the converge, then running unattended on the box:
   above draws for `app_gamedir`; `roles/tls_telnet_cert`'s `ttc_game_dir` and
   `roles/django_hardening`'s `dh_game_dir` both had this off-by-one until #2236 review).
   The heartbeat's cert-expiry and self-signed-issuer checks catch the case where this sync
-  has silently stopped working.
+  has silently stopped working. The sync installs `ssl.cert` at `0644` and `ssl.key` at
+  `0600`, and Evennia writes the same split when it generates the self-signed pair on a
+  first start; `roles/secrets_perms` asserts that posture per file, so do not "harden" the
+  cert to `0600` — the next renewal would revert it and fail the converge.
 
 ## Generating the SSH admin key (one-time)
 

--- a/infra/ansible/roles/secrets_perms/defaults/main.yml
+++ b/infra/ansible/roles/secrets_perms/defaults/main.yml
@@ -16,8 +16,24 @@ secrets_scan_exclude_venv_re: '/\.venv/'
 #    Evennia, not settings-driven. Runtime state, not committed secrets.
 #    Excluded from the scan and then positively checked below, so the posture
 #    is asserted rather than merely ignored.
+#
+#    The three files do not share one posture, so the checks are split. Only
+#    ssl.key is private and must be 0600. ssl.cert is an X.509 certificate and
+#    ssl-public.key is a public key: both are published to every client that
+#    opens an SSL-telnet connection, so 0600 buys nothing. Worse, it cannot
+#    hold — Evennia writes the pair at the default umask when it generates a
+#    self-signed cert on first start, and tls_telnet_cert's sync script
+#    installs the renewed Caddy cert at 0644 by design. Asserting 0600 on the
+#    public files therefore fails the converge on a correctly configured box,
+#    which is the "always fails, gets switched off" failure this role's other
+#    exclusions exist to avoid. They are checked for owner and for not being
+#    group- or world-writable instead.
 secrets_ssl_telnet_dir: "{{ app_gamedir | default('/opt/arxii/current/src') }}/server"
-secrets_ssl_telnet_files:
-  - "{{ secrets_ssl_telnet_dir }}/ssl.cert"
+secrets_ssl_telnet_private_files:
   - "{{ secrets_ssl_telnet_dir }}/ssl.key"
+secrets_ssl_telnet_public_files:
+  - "{{ secrets_ssl_telnet_dir }}/ssl.cert"
   - "{{ secrets_ssl_telnet_dir }}/ssl-public.key"
+# Combined, for the scan exclusion above — every one of them is runtime state.
+secrets_ssl_telnet_files: >-
+  {{ secrets_ssl_telnet_private_files + secrets_ssl_telnet_public_files }}

--- a/infra/ansible/roles/secrets_perms/tasks/main.yml
+++ b/infra/ansible/roles/secrets_perms/tasks/main.yml
@@ -59,16 +59,18 @@
     that: "leaked_unexpected | length == 0"
     fail_msg: "Secret-shaped files found in the app checkout: {{ leaked_unexpected }}"
 
-# The SSL-telnet key is excluded from the scan above, so assert its posture
-# directly rather than leaving it unchecked. A world-readable telnet private
-# key is exactly the kind of thing this role exists to catch.
-- name: Stat the SSL-telnet key material
+# The SSL-telnet material is excluded from the scan above, so assert its
+# posture directly rather than leaving it unchecked. A world-readable telnet
+# private key is exactly the kind of thing this role exists to catch. The
+# private key and the two public files get different checks — see this role's
+# defaults for why 0600 is both pointless and unholdable on the public ones.
+- name: Stat the SSL-telnet private key
   ansible.builtin.stat:
     path: "{{ item }}"
-  loop: "{{ secrets_ssl_telnet_files }}"
-  register: secrets_ssl_stat
+  loop: "{{ secrets_ssl_telnet_private_files }}"
+  register: secrets_ssl_private_stat
 
-- name: SSL-telnet key material must be 0600 and service-user-owned
+- name: SSL-telnet private key must be 0600 and service-user-owned
   ansible.builtin.assert:
     quiet: true
     that:
@@ -78,6 +80,29 @@
       {{ item.item }} is not 0600/service-user-owned
       (mode={{ item.stat.mode | default('absent') }},
       owner={{ item.stat.pw_name | default('absent') }}).
-  loop: "{{ secrets_ssl_stat.results }}"
+  loop: "{{ secrets_ssl_private_stat.results }}"
+  loop_control:
+    label: "{{ item.item }}"
+
+- name: Stat the SSL-telnet public material
+  ansible.builtin.stat:
+    path: "{{ item }}"
+  loop: "{{ secrets_ssl_telnet_public_files }}"
+  register: secrets_ssl_public_stat
+
+# Readable by anyone is fine and expected here. Writable by anyone is not: an
+# attacker who can rewrite the cert can serve players a key it also controls.
+- name: SSL-telnet public material must be service-user-owned and not group/world-writable
+  ansible.builtin.assert:
+    quiet: true
+    that:
+      - "not item.stat.exists or not item.stat.wgrp"
+      - "not item.stat.exists or not item.stat.woth"
+      - "not item.stat.exists or item.stat.pw_name == (secrets_owner | default('arxii'))"
+    fail_msg: >-
+      {{ item.item }} is group/world-writable or not service-user-owned
+      (mode={{ item.stat.mode | default('absent') }},
+      owner={{ item.stat.pw_name | default('absent') }}).
+  loop: "{{ secrets_ssl_public_stat.results }}"
   loop_control:
     label: "{{ item.item }}"

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -151,8 +151,17 @@ chk   "secrets_vault uses lookup('env')"      "grep -q \"lookup('env'\" infra/an
 # ignored.
 chk   "secret scan excludes the venv and Evennia's SSL-telnet material" \
   "grep -q 'secrets_scan_exclude_venv_re' infra/ansible/roles/secrets_perms/tasks/main.yml && grep -q 'secrets_ssl_telnet_files' infra/ansible/roles/secrets_perms/tasks/main.yml"
-chk   "SSL-telnet key material has its own 0600/owner assertion" \
-  "grep -q 'SSL-telnet key material must be 0600' infra/ansible/roles/secrets_perms/tasks/main.yml"
+# Split by what each file actually is. Only ssl.key is private. ssl.cert and
+# ssl-public.key go to every SSL-telnet client, and both Evennia's first-start
+# generation and tls_telnet_cert's sync write them 0644 — so a 0600 assertion
+# on them fails the converge on a healthy box. They get an owner +
+# not-group/world-writable assertion instead, which is the property that holds.
+chk   "SSL-telnet PRIVATE key has its own 0600/owner assertion" \
+  "grep -q 'SSL-telnet private key must be 0600' infra/ansible/roles/secrets_perms/tasks/main.yml"
+chk   "SSL-telnet PUBLIC material is asserted not group/world-writable" \
+  "grep -q 'SSL-telnet public material must be service-user-owned and not group/world-writable' infra/ansible/roles/secrets_perms/tasks/main.yml"
+chkno "no assertion demands 0600 on the public SSL-telnet cert/public key" \
+  "grep -n 'secrets_ssl_telnet_public_files' -A 12 infra/ansible/roles/secrets_perms/tasks/main.yml | grep \"mode == '0600'\""
 chk   "forbidden-env guard uses REAL token names (not a dead ARXII_ guard)" \
   "grep -A4 secrets_forbidden_env infra/ansible/roles/secrets_vault/defaults/main.yml | grep -q '^[[:space:]]*- LINODE_TOKEN$'"
 chkno "standup.sh never passes secrets via --extra-vars" "nc infra/scripts/standup.sh | grep -- '--extra-vars'"


### PR DESCRIPTION
## What broke

The 2026-08-16 standup run failed at `secrets_perms`:

```
/opt/arxii/current/src/server/ssl.cert is not 0600/service-user-owned
(mode=0644, owner=arxii).
```

The box is configured correctly. The assertion is wrong.

`secrets_perms` asserted mode `0600` on all three SSL-telnet paths. Only one of
them is private:

| file | content | correct mode |
| --- | --- | --- |
| `ssl.key` | private key | `0600` |
| `ssl.cert` | X.509 certificate | `0644` |
| `ssl-public.key` | public key | `0644` |

The certificate and the public key go to every client that opens an SSL-telnet
connection, so `0600` protects nothing on them.

It also cannot hold. Evennia writes the pair at the default umask when it
generates the self-signed cert on a first start, and `tls_telnet_cert`'s sync
script installs the renewed Caddy cert with `install -m 0644` by design:

```sh
install -o ... -m 0644 "$SRC_CRT" "$DST_CRT"
install -o ... -m 0600 "$SRC_KEY" "$DST_KEY"
```

So a hand `chmod 0600` on the box would be reverted at the next cert renewal
and the converge would fail again. This is the same "a check that always fails
gets switched off" failure the role's other exclusions already exist to avoid.

## Why it surfaced now

The assertion has been wrong since it landed. The play never reached it: the
`app_deploy` reload step failed first on every run. #3196 cleared that step, the
play ran further than before, and hit this.

## The change

Split the check by what the file actually is.

- `ssl.key` keeps the `0600` and owner assertion.
- `ssl.cert` and `ssl-public.key` are asserted for owner and for not being
  group- or world-writable. That is the property that matters: an attacker who
  can rewrite the certificate can serve players a key it also controls.

`secrets_ssl_telnet_files` stays as the combined list, so the secret-shaped-file
scan exclusion above is unchanged.

`infra/README.md` records the split next to the cert-renewal description, so a
later reader does not "harden" the certificate back to `0600`.

## Verification

Read off production during the failed run:

```
-rw-r--r-- 1 arxii arxii 4811 Aug 16 04:30 ssl.cert
-rw------- 1 arxii arxii  227 Aug 16 04:30 ssl.key
```

`ssl.cert` passes the new public-material check (owner `arxii`, not
group/world-writable). `ssl.key` passes the unchanged private check. The next
standup run is the end-to-end proof.
