### PR TITLE
Staff approval of roster-character applications has no web surface (Django admin only)

### DIFF
--- a/docs/roadmap/gm-system.md
+++ b/docs/roadmap/gm-system.md
@@ -42,6 +42,10 @@ Progression is driven by player feedback/upvotes tied to stories run and how pla
 - GMs create new roster characters scoped to their table (gated by level)
 - Created characters go through the normal roster application flow
 - GM approves/denies applications to their table's roster (via their own job queue)
+- **Site-wide staff approval shipped (#3265):** `RosterApplicationViewSet` +
+  `/staff/roster-applications` give staff a review queue for applications to any
+  staff-authored roster character. The table-scoped GM job queue frontend (a GM
+  seeing only applications to their own table) remains open - see #3268.
 - **Invite codes** — GM sends an out-of-game invite code (email); new player signs up and can claim the character during registration. Crucial for recruitment — brings in players who aren't on the game at all.
 
 ### Stories (GM's role only — stories app owns itself)

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -1963,6 +1963,20 @@ Character lifecycle management with web-first applications and player anonymity.
   `RegistrationClosedError` (403 at the API) and `resolve_invite` returns None
   (404) — a player invite is never a side door around the staff
   `AccountInvite` gate.
+- **Staff application review queue (#3265):** `RosterApplicationViewSet`
+  (`/api/roster/applications/`, staff-only via `CanApproveApplications` →
+  `PlayerData.can_approve_applications()`) surfaces the review workflow the admin
+  bulk actions previously gated alone. List/detail use the new
+  `RosterApplicationListSerializer` and the (now-wired) pre-existing
+  `RosterApplicationDetailSerializer`; `review` posts through the pre-existing
+  `RosterApplicationApprovalSerializer` to `RosterApplication.approve()`/`.deny()`.
+  Fixed in the same change: `character_name` on both serializers now sources
+  `character.character.db_key` (was `character.db_key`, one hop short of the
+  `ObjectDB` - `character` here is the `CharacterSheet`, not the game object).
+  Frontend: `/staff/roster-applications` (queue) + `/staff/roster-applications/:id`
+  (detail, approve/deny), linked from the staff hub's "Roster Character
+  Applications" card; the pre-existing hub card was retitled "Character
+  Applications" to disambiguate from CG's DraftApplication queue.
 - **Integrates with:** accounts, character_sheets, scenes
 - **Source:** `src/world/roster/`
 - **Details:** [roster.md](roster.md)

--- a/docs/systems/roster.md
+++ b/docs/systems/roster.md
@@ -329,6 +329,23 @@ Web-only surface: compose at `/profile/mail` or in-scene via `SendLetterDialog` 
 `ComposeMailForm` from the character card quick actions), unread badge in the header
 (`UnreadMailBadge`), mark-read-on-open in `ReceivedMailList`. No telnet mail command.
 
+### Applications (`/api/roster/applications/`) - staff review queue (#3265)
+- `GET /api/roster/applications/` - List applications; `?status=` filters by
+  `ApplicationStatus` (`pending`/`approved`/`denied`/`withdrawn`), defaulting to
+  pending-only when omitted (`RosterApplicationFilterSet.qs`) so the queue opens on
+  what needs action
+- `GET /api/roster/applications/{id}/` - Application detail (full text, `policy_review_info`)
+- `POST /api/roster/applications/{id}/review/` - `{"action": "approve"|"deny",
+  "review_notes"}` drives `RosterApplication.approve()`/`.deny()`
+- `GET /api/roster/applications/pending-count/` - Count of pending applications, for
+  the staff hub badge
+
+All four routes are staff-only, gated by `CanApproveApplications`
+(`PlayerData.can_approve_applications()` - staff today; trust-system integration is
+future work). Distinct from `character_creation`'s DraftApplication review: this
+queue is players applying for staff-authored characters already on the Available
+shelf, not new player-made characters going through CG.
+
 ### Families (`/api/roster/families/`)
 - `GET /api/roster/families/` - List playable families
 - `GET /api/roster/families/{id}/` - Family detail
@@ -362,6 +379,7 @@ Web-only surface: compose at `/profile/mail` or in-scene via `SendLetterDialog` 
 | `IsPlayerOrStaff` | Roster entry modifications | Active tenure for the entry or staff |
 | `ReadOnlyOrOwner` | Media/gallery viewing | Safe methods for all; write requires ownership |
 | `StaffOnlyWrite` | Roster management | Safe methods for all; write requires staff |
+| `CanApproveApplications` | Application review queue (#3265) | `PlayerData.can_approve_applications()` (staff today) |
 
 ---
 
@@ -379,7 +397,7 @@ Web-only surface: compose at `/profile/mail` or in-scene via `SendLetterDialog` 
 - `RosterAdmin` - List/filter by active status and application permission
 - `RosterEntryAdmin` - Autocomplete for characters; fieldsets for status, history, notes, timestamps
 - `RosterTenureAdmin` - Autocomplete for entry/player_data; date hierarchy on start_date; displays `is_current` boolean
-- `RosterApplicationAdmin` - Bulk approve/deny actions; autocomplete for character/player_data; date hierarchy on applied_date
+- `RosterApplicationAdmin` - Bulk approve/deny actions; autocomplete for character/player_data; date hierarchy on applied_date. No longer the only review surface: staff also review from `/staff/roster-applications` via `RosterApplicationViewSet` (#3265)
 - `TenureDisplaySettingsAdmin` - Grouped fieldsets for display, communication, and roleplay preferences
 - `TenureGalleryAdmin` - Autocomplete for tenure and allowed_viewers
 - `TenureMediaAdmin` - Autocomplete for tenure, media, and gallery

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -100,6 +100,7 @@ const StoryRoomsPage = lazy(() =>
 import { StaffInboxPage } from './staff/pages/StaffInboxPage';
 import { StaffApplicationsPage } from './staff/pages/StaffApplicationsPage';
 import { StaffRosterApplicationsPage } from './staff/pages/StaffRosterApplicationsPage';
+import { StaffRosterApplicationDetailPage } from './staff/pages/StaffRosterApplicationDetailPage';
 import { StaffInvitesPage } from './staff/pages/StaffInvitesPage';
 import { StaffApplicationDetailPage } from './staff/pages/StaffApplicationDetailPage';
 import { StaffFeedbackPage } from './staff/pages/StaffFeedbackPage';
@@ -643,6 +644,14 @@ function App() {
             element={
               <StaffRoute>
                 <StaffRosterApplicationsPage />
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/roster-applications/:id"
+            element={
+              <StaffRoute>
+                <StaffRosterApplicationDetailPage />
               </StaffRoute>
             }
           />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -99,6 +99,7 @@ const StoryRoomsPage = lazy(() =>
 );
 import { StaffInboxPage } from './staff/pages/StaffInboxPage';
 import { StaffApplicationsPage } from './staff/pages/StaffApplicationsPage';
+import { StaffRosterApplicationsPage } from './staff/pages/StaffRosterApplicationsPage';
 import { StaffInvitesPage } from './staff/pages/StaffInvitesPage';
 import { StaffApplicationDetailPage } from './staff/pages/StaffApplicationDetailPage';
 import { StaffFeedbackPage } from './staff/pages/StaffFeedbackPage';
@@ -634,6 +635,14 @@ function App() {
             element={
               <StaffRoute>
                 <StaffApplicationDetailPage />
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/roster-applications"
+            element={
+              <StaffRoute>
+                <StaffRosterApplicationsPage />
               </StaffRoute>
             }
           />

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -17455,6 +17455,86 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/roster/applications/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Staff-only review queue for applications to existing roster characters.
+     *
+     *     Distinct from character_creation's DraftApplication review (new player-made
+     *     characters): this queue is players applying for staff-authored characters
+     *     on the Available shelf.
+     */
+    get: operations['roster_applications_list'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/roster/applications/{id}/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /**
+     * @description Staff-only review queue for applications to existing roster characters.
+     *
+     *     Distinct from character_creation's DraftApplication review (new player-made
+     *     characters): this queue is players applying for staff-authored characters
+     *     on the Available shelf.
+     */
+    get: operations['roster_applications_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/roster/applications/{id}/review/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /** @description Approve or deny one pending application. */
+    post: operations['roster_applications_review_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
+  '/api/roster/applications/pending-count/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    /** @description Count of applications awaiting review, for the staff hub badge. */
+    get: operations['roster_applications_pending_count_retrieve'];
+    put?: never;
+    post?: never;
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/roster/entries/': {
     parameters: {
       query?: never;
@@ -32727,6 +32807,21 @@ export interface components {
       previous?: string | null;
       results: components['schemas']['RoomWardDetails'][];
     };
+    PaginatedRosterApplicationListList: {
+      /** @example 123 */
+      count: number;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=4
+       */
+      next?: string | null;
+      /**
+       * Format: uri
+       * @example http://api.example.org/accounts/?page=2
+       */
+      previous?: string | null;
+      results: components['schemas']['RosterApplicationList'][];
+    };
     PaginatedRosterEntryList: {
       /** @example 123 */
       count: number;
@@ -37255,6 +37350,37 @@ export interface components {
     /** @description Validate a roster application message. */
     RosterApplication: {
       message: string;
+    };
+    /** @description Serializer for retrieving application details. */
+    RosterApplicationDetail: {
+      readonly id: number;
+      readonly character_name: string;
+      readonly player_username: string;
+      status?: components['schemas']['StatusBa9Enum'];
+      readonly status_display: string;
+      /** @description Why player wants this character */
+      application_text: string;
+      /** @description Staff notes on application */
+      review_notes?: string;
+      /** Format: date-time */
+      readonly applied_date: string;
+      /** Format: date-time */
+      readonly reviewed_date: string | null;
+      readonly policy_review_info: string;
+    };
+    /** @description Slim row for the staff review queue (no per-row policy queries). */
+    RosterApplicationList: {
+      readonly id: number;
+      readonly character_name: string;
+      readonly player_username: string;
+      status?: components['schemas']['StatusBa9Enum'];
+      readonly status_display: string;
+      /** Format: date-time */
+      readonly applied_date: string;
+    };
+    /** @description Slim row for the staff review queue (no per-row policy queries). */
+    RosterApplicationListRequest: {
+      status?: components['schemas']['StatusBa9Enum'];
     };
     /** @description Validate a roster application message. */
     RosterApplicationRequest: {
@@ -65534,6 +65660,102 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['Trap'][];
+        };
+      };
+    };
+  };
+  roster_applications_list: {
+    parameters: {
+      query?: {
+        /** @description A page number within the paginated result set. */
+        page?: number;
+        /**
+         * @description * `pending` - Pending Review
+         *     * `approved` - Approved
+         *     * `denied` - Denied
+         *     * `withdrawn` - Withdrawn
+         */
+        status?: 'approved' | 'denied' | 'pending' | 'withdrawn';
+      };
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['PaginatedRosterApplicationListList'];
+        };
+      };
+    };
+  };
+  roster_applications_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this Roster Application. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['RosterApplicationDetail'];
+        };
+      };
+    };
+  };
+  roster_applications_review_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path: {
+        /** @description A unique integer value identifying this Roster Application. */
+        id: number;
+      };
+      cookie?: never;
+    };
+    requestBody?: {
+      content: {
+        'application/json': components['schemas']['RosterApplicationListRequest'];
+      };
+    };
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['RosterApplicationList'];
+        };
+      };
+    };
+  };
+  roster_applications_pending_count_retrieve: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody?: never;
+    responses: {
+      200: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['RosterApplicationList'];
         };
       };
     };

