### PR TITLE
Make the authoring queue navigable: group by model, filter by model, link out to the admin

### DIFF
--- a/src/web/admin/CLAUDE.md
+++ b/src/web/admin/CLAUDE.md
@@ -234,8 +234,15 @@ to `_authoring/` (`admin_authoring`).
   `CreditedContent` but sit outside the export registry (`NPCRole` left the
   exclusion 2026-08-07: missions name it by natural key, so it now rides
   the catalog). Rows sort
-  worst-first: placeholder-marked, then unwritten, then unreviewed, then
-  alphabetically by domain and identity. An FK-typed natural-key field spans
+  worst-first: placeholder-marked, then unwritten, then unreviewed; within a
+  tier, by domain, then **model**, then **pk**. The model term is what keeps a
+  tier readable - sorting straight to identity interleaved every model in a
+  domain into one alphabetical soup, so no two adjacent rows shared a shape -
+  and pk within a model is authoring order, which for an ordered set like
+  `OriginTemplateSlot` tracks its own `sort_order`. Alphabetical-by-identity is
+  arbitrary even inside one model and is the tiebreak nowhere. A model still
+  appears in up to three clumps, one per tier; the queue's model filter is what
+  collapses that to one model's rows worst-first. An FK-typed natural-key field spans
   one hop into the related row's own first natural-key field for display
   (`"The Sleeper's Rest, Sleeper"`, not a raw related pk) - still one query
   per model, since the span is a SQL join; a related field that is itself
