### PR TITLE
Self-heal Evennia through reboot-time restart races and start-limit death

### DIFF
--- a/infra/ansible/roles/app_deploy/templates/arxii-watchdog.sh.j2
+++ b/infra/ansible/roles/app_deploy/templates/arxii-watchdog.sh.j2
@@ -7,7 +7,10 @@
 # leaves the unit "active" from systemd's point of view (Server is fine)
 # while players cannot connect. This timer-driven script checks BOTH
 # pidfiles every run and restarts the unit (+ fires an off-box alert) when
-# the unit claims active but a daemon is dead.
+# the unit claims active but a daemon is dead. Since the 2026-08-17 reboot
+# outage it also resurrects a unit that systemd has parked in `failed`
+# (start-limit hit) — rate-limited, see the failed branch below — so a
+# crash-looped start eventually converges back to running without a human.
 #
 # Failure modes this deliberately guards against becoming false positives —
 # a watchdog that flaps (restarts on every transient blip) is worse than no
@@ -44,11 +47,41 @@ GRACE_PERIOD_S=120
 
 log() { printf '[watchdog] %s\n' "$*"; }
 
-# Not active at all (stopped/failed) — not our concern; systemd's own
-# Restart=on-failure handles a fully-dead unit. We only catch the "unit
-# says active but one daemon silently died" case.
+# Three states matter here:
+#   active  -> fall through to the half-dead pidfile checks below.
+#   failed  -> systemd's Restart= gave up (start-limit hit). Nothing else
+#              will ever retry — this was the 2026-08-17 outage: a reboot-
+#              time restart race parked the unit in `failed` and the site
+#              served 502s until a human pressed the deploy button. Resurrect
+#              it here, rate-limited by a stamp file so a genuinely broken
+#              build gets one attempt per RESURRECT_INTERVAL_S, not a flap
+#              storm (each attempt still gets the unit's own StartLimitBurst
+#              of internal retries).
+#   other (inactive/activating/...) -> deliberate stop or start in flight;
+#              not ours to touch.
+RESURRECT_INTERVAL_S=300
+RESURRECT_STAMP=/run/arxii-watchdog.resurrect-stamp
+
 active_state="$(systemctl is-active "${SERVICE}" 2>/dev/null || true)"
 if [ "${active_state}" != "active" ]; then
+  if [ "${active_state}" = "failed" ]; then
+    now_s="$(date +%s)"
+    last_s="$(stat -c %Y "${RESURRECT_STAMP}" 2>/dev/null || echo 0)"
+    if [ $(( now_s - last_s )) -lt "${RESURRECT_INTERVAL_S}" ]; then
+      log "unit failed but last resurrection was $(( now_s - last_s ))s ago" \
+        "(< ${RESURRECT_INTERVAL_S}s) — waiting"
+      exit 0
+    fi
+    touch "${RESURRECT_STAMP}"
+    log "unit is failed and nothing else will retry — reset-failed + start"
+    systemctl reset-failed "${SERVICE}"
+    systemctl start "${SERVICE}" || log "start failed; will retry next interval"
+    if [ -x /usr/local/sbin/arxii-alert ]; then
+      /usr/local/sbin/arxii-alert \
+        "watchdog resurrected ${SERVICE} from systemd 'failed' state (start-limit had been hit)"
+    fi
+    exit 0
+  fi
   log "unit not active (${active_state}) — nothing to do"
   exit 0
 fi

--- a/infra/ansible/roles/app_deploy/templates/arxii.service.j2
+++ b/infra/ansible/roles/app_deploy/templates/arxii.service.j2
@@ -2,6 +2,16 @@
 Description=Arx II (Evennia) game server
 After=network-online.target postgresql.service
 Wants=network-online.target