--- a/frontend/src/staff/api.ts
+++ b/frontend/src/staff/api.ts
@@ -15,6 +15,9 @@ import type {
   InboxResponse,
   PlayerFeedback,
   PlayerReport,
+  RosterApplicationDetail,
+  RosterApplicationListItem,
+  RosterApplicationStatus,
   SubmissionCategory,
   SubmissionStatus,
   SystemErrorReport,
@@ -24,6 +27,7 @@ const INBOX_URL = '/api/staff-inbox';
 const SUBMISSIONS_URL = '/api/player-submissions';
 const GM_URL = '/api/gm/applications';
 const INVITES_URL = '/api/staff/invites';
+const ROSTER_APPS_URL = '/api/roster/applications';
 
 // =============================================================================
 // Staff Inbox
@@ -338,6 +342,56 @@ export async function resendAccountInvite(id: number): Promise<AccountInvite> {
     throw new Error(data?.detail ?? 'Failed to resend invite');
   }
   return res.json();
+}
+
+// =============================================================================
+// Roster-Character Applications (#3265)
+// =============================================================================
+
+export async function getRosterApplications(
+  status?: RosterApplicationStatus,
+  page?: number
+): Promise<PaginatedResponse<RosterApplicationListItem>> {
+  const params = new URLSearchParams();
+  if (status) {
+    params.append('status', status);
+  }
+  if (page != null) {
+    params.append('page', page.toString());
+  }
+  const qs = params.toString();
+  const res = await apiFetch(`${ROSTER_APPS_URL}/${qs ? `?${qs}` : ''}`);
+  if (!res.ok) throw new Error('Failed to load roster application list');
+  return res.json();
+}
+
+export async function getRosterApplicationDetail(id: number): Promise<RosterApplicationDetail> {
+  const res = await apiFetch(`${ROSTER_APPS_URL}/${id}/`);
+  if (!res.ok) throw new Error('Failed to load roster application detail');
+  return res.json();
+}
+
+export async function reviewRosterApplication(
+  id: number,
+  action: 'approve' | 'deny',
+  reviewNotes?: string
+): Promise<RosterApplicationDetail> {
+  const res = await apiFetch(`${ROSTER_APPS_URL}/${id}/review/`, {
+    method: 'POST',
+    body: JSON.stringify({ action, review_notes: reviewNotes ?? '' }),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => null);
+    throw new Error(data?.detail ?? 'Failed to review roster application');
+  }
+  return res.json();
+}
+
+export async function getPendingRosterApplicationCount(): Promise<number> {
+  const res = await apiFetch(`${ROSTER_APPS_URL}/pending-count/`);
+  if (!res.ok) return 0;
+  const data = await res.json();
+  return data.count;
 }
 
 // Staff-only fallback when mail cannot reach the player (#3193): produces the

--- a/frontend/src/staff/api.ts
+++ b/frontend/src/staff/api.ts
@@ -17,6 +17,7 @@ import type {
   PlayerReport,
   RosterApplicationDetail,
   RosterApplicationListItem,
+  RosterApplicationReviewResult,
   RosterApplicationStatus,
   SubmissionCategory,
   SubmissionStatus,
@@ -375,7 +376,7 @@ export async function reviewRosterApplication(
   id: number,
   action: 'approve' | 'deny',
   reviewNotes?: string
-): Promise<RosterApplicationDetail> {
+): Promise<RosterApplicationReviewResult> {
   const res = await apiFetch(`${ROSTER_APPS_URL}/${id}/review/`, {
     method: 'POST',
     body: JSON.stringify({ action, review_notes: reviewNotes ?? '' }),

--- a/frontend/src/staff/api.ts
+++ b/frontend/src/staff/api.ts
@@ -361,7 +361,8 @@ export async function getRosterApplications(
     params.append('page', page.toString());
   }
   const qs = params.toString();
-  const res = await apiFetch(`${ROSTER_APPS_URL}/${qs ? `?${qs}` : ''}`);
+  const suffix = qs ? `?${qs}` : '';
+  const res = await apiFetch(`${ROSTER_APPS_URL}/${suffix}`);
   if (!res.ok) throw new Error('Failed to load roster application list');
   return res.json();
 }

--- a/frontend/src/staff/pages/StaffBugReportsPage.tsx
+++ b/frontend/src/staff/pages/StaffBugReportsPage.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { NextPrevPagination, StatusFilterBar } from '@/staff/components/listControls';
 import { useBugReportList } from '@/staff/queries';
 import type { SubmissionStatus } from '@/staff/types';
 import { STATUS_OPTIONS, statusVariant } from '@/staff/utils';
@@ -18,21 +18,14 @@ export function StaffBugReportsPage() {
     <div className="container mx-auto max-w-6xl px-4 py-8">
       <h1 className="mb-6 text-2xl font-bold">Bug Reports</h1>
 
-      <div className="mb-6 flex flex-wrap gap-2">
-        {STATUS_OPTIONS.map((opt) => (
-          <Button
-            key={opt.label}
-            variant={statusFilter === opt.value ? 'default' : 'outline'}
-            size="sm"
-            onClick={() => {
-              setStatusFilter(opt.value);
-              setPage(1);
-            }}
-          >
-            {opt.label}
-          </Button>
-        ))}
-      </div>
+      <StatusFilterBar
+        options={STATUS_OPTIONS}
+        value={statusFilter}
+        onChange={(value) => {
+          setStatusFilter(value);
+          setPage(1);
+        }}
+      />
 
       {isLoading ? (
         <p className="text-muted-foreground">Loading...</p>
@@ -63,27 +56,12 @@ export function StaffBugReportsPage() {
             ))}
           </div>
 
-          {data && data.count > 0 && (data.next || data.previous) && (
-            <div className="mt-6 flex items-center justify-center gap-4">
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!data.previous}
-                onClick={() => setPage((p) => p - 1)}
-              >
-                Previous
-              </Button>
-              <span className="text-sm text-muted-foreground">Page {page}</span>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!data.next}
-                onClick={() => setPage((p) => p + 1)}
-              >
-                Next
-              </Button>
-            </div>
-          )}
+          <NextPrevPagination
+            page={page}
+            hasPrevious={!!data?.previous}
+            hasNext={!!data?.next}
+            onPageChange={setPage}
+          />
         </>
       )}
     </div>

--- a/frontend/src/staff/pages/StaffFeedbackPage.tsx
+++ b/frontend/src/staff/pages/StaffFeedbackPage.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { NextPrevPagination, StatusFilterBar } from '@/staff/components/listControls';
 import { useFeedbackList } from '@/staff/queries';
 import type { SubmissionStatus } from '@/staff/types';
 import { STATUS_OPTIONS, statusVariant } from '@/staff/utils';
