### PR TITLE
Make game memory visible before an OOM kill erases the evidence

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -328,6 +328,26 @@ Installed once by the converge, then running unattended on the box:
   the Portal alone dies, systemd sees the unit as "active" and does nothing while players
   can no longer connect. The watchdog checks both pidfiles, restarts the unit, and fires an
   off-box alert when either is dead but the unit claims active.
+- **Memory alerting** (#3200, in the heartbeat). The game runs inside `arxii.slice`, capped
+  at `base_game_memory_max` (1500 M), so a leak gets the SLICE OOM-killed instead of taking
+  the box and Postgres down. That contains the damage but makes it **invisible**: the kernel
+  kills inside the slice, the watchdog above restarts the service, and the restart clears the
+  idmapper cache, so the box looks healthy the whole time. The only visible symptom would be
+  periodic unexplained restarts. Two signals close that gap, both read from the cgroup rather
+  than from process RSS, because the slice is what carries the cap:
+  - `memory.events`' cumulative `oom_kill` counter — definitive, and it lives on the slice,
+    which a service restart does not recreate, so it survives the restart that erases
+    everything else. Non-zero means it already happened.
+  - `memory.stat`'s `anon` against `memory.max`, warning at `offbox_slice_anon_warn_percent`
+    (60%). Deliberately **not** `memory.current`: that includes reclaimable page cache
+    (measured on prod 2026-08-16: 447 MB current, of which 152 MB was file cache against only
+    286 MB anon), so thresholding it would alert on a healthy kernel doing its job.
+
+  Related: `IDMAPPER_CACHE_MAXSIZE` is set explicitly in `settings.py` (400 MB) rather than
+  inherited silently from Evennia. Raise it and `offbox_slice_anon_warn_percent` must move
+  with it — the alert has to stay above Evennia's own flush point or routine cache flushes
+  page us. Arx I ran on the 8 GB plan and `SharedMemoryModel` consumed all of it regularly;
+  this box has 4 GB, so the ceiling is a deliberate number, not a default.
 - **Backup-failure alerting.** `arxii-backup.service` and `arxii-offsite.service` both carry
   `OnFailure=` units that fire an immediate off-box alert on failure; the daily heartbeat
   independently re-flags any backup/offsite unit still in a failed state, in case the

--- a/infra/ansible/roles/offbox_alerting/defaults/main.yml
+++ b/infra/ansible/roles/offbox_alerting/defaults/main.yml
@@ -9,3 +9,32 @@ offbox_ping_interval: "*-*-* *:0/15:00"   # every 15 min
 # itself; Evennia's ssl.cert lives under GAME_DIR/server/, one level deeper.
 offbox_cert_path: "{{ ttc_game_dir | default('/opt/arxii/current/src') }}/server/ssl.cert"
 offbox_cert_warn_days: 10
+
+# Memory observability (#3200). Nothing on the box recorded memory before this.
+#
+# The game already runs memory-capped: base creates arxii.slice with
+# MemoryMax={{ base_game_memory_max | default('1500M') }}, so a leak gets the
+# SLICE OOM-killed rather than taking the box and Postgres down. That contains
+# the damage but makes it invisible — the kernel kills inside the slice, the
+# watchdog restarts the service, the restart clears the idmapper cache, and the
+# box looks healthy the whole time. The failure erases its own evidence.
+#
+# Two signals, read straight from the cgroup rather than summing process RSS.
+#
+# 1. memory.events' oom_kill counter is DEFINITIVE — non-zero means the thing
+#    we are afraid of already happened. It lives on the slice, not the service,
+#    so it survives the watchdog restart that hides everything else. This is
+#    the single highest-value number on the box for this failure mode.
+# 2. memory.stat's `anon` is the early warning. Deliberately NOT memory.current:
+#    that includes reclaimable page cache (measured 2026-08-16 on prod:
+#    current 447 MB, of which 152 MB was file cache against only 286 MB anon),
+#    so alerting on it would page us for a healthy kernel doing its job. `anon`
+#    is the non-reclaimable part that actually drives an OOM kill.
+#
+# 60% of the cap gives real lead time: at the 1500 M cap that is 900 MB, versus
+# an idle anon baseline of ~286 MB measured on prod. It also sits well above
+# Evennia's own brake (conditional_flush targets IDMAPPER_CACHE_MAXSIZE, 400 MB),
+# so routine flush cycles never page us. Raise IDMAPPER_CACHE_MAXSIZE and this
+# must move with it.
+offbox_slice_name: arxii.slice
+offbox_slice_anon_warn_percent: 60

--- a/infra/ansible/roles/offbox_alerting/templates/arxii-heartbeat.sh.j2
+++ b/infra/ansible/roles/offbox_alerting/templates/arxii-heartbeat.sh.j2
@@ -45,6 +45,45 @@ if [ "${{ '{#' }}failed_units[@]}" -gt 0 ]; then
   exit 0
 fi
 
+# Memory (#3200). Checked BEFORE the cert window below: memory heading for an
+# OOM kill is more urgent than a cert expiring in {{ offbox_cert_warn_days }} days.
+#
+# Read from the cgroup, not from process RSS: the slice is what carries the
+# MemoryMax cap, so the slice's own accounting is what decides whether the
+# kernel kills anything. Liveness is deliberately NOT reported here —
+# arxii-watchdog owns that, and two components reporting the same dead process
+# makes an incident harder to read. A missing cgroup (rehearsal, or the slice
+# not yet started) is skipped silently.
+cg="/sys/fs/cgroup/{{ offbox_slice_name }}"
+if [ -d "${cg}" ] && [ -r "${cg}/memory.events" ]; then
+  # 1. Did it ALREADY happen. oom_kill is cumulative and lives on the slice,
+  #    which the watchdog's service restart does not recreate — so this is the
+  #    one number that survives the restart that erases everything else. Any
+  #    non-zero value means a process in the game slice was OOM-killed and
+  #    nothing else on this box would ever have told us.
+  oom_kills="$(awk '$1 == "oom_kill" {print $2}' "${cg}/memory.events" 2>/dev/null || echo 0)"
+  if [ -n "${oom_kills}" ] && [ "${oom_kills}" -gt 0 ]; then
+    /usr/local/sbin/arxii-alert \
+      "{{ offbox_slice_name }} has ${oom_kills} OOM kill(s) — a leak hit the memory cap and the watchdog restart hid it"
+    exit 0
+  fi
+  # 2. Is it heading there. `anon` is the non-reclaimable footprint; page cache
+  #    in memory.current is reclaimable and would false-positive (see this
+  #    role's defaults for the measured split).
+  if [ -r "${cg}/memory.stat" ] && [ -r "${cg}/memory.max" ]; then
+    anon="$(awk '$1 == "anon" {print $2}' "${cg}/memory.stat" 2>/dev/null || echo 0)"
+    cap="$(cat "${cg}/memory.max" 2>/dev/null || echo max)"
+    # "max" means uncapped — no percentage to compute, so nothing to warn about.
+    if [ "${cap}" != "max" ] && [ -n "${anon}" ] && [ "${cap}" -gt 0 ]; then
+      pct=$(( anon * 100 / cap ))
+      if [ "${pct}" -ge {{ offbox_slice_anon_warn_percent }} ]; then
+        /usr/local/sbin/arxii-alert \
+          "{{ offbox_slice_name }} anon memory $(( anon / 1048576 ))MB is ${pct}% of its $(( cap / 1048576 ))MB cap"
+        exit 0
+      fi
+    fi
+  fi
+fi
 # Cert-expiry: if the SSL-telnet/web cert expires within the warn window,
 # signal the /fail endpoint so the external service alerts EARLY.
 if [ -f "{{ offbox_cert_path }}" ]; then

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -521,6 +521,26 @@ chk   "arxii-media-mirror.service carries OnFailure= alerting (same convention a
 chk   "offbox_alerting heartbeat watches arxii-media-mirror.service" \
   "grep -q 'arxii-media-mirror.service' infra/ansible/roles/offbox_alerting/templates/arxii-heartbeat.sh.j2"
 
+echo "== #3200 memory observability =="
+# The game slice carries the MemoryMax cap, so a leak is contained but SILENT:
+# the kernel kills inside the slice, the watchdog restarts the service, and the
+# restart clears the idmapper cache. These checks keep the two signals that
+# survive that restart wired up.
+chk   "base still caps the game slice (the heartbeat's percentage is meaningless without it)" \
+  "grep -q 'MemoryMax={{ base_game_memory_max }}' infra/ansible/roles/base/tasks/main.yml"
+chk   "heartbeat alerts on the slice's cumulative oom_kill counter" \
+  "grep -q 'oom_kill' infra/ansible/roles/offbox_alerting/templates/arxii-heartbeat.sh.j2"
+# anon, NOT memory.current: page cache is reclaimable and would page us for a
+# healthy kernel. Measured on prod 2026-08-16: current 447MB vs anon 286MB.
+chk   "heartbeat's early warning reads anon, not memory.current" \
+  "grep -q 'anon' infra/ansible/roles/offbox_alerting/templates/arxii-heartbeat.sh.j2"
+chkno "heartbeat never thresholds on the reclaimable memory.current figure" \
+  "nc infra/ansible/roles/offbox_alerting/templates/arxii-heartbeat.sh.j2 | grep -nE 'memory\.current'"
+chk   "the idmapper ceiling is set explicitly, not inherited from Evennia" \
+  "grep -q 'IDMAPPER_CACHE_MAXSIZE' src/server/conf/settings.py"
+chk   "a periodic task logs idmapper cache size (the trend survives a restart)" \
+  "grep -q 'ops.memory_snapshot' src/world/game_clock/tasks.py"
+
 echo "== #2236 Phase 5 (real Sentry wiring) =="
 # The dependency declaration and the guarded init call are paired — either
 # half missing without the other is a real bug (a declared-but-never-

--- a/src/server/conf/settings.py
+++ b/src/server/conf/settings.py
@@ -159,6 +159,31 @@ else:
 DEFAULT_FROM_EMAIL = env("DEFAULT_FROM_EMAIL", default="noreply@arx2.com")
 SITE_URL = env("SITE_URL", default="https://arxmush.org")
 
+# Idmapper cache ceiling in MB (#3200). Stated explicitly rather than inherited.
+#
+# We used to take Evennia's settings_default value of 400 silently. That is a
+# number nobody chose, on a box nobody measured it against, guarding the failure
+# mode most likely to take this game down: Arx I ran on the 8 GB plan and
+# SharedMemoryModel consumed all of it on a regular basis. Arx II runs on 4 GB
+# with Postgres co-resident, and leans HARDER on the identity map (cached_property
+# handlers hang off model instances throughout world/).
+#
+# 400 is kept as the value, now on purpose: idle Server RSS on prod measured
+# ~156 MB (2026-08-16, no players, no content), so 400 leaves real working room
+# while capping growth at roughly a tenth of the box. Raise it only with a
+# measurement, and move offbox_rss_warn_mb (roles/offbox_alerting) up with it —
+# the heartbeat alert must stay above this ceiling or routine flushes page us.
+#
+# How the ceiling is enforced, and its limits: Evennia's server_maintenance()
+# runs every minute and calls conditional_flush, which flushes only when the
+# cache count is above an estimated maximum AND RSS is already above 90% of this
+# value. It is a last-ditch brake, not a governor. The cache-size estimate is
+# openly a guess (`Ncache = |RMEM - 35.0| / 0.0157`, "empirically estimated from
+# usage tests"), and a flush frees only what nothing else references — a
+# module-level registry or long-lived service pinning instances defeats it.
+# That is why #3200 pairs this with an external RSS alert instead of trusting it.
+IDMAPPER_CACHE_MAXSIZE = env.int("ARXII_IDMAPPER_CACHE_MAXSIZE", default=400)
+
 # Sample world content in the dev seeders (#2698). OFF by default.
 #
 # ``seed_dev_database()`` (the admin "Big Button") is mandatory — it is the only

--- a/src/world/game_clock/tasks.py
+++ b/src/world/game_clock/tasks.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from datetime import timedelta
 import logging
+from pathlib import Path
 
 from django.db import models
 
@@ -1091,6 +1092,7 @@ def _register_late_tasks(roll_and_echo_weather: object) -> None:
         )
     )
     _register_area_quality_decay_task()
