### PR TITLE
Stop scanning RENAMES.json as if it were a fixture file

### DIFF
--- a/src/core_management/content_fixtures.py
+++ b/src/core_management/content_fixtures.py
@@ -820,13 +820,21 @@ def build_fixture_json(content_root: Path, result: BuildResult) -> None:
     reader for that subtree. Without this exclusion, any content repo with
     authored grid content would fail every ``build_all`` call (including
     ``--check``) with "expected a JSON array of fixture objects."
+
+    ``RENAMES.json`` is excluded for exactly the same reason (#3162 added it,
+    this exclusion was missed). It lives at ``fixtures/RENAMES.json`` — inside
+    the scanned tree — and is a mapping of ``{"app.model": {"old": "new"}}``,
+    not an array, so a corpus that has one failed every load with that same
+    error. ``_apply_renames`` is its only reader. The name is reserved corpus-
+    wide rather than only at the top level: a nested one would be ignored by
+    the renames reader anyway, so failing the whole load over it helps nobody.
     """
     fixtures_dir = content_root / "fixtures"
     if not fixtures_dir.is_dir():
         return
     grid_dir = fixtures_dir / "grid"
     for path in sorted(fixtures_dir.rglob("*.json")):
-        if path.is_relative_to(grid_dir):
+        if path.is_relative_to(grid_dir) or path.name == RENAMES_FILENAME:
             continue
         try:
             raw = json.loads(path.read_text(encoding="utf-8"))

--- a/src/core_management/tests/test_content_fixtures.py
+++ b/src/core_management/tests/test_content_fixtures.py
@@ -1604,6 +1604,34 @@ class ApplyContentRenamesTests(TestCase):
         with self.assertRaises(ContentError):
             apply_content_renames(self.root)
 
+    def test_build_all_does_not_scan_renames_as_a_fixture(self) -> None:
+        """RENAMES.json must not be read as a fixture array.
+
+        It lives at fixtures/RENAMES.json, inside the tree build_all scans, and
+        is a mapping rather than an array — so before this exclusion any corpus
+        carrying one failed EVERY load with "expected a JSON array of fixture
+        objects." That is exactly what production hit on the first real content
+        load, once the corpus gained language renames.
+
+        The bug was invisible until a corpus actually had the file, which is why
+        the existing coverage above (which only ever calls apply_content_renames)
+        never caught it. This test drives build_all, the caller that broke.
+        """
+        self._write_renames({"species.language": {"Ari": "Sanguinen"}})
+        # A real fixture beside it, so this also proves the exclusion is
+        # narrow: skipping the whole directory would satisfy a bare
+        # "RENAMES is absent" assertion just as well as the correct fix.
+        _write(
+            self.root,
+            "fixtures/species/language.json",
+            json.dumps([{"model": "arxii.language", "fields": {"name": "Sanguinen"}}]),
+        )
+
+        result = build_all(self.root)
+
+        assert not any("RENAMES" in key for key in result.fixtures)
+        assert any(key.endswith("language.json") for key in result.fixtures)
+
     def test_malformed_json_raises_content_error(self) -> None:
         """A RENAMES.json that isn't valid JSON fails loud, not silently skipped."""
         _write(self.root, "fixtures/RENAMES.json", "{not valid json")


### PR DESCRIPTION
## What broke

The first real content load on production failed:

```
Content validation failed:
/opt/arxii/content/arx2/fixtures/RENAMES.json: expected a JSON array of fixture objects.
```

`build_all` scans `fixtures/**/*.json` and requires every file to be an array of
fixture objects. It excluded `fixtures/grid/` but not `fixtures/RENAMES.json`,
which lives in that same tree and is a mapping, not an array:

```json
{
  "species.language": {
    "Ari": "Sanguinen",
    "Aythir": "Aythiren"
  }
}
```

#3162 added the file and taught `_apply_renames` to read it, but never excluded
it from the fixture scan. This is the identical mistake the grid exclusion
already documents in its own comment — which even names this exact error string
as the consequence.

## Why it surfaced now

Latent until a corpus actually carried the file. The arx2 corpus gained one in
#3163's language rename pass. Every load since then would have failed here; the
loads were failing earlier, on a wrong `CONTENT_REPO_PATH` (#3191), so nothing
ever got this far.

## The change

Skip `RENAMES.json` in the scan, alongside the existing `fixtures/grid/`
exclusion.

The name is reserved corpus-wide rather than only at the top level:
`_apply_renames` reads only `fixtures/RENAMES.json`, so a nested one would be
ignored by the renames reader anyway, and failing the entire load over it helps
nobody.

## Test

`test_build_all_does_not_scan_renames_as_a_fixture` drives `build_all` — the
caller that actually broke. Verified against the unfixed code, where it
reproduces production's error exactly:

```
core_management.content_fixtures.ContentError: Content validation failed:
...\fixtures\RENAMES.json: expected a JSON array of fixture objects.
```

It writes a real fixture beside `RENAMES.json` and asserts that one IS still
scanned, so an over-broad exclusion (skipping the whole directory) cannot
satisfy it.

Worth noting why the existing coverage missed this: `ApplyContentRenamesTests`
has six tests and never once called `build_all`. The file had tests and still
shipped a bug that made every content load fail.

## Pre-existing local failures, not from this change

`arx test core_management.tests.test_content_fixtures` shows 6 failures on
Windows, in both this branch and an untouched worktree off the same main. They
assert forward-slash keys (`"fixtures/magic/effects.json"`) against
`str(path.relative_to(root))`, which uses backslashes on Windows. CI runs Linux,
where they pass. Out of scope here.