@@ -18,21 +18,14 @@ export function StaffFeedbackPage() {
     <div className="container mx-auto max-w-6xl px-4 py-8">
       <h1 className="mb-6 text-2xl font-bold">Player Feedback</h1>
 
-      <div className="mb-6 flex flex-wrap gap-2">
-        {STATUS_OPTIONS.map((opt) => (
-          <Button
-            key={opt.label}
-            variant={statusFilter === opt.value ? 'default' : 'outline'}
-            size="sm"
-            onClick={() => {
-              setStatusFilter(opt.value);
-              setPage(1);
-            }}
-          >
-            {opt.label}
-          </Button>
-        ))}
-      </div>
+      <StatusFilterBar
+        options={STATUS_OPTIONS}
+        value={statusFilter}
+        onChange={(value) => {
+          setStatusFilter(value);
+          setPage(1);
+        }}
+      />
 
       {isLoading ? (
         <p className="text-muted-foreground">Loading...</p>
@@ -63,27 +56,12 @@ export function StaffFeedbackPage() {
             ))}
           </div>
 
-          {data && data.count > 0 && (data.next || data.previous) && (
-            <div className="mt-6 flex items-center justify-center gap-4">
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!data.previous}
-                onClick={() => setPage((p) => p - 1)}
-              >
-                Previous
-              </Button>
-              <span className="text-sm text-muted-foreground">Page {page}</span>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!data.next}
-                onClick={() => setPage((p) => p + 1)}
-              >
-                Next
-              </Button>
-            </div>
-          )}
+          <NextPrevPagination
+            page={page}
+            hasPrevious={!!data?.previous}
+            hasNext={!!data?.next}
+            onPageChange={setPage}
+          />
         </>
       )}
     </div>

--- a/frontend/src/staff/pages/StaffGMApplicationsPage.tsx
+++ b/frontend/src/staff/pages/StaffGMApplicationsPage.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { NextPrevPagination, StatusFilterBar } from '@/staff/components/listControls';
 import { useGMApplicationList } from '@/staff/queries';
 import type { GMApplicationStatus } from '@/staff/types';
 
@@ -40,21 +40,14 @@ export function StaffGMApplicationsPage() {
     <div className="container mx-auto max-w-6xl px-4 py-8">
       <h1 className="mb-6 text-2xl font-bold">GM Applications</h1>
 
-      <div className="mb-6 flex flex-wrap gap-2">
-        {GM_STATUS_OPTIONS.map((opt) => (
-          <Button
-            key={opt.label}
-            variant={statusFilter === opt.value ? 'default' : 'outline'}
-            size="sm"
-            onClick={() => {
-              setStatusFilter(opt.value);
-              setPage(1);
-            }}
-          >
-            {opt.label}
-          </Button>
-        ))}
-      </div>
+      <StatusFilterBar
+        options={GM_STATUS_OPTIONS}
+        value={statusFilter}
+        onChange={(value) => {
+          setStatusFilter(value);
+          setPage(1);
+        }}
+      />
 
       {isLoading ? (
         <p className="text-muted-foreground">Loading...</p>
@@ -85,27 +78,12 @@ export function StaffGMApplicationsPage() {
             ))}
           </div>
 
-          {data && data.count > 0 && (data.next || data.previous) && (
-            <div className="mt-6 flex items-center justify-center gap-4">
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!data.previous}
-                onClick={() => setPage((p) => p - 1)}
-              >
-                Previous
-              </Button>
-              <span className="text-sm text-muted-foreground">Page {page}</span>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!data.next}
-                onClick={() => setPage((p) => p + 1)}
-              >
-                Next
-              </Button>
-            </div>
-          )}
+          <NextPrevPagination
+            page={page}
+            hasPrevious={!!data?.previous}
+            hasNext={!!data?.next}
+            onPageChange={setPage}
+          />
         </>
       )}
     </div>

