### PR TITLE
Accept a list of sessions in unpuppet_object, as the base method does

### DIFF
--- a/src/typeclasses/CLAUDE.md
+++ b/src/typeclasses/CLAUDE.md
@@ -23,6 +23,19 @@ Core game objects (characters, rooms, exits, etc.) with Arx II customizations ex
 ### `accounts.py`
 - **`Account`**: Extends `DefaultAccount`
 - Integration with roster system and character management
+- **An override must accept everything the base method accepts.** Read the
+  parent's docstring for the argument contract before narrowing it.
+  `unpuppet_object` takes `Session OR a list of sessions` and fans out with
+  `make_iter`; an override that assumed a single session raised AttributeError
+  under `unpuppet_all` — which the Server calls on every cached account during
+  reload and shutdown — killing the shutdown Deferred and hanging
+  `evennia reload` until systemd timed it out (#3195). The same trap applies to
+  every hook the reload path touches.
+- **Do not use `MagicMock` for a session in tests.** It auto-creates `__iter__`,
+  so `make_iter` treats it as an empty sequence and the base call silently does
+  nothing. Use a plain `Mock` (see `_session_mock` in
+  `tests/test_account_puppet_broadcast.py`), which behaves like a real,
+  non-iterable session.
 
 ### `channels.py`
 - **`Channel`**: Extends `DefaultChannel`

--- a/src/typeclasses/accounts.py
+++ b/src/typeclasses/accounts.py
@@ -25,6 +25,7 @@ several more options for customizing the Guest account system.
 from django.conf import settings
 from django.utils.functional import cached_property
 from evennia.accounts.accounts import DefaultAccount, DefaultGuest
+from evennia.utils.utils import make_iter
 
 from commands.utils import serialize_cmdset
 from core.descriptors import ReverseOneToOneOrNone
@@ -320,15 +321,24 @@ class Account(DefaultAccount):
         return True, f"Now controlling {character.name}."
 
     def unpuppet_object(self, session) -> None:
-        """Unpuppet a character from a session and broadcast the change.
+        """Unpuppet a character from one session, or from a list of sessions.
 
         Triggered both by explicit @ic swaps (which call this internally before
         re-puppeting) and by session disconnects (browser tab close, telnet quit).
         Broadcasting on every unpuppet keeps other tabs' portrait-grid state
         consistent without requiring a refresh.
+
+        `session` takes a Session OR a list of them, matching the base method's
+        documented contract. Honouring the list form is not optional: Evennia's
+        own `unpuppet_all` calls `self.unpuppet_object(self.sessions.all())`,
+        and the Server calls `unpuppet_all` on every cached account during
+        reload and shutdown. An override that assumed a single session raised
+        AttributeError there, which killed the shutdown Deferred and left
+        `evennia reload` hanging on AMP until systemd timed it out (#3195).
         """
         super().unpuppet_object(session)
-        self._broadcast_puppet_changed(session, character=None)
+        for sess in make_iter(session):
+            self._broadcast_puppet_changed(sess, character=None)
 
     def at_account_creation(self):
         """Called when account is first created."""

--- a/src/typeclasses/tests/test_account_puppet_broadcast.py
+++ b/src/typeclasses/tests/test_account_puppet_broadcast.py
@@ -1,6 +1,6 @@
 """Tests for Account puppet_changed broadcast on @ic swaps."""
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, Mock
 
 from django.test import TestCase
 
@@ -35,6 +35,41 @@ def _restore_super_puppet(account, original) -> None:
     """Restore the parent class's puppet_object to `original`."""
     parent = type(account).__mro__[1]
     parent.puppet_object = original
+
+
+def _session_mock(sessid, puppet=None):
+    """A stand-in session that is NOT iterable, like a real Evennia session.
+
+    Deliberately `Mock`, not `MagicMock`. MagicMock auto-creates `__iter__`,
+    and Evennia's `make_iter` dispatches on `hasattr(obj, "__iter__")` — so a
+    MagicMock session is silently treated as an empty sequence by every
+    make_iter caller, including the base `unpuppet_object`. That made the
+    single-session assertions pass for the wrong reason and hid the list-form
+    bug in #3195. A plain Mock has no `__iter__`, so make_iter wraps it exactly
+    as it wraps a real session.
+    """
+    sess = Mock(sessid=sessid)
+    sess.puppet = puppet
+    return sess
+
+
+def _patch_super_unpuppet(account, fake) -> object:
+    """Replace the parent class's unpuppet_object with `fake`; return the original.
+
+    The unpuppet tests assert what the OVERRIDE broadcasts. Stubbing the parent
+    keeps Evennia's real teardown (tag removal, signals, `del obj.account`) out
+    of a test that is not about it.
+    """
+    parent = type(account).__mro__[1]
+    original = parent.unpuppet_object
+    parent.unpuppet_object = fake
+    return original
+
+
+def _restore_super_unpuppet(account, original) -> None:
+    """Restore the parent class's unpuppet_object to `original`."""
+    parent = type(account).__mro__[1]
+    parent.unpuppet_object = original
 
 
 class PuppetCharacterBroadcastTests(TestCase):
@@ -182,12 +217,18 @@ class UnpuppetBroadcastTests(TestCase):
         )
 
     def test_unpuppet_broadcasts_with_null_character(self) -> None:
-        sess1 = MagicMock(sessid=10)
-        sess1.puppet = self.character
-        sess2 = MagicMock(sessid=11, puppet=None)
+        sess1 = _session_mock(10, puppet=self.character)
+        sess2 = _session_mock(11)
         self.account.sessions.all = lambda: [sess1, sess2]
 
-        self.account.unpuppet_object(sess1)
+        fake_super = MagicMock()
+        original = _patch_super_unpuppet(self.account, fake_super)
+        try:
+            self.account.unpuppet_object(sess1)
+        finally:
+            _restore_super_unpuppet(self.account, original)
+
+        assert fake_super.call_args.args[0] is sess1
 
         for sess in (sess1, sess2):
             puppet_calls = [
@@ -200,6 +241,36 @@ class UnpuppetBroadcastTests(TestCase):
             assert payload["session_id"] == 10
             assert payload["character_id"] is None
             assert payload["character_name"] is None
+
+    def test_unpuppet_all_passes_a_list_and_broadcasts_per_session(self) -> None:
+        """`unpuppet_all` hands `unpuppet_object` a LIST of sessions.
+
+        This is the reload/shutdown path: the Server calls `unpuppet_all` on
+        every cached account. The override used to read `.sessid` straight off
+        the argument, so the list form raised AttributeError, killed the
+        shutdown Deferred, and left `evennia reload` hanging until systemd
+        timed it out (#3195). One broadcast is expected per unpuppeted session.
+        """
+        sess1 = _session_mock(10, puppet=self.character)
+        sess2 = _session_mock(11)
+        self.account.sessions.all = lambda: [sess1, sess2]
+
+        fake_super = MagicMock()
+        original = _patch_super_unpuppet(self.account, fake_super)
+        try:
+            self.account.unpuppet_all()
+        finally:
+            _restore_super_unpuppet(self.account, original)
+
+        # The parent must receive the list unchanged — it does its own make_iter.
+        assert fake_super.call_args.args[0] == [sess1, sess2]
+
+        broadcast_session_ids = {
+            call.kwargs["args"][0]["session_id"]
+            for call in sess1.msg.call_args_list
+            if call.kwargs.get("type") == WebsocketMessageType.PUPPET_CHANGED.value
+        }
+        assert broadcast_session_ids == {10, 11}
 
 
 class CanPuppetForSeanceTests(TestCase):


### PR DESCRIPTION
## A second cause of the reload hang, this one in our code

Found in production's `server.log` while checking whether #3196's guard had
fired:

```
File "evennia/accounts/accounts.py", line 589, in unpuppet_all
    self.unpuppet_object(self.sessions.all())
File "src/typeclasses/accounts.py", line 331, in unpuppet_object
    self._broadcast_puppet_changed(session, character=None)
File "src/typeclasses/accounts.py", line 280, in _broadcast_puppet_changed
    "session_id": session.sessid,
builtins.AttributeError: 'list' object has no attribute 'sessid'
```

Evennia's `DefaultAccount.unpuppet_object` documents its argument as
`Session or list` and fans out with `make_iter`. Our override narrowed that
contract to a single session, then read `.sessid` off it. `unpuppet_all` passes
the list form, and the Server calls `unpuppet_all` on every cached account
during reload and shutdown. The exception kills the shutdown Deferred — the
same failure as #3195, reached through a different line.

## Why this one matters more than the bare AccountDB

#3195 needs a mis-typeclassed instance in the idmapper cache, which we still
cannot reproduce on demand. This needs only a logged-in account.

Both reloads on 2026-08-16 after #3196 shipped were clean, and the guard logged
zero hits — the cache had no bare instance either time, and nobody was
connected. Reload is not proven fixed by those runs. This bug would have hung
the first reload with a player online.

## The change

Fan out with `make_iter`, so the broadcast covers exactly the sessions the base
method unpuppeted.

## Test

`test_unpuppet_all_passes_a_list_and_broadcasts_per_session` drives the fix
through `unpuppet_all`, the real caller. Verified against the old code:

```
ERROR: test_unpuppet_all_passes_a_list_and_broadcasts_per_session
AttributeError: 'list' object has no attribute 'sessid'
```

`arx test typeclasses` passes (66 tests).

## A test-scaffolding bug found on the way

The existing unpuppet tests used `MagicMock` sessions. `MagicMock` auto-creates
`__iter__`, and `make_iter` dispatches on `hasattr(obj, "__iter__")` — so a
MagicMock session was treated as an *empty sequence* by every `make_iter`
caller, the base `unpuppet_object` included. The base call did nothing, and the
assertions passed for the wrong reason. That is why the suite was green while
production was raising on this path.

Replaced with plain `Mock` sessions via a `_session_mock` helper, which have no
`__iter__` and behave like real sessions. The unpuppet tests now stub the
parent explicitly and assert it received the argument unchanged.

Both traps are recorded in `src/typeclasses/CLAUDE.md`: do not narrow a base
method's argument contract, and do not use `MagicMock` for a session.

## Does not close #3195

#3195 stays open. Its root-cause question — how a bare `AccountDB` enters the
idmapper cache — is untouched by this, and the guard remains unexercised.