@@ -248,11 +255,25 @@ to `_authoring/` (`admin_authoring`).
   account (see the setup gate below), else the two HTMX panels:
   `authoring_stats_fragment` (per-domain rows/unwritten/unreviewed/word-count
   rollup) and `authoring_queue_fragment` (the worst-first queue itself,
-  filterable by `?domain=`, `?status=` - `web.admin.constants
+  filterable by `?domain=`, `?model=` (a full `domain.Model` label),
+  `?status=` - `web.admin.constants
   .BacklogStatusFilter`: `placeholder`/`unwritten`/`unreviewed` - and `?q=`
   against the row's identity string, one Python-side scan over
   `build_backlog()`'s already-sorted rows, capped at 100 displayed rows with
-  a "Showing 100 of N" note when truncated).
+  a "Showing 100 of N" note when truncated). The `?model=` dropdown's options
+  come from `_model_options`, built off those same scanned rows and narrowed
+  to the picked domain, so it can never offer a model with no rows behind it.
+  Each row carries two links: the identity cell `hx-get`s the prose editor
+  into `#authoring-editor`, and an "Edit in admin" cell (`_queue_row` ->
+  `links.admin_change_url`) opens the stock change form - how an author
+  reaches the fields the prose-only editor deliberately does not expose. That
+  cell renders empty for a credited model with no registered `ModelAdmin`
+  rather than a dead link. The queue's editor link and the
+  related/mentions/reference panels' links all anchor
+  `href="#authoring-editor"` and swap with `show:top`: the editor panel sits
+  **below** the queue table in `dashboard.html`, so the old `href="#"`
+  scrolled nowhere and the swapped-in form landed off-screen, reading to an
+  operator as a link that does nothing.
 - **Guided first-run contributor setup gate** - `authoring/contributors.py`:
   `current_contributor(user)` reads `request.user -> PlayerData ->
   ContentContributor`, `None` at any missing link; `link_contributor(user,
@@ -402,7 +423,11 @@ The stock changelists carry the same credit story the workbench queue tells:
   `change_form.html`, beside the #3018 export button, for credited models
   with prose fields. All deep links share one URL builder:
   `web/admin/authoring/links.py:workbench_editor_url` (promoted from
-  `content_row_export_views`).
+  `content_row_export_views`). Its inverse lives beside it:
+  `links.py:admin_change_url` (`(model_label, pk) -> str | None`, promoted
+  from `authoring.views._admin_change_url`) is the outward link the
+  related-entries pane and the backlog queue both build - it returns `None`,
+  never a dead link, for a credited model with no registered `ModelAdmin`.
 - Tests: `tests/test_credit_admin_extras.py`,
   `tests/test_change_form_workbench_link.py`, `tests/test_authoring_links.py`,
   plus the E001 class in `tests/test_admin_checks.py`.

--- a/src/web/admin/authoring/backlog.py
+++ b/src/web/admin/authoring/backlog.py
@@ -7,9 +7,23 @@ ids, and every prose field value). An FK-typed natural-key field spans one hop
 into the related row's own first natural-key field (see ``_display_column``) so
 the identity string shows a name, not a raw related pk - still one query per
 model, since the span becomes a SQL join rather than a per-row lookup. Rows sort
-worst-first: placeholder-marked first, then unwritten, then unreviewed, then
-alphabetically by domain and identity - so the top of the queue is always the
-thing most worth a writer's attention next.
+worst-first: placeholder-marked first, then unwritten, then unreviewed - so the
+top of the queue is always the thing most worth a writer's attention next.
+
+Within a worst-first tier rows group by domain, then by model, then by pk. The
+model term is what keeps a tier readable: sorting a tier straight to identity
+interleaves every model in the domain into one alphabetical soup, so a writer
+scrolling `magic` used to meet an `EffectType`, then a `PortalAnchorKind`, then
+a `Technique`, with no two adjacent rows sharing a shape. Grouping by model
+keeps like with like, and pk within a model is authoring order - the sequence
+the rows were actually written in, which for an ordered set like
+``OriginTemplateSlot`` tracks its own ``sort_order``. Alphabetical-by-identity
+is arbitrary even inside one model, so it is not the tiebreak anywhere.
+
+A model still appears in up to three separate clumps down the page, one per
+tier; the queue panel's model filter (`web.admin.authoring.views`) is what
+collapses that to a single model's rows, worst-first, with nothing else
+interleaved.
 
 Scale ceiling: today's corpus is on the order of 2k rows and 70k prose words
 across credited models, and this whole module does one full Python-side scan
@@ -179,7 +193,8 @@ def build_backlog(
             r.written,
             r.reviewed,
             r.domain,
-            r.identity.lower(),
+            r.model_name,
+            r.pk,
         )
     )
     return rows, _aggregate(rows)

--- a/src/web/admin/authoring/links.py
+++ b/src/web/admin/authoring/links.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 from urllib.parse import urlencode
 
-from django.urls import reverse
+from django.contrib import admin
+from django.urls import NoReverseMatch, reverse
+
+from core.app_domains import resolve_model_by_name
 
 
 def workbench_editor_url(model_label: str, pk: object) -> str:
@@ -21,3 +24,37 @@ def workbench_editor_url(model_label: str, pk: object) -> str:
     """
     query = urlencode({"model": model_label, "pk": pk})
     return f"{reverse('admin_authoring_editor')}?{query}"
+
+
+def admin_change_url(model_label: str, pk: object) -> str | None:
+    """Stock-admin change-form link for one row, or ``None`` when it has no ``ModelAdmin``.
+
+    The inverse of ``workbench_editor_url``: the workbench editor only ever
+    exposes a row's prose fields, so this is the link an author follows to
+    reach everything else on the row (sort orders, flags, foreign keys).
+
+    Not every credited model has a registered ``ModelAdmin`` - three
+    (``NPCRole``, ``BuildingKind``, ``DecorationKind``) were never
+    ``@admin.register``ed - so checking ``admin.site._registry`` first keeps
+    an unregistered model from ever reaching ``reverse()``. The
+    ``NoReverseMatch`` catch is defense in depth for any other reason
+    ``admin:<app_label>_<model_name>_change`` might not resolve. Callers
+    render nothing for ``None`` rather than a dead link.
+
+    Promoted here from ``authoring.views._admin_change_url`` so the
+    related-entries pane and the backlog queue build the same URL the same
+    way - the ``(model_label, pk)`` signature both ``RelatedEntry`` and
+    ``BacklogRow`` can satisfy, since neither carries the model class itself.
+    """
+    try:
+        model = resolve_model_by_name(model_label)
+    except LookupError:
+        return None
+    if model not in admin.site._registry:  # noqa: SLF001
+        return None
+    app_label = model._meta.app_label  # noqa: SLF001
+    model_name = model._meta.model_name  # noqa: SLF001
+    try:
+        return reverse(f"admin:{app_label}_{model_name}_change", args=[pk])
+    except NoReverseMatch:
+        return None

--- a/src/web/admin/authoring/views.py
+++ b/src/web/admin/authoring/views.py
@@ -4,10 +4,15 @@ content model (#3019).
 The dashboard page (`authoring_dashboard`) renders a skeleton of two
 HTMX-loaded panels - domain stats and the queue itself - both scanning the
 same `build_backlog()` result (Task 2, `web.admin.authoring.backlog`). The
-queue panel caps its display at 100 rows and applies `?domain=`, `?status=`,
-and `?q=` filters over the already-sorted rows in a single Python-side scan
-(no per-filter rescans, no extra DB queries - `build_backlog()` is the only
-query-issuing call in either fragment).
+queue panel caps its display at 100 rows and applies `?domain=`, `?model=`,
+`?status=`, and `?q=` filters over the already-sorted rows in a single
+Python-side scan (no per-filter rescans, no extra DB queries -
+`build_backlog()` is the only query-issuing call in either fragment). The
+`?model=` options come from `_model_options`, built off those same scanned
+rows and narrowed to the picked domain, so the dropdown can never offer a
+model with no rows behind it. Each visible row also carries a stock-admin
+change-form link (`_queue_row`): the workbench editor only exposes prose
+fields, so that link is how an author reaches the row's other fields.
 
 Task 4 gates the dashboard on a linked `ContentContributor` (see
 `web.admin.authoring.contributors`): an unlinked account gets the setup panel
@@ -65,11 +70,11 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 
-from django.contrib import admin, messages
+from django.contrib import messages
 from django.core.exceptions import ValidationError
 from django.http import HttpRequest, HttpResponse, QueryDict
 from django.shortcuts import redirect, render
-from django.urls import NoReverseMatch, reverse
+from django.urls import reverse
 from django.utils import timezone
 from django.views.decorators.http import require_POST
 
@@ -77,6 +82,7 @@ from core.app_domains import credited_content_models, resolve_model_by_name
 from core_management.prose_fields import prose_fields_for
 from web.admin.authoring.backlog import BacklogRow, build_backlog
 from web.admin.authoring.contributors import current_contributor, link_contributor
+from web.admin.authoring.links import admin_change_url
 from web.admin.authoring.reference import db_search, file_search, reference_roots
 from web.admin.authoring.relations import RelatedEntry, prose_mentions, related_entries
 from web.admin.constants import BacklogStatusFilter
@@ -112,31 +118,73 @@ def _setup_required(request: HttpRequest) -> bool:
     return current_contributor(request.user) is None
 
 
-def _row_matches(row: BacklogRow, domain: str, status: str, query: str) -> bool:
+def _row_matches(row: BacklogRow, domain: str, model: str, status: str, query: str) -> bool:
     """One row's pass/fail against every active filter, checked in one call.
 
     Called from a single list comprehension over the full row list in
     `_filtered_rows`, so the combined filter set is one scan regardless of
-    how many of `domain`/`status`/`query` are actually set.
+    how many of `domain`/`model`/`status`/`query` are actually set.
     """
     if domain and row.domain != domain:
         return False
-    if status == BacklogStatusFilter.PLACEHOLDER and not row.has_placeholder:
-        return False
-    if status == BacklogStatusFilter.UNWRITTEN and row.written:
-        return False
-    if status == BacklogStatusFilter.UNREVIEWED and row.reviewed:
+    if model and row.model_label != model:
         return False
     if query and query not in row.identity.lower():
         return False
+    return _status_matches(row, status)
+
+
+def _status_matches(row: BacklogRow, status: str) -> bool:
+    """One row against the status filter alone; an unset or unknown status matches every row.
+
+    Split out of `_row_matches` so neither function carries a branch per
+    filter *and* a branch per status value - the combined form tripped
+    ruff's return-count ceiling once the model filter joined it.
+    """
+    if status == BacklogStatusFilter.PLACEHOLDER:
+        return row.has_placeholder
+    if status == BacklogStatusFilter.UNWRITTEN:
+        return not row.written
+    if status == BacklogStatusFilter.UNREVIEWED:
+        return not row.reviewed
     return True
 
 
 def _filtered_rows(rows: list[BacklogRow], request: HttpRequest) -> list[BacklogRow]:
     domain = request.GET.get("domain") or ""
+    model = request.GET.get("model") or ""
     status = request.GET.get("status") or ""
     query = (request.GET.get("q") or "").strip().lower()
-    return [row for row in rows if _row_matches(row, domain, status, query)]
+    return [row for row in rows if _row_matches(row, domain, model, status, query)]
+
+
+def _model_options(rows: list[BacklogRow], domain: str) -> list[dict]:
+    """The `<option>` set for the model filter, narrowed to `domain` when one is picked.
+
+    Built off the same already-scanned `rows` the queue renders, so the
+    dropdown can never offer a model the backlog has no rows for. Each option
+    carries the full `domain.Model` label as its value (`model_label` is what
+    `_row_matches` compares) but shows the bare model name, since the domain
+    is already its own adjacent filter.
+    """
+    seen: dict[str, str] = {}
+    for row in rows:
+        if domain and row.domain != domain:
+            continue
+        seen.setdefault(row.model_label, row.model_name)
+    return [
+        {"label": label, "name": name} for label, name in sorted(seen.items(), key=lambda p: p[1])
+    ]
+
+
+def _queue_row(row: BacklogRow) -> dict:
+    """One queue row plus its stock-admin link, mirroring `_entry_row` below.
+
+    The link is built here rather than on `BacklogRow` itself for the same
+    reason the related-entries pane builds its own: `backlog.py` is the data
+    tier and knows nothing about the admin registry or URL routing.
+    """
+    return {"row": row, "admin_url": admin_change_url(row.model_label, row.pk)}
 
 
 @superuser_required
@@ -174,18 +222,21 @@ def authoring_queue_fragment(request: HttpRequest) -> HttpResponse:
     """
     rows, _ = build_backlog()
     domains = sorted({row.domain for row in rows})
+    selected_domain = request.GET.get("domain", "")
 
     filtered = _filtered_rows(rows, request)
     total = len(filtered)
     visible = filtered[:_QUEUE_DISPLAY_CAP]
 
     context = {
-        "rows": visible,
+        "rows": [_queue_row(row) for row in visible],
         "total": total,
         "display_cap": _QUEUE_DISPLAY_CAP,
         "capped": total > _QUEUE_DISPLAY_CAP,
         "domains": domains,
-        "selected_domain": request.GET.get("domain", ""),
+        "selected_domain": selected_domain,
+        "models": _model_options(rows, selected_domain),
+        "selected_model": request.GET.get("model", ""),
         "selected_status": request.GET.get("status", ""),
         "status_choices": BacklogStatusFilter.choices,
         "query": request.GET.get("q", ""),
@@ -441,37 +492,11 @@ def _workbench_url(entry: RelatedEntry) -> str | None:
     return f"{reverse('admin_authoring_editor')}?model={entry.model_label}&pk={entry.pk}"
 
 
-def _admin_change_url(entry: RelatedEntry) -> str | None:
-    """Admin change-form link for `entry`, or `None` when it has no `ModelAdmin`.
-
-    Three credited models `credited_content_models()`
-    covers (`NPCRole`, `BuildingKind`, `DecorationKind`) have never been
-    `@admin.register`ed - checking `admin.site._registry` first keeps an
-    unregistered model from ever reaching `reverse()`; the `NoReverseMatch`
-    catch below is defense in depth for any other reason `admin:<label>_
-    <model>_change` might not resolve (mirrors `content_row_export_views
-    ._change_url`'s app_label/model_name lookup, but never assumes the URL
-    exists the way that helper does).
-    """
-    try:
-        model = resolve_model_by_name(entry.model_label)
-    except LookupError:
-        return None
-    if model not in admin.site._registry:  # noqa: SLF001
-        return None
-    app_label = model._meta.app_label  # noqa: SLF001
-    model_name = model._meta.model_name  # noqa: SLF001
-    try:
-        return reverse(f"admin:{app_label}_{model_name}_change", args=[entry.pk])
-    except NoReverseMatch:
-        return None
-
-
 def _entry_row(entry: RelatedEntry) -> dict:
     return {
         "entry": entry,
         "workbench_url": _workbench_url(entry),
-        "admin_url": _admin_change_url(entry),
+        "admin_url": admin_change_url(entry.model_label, entry.pk),
     }
 
 

--- a/src/web/admin/tests/test_authoring_backlog.py
+++ b/src/web/admin/tests/test_authoring_backlog.py
@@ -23,6 +23,7 @@ from web.admin.authoring.backlog import _rows_for_model, build_backlog
 from world.character_creation.factories import BeginningsFactory, StartingAreaFactory
 from world.contributors.factories import ContentContributorFactory
 from world.items.factories import ItemTemplateFactory
+from world.magic.factories import AffinityFactory, EffectTypeFactory
 from world.mechanics.factories import ChallengeApproachFactory
 from world.mechanics.models import ChallengeApproach
 from world.tarot.constants import ArcanaType
@@ -53,10 +54,11 @@ class BuildBacklogTests(TestCase):
         )
 
     def test_full_sort_key_across_every_tier(self):
-        # (not has_placeholder, written, reviewed, domain, identity.lower()):
+        # (not has_placeholder, written, reviewed, domain, model_name, pk):
         # placeholder-marked rows first regardless of credit, then unwritten,
-        # then unreviewed, then domain, then identity - all six rows below
-        # land in a different tier boundary from their neighbor.
+        # then unreviewed, then domain, then model, then authoring order - all
+        # six rows below land in a different tier boundary from their neighbor,
+        # so no two of them ever reach the model/pk tiebreak.
         self._trait("Alpha Placeholder", "PLACEHOLDER text here.")
         self._trait("Zeta Placeholder Written", "PLACEHOLDER also here.", written=True)
         ItemTemplateFactory(name="Aardvark Cloak", description="Ordinary described cloak here.")
@@ -83,6 +85,31 @@ class BuildBacklogTests(TestCase):
                 "Charlie Regular Written",
                 "Delta Regular Written Reviewed",
             ],
+        )
+
+    def test_rows_group_by_model_within_one_domain(self):
+        """Sorting a tier straight to identity interleaved a domain's models into one soup."""
+        identities = {"Aaa Effect", "Bbb Affinity", "Ccc Effect"}
+        EffectTypeFactory(name="Aaa Effect", description="Ordinary finished prose here.")
+        AffinityFactory(name="Bbb Affinity", description="Ordinary finished prose here.")
+        EffectTypeFactory(name="Ccc Effect", description="Ordinary finished prose here.")
+
+        rows, _ = build_backlog()
+        magic_rows = [r for r in rows if r.identity in identities]
+        # All three are magic-domain, so domain cannot be what separates them.
+        # Alphabetical-by-identity gave EffectType, Affinity, EffectType.
+        self.assertEqual(
+            [r.model_name for r in magic_rows], ["Affinity", "EffectType", "EffectType"]
+        )
+
+    def test_rows_within_one_model_follow_authoring_order_not_the_alphabet(self):
+        self._trait("Zeta Written First", "Ordinary finished prose here.")
+        self._trait("Alpha Written Second", "Ordinary finished prose here.")
+
+        rows, _ = build_backlog()
+        trait_rows = [r for r in rows if r.model_label == "traits.Trait"]
+        self.assertEqual(
+            [r.identity for r in trait_rows], ["Zeta Written First", "Alpha Written Second"]
         )
 
     def test_placeholder_row_sorts_first_even_when_fully_credited(self):

--- a/src/web/admin/tests/test_authoring_links.py
+++ b/src/web/admin/tests/test_authoring_links.py
@@ -3,7 +3,7 @@
 from django.test import TestCase
 from django.urls import reverse
 
-from web.admin.authoring.links import workbench_editor_url
+from web.admin.authoring.links import admin_change_url, workbench_editor_url
 
 
 class WorkbenchEditorUrlTests(TestCase):
@@ -14,3 +14,19 @@ class WorkbenchEditorUrlTests(TestCase):
 
         expected = f"{reverse('admin_authoring_editor')}?model=magic.EffectType&pk=7"
         self.assertEqual(url, expected)
+
+
+class AdminChangeUrlTests(TestCase):
+    """The outward link, shared by the related-entries pane and the backlog queue."""
+
+    def test_builds_change_url_for_a_registered_model(self) -> None:
+        url = admin_change_url("traits.Trait", 7)
+
+        self.assertEqual(url, reverse("admin:arxii_trait_change", args=[7]))
+
+    def test_returns_none_for_a_model_with_no_registered_admin(self) -> None:
+        """Not every credited model has a ModelAdmin; callers render nothing rather than 500."""
+        self.assertIsNone(admin_change_url("builders.BuildingKind", 7))
+
+    def test_returns_none_for_an_unresolvable_label(self) -> None:
+        self.assertIsNone(admin_change_url("nosuchdomain.NoSuchModel", 7))

--- a/src/web/admin/tests/test_authoring_views.py
+++ b/src/web/admin/tests/test_authoring_views.py
@@ -8,6 +8,7 @@ from evennia.accounts.models import AccountDB
 
 from evennia_extensions.models import PlayerData
 from world.contributors.factories import ContentContributorFactory
+from world.magic.factories import EffectTypeFactory
 from world.traits.models import Trait, TraitCategory, TraitType
 
 
@@ -157,6 +158,44 @@ class TestAuthoringQueueFragment(AuthoringViewsTestCase):
         self.assertIn(editor_url, body)
         self.assertIn("model=traits.Trait", body)
         self.assertIn(f"pk={trait.pk}", body)
+
+    def test_model_filter_excludes_other_models(self) -> None:
+        self._trait("Trait Row", "Ordinary finished prose here.")
+        EffectTypeFactory(name="Effect Row", description="Ordinary finished prose here.")
+
+        self.client.force_login(self.super)
+        resp = self.client.get(reverse("admin_authoring_queue"), {"model": "traits.Trait"})
+        body = resp.content.decode()
+        self.assertIn("Trait Row", body)
+        self.assertNotIn("Effect Row", body)
+
+    def test_model_options_narrow_to_the_selected_domain(self) -> None:
+        """Picking a domain must not leave other domains' models offered in the dropdown."""
+        self._trait("Trait Row", "Ordinary finished prose here.")
+        EffectTypeFactory(name="Effect Row", description="Ordinary finished prose here.")
+
+        self.client.force_login(self.super)
+        resp = self.client.get(reverse("admin_authoring_queue"), {"domain": "traits"})
+        body = resp.content.decode()
+        self.assertIn('value="traits.Trait"', body)
+        self.assertNotIn('value="magic.EffectType"', body)
+
+    def test_row_carries_admin_change_link(self) -> None:
+        """The workbench editor only exposes prose, so the queue links out to the full row."""
+        trait = self._trait("Linked Row", "Ordinary finished prose here.")
+
+        self.client.force_login(self.super)
+        resp = self.client.get(reverse("admin_authoring_queue"))
+        self.assertIn(reverse("admin:arxii_trait_change", args=[trait.pk]), resp.content.decode())
+
+    def test_editor_link_anchors_to_the_editor_panel(self) -> None:
+        """`href="#"` scrolled nowhere, so the swapped-in editor stayed below the fold."""
+        self._trait("Anchored Row", "Ordinary finished prose here.")
+
+        self.client.force_login(self.super)
+        body = self.client.get(reverse("admin_authoring_queue")).content.decode()
+        self.assertIn('href="#authoring-editor"', body)
+        self.assertIn('hx-swap="innerHTML show:top"', body)
 
     def test_display_capped_at_100_with_showing_note(self) -> None:
         for i in range(101):

--- a/src/web/templates/admin/authoring/_mentions_panel.html
+++ b/src/web/templates/admin/authoring/_mentions_panel.html
@@ -33,8 +33,8 @@
       </td>
       <td>
         {% if row.workbench_url %}
-        <a href="#" hx-get="{{ row.workbench_url }}"
-           hx-target="#authoring-editor" hx-swap="innerHTML">
+        <a href="#authoring-editor" hx-get="{{ row.workbench_url }}"
+           hx-target="#authoring-editor" hx-swap="innerHTML show:top">
           {% translate "Open in editor" %}
         </a>
         {% endif %}

--- a/src/web/templates/admin/authoring/_queue_panel.html
+++ b/src/web/templates/admin/authoring/_queue_panel.html
@@ -60,6 +60,17 @@
     </select>
   </div>
   <div class="tuning-field">
+    <label for="queue-model">{% translate "Model" %}</label>
+    <select id="queue-model" name="model">
+      <option value="">{% translate "All models" %}</option>
+      {% for model in models %}
+      <option value="{{ model.label }}" {% if model.label == selected_model %}selected{% endif %}>
+        {{ model.name }}
+      </option>
+      {% endfor %}
+    </select>
+  </div>
+  <div class="tuning-field">
     <label for="queue-status">{% translate "Status" %}</label>
     <select id="queue-status" name="status">
       <option value="">{% translate "All statuses" %}</option>
@@ -91,31 +102,41 @@
       <th>{% translate "Domain" %}</th>
       <th>{% translate "Words" %}</th>
       <th>{% translate "Flags" %}</th>
+      <th>{% translate "All fields" %}</th>
     </tr>
   </thead>
   <tbody>
-    {% for row in rows %}
+    {% for entry in rows %}
     <tr>
       <td>
-        <a href="#"
-           hx-get="{{ editor_url }}?model={{ row.model_label|urlencode }}&amp;pk={{ row.pk }}"
-           hx-target="#authoring-editor" hx-swap="innerHTML">
-          {{ row.identity }}
+        <a href="#authoring-editor"
+           hx-get="{{ editor_url }}?model={{ entry.row.model_label|urlencode }}&amp;pk={{ entry.row.pk }}"
+           hx-target="#authoring-editor" hx-swap="innerHTML show:top">
+          {{ entry.row.identity }}
         </a>
       </td>
-      <td>{{ row.model_name }}</td>
-      <td>{{ row.domain }}</td>
-      <td>{{ row.words }}</td>
+      <td>{{ entry.row.model_name }}</td>
+      <td>{{ entry.row.domain }}</td>
+      <td>{{ entry.row.words }}</td>
       <td>
-        {% if row.has_placeholder %}
+        {% if entry.row.has_placeholder %}
         <span class="badge badge-placeholder">{% translate "Placeholder" %}</span>
         {% endif %}
-        {% if not row.written %}<span class="badge">{% translate "Unwritten" %}</span>{% endif %}
-        {% if not row.reviewed %}<span class="badge">{% translate "Unreviewed" %}</span>{% endif %}
+        {% if not entry.row.written %}
+        <span class="badge">{% translate "Unwritten" %}</span>
+        {% endif %}
+        {% if not entry.row.reviewed %}
+        <span class="badge">{% translate "Unreviewed" %}</span>
+        {% endif %}
+      </td>
+      <td>
+        {% if entry.admin_url %}
+        <a href="{{ entry.admin_url }}">{% translate "Edit in admin" %}</a>
+        {% endif %}
       </td>
     </tr>
     {% empty %}
-    <tr><td colspan="5">{% translate "No rows match these filters." %}</td></tr>
+    <tr><td colspan="6">{% translate "No rows match these filters." %}</td></tr>
     {% endfor %}
   </tbody>
 </table>

--- a/src/web/templates/admin/authoring/_reference_panel.html
+++ b/src/web/templates/admin/authoring/_reference_panel.html
@@ -80,8 +80,8 @@
     {% for hit in group.hits %}
     <tr>
       <td>
-        <a href="#" hx-get="{% url 'admin_authoring_editor' %}?model={{ group.model_label|urlencode }}&pk={{ hit.pk }}"
-           hx-target="#authoring-editor" hx-swap="innerHTML">
+        <a href="#authoring-editor" hx-get="{% url 'admin_authoring_editor' %}?model={{ group.model_label|urlencode }}&pk={{ hit.pk }}"
+           hx-target="#authoring-editor" hx-swap="innerHTML show:top">
           {{ hit.label }}
         </a>
       </td>

--- a/src/web/templates/admin/authoring/_related_panel.html
+++ b/src/web/templates/admin/authoring/_related_panel.html
@@ -58,8 +58,8 @@
       </td>
       <td>
         {% if row.workbench_url %}
-        <a href="#" hx-get="{{ row.workbench_url }}"
-           hx-target="#authoring-editor" hx-swap="innerHTML">
+        <a href="#authoring-editor" hx-get="{{ row.workbench_url }}"
+           hx-target="#authoring-editor" hx-swap="innerHTML show:top">
           {% translate "Open in editor" %}
         </a>
         {% endif %}


### PR DESCRIPTION
Three things an operator hits on the first real pass through the Authoring
Workbench queue, now that the seed put 5762 rows behind it.

## Clicking a row looked like a dead link

It was not. htmx swapped the prose editor in correctly, but `#authoring-editor`
sits below the whole queue table in `dashboard.html`, and the anchor was
`href="#"`, which scrolls nowhere. The form arrived off-screen, so the click
read as doing nothing.