--- a/frontend/src/staff/pages/StaffHubPage.tsx
+++ b/frontend/src/staff/pages/StaffHubPage.tsx
@@ -2,11 +2,16 @@ import { Link } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
-import { useOpenSubmissionCount, usePendingApplicationCount } from '@/staff/queries';
+import {
+  useOpenSubmissionCount,
+  usePendingApplicationCount,
+  usePendingRosterApplicationCount,
+} from '@/staff/queries';
 
 export function StaffHubPage() {
   const { data: pendingAppCount } = usePendingApplicationCount();
   const { data: openInboxCount } = useOpenSubmissionCount();
+  const { data: pendingRosterAppCount } = usePendingRosterApplicationCount();
 
   return (
     <div className="container mx-auto max-w-4xl px-4 py-8">
@@ -91,7 +96,7 @@ export function StaffHubPage() {
           <Card className="cursor-pointer transition-colors hover:bg-muted/50">
             <CardHeader>
               <CardTitle className="flex items-center gap-2">
-                Roster Applications
+                Character Applications
                 {pendingAppCount && pendingAppCount > 0 ? (
                   <Badge variant="destructive">{pendingAppCount}</Badge>
                 ) : null}
@@ -99,7 +104,24 @@ export function StaffHubPage() {
             </CardHeader>
             <CardContent>
               <p className="text-sm text-muted-foreground">
-                Review character creation submissions.
+                Review player-created character submissions.
+              </p>
+            </CardContent>
+          </Card>
+        </Link>
+        <Link to="/staff/roster-applications">
+          <Card className="cursor-pointer transition-colors hover:bg-muted/50">
+            <CardHeader>
+              <CardTitle className="flex items-center gap-2">
+                Roster Character Applications
+                {pendingRosterAppCount && pendingRosterAppCount > 0 ? (
+                  <Badge variant="destructive">{pendingRosterAppCount}</Badge>
+                ) : null}
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <p className="text-sm text-muted-foreground">
+                Review applications for existing staff-authored roster characters.
               </p>
             </CardContent>
           </Card>

--- a/frontend/src/staff/pages/StaffPlayerReportsPage.tsx
+++ b/frontend/src/staff/pages/StaffPlayerReportsPage.tsx
@@ -2,8 +2,8 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { NextPrevPagination, StatusFilterBar } from '@/staff/components/listControls';
 import { usePlayerReportList } from '@/staff/queries';
 import type { SubmissionStatus } from '@/staff/types';
 import { STATUS_OPTIONS, statusVariant } from '@/staff/utils';
@@ -18,21 +18,14 @@ export function StaffPlayerReportsPage() {
     <div className="container mx-auto max-w-6xl px-4 py-8">
       <h1 className="mb-6 text-2xl font-bold">Player Reports</h1>
 
-      <div className="mb-6 flex flex-wrap gap-2">
-        {STATUS_OPTIONS.map((opt) => (
-          <Button
-            key={opt.label}
-            variant={statusFilter === opt.value ? 'default' : 'outline'}
-            size="sm"
-            onClick={() => {
-              setStatusFilter(opt.value);
-              setPage(1);
-            }}
-          >
-            {opt.label}
-          </Button>
-        ))}
-      </div>
+      <StatusFilterBar
+        options={STATUS_OPTIONS}
+        value={statusFilter}
+        onChange={(value) => {
+          setStatusFilter(value);
+          setPage(1);
+        }}
+      />
 
       {isLoading ? (
         <p className="text-muted-foreground">Loading...</p>
@@ -66,27 +59,12 @@ export function StaffPlayerReportsPage() {
             ))}
           </div>
 
-          {data && data.count > 0 && (data.next || data.previous) && (
-            <div className="mt-6 flex items-center justify-center gap-4">
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!data.previous}
-                onClick={() => setPage((p) => p - 1)}
-              >
-                Previous
-              </Button>
-              <span className="text-sm text-muted-foreground">Page {page}</span>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!data.next}
-                onClick={() => setPage((p) => p + 1)}
-              >
-                Next
-              </Button>
-            </div>
-          )}
+          <NextPrevPagination
+            page={page}
+            hasPrevious={!!data?.previous}
+            hasNext={!!data?.next}
+            onPageChange={setPage}
+          />
         </>
       )}
     </div>

--- a/frontend/src/staff/pages/StaffRosterApplicationDetailPage.test.tsx
+++ b/frontend/src/staff/pages/StaffRosterApplicationDetailPage.test.tsx
@@ -78,9 +78,10 @@ describe('StaffRosterApplicationDetailPage', () => {
 
   it('fires the approve mutation without requiring notes', async () => {
     vi.mocked(api.getRosterApplicationDetail).mockResolvedValue(makeApplication());
-    vi.mocked(api.reviewRosterApplication).mockResolvedValue(
-      makeApplication({ status: 'approved', status_display: 'Approved' })
-    );
+    vi.mocked(api.reviewRosterApplication).mockResolvedValue({
+      action: 'approved',
+      tenure_created: true,
+    });
 
     renderDetail();
 
@@ -94,9 +95,10 @@ describe('StaffRosterApplicationDetailPage', () => {
 
   it('requires notes before firing the deny mutation, then sends the typed notes', async () => {
     vi.mocked(api.getRosterApplicationDetail).mockResolvedValue(makeApplication());
-    vi.mocked(api.reviewRosterApplication).mockResolvedValue(
-      makeApplication({ status: 'denied', status_display: 'Denied' })
-    );
+    vi.mocked(api.reviewRosterApplication).mockResolvedValue({
+      action: 'denied',
+      success: true,
+    });
 
     renderDetail();
 

--- a/frontend/src/staff/pages/StaffRosterApplicationDetailPage.test.tsx
+++ b/frontend/src/staff/pages/StaffRosterApplicationDetailPage.test.tsx
@@ -1,0 +1,136 @@
+import { Route, Routes } from 'react-router-dom';
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { renderWithProviders } from '@/test/utils/renderWithProviders';
+import * as api from '@/staff/api';
+import type { RosterApplicationDetail } from '@/staff/types';
+import { StaffRosterApplicationDetailPage } from './StaffRosterApplicationDetailPage';
+
+vi.mock('@/staff/api');
+
+function makeApplication(
+  overrides: Partial<RosterApplicationDetail> = {}
+): RosterApplicationDetail {
+  return {
+    id: 1,
+    character_name: 'Aldric Valentine',
+    player_username: 'playerone',
+    status: 'pending',
+    status_display: 'Pending',
+    applied_date: '2026-08-08T00:00:00Z',
+    application_text: 'I would love to play this character because...',
+    review_notes: '',
+    reviewed_date: null,
+    policy_review_info: null,
+    ...overrides,
+  };
+}
+
+function renderDetail(id = '1') {
+  return renderWithProviders(
+    <Routes>
+      <Route path="/staff/roster-applications/:id" element={<StaffRosterApplicationDetailPage />} />
+    </Routes>,
+    { initialEntries: [`/staff/roster-applications/${id}`] }
+  );
+}
+
+describe('StaffRosterApplicationDetailPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('renders the application detail from the mock', async () => {
+    vi.mocked(api.getRosterApplicationDetail).mockResolvedValue(makeApplication());
+
+    renderDetail();
+
+    expect(await screen.findByText('Aldric Valentine')).toBeInTheDocument();
+    expect(screen.getByText('playerone')).toBeInTheDocument();
+    expect(screen.getByText('I would love to play this character because...')).toBeInTheDocument();
+    expect(api.getRosterApplicationDetail).toHaveBeenCalledWith(1);
+  });
+
+  it('renders policy review info as a definition list when present', async () => {
+    vi.mocked(api.getRosterApplicationDetail).mockResolvedValue(
+      makeApplication({ policy_review_info: { alt_count: 2, flagged: true } })
+    );
+
+    renderDetail();
+
+    expect(await screen.findByText('Policy Review')).toBeInTheDocument();
+    expect(screen.getByText('Alt Count')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('Flagged')).toBeInTheDocument();
+    expect(screen.getByText('Yes')).toBeInTheDocument();
+  });
+
+  it('hides the policy review panel when null', async () => {
+    vi.mocked(api.getRosterApplicationDetail).mockResolvedValue(makeApplication());
+
+    renderDetail();
+
+    await screen.findByText('Aldric Valentine');
+    expect(screen.queryByText('Policy Review')).not.toBeInTheDocument();
+  });
+
+  it('fires the approve mutation without requiring notes', async () => {
+    vi.mocked(api.getRosterApplicationDetail).mockResolvedValue(makeApplication());
+    vi.mocked(api.reviewRosterApplication).mockResolvedValue(
+      makeApplication({ status: 'approved', status_display: 'Approved' })
+    );
+
+    renderDetail();
+
+    await screen.findByText('Aldric Valentine');
+    await userEvent.click(screen.getByRole('button', { name: 'Approve' }));
+
+    await waitFor(() => {
+      expect(api.reviewRosterApplication).toHaveBeenCalledWith(1, 'approve', '');
+    });
+  });
+
+  it('requires notes before firing the deny mutation, then sends the typed notes', async () => {
+    vi.mocked(api.getRosterApplicationDetail).mockResolvedValue(makeApplication());
+    vi.mocked(api.reviewRosterApplication).mockResolvedValue(
+      makeApplication({ status: 'denied', status_display: 'Denied' })
+    );
+
+    renderDetail();
+
+    await screen.findByText('Aldric Valentine');
+    await userEvent.click(screen.getByRole('button', { name: 'Deny' }));
+
+    expect(
+      await screen.findByText('Notes are required to deny an application.')
+    ).toBeInTheDocument();
+    expect(api.reviewRosterApplication).not.toHaveBeenCalled();
+
+    await userEvent.type(screen.getByPlaceholderText(/notes for the applicant/i), 'Not a fit.');
+    await userEvent.click(screen.getByRole('button', { name: 'Deny' }));
+
+    await waitFor(() => {
+      expect(api.reviewRosterApplication).toHaveBeenCalledWith(1, 'deny', 'Not a fit.');
+    });
+  });
+
+  it('hides the review panel for a non-pending application', async () => {
+    vi.mocked(api.getRosterApplicationDetail).mockResolvedValue(
+      makeApplication({
+        status: 'approved',
+        status_display: 'Approved',
+        review_notes: 'Looks great.',
+        reviewed_date: '2026-08-10T00:00:00Z',
+      })
+    );
+
+    renderDetail();
+
+    await screen.findByText('Aldric Valentine');
+    expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Deny' })).not.toBeInTheDocument();
+    expect(screen.getByText('Looks great.')).toBeInTheDocument();
+  });
+});

--- a/frontend/src/staff/pages/StaffRosterApplicationDetailPage.tsx
+++ b/frontend/src/staff/pages/StaffRosterApplicationDetailPage.tsx
@@ -7,7 +7,12 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Textarea } from '@/components/ui/textarea';
 import { useReviewRosterApplication, useRosterApplicationDetail } from '@/staff/queries';
 
-function InfoRow({ label, value }: { label: string; value: string }) {
+interface InfoRowProps {
+  label: string;
+  value: string;
+}
+
+function InfoRow({ label, value }: Readonly<InfoRowProps>) {
   return (
     <div className="flex gap-2">
       <span className="min-w-32 font-medium text-muted-foreground">{label}</span>
@@ -26,13 +31,14 @@ function formatPolicyLabel(key: string): string {
 function formatPolicyValue(value: unknown): string {
   if (typeof value === 'boolean') return value ? 'Yes' : 'No';
   if (value === null || value === undefined) return '';
+  if (typeof value === 'object') return JSON.stringify(value);
   return String(value);
 }
 
 export function StaffRosterApplicationDetailPage() {
   const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
-  const appId = id ? parseInt(id, 10) : undefined;
+  const appId = id ? Number.parseInt(id, 10) : undefined;
   const { data: application, isLoading, isError } = useRosterApplicationDetail(appId);
   const review = useReviewRosterApplication();
 

--- a/frontend/src/staff/pages/StaffRosterApplicationDetailPage.tsx
+++ b/frontend/src/staff/pages/StaffRosterApplicationDetailPage.tsx
@@ -1,0 +1,168 @@
+import { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Textarea } from '@/components/ui/textarea';
+import { useReviewRosterApplication, useRosterApplicationDetail } from '@/staff/queries';
+
+function InfoRow({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="flex gap-2">
+      <span className="min-w-32 font-medium text-muted-foreground">{label}</span>
+      <span>{value}</span>
+    </div>
+  );
+}
+
+function formatPolicyLabel(key: string): string {
+  return key
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
+}
+
+function formatPolicyValue(value: unknown): string {
+  if (typeof value === 'boolean') return value ? 'Yes' : 'No';
+  if (value === null || value === undefined) return '';
+  return String(value);
+}
+
+export function StaffRosterApplicationDetailPage() {
+  const navigate = useNavigate();
+  const { id } = useParams<{ id: string }>();
+  const appId = id ? parseInt(id, 10) : undefined;
+  const { data: application, isLoading, isError } = useRosterApplicationDetail(appId);
+  const review = useReviewRosterApplication();
+
+  const [reviewNotes, setReviewNotes] = useState('');
+  const [denyNotesMissing, setDenyNotesMissing] = useState(false);
+
+  if (isLoading) return <p className="p-8 text-muted-foreground">Loading...</p>;
+  if (isError) return <p className="p-8 text-muted-foreground">Failed to load application.</p>;
+  if (!application) {
+    return <p className="p-8 text-muted-foreground">Roster application not found.</p>;
+  }
+
+  const isPending = application.status === 'pending';
+
+  function handleApprove() {
+    if (!appId) return;
+    setDenyNotesMissing(false);
+    review.mutate(
+      { id: appId, action: 'approve', reviewNotes },
+      { onSuccess: () => navigate('/staff/roster-applications') }
+    );
+  }
+
+  function handleDeny() {
+    if (!appId) return;
+    if (!reviewNotes.trim()) {
+      setDenyNotesMissing(true);
+      return;
+    }
+    setDenyNotesMissing(false);
+    review.mutate(
+      { id: appId, action: 'deny', reviewNotes },
+      { onSuccess: () => navigate('/staff/roster-applications') }
+    );
+  }
+
+  return (
+    <div className="container mx-auto max-w-4xl space-y-6 px-4 py-8">
+      <h1 className="text-2xl font-bold">Roster Application Review</h1>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center justify-between">
+            <span>{application.character_name}</span>
+            <Badge>{application.status_display}</Badge>
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm">
+          <InfoRow label="Applicant" value={application.player_username} />
+          <InfoRow label="Applied" value={new Date(application.applied_date).toLocaleString()} />
+          <div>
+            <p className="font-medium text-muted-foreground">Application</p>
+            <p className="whitespace-pre-wrap">{application.application_text}</p>
+          </div>
+        </CardContent>
+      </Card>
+
+      {application.policy_review_info && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Policy Review</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <dl className="space-y-2 text-sm">
+              {Object.entries(application.policy_review_info).map(([key, value]) => (
+                <div key={key} className="flex gap-2">
+                  <dt className="min-w-32 font-medium text-muted-foreground">
+                    {formatPolicyLabel(key)}
+                  </dt>
+                  <dd>{formatPolicyValue(value)}</dd>
+                </div>
+              ))}
+            </dl>
+          </CardContent>
+        </Card>
+      )}
+
+      {isPending ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Review</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <Textarea
+              value={reviewNotes}
+              onChange={(e) => setReviewNotes(e.target.value)}
+              placeholder="Notes for the applicant (required to deny)..."
+              className="min-h-[100px]"
+              disabled={review.isPending}
+            />
+            <div className="flex flex-wrap gap-2">
+              <Button disabled={review.isPending} onClick={handleApprove}>
+                Approve
+              </Button>
+              <Button variant="destructive" disabled={review.isPending} onClick={handleDeny}>
+                Deny
+              </Button>
+            </div>
+            {denyNotesMissing && (
+              <p className="text-sm text-destructive">Notes are required to deny an application.</p>
+            )}
+            {review.isError && (
+              <p className="text-sm text-destructive">
+                {review.error instanceof Error
+                  ? review.error.message
+                  : 'Something went wrong. Try again.'}
+              </p>
+            )}
+          </CardContent>
+        </Card>
+      ) : (
+        (application.review_notes || application.reviewed_date) && (
+          <Card>
+            <CardHeader>
+              <CardTitle>Review Notes</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-2 text-sm">
+              {application.reviewed_date && (
+                <InfoRow
+                  label="Reviewed"
+                  value={new Date(application.reviewed_date).toLocaleString()}
+                />
+              )}
+              {application.review_notes && (
+                <p className="whitespace-pre-wrap">{application.review_notes}</p>
+              )}
+            </CardContent>
+          </Card>
+        )
+      )}
+    </div>
+  );
+}

--- a/frontend/src/staff/pages/StaffRosterApplicationsPage.test.tsx
+++ b/frontend/src/staff/pages/StaffRosterApplicationsPage.test.tsx
@@ -1,0 +1,76 @@
+import { screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { renderWithProviders } from '@/test/utils/renderWithProviders';
+import * as api from '@/staff/api';
+import type { RosterApplicationListItem } from '@/staff/types';
+import { StaffRosterApplicationsPage } from './StaffRosterApplicationsPage';
+
+vi.mock('@/staff/api');
+
+function makeApplication(
+  overrides: Partial<RosterApplicationListItem> = {}
+): RosterApplicationListItem {
+  return {
+    id: 1,
+    character_name: 'Aldric Valentine',
+    player_username: 'playerone',
+    status: 'pending',
+    status_display: 'Pending',
+    applied_date: '2026-08-08T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('StaffRosterApplicationsPage', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('lists pending roster applications by default', async () => {
+    vi.mocked(api.getRosterApplications).mockResolvedValue({
+      count: 1,
+      next: null,
+      previous: null,
+      results: [makeApplication()],
+    });
+
+    renderWithProviders(<StaffRosterApplicationsPage />);
+
+    expect(await screen.findByText('Aldric Valentine')).toBeInTheDocument();
+    expect(screen.getAllByText('Pending')).toHaveLength(2);
+    expect(api.getRosterApplications).toHaveBeenCalledWith('pending', 1);
+  });
+
+  it('shows an empty state when there are no applications', async () => {
+    vi.mocked(api.getRosterApplications).mockResolvedValue({
+      count: 0,
+      next: null,
+      previous: null,
+      results: [],
+    });
+
+    renderWithProviders(<StaffRosterApplicationsPage />);
+
+    expect(await screen.findByText(/no roster applications found/i)).toBeInTheDocument();
+  });
+
+  it('refetches with the new status when the filter changes', async () => {
+    vi.mocked(api.getRosterApplications).mockResolvedValue({
+      count: 1,
+      next: null,
+      previous: null,
+      results: [makeApplication()],
+    });
+
+    renderWithProviders(<StaffRosterApplicationsPage />);
+
+    await screen.findByText('Aldric Valentine');
+    await userEvent.click(screen.getByRole('button', { name: 'Approved' }));
+
+    await waitFor(() => {
+      expect(api.getRosterApplications).toHaveBeenCalledWith('approved', 1);
+    });
+  });
+});

--- a/frontend/src/staff/pages/StaffRosterApplicationsPage.tsx
+++ b/frontend/src/staff/pages/StaffRosterApplicationsPage.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { useRosterApplications } from '@/staff/queries';
+import type { RosterApplicationStatus } from '@/staff/types';
+
+const STATUS_OPTIONS: { label: string; value: RosterApplicationStatus | undefined }[] = [
+  { label: 'Pending', value: 'pending' },
+  { label: 'Approved', value: 'approved' },
+  { label: 'Denied', value: 'denied' },
+  { label: 'Withdrawn', value: 'withdrawn' },
+];
+
+function rosterStatusVariant(status: string): 'default' | 'secondary' | 'outline' | 'destructive' {
+  switch (status) {
+    case 'pending':
+      return 'default';
+    case 'approved':
+      return 'secondary';
+    case 'denied':
+      return 'destructive';
+    case 'withdrawn':
+      return 'outline';
+    default:
+      return 'outline';
+  }
+}
+
+export function StaffRosterApplicationsPage() {
+  const [statusFilter, setStatusFilter] = useState<RosterApplicationStatus | undefined>('pending');
+  const [page, setPage] = useState(1);
+  const { data, isLoading } = useRosterApplications(statusFilter, page);
+  const applications = data?.results;
+
+  return (
+    <div className="container mx-auto max-w-6xl px-4 py-8">
+      <h1 className="mb-6 text-2xl font-bold">Roster Character Applications</h1>
+
+      <div className="mb-6 flex flex-wrap gap-2">
+        {STATUS_OPTIONS.map((opt) => (
+          <Button
+            key={opt.label}
+            variant={statusFilter === opt.value ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => {
+              setStatusFilter(opt.value);
+              setPage(1);
+            }}
+          >
+            {opt.label}
+          </Button>
+        ))}
+      </div>
+
+      {isLoading ? (
+        <p className="text-muted-foreground">Loading...</p>
+      ) : !applications?.length ? (
+        <p className="text-muted-foreground">No roster applications found.</p>
+      ) : (
+        <>
+          <div className="space-y-3">
+            {applications.map((app) => (
+              <Link key={app.id} to={`/staff/roster-applications/${app.id}`}>
+                <Card className="cursor-pointer transition-colors hover:bg-muted/50">
+                  <CardContent className="flex items-center justify-between py-4">
+                    <div>
+                      <p className="font-medium">{app.character_name}</p>
+                      <p className="text-sm text-muted-foreground">
+                        by {app.player_username} &middot;{' '}
+                        {new Date(app.applied_date).toLocaleDateString()}
+                      </p>
+                    </div>
+                    <Badge variant={rosterStatusVariant(app.status)}>{app.status_display}</Badge>
+                  </CardContent>
+                </Card>
+              </Link>
+            ))}
+          </div>
+
+          {data && data.count > 0 && (data.next || data.previous) && (
+            <div className="mt-6 flex items-center justify-center gap-4">
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!data.previous}
+                onClick={() => setPage((p) => p - 1)}
+              >
+                Previous
+              </Button>
+              <span className="text-sm text-muted-foreground">Page {page}</span>
+              <Button
+                variant="outline"
+                size="sm"
+                disabled={!data.next}
+                onClick={() => setPage((p) => p + 1)}
+              >
+                Next
+              </Button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/staff/pages/StaffRosterApplicationsPage.tsx
+++ b/frontend/src/staff/pages/StaffRosterApplicationsPage.tsx
@@ -1,9 +1,10 @@
 import { useState } from 'react';
+import type { ReactNode } from 'react';
 import { Link } from 'react-router-dom';
 
 import { Badge } from '@/components/ui/badge';
-import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { NextPrevPagination, StatusFilterBar } from '@/staff/components/listControls';
 import { useRosterApplications } from '@/staff/queries';
 import type { RosterApplicationStatus } from '@/staff/types';
 
@@ -35,74 +36,57 @@ export function StaffRosterApplicationsPage() {
   const { data, isLoading } = useRosterApplications(statusFilter, page);
   const applications = data?.results;
 
+  let content: ReactNode;
+  if (isLoading) {
+    content = <p className="text-muted-foreground">Loading...</p>;
+  } else if (!applications?.length) {
+    content = <p className="text-muted-foreground">No roster applications found.</p>;
+  } else {
+    content = (
+      <>
+        <div className="space-y-3">
+          {applications.map((app) => (
+            <Link key={app.id} to={`/staff/roster-applications/${app.id}`}>
+              <Card className="cursor-pointer transition-colors hover:bg-muted/50">
+                <CardContent className="flex items-center justify-between py-4">
+                  <div>
+                    <p className="font-medium">{app.character_name}</p>
+                    <p className="text-sm text-muted-foreground">
+                      by {app.player_username} &middot;{' '}
+                      {new Date(app.applied_date).toLocaleDateString()}
+                    </p>
+                  </div>
+                  <Badge variant={rosterStatusVariant(app.status)}>{app.status_display}</Badge>
+                </CardContent>
+              </Card>
+            </Link>
+          ))}
+        </div>
+
+        <NextPrevPagination
+          page={page}
+          hasPrevious={!!data?.previous}
+          hasNext={!!data?.next}
+          onPageChange={setPage}
+        />
+      </>
+    );
+  }
+
   return (
     <div className="container mx-auto max-w-6xl px-4 py-8">
       <h1 className="mb-6 text-2xl font-bold">Roster Character Applications</h1>
 
-      <div className="mb-6 flex flex-wrap gap-2">
-        {STATUS_OPTIONS.map((opt) => (
-          <Button
-            key={opt.label}
-            variant={statusFilter === opt.value ? 'default' : 'outline'}
-            size="sm"
-            onClick={() => {
-              setStatusFilter(opt.value);
-              setPage(1);
-            }}
-          >
-            {opt.label}
-          </Button>
-        ))}
-      </div>
+      <StatusFilterBar
+        options={STATUS_OPTIONS}
+        value={statusFilter}
+        onChange={(value) => {
+          setStatusFilter(value);
+          setPage(1);
+        }}
+      />
 
-      {isLoading ? (
-        <p className="text-muted-foreground">Loading...</p>
-      ) : !applications?.length ? (
-        <p className="text-muted-foreground">No roster applications found.</p>
-      ) : (
-        <>
-          <div className="space-y-3">
-            {applications.map((app) => (
-              <Link key={app.id} to={`/staff/roster-applications/${app.id}`}>
-                <Card className="cursor-pointer transition-colors hover:bg-muted/50">
-                  <CardContent className="flex items-center justify-between py-4">
-                    <div>
-                      <p className="font-medium">{app.character_name}</p>
-                      <p className="text-sm text-muted-foreground">
-                        by {app.player_username} &middot;{' '}
-                        {new Date(app.applied_date).toLocaleDateString()}
-                      </p>
-                    </div>
-                    <Badge variant={rosterStatusVariant(app.status)}>{app.status_display}</Badge>
-                  </CardContent>
-                </Card>
-              </Link>
-            ))}
-          </div>
-
-          {data && data.count > 0 && (data.next || data.previous) && (
-            <div className="mt-6 flex items-center justify-center gap-4">
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!data.previous}
-                onClick={() => setPage((p) => p - 1)}
-              >
-                Previous
-              </Button>
-              <span className="text-sm text-muted-foreground">Page {page}</span>
-              <Button
-                variant="outline"
-                size="sm"
-                disabled={!data.next}
-                onClick={() => setPage((p) => p + 1)}
-              >
-                Next
-              </Button>
-            </div>
-          )}
-        </>
-      )}
+      {content}
     </div>
   );
 }

--- a/frontend/src/staff/queries.ts
+++ b/frontend/src/staff/queries.ts
@@ -21,6 +21,9 @@ import type {
   InboxResponse,
   PlayerFeedback,
   PlayerReport,
+  RosterApplicationDetail,
+  RosterApplicationListItem,
+  RosterApplicationStatus,
   SubmissionCategory,
   SubmissionStatus,
   SystemErrorReport,
@@ -51,6 +54,10 @@ import {
   issueAccountInvite,
   resendAccountInvite,
   revokeAccountInvite,
+  getRosterApplications,
+  getRosterApplicationDetail,
+  reviewRosterApplication,
+  getPendingRosterApplicationCount,
 } from './api';
 
 interface FileIssueArgs {
@@ -85,6 +92,11 @@ export const staffKeys = {
   gmApplicationDetail: (id: number) => [...staffKeys.all, 'gm-application-detail', id] as const,
   accountInvites: (status?: string, page?: number) =>
     [...staffKeys.all, 'account-invites', status, page] as const,
+  rosterApplications: (status?: string, page?: number) =>
+    [...staffKeys.all, 'roster-applications', status, page] as const,
+  rosterApplication: (id: number) => [...staffKeys.all, 'roster-application', id] as const,
+  rosterApplicationPendingCount: () =>
+    [...staffKeys.all, 'roster-application-pending-count'] as const,
 };
 
 export function useApplications(statusFilter?: string) {
@@ -408,6 +420,52 @@ export function useFetchVerificationLink() {
   // No cache invalidation: generating a link mutates nothing server-side (#3193).
   return useMutation({
     mutationFn: (email: string) => fetchVerificationLink(email),
+  });
+}
+
+// =============================================================================
+// Roster-Character Application Hooks (#3265)
+// =============================================================================
+
+export function useRosterApplications(status?: RosterApplicationStatus, page?: number) {
+  return useQuery<PaginatedResponse<RosterApplicationListItem>>({
+    queryKey: staffKeys.rosterApplications(status, page),
+    queryFn: () => getRosterApplications(status, page),
+  });
+}
+
+export function useRosterApplicationDetail(id: number | undefined) {
+  return useQuery<RosterApplicationDetail>({
+    queryKey: staffKeys.rosterApplication(id!),
+    queryFn: () => getRosterApplicationDetail(id!),
+    enabled: !!id,
+  });
+}
+
+export function useReviewRosterApplication() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      action,
+      reviewNotes,
+    }: {
+      id: number;
+      action: 'approve' | 'deny';
+      reviewNotes?: string;
+    }) => reviewRosterApplication(id, action, reviewNotes),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: staffKeys.all });
+    },
+  });
+}
+
+export function usePendingRosterApplicationCount(enabled = true) {
+  return useQuery({
+    queryKey: staffKeys.rosterApplicationPendingCount(),
+    queryFn: getPendingRosterApplicationCount,
+    refetchInterval: 60_000,
+    enabled,
   });
 }
 

--- a/frontend/src/staff/types.ts
+++ b/frontend/src/staff/types.ts
@@ -193,6 +193,13 @@ export interface RosterApplicationDetail extends RosterApplicationListItem {
   policy_review_info: Record<string, unknown> | null;
 }
 
+// Response shape from POST .../review/ — a discriminated union on `action`,
+// NOT a RosterApplicationDetail. See RosterApplicationApprovalSerializer.save()
+// in world/roster/serializers/applications.py.
+export type RosterApplicationReviewResult =
+  | { action: 'approved'; tenure_created: boolean }
+  | { action: 'denied'; success: boolean };
+
 // Submission status values
 export type SubmissionStatus = 'open' | 'reviewed' | 'dismissed';
 

--- a/frontend/src/staff/types.ts
+++ b/frontend/src/staff/types.ts
@@ -172,6 +172,27 @@ export interface AccountInvite {
   redeemed_by_username: string | null;
 }
 
+// Roster-character applications (#3265) — players applying for staff-authored
+// characters on the Available shelf, from /api/roster/applications/. Distinct
+// from character_creation's DraftApplication (new player-made characters).
+export type RosterApplicationStatus = 'pending' | 'approved' | 'denied' | 'withdrawn';
+
+export interface RosterApplicationListItem {
+  id: number;
+  character_name: string;
+  player_username: string;
+  status: string;
+  status_display: string;
+  applied_date: string;
+}
+
+export interface RosterApplicationDetail extends RosterApplicationListItem {
+  application_text: string;
+  review_notes: string;
+  reviewed_date: string | null;
+  policy_review_info: Record<string, unknown> | null;
+}
+
 // Submission status values
 export type SubmissionStatus = 'open' | 'reviewed' | 'dismissed';
 

--- a/src/schema.json
+++ b/src/schema.json
@@ -28149,6 +28149,116 @@ paths:
                 items:
                   $ref: '#/components/schemas/Trap'
           description: ''
+  /api/roster/applications/:
+    get:
+      operationId: roster_applications_list
+      description: |-
+        Staff-only review queue for applications to existing roster characters.
+
+        Distinct from character_creation's DraftApplication review (new player-made
+        characters): this queue is players applying for staff-authored characters
+        on the Available shelf.
+      parameters:
+      - name: page
+        required: false
+        in: query
+        description: A page number within the paginated result set.
+        schema:
+          type: integer
+      - in: query
+        name: status
+        schema:
+          type: string
+          enum:
+          - approved
+          - denied
+          - pending
+          - withdrawn
+        description: |-
+          * `pending` - Pending Review
+          * `approved` - Approved
+          * `denied` - Denied
+          * `withdrawn` - Withdrawn
+      tags:
+      - roster
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PaginatedRosterApplicationListList'
+          description: ''
+  /api/roster/applications/{id}/:
+    get:
+      operationId: roster_applications_retrieve
+      description: |-
+        Staff-only review queue for applications to existing roster characters.
+
+        Distinct from character_creation's DraftApplication review (new player-made
+        characters): this queue is players applying for staff-authored characters
+        on the Available shelf.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this Roster Application.
+        required: true
+      tags:
+      - roster
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RosterApplicationDetail'
+          description: ''
+  /api/roster/applications/{id}/review/:
+    post:
+      operationId: roster_applications_review_create
+      description: Approve or deny one pending application.
+      parameters:
+      - in: path
+        name: id
+        schema:
+          type: integer
+        description: A unique integer value identifying this Roster Application.
+        required: true
+      tags:
+      - roster
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RosterApplicationListRequest'
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RosterApplicationList'
+          description: ''
+  /api/roster/applications/pending-count/:
+    get:
+      operationId: roster_applications_pending_count_retrieve
+      description: Count of applications awaiting review, for the staff hub badge.
+      tags:
+      - roster
+      security:
+      - cookieAuth: []
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RosterApplicationList'
+          description: ''
   /api/roster/entries/:
     get:
       operationId: roster_entries_list
@@ -57419,6 +57529,29 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/RoomWardDetails'
+    PaginatedRosterApplicationListList:
+      type: object
+      required:
+      - count
+      - results
+      properties:
+        count:
+          type: integer
+          example: 123
+        next:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=4
+        previous:
+          type: string
+          nullable: true
+          format: uri
+          example: http://api.example.org/accounts/?page=2
+        results:
+          type: array
+          items:
+            $ref: '#/components/schemas/RosterApplicationList'
     PaginatedRosterEntryList:
       type: object
       required:
@@ -65754,6 +65887,85 @@ components:
           type: string
       required:
       - message
+    RosterApplicationDetail:
+      type: object
+      description: Serializer for retrieving application details.
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        character_name:
+          type: string
+          readOnly: true
+        player_username:
+          type: string
+          readOnly: true
+        status:
+          $ref: '#/components/schemas/StatusBa9Enum'
+        status_display:
+          type: string
+          readOnly: true
+        application_text:
+          type: string
+          description: Why player wants this character
+        review_notes:
+          type: string
+          description: Staff notes on application
+        applied_date:
+          type: string
+          format: date-time
+          readOnly: true
+        reviewed_date:
+          type: string
+          format: date-time
+          readOnly: true
+          nullable: true
+        policy_review_info:
+          type: string
+          readOnly: true
+      required:
+      - application_text
+      - applied_date
+      - character_name
+      - id
+      - player_username
+      - policy_review_info
+      - reviewed_date
+      - status_display
+    RosterApplicationList:
+      type: object
+      description: Slim row for the staff review queue (no per-row policy queries).
+      properties:
+        id:
+          type: integer
+          readOnly: true
+        character_name:
+          type: string
+          readOnly: true
+        player_username:
+          type: string
+          readOnly: true
+        status:
+          $ref: '#/components/schemas/StatusBa9Enum'
+        status_display:
+          type: string
+          readOnly: true
+        applied_date:
+          type: string
+          format: date-time
+          readOnly: true
+      required:
+      - applied_date
+      - character_name
+      - id
+      - player_username
+      - status_display
+    RosterApplicationListRequest:
+      type: object
+      description: Slim row for the staff review queue (no per-row policy queries).
+      properties:
+        status:
+          $ref: '#/components/schemas/StatusBa9Enum'
     RosterApplicationRequest:
       type: object
       description: Validate a roster application message.

--- a/src/world/roster/filters.py
+++ b/src/world/roster/filters.py
@@ -1,7 +1,8 @@
 from django.db.models import Q, QuerySet
 import django_filters
 
-from world.roster.models import Family, RosterEntry, RosterTenure, TenureGallery
+from world.roster.models import Family, RosterApplication, RosterEntry, RosterTenure, TenureGallery
+from world.roster.models.choices import ApplicationStatus
 
 
 class RosterEntryFilterSet(django_filters.FilterSet):
@@ -100,3 +101,27 @@ class RosterTenureFilterSet(django_filters.FilterSet):
         return queryset.filter(
             roster_entry__character_sheet__character__db_key__icontains=value,
         )
+
+
+class RosterApplicationFilterSet(django_filters.FilterSet):
+    """Filter roster applications by review status.
+
+    The staff review queue opens on what needs action, so an omitted ``status``
+    defaults to pending-only rather than showing every application ever filed.
+    ``self.data`` is the raw incoming query dict django-filters hands every
+    FilterSet (not a view's ``query_params``/``GET``, which this repo's
+    use-filterset lint reserves views from touching directly).
+    """
+
+    status = django_filters.ChoiceFilter(choices=ApplicationStatus.choices)
+
+    class Meta:
+        model = RosterApplication
+        fields = ["status"]
+
+    @property
+    def qs(self) -> QuerySet[RosterApplication]:
+        queryset = super().qs
+        if self.data.get("status") is None:
+            queryset = queryset.filter(status=ApplicationStatus.PENDING)
+        return queryset

--- a/src/world/roster/permissions.py
+++ b/src/world/roster/permissions.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import ObjectDoesNotExist
 from rest_framework import permissions
 from rest_framework.request import Request
 from rest_framework.views import APIView
@@ -96,3 +97,19 @@ class StaffOnlyWrite(permissions.BasePermission):
 
         # Write permissions require staff
         return request.user.is_staff
+
+
+class CanApproveApplications(permissions.BasePermission):
+    """Allow only reviewers (PlayerData.can_approve_applications; staff today)."""
+
+    message = "You do not have permission to review roster applications."
+
+    def has_permission(self, request: Request, view: APIView) -> bool:
+        user = request.user
+        if not (user and user.is_authenticated):
+            return False
+        try:
+            player_data = user.player_data
+        except ObjectDoesNotExist:
+            return False
+        return player_data.can_approve_applications()

--- a/src/world/roster/serializers/__init__.py
+++ b/src/world/roster/serializers/__init__.py
@@ -17,6 +17,7 @@ from world.roster.serializers.applications import (
     RosterApplicationCreateSerializer,
     RosterApplicationDetailSerializer,
     RosterApplicationEligibilitySerializer,
+    RosterApplicationListSerializer,
     RosterApplicationSerializer,
 )
 from world.roster.serializers.characters import (
@@ -78,6 +79,7 @@ __all__ = [
     "RosterApplicationCreateSerializer",
     "RosterApplicationDetailSerializer",
     "RosterApplicationEligibilitySerializer",
+    "RosterApplicationListSerializer",
     # Application serializers
     "RosterApplicationSerializer",
     "RosterEntryListSerializer",

--- a/src/world/roster/serializers/applications.py
+++ b/src/world/roster/serializers/applications.py
@@ -169,7 +169,7 @@ class RosterApplicationDetailSerializer(serializers.ModelSerializer):
     Serializer for retrieving application details.
     """
 
-    character_name = serializers.CharField(source="character.db_key", read_only=True)
+    character_name = serializers.CharField(source="character.character.db_key", read_only=True)
     player_username = serializers.CharField(
         source="player_data.account.username",
         read_only=True,
@@ -199,6 +199,28 @@ class RosterApplicationDetailSerializer(serializers.ModelSerializer):
         if request and request.user.player_data.can_approve_applications():
             return obj.get_policy_review_info()
         return None
+
+
+class RosterApplicationListSerializer(serializers.ModelSerializer):
+    """Slim row for the staff review queue (no per-row policy queries)."""
+
+    character_name = serializers.CharField(source="character.character.db_key", read_only=True)
+    player_username = serializers.CharField(
+        source="player_data.account.username",
+        read_only=True,
+    )
+    status_display = serializers.CharField(source="get_status_display", read_only=True)
+
+    class Meta:
+        model = RosterApplication
+        fields: ClassVar[list[str]] = [
+            "id",
+            "character_name",
+            "player_username",
+            "status",
+            "status_display",
+            "applied_date",
+        ]
 
 
 class RosterApplicationApprovalSerializer(serializers.Serializer):

--- a/src/world/roster/serializers/applications.py
+++ b/src/world/roster/serializers/applications.py
@@ -157,7 +157,7 @@ class RosterApplicationCreateSerializer(serializers.Serializer):
         return {
             "id": instance.id,
             "status": instance.status,
-            "character_name": instance.character.db_key,
+            "character_name": instance.character.character.db_key,
             "applied_date": instance.applied_date,
             "policy_issues": policy_issues,
             "requires_staff_review": bool(policy_issues),

--- a/src/world/roster/tests/test_application_views.py
+++ b/src/world/roster/tests/test_application_views.py
@@ -1,0 +1,106 @@
+"""Tests for the staff roster-application review endpoints (#3265)."""
+
+from django.test import TestCase
+from django.urls import reverse
+from rest_framework.test import APIClient
+
+from evennia_extensions.factories import AccountFactory
+from world.roster.factories import (
+    RosterApplicationFactory,
+    RosterEntryFactory,
+    RosterFactory,
+)
+from world.roster.models import RosterApplication, RosterTenure
+from world.roster.models.choices import ApplicationStatus, RosterType
+
+
+class StaffRosterApplicationViewTests(TestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.staff = AccountFactory(is_staff=True)
+        cls.player = AccountFactory(is_staff=False)
+        cls.available = RosterFactory(roster_type=RosterType.AVAILABLE, name="Available")
+        cls.active = RosterFactory(roster_type=RosterType.ACTIVE, name="Active Characters")
+        cls.pending_app = RosterApplicationFactory(status=ApplicationStatus.PENDING)
+        RosterEntryFactory(character_sheet=cls.pending_app.character, roster=cls.available)
+        cls.denied_app = RosterApplicationFactory(status=ApplicationStatus.DENIED)
+
+    def setUp(self):
+        self.client = APIClient()
+
+    def test_anonymous_rejected(self):
+        url = reverse("roster:applications-list")
+        response = self.client.get(url)
+        assert response.status_code == 403
+
+    def test_non_staff_rejected(self):
+        self.client.force_authenticate(self.player)
+        url = reverse("roster:applications-list")
+        response = self.client.get(url)
+        assert response.status_code == 403
+
+    def test_list_defaults_to_pending(self):
+        self.client.force_authenticate(self.staff)
+        url = reverse("roster:applications-list")
+        response = self.client.get(url)
+        assert response.status_code == 200
+        ids = [row["id"] for row in response.data["results"]]
+        assert self.pending_app.id in ids
+        assert self.denied_app.id not in ids
+
+    def test_list_status_filter(self):
+        self.client.force_authenticate(self.staff)
+        url = reverse("roster:applications-list")
+        response = self.client.get(url, {"status": ApplicationStatus.DENIED})
+        assert response.status_code == 200
+        ids = [row["id"] for row in response.data["results"]]
+        assert ids == [self.denied_app.id]
+
+    def test_detail_includes_policy_info_and_character_name(self):
+        self.client.force_authenticate(self.staff)
+        url = reverse("roster:applications-detail", args=[self.pending_app.id])
+        response = self.client.get(url)
+        assert response.status_code == 200
+        expected_name = self.pending_app.character.character.db_key
+        assert response.data["character_name"] == expected_name
+        assert "policy_review_info" in response.data
+        assert "application_text" in response.data
+
+    def test_review_approve_creates_tenure_and_moves_shelf(self):
+        self.client.force_authenticate(self.staff)
+        url = reverse("roster:applications-review", args=[self.pending_app.id])
+        response = self.client.post(url, {"action": "approve"}, format="json")
+        assert response.status_code == 200, response.data
+        self.pending_app.refresh_from_db()
+        assert self.pending_app.status == ApplicationStatus.APPROVED
+        tenure = RosterTenure.objects.current().get(
+            roster_entry=self.pending_app.character.roster_entry
+        )
+        assert tenure.player_data == self.pending_app.player_data
+        assert self.pending_app.character.roster_entry.roster == self.active
+
+    def test_review_deny_records_notes(self):
+        app = RosterApplicationFactory(status=ApplicationStatus.PENDING)
+        RosterEntryFactory(character_sheet=app.character, roster=self.available)
+        self.client.force_authenticate(self.staff)
+        url = reverse("roster:applications-review", args=[app.id])
+        response = self.client.post(
+            url, {"action": "deny", "review_notes": "Not a fit."}, format="json"
+        )
+        assert response.status_code == 200, response.data
+        app.refresh_from_db()
+        assert app.status == ApplicationStatus.DENIED
+        assert app.review_notes == "Not a fit."
+
+    def test_review_rejects_non_pending(self):
+        self.client.force_authenticate(self.staff)
+        url = reverse("roster:applications-review", args=[self.denied_app.id])
+        response = self.client.post(url, {"action": "approve"}, format="json")
+        assert response.status_code == 400
+
+    def test_pending_count(self):
+        self.client.force_authenticate(self.staff)
+        url = reverse("roster:applications-pending-count")
+        response = self.client.get(url)
+        assert response.status_code == 200
+        assert response.data["count"] == RosterApplication.objects.pending().count()

--- a/src/world/roster/tests/test_serializers.py
+++ b/src/world/roster/tests/test_serializers.py
@@ -359,6 +359,11 @@ class RosterApplicationCreateSerializerTestCase(TestCase):
         assert app.player_data == self.player_data
         assert app.character == self.character.sheet_data
 
+        # #3265: to_representation must resolve character_name through
+        # CharacterSheet -> ObjectDB (character FK is a CharacterSheet since
+        # #2608), not read db_key directly off the sheet.
+        assert serializer.data["character_name"] == self.character.db_key
+
     def test_application_validation_scenarios(self):
         """Test all scenarios where applications should be rejected"""
         test_cases = [

--- a/src/world/roster/urls.py
+++ b/src/world/roster/urls.py
@@ -13,6 +13,7 @@ from world.roster.views import (
     KinRelationshipView,
     MediaViewSet,
     PlayerMailViewSet,
+    RosterApplicationViewSet,
     RosterEntryViewSet,
     RosterTenureViewSet,
     RosterViewSet,
@@ -23,6 +24,7 @@ from world.roster.views.settings_views import VisibilitySettingsView
 app_name = "roster"
 
 router = DefaultRouter()
+router.register("applications", RosterApplicationViewSet, basename="applications")
 router.register("rosters", RosterViewSet, basename="rosters")
 router.register("entries", RosterEntryViewSet, basename="entries")
 router.register("families", FamilyViewSet, basename="families")

--- a/src/world/roster/views/__init__.py
+++ b/src/world/roster/views/__init__.py
@@ -9,6 +9,10 @@ This module is organized into logical groups:
 """
 
 # Import all views for backward compatibility
+from world.roster.views.application_views import (
+    RosterApplicationPagination,
+    RosterApplicationViewSet,
+)
 from world.roster.views.entry_views import RosterEntryPagination, RosterEntryViewSet
 from world.roster.views.family_views import (
     CharacterKinTreeView,
@@ -29,6 +33,8 @@ __all__ = [
     "MediaViewSet",
     "PlayerMailPagination",
     "PlayerMailViewSet",
+    "RosterApplicationPagination",
+    "RosterApplicationViewSet",
     "RosterEntryPagination",
     "RosterEntryViewSet",
     "RosterTenureViewSet",

--- a/src/world/roster/views/application_views.py
+++ b/src/world/roster/views/application_views.py
@@ -1,0 +1,82 @@
+"""Staff review endpoints for roster-character applications (#3265)."""
+
+from http import HTTPMethod
+
+from django.db.models import QuerySet
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.serializers import BaseSerializer
+
+from world.roster.filters import RosterApplicationFilterSet
+from world.roster.models import RosterApplication
+from world.roster.permissions import CanApproveApplications
+from world.roster.serializers import (
+    RosterApplicationApprovalSerializer,
+    RosterApplicationDetailSerializer,
+    RosterApplicationListSerializer,
+)
+
+
+class RosterApplicationPagination(PageNumberPagination):
+    """Default pagination for the staff review queue."""
+
+    page_size = 20
+
+
+class RosterApplicationViewSet(viewsets.ReadOnlyModelViewSet):
+    """Staff-only review queue for applications to existing roster characters.
+
+    Distinct from character_creation's DraftApplication review (new player-made
+    characters): this queue is players applying for staff-authored characters
+    on the Available shelf.
+    """
+
+    serializer_class = RosterApplicationListSerializer
+    permission_classes = [CanApproveApplications]
+    filter_backends = [DjangoFilterBackend]
+    filterset_class = RosterApplicationFilterSet
+    pagination_class = RosterApplicationPagination
+
+    def get_queryset(self) -> QuerySet[RosterApplication]:
+        return RosterApplication.objects.select_related(
+            "character__character",
+            "player_data__account",
+            "reviewed_by",
+        ).order_by("applied_date")
+
+    def filter_queryset(self, queryset: QuerySet[RosterApplication]) -> QuerySet[RosterApplication]:
+        # The pending-only default (applied by RosterApplicationFilterSet.qs) is
+        # a *list*-view convenience: the staff queue opens on what needs action.
+        # Detail/review lookups go through get_object(), which also routes
+        # through filter_queryset(); skipping the filterset there lets `review`
+        # resolve an already-decided application and 400 instead of 404ing
+        # before it gets the chance.
+        if self.action != "list":
+            return queryset
+        return super().filter_queryset(queryset)
+
+    def get_serializer_class(self) -> type[BaseSerializer]:
+        if self.action == "retrieve":
+            return RosterApplicationDetailSerializer
+        return super().get_serializer_class()
+
+    @action(detail=True, methods=[HTTPMethod.POST])
+    def review(self, request: Request, pk: str | None = None) -> Response:
+        """Approve or deny one pending application."""
+        application = self.get_object()
+        serializer = RosterApplicationApprovalSerializer(
+            data=request.data,
+            context={"request": request, "application": application},
+        )
+        serializer.is_valid(raise_exception=True)
+        result = serializer.save()
+        return Response(result)
+
+    @action(detail=False, methods=[HTTPMethod.GET], url_path="pending-count")
+    def pending_count(self, request: Request) -> Response:
+        """Count of applications awaiting review, for the staff hub badge."""
+        return Response({"count": RosterApplication.objects.pending().count()})


### PR DESCRIPTION
Closes #3265

## Summary

Staff web surface for reviewing applications to roster characters: new staff-only RosterApplicationViewSet at /api/roster/applications/ (list defaulting to pending, detail with policy review info, approve/deny driving the existing RosterApplication lifecycle, pending count), staff pages at /staff/roster-applications (+/:id), a staff-hub card with pending badge, and a rename of the mislabeled hub card so the two application queues are distinguishable. Wires the previously-unwired detail/approval serializers and fixes their stale #2608 FK hop.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #3265 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch up to date with origin/main; no conflicts; no migrations on this branch.

<!-- last-addressed-comment: 0 -->