+    _register_memory_snapshot_task()
 
 
 def _register_room_ward_upkeep_task() -> None:
@@ -1141,6 +1143,79 @@ def _register_agriculture_tasks() -> None:
                 "Weekly inactivity-detection sweep (#671). Flips activity_state"
                 " ACTIVE↔INACTIVE based on decay_tier and expires HIATUS when"
                 " activity_state_until has passed."
+            ),
+        )
+    )
+
+
+def _process_rss_mb() -> int | None:
+    """Resident set size of this process in MB, or None where unavailable.
+
+    Reads ``/proc/self/status`` directly rather than shelling out to ``ps``
+    (Evennia's own ``conditional_flush`` uses ``os.popen("ps ...")``, which
+    spawns a process on every check) or using ``resource.getrusage``, whose
+    ``ru_maxrss`` is the PEAK — useless for watching a value climb. Returns
+    None off Linux so a Windows dev box logs the cache figures anyway instead
+    of raising.
+    """
+    try:
+        with Path("/proc/self/status").open(encoding="utf-8") as handle:
+            for line in handle:
+                if line.startswith("VmRSS:"):
+                    return int(line.split()[1]) // 1024
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+def memory_snapshot_task() -> None:
+    """Log idmapper cache size and process RSS so growth is visible (#3200).
+
+    The failure this exists to expose is self-erasing: the cache climbs, the
+    game drags, the OOM killer takes the Server, the watchdog restarts it, and
+    the restart clears the cache. Afterwards nothing anywhere says memory was
+    the cause. A periodic line in the log survives the restart and turns that
+    into a readable trend.
+
+    The per-class breakdown is the point of logging cache contents rather than
+    RSS alone: RSS says memory grew, the top classes say WHICH model is
+    accumulating, which is the first question anyone asks during an incident.
+    """
+    from evennia.utils.idmapper.models import cache_size
+
+    total, per_class = cache_size()
+    rss_mb = _process_rss_mb()
+    top = ", ".join(
+        f"{name}={count}"
+        for name, count in sorted(per_class.items(), key=lambda item: item[1], reverse=True)[:5]
+        if count
+    )
+    logger.info(
+        "Memory snapshot: rss=%s idmapper_objects=%d top=[%s]",
+        f"{rss_mb}MB" if rss_mb is not None else "unavailable",
+        total,
+        top or "empty",
+    )
+
+
+def _register_memory_snapshot_task() -> None:
+    """Register the periodic memory snapshot (#3200).
+
+    Ten minutes: frequent enough that a leak's slope is visible within an
+    evening, infrequent enough that the log stays readable. CLEANUP phase
+    because it observes and never mutates, so it should read state after the
+    tasks that change it.
+    """
+    register_task(
+        CronDefinition(
+            task_key="ops.memory_snapshot",
+            callable=memory_snapshot_task,
+            interval=timedelta(minutes=10),
+            phase=CronPhase.CLEANUP,
+            description=(
+                "Log process RSS and idmapper cache size (total plus the five "
+                "largest classes) so memory growth is visible before the OOM "
+                "killer and the watchdog restart erase the evidence. #3200."
             ),
         )
     )