Every link into the editor (queue, related entries, prose mentions, reference
search) now anchors `href="#authoring-editor"` and swaps with `show:top`, so
htmx scrolls the panel into view *after* the content lands.

## Rows in a tier were ordered arbitrarily

The sort key ended `..., domain, identity.lower()`, which interleaves every
model in a domain into one alphabetical soup. A writer scrolling `magic` met an
`EffectType`, then a `PortalAnchorKind`, then a `Technique`, with no two
adjacent rows sharing a shape.

The key now groups by model, then orders by pk within it. pk is authoring
order - the sequence the rows were actually written in, which for an ordered
set like `OriginTemplateSlot` tracks its own `sort_order`.
Alphabetical-by-identity is arbitrary even inside one model, so it is the
tiebreak nowhere.

The worst-first tiers still come first, so a model can still appear in up to
three clumps down the page. The next item is what collapses that.

## The queue could not be narrowed to one model

It now filters on `?model=`, beside the existing domain filter. Options come
from `_model_options`, built off the already-scanned rows and narrowed to the
picked domain, so the dropdown can never offer a model with no rows behind it.
Pick a model and you get its rows worst-first with nothing else interleaved.

## No route from the queue to a row's other fields

The workbench editor is prose-only by design, so an author who needed to change
a sort order or a flag had to go hunting in the stock admin. Each row now
carries an "Edit in admin" link.

`_admin_change_url` already built exactly this URL for the related-entries
pane, so it moves to `authoring/links.py` beside `workbench_editor_url` and
widens to `(model_label, pk)` - the signature both `RelatedEntry` and
`BacklogRow` satisfy, since neither carries the model class. It still returns
`None` for the credited models with no registered `ModelAdmin`, and the cell
renders empty rather than a dead link.

## Notes

- `_row_matches` splits its status branches into `_status_matches`: adding the
  model filter pushed the combined form past ruff's `PLR0911` ceiling.
- No migration, no model change.
- `web.admin` locally: 359 tests, same 2 failures / 18 errors as `origin/main`
  (350 tests) - all pre-existing, a local test-DB migration gap plus the
  git-dependent row-export tests. The 9 new tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
