### PR TITLE
Tighten edge TLS posture: strict origin verification, enforced HTTPS, TLS 1.2 floor

### DIFF
--- a/infra/terraform/modules/cloudflare_zone_security/main.tf
+++ b/infra/terraform/modules/cloudflare_zone_security/main.tf
@@ -1,8 +1,9 @@
 # Zone security configuration, codified from the live dashboard state on
-# 2026-08-17 (#3205). Values below are a FAITHFUL IMPORT of what the zone held
-# that day — first apply is a no-op write of identical values. Tightening any
-# of them is a deliberate, reviewed diff on this file, never a dashboard edit:
-# dashboard-side changes now surface as drift in `tofu plan`.
+# 2026-08-17 (#3205) and applied that day as a verified no-op. The TLS/HTTPS
+# cluster was then deliberately tightened (same day, reviewed diff — see its
+# comment below). Changing any value here is a reviewed diff on this file,
+# never a dashboard edit: dashboard-side changes surface as drift in
+# `tofu plan`.
 #
 # Why this module exists: #3189 — a dashboard-side rule 403'd lazily-imported
 # frontend chunks (`/static/dist/assets/*.js`) before they reached origin,
@@ -33,14 +34,19 @@ resource "cloudflare_zone_settings_override" "this" {
     browser_check  = "on"
     challenge_ttl  = 1800
 
-    # TLS/HTTPS posture, as found. KNOWN-WEAK, kept as-is by #3205's
-    # faithful-import rule (behavior change = its own reviewed PR):
-    #   - ssl "full" accepts any origin cert (not "strict")
-    #   - always_use_https off leaves plain HTTP unredirected at the edge
-    #   - min_tls_version 1.0 admits legacy clients
-    ssl                      = "full"
-    always_use_https         = "off"
-    min_tls_version          = "1.0"
+    # TLS/HTTPS posture, tightened 2026-08-17 (Tehom's call) from the weaker
+    # as-found dashboard values the #3205 import recorded (full / off / 1.0).
+    # The origin was already built for this: Caddy terminates real ACME
+    # DNS-01 certs for the web fqdn and its own Caddyfile assumed "Full
+    # strict", and Caddy 308-redirects plain HTTP itself — the edge was the
+    # only weak link.
+    #   - ssl "strict": Cloudflare verifies the origin cert (a bad origin
+    #     cert now fails loudly as 526 instead of silently accepting MITM)
+    #   - always_use_https on: edge 301s http:// before origin round-trip
+    #   - min_tls_version 1.2: refuses TLS 1.0/1.1 museum handshakes
+    ssl                      = "strict"
+    always_use_https         = "on"
+    min_tls_version          = "1.2"
     tls_1_3                  = "on"
     automatic_https_rewrites = "on"
   }


### PR DESCRIPTION
## Summary

Tightens the Cloudflare edge TLS posture that the #3205 import (#3260) recorded at its weak as-found dashboard values. Ruled by Tehom 2026-08-17: enforce TLS.

- `ssl`: `full` → `strict` — Cloudflare now verifies the origin certificate instead of accepting any cert on the Cloudflare→origin leg. The origin has always been ready for this: Caddy terminates valid Let's Encrypt certs for the web fqdn via ACME DNS-01, and the Caddyfile's own header comment assumed "Full strict" was already in force.
- `always_use_https`: `off` → `on` — the edge redirects `http://` itself. (No plaintext was being served: Caddy already 308-redirects HTTP, verified live before this change. This moves the redirect to the edge and keeps it if the origin config ever changes.)
- `min_tls_version`: `1.0` → `1.2` — refuses TLS 1.0/1.1 handshakes; every browser of the last decade speaks 1.2+.

Player-visible effect: none expected. Failure mode if the origin cert were ever invalid: loud 526s rather than silent MITM acceptance — the correct trade.

Post-apply verification plan (next Big Button run): confirm `https://play.arx2.com` loads, `http://` 301s at the edge, and a TLS 1.0 handshake is refused.

## Notes

- `tofu fmt` clean; `tofu init -backend=false && tofu validate` passes (same pre-existing compute deprecation warning only)
- No issue reference: direct follow-up to #3205 ruled in-session by Tehom

🤖 Generated with [Claude Code](https://claude.com/claude-code)