--- a/src/world/game_clock/tests/test_tasks.py
+++ b/src/world/game_clock/tests/test_tasks.py
@@ -439,3 +439,65 @@ class WeeklyMoneyOrderingWiringTests(TestCase):
             tasks["weekly_rollover"].phase,
             tasks["buildings.weekly_upkeep"].phase,
         )
+
+
+class MemorySnapshotTaskTests(TestCase):
+    """The periodic memory snapshot (#3200).
+
+    The value of this task is that its line survives the restart that erases
+    every other trace of an OOM kill, so the tests assert the line is actually
+    emitted and carries the numbers an incident needs — not merely that the
+    call returns.
+    """
+
+    def test_registered_in_cleanup_phase(self) -> None:
+        from world.game_clock.task_registry import CronPhase, get_registered_tasks
+        from world.game_clock.tasks import register_all_tasks
+
+        register_all_tasks()
+
+        tasks = {t.task_key: t for t in get_registered_tasks()}
+        self.assertIn("ops.memory_snapshot", tasks)
+        # Observes without mutating, so it reads state after the tasks that
+        # change it.
+        self.assertEqual(tasks["ops.memory_snapshot"].phase, CronPhase.CLEANUP)
+
+    def test_logs_cache_totals_and_rss(self) -> None:
+        from world.game_clock.tasks import memory_snapshot_task
+
+        with self.assertLogs("world.game_clock.tasks", level="INFO") as captured:
+            memory_snapshot_task()
+
+        line = "\n".join(captured.output)
+        self.assertIn("Memory snapshot", line)
+        self.assertIn("idmapper_objects=", line)
+        self.assertIn("rss=", line)
+
+    def test_names_the_largest_cached_class(self) -> None:
+        """The per-class breakdown answers 'which model is growing'."""
+        from unittest.mock import patch
+
+        from world.game_clock.tasks import memory_snapshot_task
+
+        with patch(
+            "evennia.utils.idmapper.models.cache_size",
+            return_value=(1234, {"SmallThing": 4, "BigThing": 999}),
+        ):
+            with self.assertLogs("world.game_clock.tasks", level="INFO") as captured:
+                memory_snapshot_task()
+
+        line = "\n".join(captured.output)
+        self.assertIn("idmapper_objects=1234", line)
+        self.assertIn("BigThing=999", line)
+
+    def test_rss_unavailable_does_not_raise(self) -> None:
+        """A non-Linux dev box still logs the cache figures."""
+        from unittest.mock import patch
+
+        from world.game_clock.tasks import memory_snapshot_task
+
+        with patch("world.game_clock.tasks._process_rss_mb", return_value=None):
+            with self.assertLogs("world.game_clock.tasks", level="INFO") as captured:
+                memory_snapshot_task()
+
+        self.assertIn("rss=unavailable", "\n".join(captured.output))


