### PR TITLE
Gate GameInvite on registration_open so player invites cannot bypass the staff gate

### DIFF
--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -1958,7 +1958,11 @@ Character lifecycle management with web-first applications and player anonymity.
   gets a websocket push on submission. Services use the `game_invite` prefix
   (`create_game_invite`/`claim_game_invite`/`revoke_game_invite`) to avoid
   collision with `world/gm/services.py`'s `GMRosterInvite` functions. See
-  ADR-0141.
+  ADR-0141. **Gated on `RegistrationConfig.registration_open` (#3182):** while
+  registration is closed, `create_game_invite` and `claim_game_invite` raise
+  `RegistrationClosedError` (403 at the API) and `resolve_invite` returns None
+  (404) — a player invite is never a side door around the staff
+  `AccountInvite` gate.
 - **Integrates with:** accounts, character_sheets, scenes
 - **Source:** `src/world/roster/`
 - **Details:** [roster.md](roster.md)

--- a/docs/systems/registration.md
+++ b/docs/systems/registration.md
@@ -39,6 +39,17 @@ address. Its `status` property derives `InviteStatus` from the three timestamp
 columns — never stored redundantly. `is_redeemable` is `True` only when none of
 `is_redeemed`/`is_revoked`/`is_expired` hold.
 
+**Two invite systems, one gate (#3182).** `world.roster.GameInvite` (#2483,
+player-issued invite-a-friend, trust-gated, no email binding) shares the
+`/register?invite=TOKEN` URL but does **not** open signup:
+`ArxAccountAdapter.is_open_for_signup` consults `AccountInvite` only. While
+`registration_open` is False the invite-a-friend feature is off entirely —
+`create_game_invite` and `claim_game_invite` raise
+`world.roster.services.invite_services.RegistrationClosedError` and
+`resolve_invite` returns None — so a player invite can never side-door the
+staff gate. When registration is open, `GameInvite` adds context (inviter
+message, application annotation) on top of open signup.
+
 ---
 
 ## Service functions (`world.registration.services`)

--- a/src/world/roster/services/invite_services.py
+++ b/src/world/roster/services/invite_services.py
@@ -15,6 +15,7 @@ from typing import TYPE_CHECKING
 from django.db import transaction
 from django.utils import timezone
 
+from world.registration.models import get_registration_config
 from world.roster.models import GameInvite, InviteStatus
 
 if TYPE_CHECKING:
@@ -26,6 +27,20 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 DEFAULT_INVITE_EXPIRY_DAYS = 30
+
+
+class RegistrationClosedError(Exception):
+    """Player invites are unavailable while registration is closed (#3182).
+
+    A closed game means staff decide who gets in via ``AccountInvite``; a
+    player-issued ``GameInvite`` must not be a side door around that gate.
+    Distinct from ``PermissionError`` (the trust threshold) so the API can
+    return a different message for each.
+    """
+
+
+def _registration_is_open() -> bool:
+    return get_registration_config().registration_open
 
 
 def _inviter_meets_trust_threshold(inviter: PlayerData) -> bool:
@@ -66,8 +81,13 @@ def create_game_invite(
         The created GameInvite instance.
 
     Raises:
+        RegistrationClosedError: If registration is closed (invites are off).
         PermissionError: If the inviter does not meet the trust threshold.
     """
+    if not _registration_is_open():
+        msg = "Player invites are disabled while registration is closed."
+        raise RegistrationClosedError(msg)
+
     if not _inviter_meets_trust_threshold(inviter):
         msg = "Inviter does not meet the trust threshold to send invites."
         raise PermissionError(msg)
@@ -89,9 +109,14 @@ def resolve_invite(token: str) -> GameInvite | None:
     """Resolve a token to its invite for registration-page context display.
 
     Returns the invite if it's pending and not expired. Returns None for
-    claimed, revoked, expired, or nonexistent tokens. This is safe to expose
+    claimed, revoked, expired, or nonexistent tokens — and for any token
+    while registration is closed, so a stale link cannot show a welcoming
+    banner for an invite that will not work (#3182). This is safe to expose
     to unauthenticated users — it only returns display-safe context.
     """
+    if not _registration_is_open():
+        return None
+
     try:
         invite = GameInvite.objects.get(token=token)
     except GameInvite.DoesNotExist:
@@ -118,8 +143,13 @@ def claim_game_invite(token: str, account: AccountDB) -> GameInvite:
         The claimed GameInvite instance.
 
     Raises:
+        RegistrationClosedError: If registration is closed (invites are off).
         ValueError: If the token is invalid, already claimed, revoked, or expired.
     """
+    if not _registration_is_open():
+        msg = "Player invites are disabled while registration is closed."
+        raise RegistrationClosedError(msg)
+
     try:
         invite = GameInvite.objects.get(token=token)
     except GameInvite.DoesNotExist:

--- a/src/world/roster/tests/test_invite_journey.py
+++ b/src/world/roster/tests/test_invite_journey.py
@@ -27,6 +27,13 @@ from world.stories.types import TrustLevel
 class InvitedPlayerFullJourneyTests(TestCase):
     def test_full_invite_journey(self):
         """Full flow: inviter creates invite → friend claims → submits → inviter notified."""
+        # 0. Invite-a-friend only runs while registration is open (#3182)
+        from world.registration.models import get_registration_config
+
+        config = get_registration_config()
+        config.registration_open = True
+        config.save(update_fields=["registration_open"])
+
         # 1. Inviter creates invite
         inviter_pd = PlayerDataFactory()
         invite_category = TrustCategoryFactory(name="INVITE")

--- a/src/world/roster/tests/test_invite_services.py
+++ b/src/world/roster/tests/test_invite_services.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 from django.test import TestCase
 
+from world.registration.models import get_registration_config
 from world.roster.factories import GameInviteFactory, PlayerDataFactory
 from world.roster.models import InviteStatus
 from world.roster.services.invite_services import (
+    RegistrationClosedError,
     claim_game_invite,
     create_game_invite,
     get_invite_for_account,
@@ -18,9 +20,27 @@ from world.stories.models import PlayerTrustLevel
 from world.stories.types import TrustLevel
 
 
+def _set_registration_open(is_open: bool) -> None:
+    config = get_registration_config()
+    config.registration_open = is_open
+    config.save(update_fields=["registration_open"])
+
+
+def _make_trusted_inviter(invite_category):
+    player_data = PlayerDataFactory()
+    trust = PlayerTrustFactory(account=player_data.account)
+    PlayerTrustLevel.objects.create(
+        player_trust=trust,
+        trust_category=invite_category,
+        trust_level=TrustLevel.BASIC,
+    )
+    return player_data
+
+
 class CreateGameInviteTests(TestCase):
     def setUp(self):
         self.invite_category = TrustCategoryFactory(name="INVITE")
+        _set_registration_open(True)
 
     def test_creates_invite_with_token_and_pending_status(self):
         """create_game_invite generates a token and sets PENDING status."""
@@ -96,8 +116,21 @@ class CreateGameInviteTests(TestCase):
         )
         self.assertIsNone(invite.expires_at)
 
+    def test_rejects_trusted_inviter_when_registration_closed(self):
+        """create_game_invite refuses while registration is closed (#3182)."""
+        player_data = _make_trusted_inviter(self.invite_category)
+        _set_registration_open(False)
+        with self.assertRaises(RegistrationClosedError):
+            create_game_invite(
+                inviter=player_data,
+                message="Come play!",
+            )
+
 
 class ResolveInviteTests(TestCase):
+    def setUp(self):
+        _set_registration_open(True)
+
     def test_resolves_pending_invite(self):
         """resolve_invite returns a pending invite by token."""
         invite = GameInviteFactory(status=InviteStatus.PENDING)
@@ -118,8 +151,17 @@ class ResolveInviteTests(TestCase):
         """resolve_invite returns None for a nonexistent token."""
         self.assertIsNone(resolve_invite("nonexistent-token"))
 
+    def test_returns_none_for_pending_invite_when_registration_closed(self):
+        """resolve_invite hides even a valid invite while registration is closed (#3182)."""
+        invite = GameInviteFactory(status=InviteStatus.PENDING)
+        _set_registration_open(False)
+        self.assertIsNone(resolve_invite(invite.token))
+
 
 class ClaimGameInviteTests(TestCase):
+    def setUp(self):
+        _set_registration_open(True)
+
     def test_claims_pending_invite(self):
         """claim_game_invite links account and sets CLAIMED status."""
         from evennia_extensions.factories import AccountFactory
@@ -146,6 +188,17 @@ class ClaimGameInviteTests(TestCase):
         invite = GameInviteFactory(status=InviteStatus.REVOKED)
         with self.assertRaises(ValueError):
             claim_game_invite(invite.token, AccountFactory())
+
+    def test_rejects_pending_invite_when_registration_closed(self):
+        """claim_game_invite refuses even a valid token while registration is closed (#3182)."""
+        from evennia_extensions.factories import AccountFactory
+
+        invite = GameInviteFactory(status=InviteStatus.PENDING)
+        _set_registration_open(False)
+        with self.assertRaises(RegistrationClosedError):
+            claim_game_invite(invite.token, AccountFactory())
+        invite.refresh_from_db()
+        self.assertEqual(invite.status, InviteStatus.PENDING)
 
 
 class RevokeGameInviteTests(TestCase):

--- a/src/world/roster/tests/test_invite_views.py
+++ b/src/world/roster/tests/test_invite_views.py
@@ -7,11 +7,18 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 
 from evennia_extensions.factories import AccountFactory
+from world.registration.models import get_registration_config
 from world.roster.factories import GameInviteFactory, PlayerDataFactory
 from world.roster.models import InviteStatus
 from world.stories.factories import PlayerTrustFactory, TrustCategoryFactory
 from world.stories.models import PlayerTrustLevel
 from world.stories.types import TrustLevel
+
+
+def _set_registration_open(is_open: bool) -> None:
+    config = get_registration_config()
+    config.registration_open = is_open
+    config.save(update_fields=["registration_open"])
 
 
 class GameInviteAPITests(TestCase):
@@ -27,6 +34,7 @@ class GameInviteAPITests(TestCase):
             trust_level=TrustLevel.BASIC,
         )
         self.client.force_authenticate(user=self.account)
+        _set_registration_open(True)
 
     def test_create_invite(self):
         """POST /api/roster/invites/ creates an invite."""
@@ -84,4 +92,46 @@ class GameInviteAPITests(TestCase):
         self.client.force_authenticate(user=None)
         url = reverse("roster:gameinvite-resolve")
         response = self.client.get(url, {"token": "nonexistent"}, format="json")
+        self.assertEqual(response.status_code, 404)
+
+
+class GameInviteRegistrationClosedAPITests(TestCase):
+    """While registration is closed, the invite-a-friend API is off (#3182)."""
+
+    def setUp(self):
+        self.client = APIClient()
+        self.account = AccountFactory()
+        self.player_data = PlayerDataFactory(account=self.account)
+        self.invite_category = TrustCategoryFactory(name="INVITE")
+        trust = PlayerTrustFactory(account=self.account)
+        PlayerTrustLevel.objects.create(
+            player_trust=trust,
+            trust_category=self.invite_category,
+            trust_level=TrustLevel.BASIC,
+        )
+        self.client.force_authenticate(user=self.account)
+        _set_registration_open(False)
+
+    def test_create_returns_403_with_closed_message(self):
+        """POST create is refused with the registration-closed message, not the trust one."""
+        url = reverse("roster:gameinvite-list")
+        response = self.client.post(url, {"message": "Come play Arx!"}, format="json")
+        self.assertEqual(response.status_code, 403)
+        self.assertIn("registration is closed", response.data["detail"])
+
+    def test_claim_returns_403(self):
+        """POST claim is refused for a valid pending token."""
+        invite = GameInviteFactory(status=InviteStatus.PENDING)
+        url = reverse("roster:gameinvite-claim")
+        response = self.client.post(url, {"token": invite.token}, format="json")
+        self.assertEqual(response.status_code, 403)
+        invite.refresh_from_db()
+        self.assertEqual(invite.status, InviteStatus.PENDING)
+
+    def test_resolve_returns_404_for_valid_token(self):
+        """GET resolve hides a valid pending invite while registration is closed."""
+        invite = GameInviteFactory(status=InviteStatus.PENDING)
+        self.client.force_authenticate(user=None)
+        url = reverse("roster:gameinvite-resolve")
+        response = self.client.get(url, {"token": invite.token}, format="json")
         self.assertEqual(response.status_code, 404)

--- a/src/world/roster/views/invite_views.py
+++ b/src/world/roster/views/invite_views.py
@@ -18,11 +18,14 @@ from world.roster.serializers.invites import (
     GameInviteSerializer,
 )
 from world.roster.services.invite_services import (
+    RegistrationClosedError,
     claim_game_invite,
     create_game_invite,
     resolve_invite,
     revoke_game_invite,
 )
+
+INVITES_CLOSED_DETAIL = "Player invites are disabled while registration is closed."
 
 
 class GameInviteViewSet(viewsets.ModelViewSet):
@@ -64,6 +67,11 @@ class GameInviteViewSet(viewsets.ModelViewSet):
             invite = create_game_invite(
                 inviter=player_data,
                 message=serializer.validated_data["message"],
+            )
+        except RegistrationClosedError:
+            return Response(
+                {"detail": INVITES_CLOSED_DETAIL},
+                status=status.HTTP_403_FORBIDDEN,
             )
         except PermissionError:
             return Response(
@@ -112,6 +120,11 @@ class GameInviteViewSet(viewsets.ModelViewSet):
             )
         try:
             invite = claim_game_invite(token=token, account=request.user)  # type: ignore[arg-type]
+        except RegistrationClosedError:
+            return Response(
+                {"detail": INVITES_CLOSED_DETAIL},
+                status=status.HTTP_403_FORBIDDEN,
+            )
         except ValueError:
             return Response(
                 {"detail": "Invite could not be claimed (invalid, claimed, revoked, or expired)."},


### PR DESCRIPTION
Closes #3182

## Summary

While registration is closed, the player invite-a-friend surface is off end to end: create and claim raise a typed RegistrationClosedError (distinct 403 from the trust-threshold PermissionError), and resolve returns None so stale links get a 404 rather than a welcoming banner for an invite that cannot work. Claimed invites keep annotating applications. Docs: registration.md now states which invite system the gate governs; INDEX.md roster entry updated. Spec skipped per Tehom (infra/hardening work, latent bug - no frontend caller exists yet).

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #3182 (in the issue body)
- Brainstorm/plan: skipped
- Sync-with-main: Rebased onto origin/main cleanly (no conflicts).

<!-- last-addressed-comment: 0 -->