+# Keep retrying for minutes, not systemd's default 5-tries-in-10s. During the
+# 2026-08-17 unattended-upgrades reboot, a slow cold start + RestartSec=5
+# made restart attempts race the dying predecessor ("Couldn't listen on
+# 127.0.0.1:4005: Address already in use"), burn the default start limit in
+# seconds, and park the unit in `failed` — where nothing retried and the
+# site stayed 502 until a human intervened. 10 tries spaced 15s apart cover
+# ~2.5 minutes; past that the watchdog's failed-state resurrection (see
+# arxii-watchdog.sh.j2) takes over with its own rate limit.
+StartLimitIntervalSec=600
+StartLimitBurst=10
 
 [Service]
 # Non-root, memory-isolated slice, secrets via the 0600 EnvironmentFile.
@@ -19,11 +29,23 @@ EnvironmentFile={{ secrets_env_file | default('/etc/arxii/arxii.env') }}
 # so the `evennia` entrypoint installed via uv sync is on PATH.
 Type=forking
 PIDFile={{ app_pidfile }}
+# A cold start after a host reboot (DB warmup, uv resolution, both daemons
+# forking) can exceed systemd's default 90s; declaring failure early is what
+# triggered the 2026-08-17 restart race. Five minutes is generous, and a
+# genuinely hung start still fails and retries.
+TimeoutStartSec=300
 ExecStart={{ base_uv_bin }} run evennia start
 ExecReload={{ base_uv_bin }} run evennia reload
 ExecStop={{ base_uv_bin }} run evennia stop
+# Runs after every stop AND after a failed start: force-clear any twistd
+# survivor so the next start can never collide with a predecessor still
+# holding a port. `-` prefix: pkill exiting 1 (nothing to kill, the normal
+# case) must not mark the stop failed. Scoped to the app user's twistd
+# processes only — deploy-time django commands under the same user don't
+# match.
+ExecStopPost=-/usr/bin/pkill -KILL -u {{ app_user }} -f twistd
 Restart=on-failure
-RestartSec=5
+RestartSec=15
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

Makes the Evennia service self-heal through the failure class that took the site down on 2026-08-17: the unattended-upgrades host reboot produced a slow cold start, systemd declared it failed at the default 90s, and the `RestartSec=5` retry raced the dying predecessor (`CannotListenError: Couldn't listen on 127.0.0.1:4005: Address already in use`), burning the default 5-in-10s start limit within seconds. The unit parked in `failed`, where `Restart=on-failure` was spent and the watchdog deliberately ignored non-active units — so the site served Cloudflare 502s until a human pressed the deploy button.

Three complementary layers:

1. **Unit hardening** (`arxii.service.j2`): `TimeoutStartSec=300` (a cold post-reboot start is not a failure at 90s — this was the race trigger); `RestartSec=15` with `StartLimitIntervalSec=600` / `StartLimitBurst=10` (retries spaced past a dying predecessor, lasting ~2.5 minutes instead of giving up inside 10 seconds).
2. **Port-holder cleanup** (`ExecStopPost`): after every stop *and* every failed start, force-kill the app user's surviving `twistd` processes, so no retry can ever collide with a leftover port-holder.
3. **Watchdog resurrection** (`arxii-watchdog.sh.j2`): the failed state is no longer nobody's job — the every-minute watchdog now does `reset-failed` + `start` on a `failed` unit, rate-limited by a stamp file to one attempt per 5 minutes (a genuinely broken build gets bounded retries plus the existing off-box alert, not a flap storm).

Escalation ladder after this PR: transient crash → systemd retries for minutes → still failed → watchdog resurrects every 5 minutes with alerts → a human only needed for a genuinely broken build, and they hear about it from the alert rather than a player.

Takes effect on the next Big Button converge (template deploy + daemon-reload; new restart semantics apply from the next stop/start).

## Notes

- `bash -n` clean on the rendered-shape watchdog script; ansible-lint/caddy validation gates run in CI
- Direct follow-up to today's outage, diagnosed live with Tehom; no separate issue filed (fix-now class)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