### PR DESCRIPTION
Closes #3200.

## Two assumptions the box corrected before any code got written

**The game is already capped.** `base` puts it in `arxii.slice` with
`MemoryMax=1500M`, so a leak gets the slice OOM-killed rather than taking the box
and Postgres down the way it did on Arx I's 8 GB plan. The issue was filed
believing the box was at risk. It isn't. The real problem is narrower and worse:
the whole event is **silent**.

The watchdog is liveness-only, so the sequence is — memory climbs, the game
drags, the kernel kills inside the slice, the watchdog restarts the service, and
the restart clears the idmapper cache. The box looks healthy throughout. The only
visible symptom would be periodic unexplained restarts.

**The right signal is the cgroup, not process RSS**, because the slice is what
carries the cap.

## The two signals

| Signal | Role |
| --- | --- |
| `memory.events` → `oom_kill` | Definitive. Non-zero means it already happened. |
| `memory.stat` → `anon` vs `memory.max` | Early warning at 60%. |

`oom_kill` is the important one: it is cumulative and lives on the **slice**,
which a service restart does not recreate — so it survives the restart that
erases everything else.

`anon`, deliberately **not** `memory.current`. Measured on prod:

```
memory.current  447 MB   <- includes 152 MB reclaimable page cache
anon            286 MB   <- the part that actually drives an OOM kill
```

Thresholding `memory.current` would page us for a healthy kernel doing its job.

## Verification

Rendered the Jinja template and drove the real script against a fake cgroup:

```
== healthy: 286MB anon (prod today), 0 kills ==
HEALTHY
== warn: 950MB anon =="
ALERT: arxii.slice anon memory 950MB is 63% of its 1500MB cap
== definitive: an OOM kill already happened ==
ALERT: arxii.slice has 3 OOM kill(s) — a leak hit the memory cap and the watchdog restart hid it
```

Prod's real current numbers stay healthy, so this does not ship a false positive.
`bash -n` on the rendered output passes; `infra/scripts/acceptance.sh` passes
with six new contracts.

## Also in scope

- **`IDMAPPER_CACHE_MAXSIZE` set explicitly** — 400 MB, the value we were already
  inheriting silently from `settings_default`. Same number, now chosen, with the
  reasoning and the coupling to the alert threshold recorded. Evennia's
  `conditional_flush` is a last-ditch brake, not a governor: it fires only when
  RSS is already past 90% of this, its cache-size estimate is openly a guess, and
  a flush frees only what nothing else references.
- **A ten-minute `ops.memory_snapshot` task** logging RSS plus idmapper totals and
  the five largest classes. RSS says memory grew; the class breakdown says *which
  model* is accumulating, which is the first question anyone asks mid-incident.
  Four tests, including one asserting the largest class is named.

## Dropped from the issue's plan: raise swap

Proposed on the belief the box was at risk. With the slice cap in place it would
trade a fast restart for exactly the slow drag-to-a-halt this work exists to
prevent. Not done, and the issue is updated to say so.

## Not in scope

Fixing an actual leak. This is about being able to see one. If the snapshot task
shows idmapper growth under real load, that is separate work.
