### PR TITLE
GM-owned roster creation has no frontend: finalize-gm, GM roster invites, and the GM application queue are backend-only

### DIFF
--- a/docs/roadmap/gm-system.md
+++ b/docs/roadmap/gm-system.md
@@ -229,7 +229,9 @@ unlocks, never grants" makes XP scarce, so this is the pull). Built:
 - ✅ ViewSets with staff/GM permission split and staff-only actions (archive, transfer_ownership)
 - ✅ `last_active_at` stub on GMProfile (not yet auto-stamped)
 - ✅ Story attachment (`Story.primary_table`, Phase 3) and frontend pages (`TablesListPage`,
-  `TableDetailPage`, #3268 Task 3) — both landed once Stories existed to attach to
+  `TableDetailPage` — Stories phase 5, #407, 73fa32d2a) — both landed once Stories existed to
+  attach to. #3268 built on top of that frontend rather than adding it: `RecruitmentTab` on
+  `TableDetailPage` (Task 2) and `ClaimInvitePage` (Task 3) — see Phase 3 below
 
 ### Phase 3 — Roster & Recruitment ✅
 - ✅ `Story.primary_table` FK links stories to tables (orphaned stories are legal, character falls out of default visibility)

--- a/docs/roadmap/gm-system.md
+++ b/docs/roadmap/gm-system.md
@@ -228,7 +228,8 @@ unlocks, never grants" makes XP scarce, so this is the pull). Built:
 - ✅ Service functions (create, archive, transfer_ownership, join, leave, retire-persona hook)
 - ✅ ViewSets with staff/GM permission split and staff-only actions (archive, transfer_ownership)
 - ✅ `last_active_at` stub on GMProfile (not yet auto-stamped)
-- Remaining: story attachment (future phase when stories are wired up), frontend pages (Phase 5)
+- ✅ Story attachment (`Story.primary_table`, Phase 3) and frontend pages (`TablesListPage`,
+  `TableDetailPage`, #3268 Task 3) — both landed once Stories existed to attach to
 
 ### Phase 3 — Roster & Recruitment ✅
 - ✅ `Story.primary_table` FK links stories to tables (orphaned stories are legal, character falls out of default visibility)
@@ -243,7 +244,11 @@ unlocks, never grants" makes XP scarce, so this is the pull). Built:
 - ✅ Invite services: `create_invite`, `revoke_invite`, `claim_invite` with `select_for_update` for race safety
 - ✅ API: `GMRosterInviteViewSet`, `GMApplicationQueueView`, `GMApplicationActionView`, `GMInviteClaimView`
 - ✅ Staff continue to see applications via existing staff inbox; GM queue surfaces the same apps to the overseeing GM
-- Remaining: frontend (Phase 5), email delivery for private invites (follow-up), level-gated character creation exceptions (kudo points / GM leeway — post-MVP)
+- ✅ Frontend (#3268): `RecruitmentTab` on `TableDetailPage` (invite minting/revocation, application
+  approve/deny — Task 2); `FinalizeForTableDialog` on the CG Review stage (a player-GM finalizes
+  their own draft straight onto their table's Available roster, no staff review needed) and
+  `ClaimInvitePage` (`/invites/claim?code=...`, any authenticated player) — Task 3
+- Remaining: email delivery for private invites (follow-up), level-gated character creation exceptions (kudo points / GM leeway — post-MVP)
 
 ### Phase 4 — Reward Tooling (cut — moved to Stories)
 Rewards are not a GM concern. GMs are storytellers and umpires, not
@@ -293,6 +298,9 @@ it. `surrender_character_story` is wired (`POST /api/stories/{id}/surrender/`
 from GM-verb services; idle-table detection surfaces on `StaffWorkloadView`
 and a weekly cron summary. GMProfile presence (`is_gm`) added to the account
 payload so the frontend can gate navigation without probing for 403s.
+`pending_applications`/`open_invites` counts (recruitment attention, #3268) joined
+the payload and render as two tiles on `GMDashboardPage`, both linking to `/tables`
+since the actual review/mint actions live per-table on `RecruitmentTab`.
 
 Day-to-day GM ops that the staff inbox + existing APIs cover for now:
 - Application queue (staff / admin can action; GMs will get the

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -2115,7 +2115,17 @@ GM at a given level may author (#2000, ADR-0097).
   staff-only actions), `GMTableMembershipViewSet`, `GMRosterInviteViewSet`,
   `GMApplicationQueueView`/`GMApplicationActionView` (a GM's own pending-application
   queue), `GMInviteClaimView`, `DemandRansomView`, `GMSummonOfferViewSet`
-  (`/api/gm/summon-offers/`, read-only, #3071 — see "GM summon" below)
+  (`/api/gm/summon-offers/`, read-only, #3071 — see "GM summon" below). **UI-wired
+  (#3268):** the invite/application group (`GMRosterInviteViewSet`,
+  `GMApplicationQueueView`/`GMApplicationActionView`) renders in `RecruitmentTab` on
+  `frontend/src/tables/pages/TableDetailPage.tsx`; `GMInviteClaimView` renders in
+  `frontend/src/tables/pages/ClaimInvitePage.tsx` (route `/invites/claim`); the
+  `character_creation` app's `finalize-gm` draft action renders in
+  `FinalizeForTableDialog` off the CG Review stage (see character_creation.md).
+  `GMDashboardView` (`GET /api/gm/dashboard/`) payload gained `pending_applications`
+  (count from `gm_application_queue(gm)`) and `open_invites` (this GM's unclaimed,
+  unexpired `GMRosterInvite` rows) as the tile source for those same recruitment
+  surfaces (#3268).
 - **Telnet:** `CmdGMTable` (`gmtable`) — table admin parity. `CmdGMTrust` (`gmtrust`,
   #2000) — `gmtrust show [account]` (self-service; naming another is staff-only),
   `gmtrust evidence <account>` (staff-only), `gmtrust promote <account>=<level>

--- a/docs/systems/character_creation.md
+++ b/docs/systems/character_creation.md
@@ -252,7 +252,14 @@ by `ty`'s `invalid-method-override`). The applicant's email comes from `DraftApp
 - `GET /api/character-creation/drafts/{id}/cg-points/` - CG points breakdown
 - `POST /api/character-creation/drafts/{id}/select-tradition/` - Select/clear tradition
 - `POST /api/character-creation/drafts/{id}/add-to-roster/` - Staff: finalize directly to roster (STAFF provenance)
-- `POST /api/character-creation/drafts/{id}/finalize-gm/` - Player-GM: finalize onto the Available roster for a table they own (GM_TABLE provenance; body `target_table`, `story_title`, optional `story_description`) (#1506)
+- `POST /api/character-creation/drafts/{id}/finalize-gm/` - Player-GM: finalize onto the Available roster for a table they own (GM_TABLE provenance; body `target_table`, `story_title`, optional `story_description`) (#1506). Gated by
+  `require_draft_complete` (#3268), the same completeness check `finalize_character`
+  applies at submit, now factored out so `add-to-roster` and `finalize-gm` share it
+  instead of each re-deriving stage completion. A 400 with `{"detail": "Cannot finalize:
+  incomplete stages: <label>, ..."}` means the draft isn't ready; a
+  `GiftResonanceUnresolvable` from `finalize_gm_character` is caught the same way
+  `add-to-roster` catches it (logged, `{"detail": "Character creation failed."}`, 400)
+  rather than surfacing a 500.
 
 ### Magic (Gift/Technique Selection, #2426)
 - `GET /api/character-creation/gifts/?draft_id=X` - List gifts pickable for the draft's chosen tradition + path

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -169,6 +169,9 @@ const GMUpdateRequestsPage = lazy(() =>
 const TableDetailPage = lazy(() =>
   import('@/tables/pages/TableDetailPage').then((m) => ({ default: m.TableDetailPage }))
 );
+const ClaimInvitePage = lazy(() =>
+  import('@/tables/pages/ClaimInvitePage').then((m) => ({ default: m.ClaimInvitePage }))
+);
 const EraAdminPage = lazy(() =>
   import('@/stories/pages/EraAdminPage').then((m) => ({ default: m.EraAdminPage }))
 );
@@ -893,6 +896,16 @@ function App() {
               <Suspense fallback={<PageLoadingFallback />}>
                 <ProtectedRoute>
                   <TableDetailPage />
+                </ProtectedRoute>
+              </Suspense>
+            }
+          />
+          <Route
+            path="/invites/claim"
+            element={
+              <Suspense fallback={<PageLoadingFallback />}>
+                <ProtectedRoute>
+                  <ClaimInvitePage />
                 </ProtectedRoute>
               </Suspense>
             }

--- a/frontend/src/character-creation/CLAUDE.md
+++ b/frontend/src/character-creation/CLAUDE.md
@@ -30,6 +30,7 @@ character-creation/
     ├── IdentityStage.tsx    # Stage 9: Identity
     ├── FinalTouchesStage.tsx # Stage 10: Goals
     ├── ReviewStage.tsx      # Stage 11: Review and submit
+    ├── FinalizeForTableDialog.tsx # Player-GM direct-to-roster flow from ReviewStage (#3268)
     ├── TraditionPicker.tsx  # Tradition card grid — mounted inside gift/TraditionStep
     └── gift/                # GiftStage funnel steps (#2426 Task 10)
         ├── TraditionStep.tsx    # Wraps TraditionPicker
@@ -49,6 +50,11 @@ character-creation/
 - **Visual cards**: Starting areas displayed as cards with crest images or gradient placeholders
 - **Real-time validation**: Stage completion tracked, submit blocked until all required stages complete
 - **Staff-only features**: "Add to Roster" button visible only to staff
+- **Player-GM direct-to-roster (#3268)**: a non-staff account that owns at least one active
+  GM-role table sees a "Finalize for My Table" button beside Submit, gated by the same
+  completeness condition. Opens `FinalizeForTableDialog` — picks the target table, names a
+  story, and finalizes onto that table's Available roster (`POST .../finalize-gm/`) without
+  going through staff review.
 
 ## API Endpoints Used
 
@@ -65,6 +71,8 @@ character-creation/
 - `GET /api/character-creation/form-options/{species_id}/?draft=X` - Trait palettes (`{traits, inherited}`; traits carry `is_required`, `?draft=` appends cross-line option groups from the draft's parents, #2815)
 - `POST /api/character-creation/drafts/{id}/submit/` - Submit for review
 - `POST /api/character-creation/drafts/{id}/add-to-roster/` - Staff direct add
+- `POST /api/character-creation/drafts/{id}/finalize-gm/` - Player-GM direct-to-roster for a
+  table they own (`target_table`, `story_title`, optional `story_description`) (#3268)
 
 ## Route
 

--- a/frontend/src/character-creation/__tests__/components/FinalizeForTableDialog.test.tsx
+++ b/frontend/src/character-creation/__tests__/components/FinalizeForTableDialog.test.tsx
@@ -14,10 +14,10 @@ import userEvent from '@testing-library/user-event';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { MemoryRouter } from 'react-router-dom';
 import { vi } from 'vitest';
-import type { ReactNode } from 'react';
 import { ApiError } from '@/lib/errors';
 import type { GMTable } from '@/tables/types';
 import { FinalizeForTableDialog } from '../../components/FinalizeForTableDialog';
+import { characterCreationKeys } from '../../queries';
 import type { FinalizeForTableResponse } from '../../api';
 
 /** Shape of the second argument `mutate(variables, opts)` is called with. */
@@ -82,22 +82,26 @@ function makeTable(overrides: Partial<GMTable> = {}): GMTable {
   } as GMTable;
 }
 
-function Wrapper({ children }: { children: ReactNode }) {
-  const client = new QueryClient({
+function makeQueryClient(): QueryClient {
+  return new QueryClient({
     defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
   });
-  return (
-    <QueryClientProvider client={client}>
-      <MemoryRouter>{children}</MemoryRouter>
-    </QueryClientProvider>
-  );
 }
 
-function renderDialog(tables: GMTable[] = [makeTable()]) {
-  return render(
-    <FinalizeForTableDialog draftId={7} tables={tables} open={true} onOpenChange={vi.fn()} />,
-    { wrapper: Wrapper }
+/**
+ * Renders the dialog with an explicit (returned) QueryClient — tests that
+ * check cache side effects (the unmount-cleanup safety net, #3268 review fix)
+ * need a handle on the same client instance the component reads/writes.
+ */
+function renderDialog(tables: GMTable[] = [makeTable()], client: QueryClient = makeQueryClient()) {
+  const utils = render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter>
+        <FinalizeForTableDialog draftId={7} tables={tables} open={true} onOpenChange={vi.fn()} />
+      </MemoryRouter>
+    </QueryClientProvider>
   );
+  return { ...utils, client };
 }
 
 describe('FinalizeForTableDialog', () => {
@@ -175,7 +179,7 @@ describe('FinalizeForTableDialog', () => {
     expect(await screen.findByText('That draft is not complete yet.')).toBeInTheDocument();
   });
 
-  it('shows a success panel naming the message and linking to /tables', async () => {
+  it('shows a success panel naming the message and linking to the specific table', async () => {
     const mutateFn = vi.fn((_vars: unknown, opts: MutateOpts) => {
       opts.onSuccess?.({
         character_id: 55,
@@ -190,17 +194,91 @@ describe('FinalizeForTableDialog', () => {
     } as unknown as ReturnType<typeof queries.useFinalizeDraftForTable>);
 
     const user = userEvent.setup();
-    renderDialog();
+    renderDialog([makeTable({ id: 42 })]);
 
-    await userEvent.selectOptions(screen.getByTestId('mock-select'), '1');
+    await userEvent.selectOptions(screen.getByTestId('mock-select'), '42');
     await user.type(screen.getByLabelText(/story title/i), 'The Long Road Home');
     await user.click(screen.getByRole('button', { name: /^finalize for my table$/i }));
 
     expect(
       await screen.findByText('GM character created on the Available roster.')
     ).toBeInTheDocument();
-    const link = screen.getByRole('link', { name: /go to my tables/i });
-    expect(link).toHaveAttribute('href', '/tables');
+    const link = screen.getByRole('link', { name: /go to my table/i });
+    expect(link).toHaveAttribute('href', '/tables/42');
+  });
+
+  it('clears the finalized draft from cache when the link to the table is clicked', async () => {
+    const mutateFn = vi.fn((_vars: unknown, opts: MutateOpts) => {
+      opts.onSuccess?.({
+        character_id: 55,
+        roster_entry_id: 66,
+        story_id: 77,
+        message: 'GM character created on the Available roster.',
+      });
+    });
+    vi.mocked(queries.useFinalizeDraftForTable).mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useFinalizeDraftForTable>);
+
+    const user = userEvent.setup();
+    const client = makeQueryClient();
+    client.setQueryData(characterCreationKeys.draft(), { id: 7 });
+    renderDialog([makeTable()], client);
+
+    await userEvent.selectOptions(screen.getByTestId('mock-select'), '1');
+    await user.type(screen.getByLabelText(/story title/i), 'The Long Road Home');
+    await user.click(screen.getByRole('button', { name: /^finalize for my table$/i }));
+    await user.click(await screen.findByRole('link', { name: /go to my table/i }));
+
+    expect(client.getQueryData(characterCreationKeys.draft())).toBeNull();
+  });
+
+  it('clears the finalized draft from cache on unmount even if the player never dismisses the panel (#3268 review fix)', async () => {
+    const mutateFn = vi.fn((_vars: unknown, opts: MutateOpts) => {
+      opts.onSuccess?.({
+        character_id: 55,
+        roster_entry_id: 66,
+        story_id: 77,
+        message: 'GM character created on the Available roster.',
+      });
+    });
+    vi.mocked(queries.useFinalizeDraftForTable).mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useFinalizeDraftForTable>);
+
+    const user = userEvent.setup();
+    const client = makeQueryClient();
+    client.setQueryData(characterCreationKeys.draft(), { id: 7 });
+    const { unmount } = renderDialog([makeTable()], client);
+
+    await userEvent.selectOptions(screen.getByTestId('mock-select'), '1');
+    await user.type(screen.getByLabelText(/story title/i), 'The Long Road Home');
+    await user.click(screen.getByRole('button', { name: /^finalize for my table$/i }));
+    await screen.findByText('GM character created on the Available roster.');
+
+    // Simulates a router navigation away (e.g. browser Back) that unmounts
+    // ReviewStage/this dialog directly, bypassing the X/Cancel/Link handlers.
+    unmount();
+
+    expect(client.getQueryData(characterCreationKeys.draft())).toBeNull();
+  });
+
+  it('does not touch the draft cache on unmount when the player never finalized', () => {
+    vi.mocked(queries.useFinalizeDraftForTable).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useFinalizeDraftForTable>);
+
+    const client = makeQueryClient();
+    const sentinelDraft = { id: 7 };
+    client.setQueryData(characterCreationKeys.draft(), sentinelDraft);
+    const { unmount } = renderDialog([makeTable()], client);
+
+    unmount();
+
+    expect(client.getQueryData(characterCreationKeys.draft())).toBe(sentinelDraft);
   });
 
   describe('submit gating', () => {

--- a/frontend/src/character-creation/__tests__/components/FinalizeForTableDialog.test.tsx
+++ b/frontend/src/character-creation/__tests__/components/FinalizeForTableDialog.test.tsx
@@ -1,0 +1,237 @@
+/**
+ * FinalizeForTableDialog Tests (#3268)
+ *
+ * Covers: submit payload shape, rendering the backend's 400 `{detail}`
+ * verbatim, and the submit-button gating (table + story title required).
+ *
+ * `@/components/ui/select` is mocked to a plain `<select>` — the real Radix
+ * Select doesn't do layout/pointer-capture in jsdom (established pattern,
+ * see `boundaries/__tests__/PlayerBoundaryFormDialog.test.tsx`).
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { ApiError } from '@/lib/errors';
+import type { GMTable } from '@/tables/types';
+import { FinalizeForTableDialog } from '../../components/FinalizeForTableDialog';
+import type { FinalizeForTableResponse } from '../../api';
+
+/** Shape of the second argument `mutate(variables, opts)` is called with. */
+interface MutateOpts {
+  onSuccess?: (data: FinalizeForTableResponse) => void;
+  onError?: (err: unknown) => void;
+}
+
+vi.mock('@/components/ui/select', () => ({
+  Select: ({
+    value,
+    onValueChange,
+    children,
+  }: {
+    value?: string;
+    onValueChange?: (v: string) => void;
+    children?: React.ReactNode;
+  }) => (
+    <select
+      value={value}
+      onChange={(e) => onValueChange?.(e.target.value)}
+      data-testid="mock-select"
+    >
+      <option value="" disabled>
+        Select a table
+      </option>
+      {children}
+    </select>
+  ),
+  SelectTrigger: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  SelectValue: () => null,
+  SelectContent: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  SelectItem: ({ value, children }: { value: string; children?: React.ReactNode }) => (
+    <option value={value}>{children}</option>
+  ),
+}));
+
+vi.mock('../../queries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../../queries')>();
+  return {
+    ...actual,
+    useFinalizeDraftForTable: vi.fn(),
+  };
+});
+
+import * as queries from '../../queries';
+
+function makeTable(overrides: Partial<GMTable> = {}): GMTable {
+  return {
+    id: 1,
+    gm: 10,
+    gm_username: 'gmUser',
+    name: 'The Salt Road',
+    description: '',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    archived_at: null,
+    member_count: 2,
+    story_count: 1,
+    viewer_role: 'gm',
+    ...overrides,
+  } as GMTable;
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={client}>
+      <MemoryRouter>{children}</MemoryRouter>
+    </QueryClientProvider>
+  );
+}
+
+function renderDialog(tables: GMTable[] = [makeTable()]) {
+  return render(
+    <FinalizeForTableDialog draftId={7} tables={tables} open={true} onOpenChange={vi.fn()} />,
+    { wrapper: Wrapper }
+  );
+}
+
+describe('FinalizeForTableDialog', () => {
+  it('submits {target_table, story_title, story_description} to finalizeDraftForTable', async () => {
+    const mutateFn = vi.fn();
+    vi.mocked(queries.useFinalizeDraftForTable).mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useFinalizeDraftForTable>);
+
+    const user = userEvent.setup();
+    renderDialog();
+
+    await userEvent.selectOptions(screen.getByTestId('mock-select'), '1');
+    await user.type(screen.getByLabelText(/story title/i), 'The Long Road Home');
+    await user.type(screen.getByLabelText(/story description/i), 'A caravan crosses the wastes.');
+    await user.click(screen.getByRole('button', { name: /^finalize for my table$/i }));
+
+    expect(mutateFn).toHaveBeenCalledWith(
+      {
+        draftId: 7,
+        payload: {
+          target_table: 1,
+          story_title: 'The Long Road Home',
+          story_description: 'A caravan crosses the wastes.',
+        },
+      },
+      expect.any(Object)
+    );
+  });
+
+  it('omits story_description when left blank', async () => {
+    const mutateFn = vi.fn();
+    vi.mocked(queries.useFinalizeDraftForTable).mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useFinalizeDraftForTable>);
+
+    const user = userEvent.setup();
+    renderDialog();
+
+    await userEvent.selectOptions(screen.getByTestId('mock-select'), '1');
+    await user.type(screen.getByLabelText(/story title/i), 'The Long Road Home');
+    await user.click(screen.getByRole('button', { name: /^finalize for my table$/i }));
+
+    expect(mutateFn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ story_description: undefined }),
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('renders the backend 400 detail verbatim on failure', async () => {
+    const mutateFn = vi.fn((_vars: unknown, opts: MutateOpts) => {
+      opts.onError?.(
+        new ApiError('That draft is not complete yet.', {
+          status: 400,
+          detail: 'That draft is not complete yet.',
+        })
+      );
+    });
+    vi.mocked(queries.useFinalizeDraftForTable).mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useFinalizeDraftForTable>);
+
+    const user = userEvent.setup();
+    renderDialog();
+
+    await userEvent.selectOptions(screen.getByTestId('mock-select'), '1');
+    await user.type(screen.getByLabelText(/story title/i), 'The Long Road Home');
+    await user.click(screen.getByRole('button', { name: /^finalize for my table$/i }));
+
+    expect(await screen.findByText('That draft is not complete yet.')).toBeInTheDocument();
+  });
+
+  it('shows a success panel naming the message and linking to /tables', async () => {
+    const mutateFn = vi.fn((_vars: unknown, opts: MutateOpts) => {
+      opts.onSuccess?.({
+        character_id: 55,
+        roster_entry_id: 66,
+        story_id: 77,
+        message: 'GM character created on the Available roster.',
+      });
+    });
+    vi.mocked(queries.useFinalizeDraftForTable).mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useFinalizeDraftForTable>);
+
+    const user = userEvent.setup();
+    renderDialog();
+
+    await userEvent.selectOptions(screen.getByTestId('mock-select'), '1');
+    await user.type(screen.getByLabelText(/story title/i), 'The Long Road Home');
+    await user.click(screen.getByRole('button', { name: /^finalize for my table$/i }));
+
+    expect(
+      await screen.findByText('GM character created on the Available roster.')
+    ).toBeInTheDocument();
+    const link = screen.getByRole('link', { name: /go to my tables/i });
+    expect(link).toHaveAttribute('href', '/tables');
+  });
+
+  describe('submit gating', () => {
+    it('is disabled until a table and a story title are both set', async () => {
+      vi.mocked(queries.useFinalizeDraftForTable).mockReturnValue({
+        mutate: vi.fn(),
+        isPending: false,
+      } as unknown as ReturnType<typeof queries.useFinalizeDraftForTable>);
+
+      const user = userEvent.setup();
+      renderDialog();
+
+      const submitButton = screen.getByRole('button', { name: /^finalize for my table$/i });
+      expect(submitButton).toBeDisabled();
+
+      await userEvent.selectOptions(screen.getByTestId('mock-select'), '1');
+      expect(submitButton).toBeDisabled();
+
+      await user.type(screen.getByLabelText(/story title/i), 'The Long Road Home');
+      expect(submitButton).not.toBeDisabled();
+    });
+
+    it('is disabled while the mutation is pending', () => {
+      vi.mocked(queries.useFinalizeDraftForTable).mockReturnValue({
+        mutate: vi.fn(),
+        isPending: true,
+      } as unknown as ReturnType<typeof queries.useFinalizeDraftForTable>);
+
+      renderDialog();
+
+      expect(screen.getByRole('button', { name: /finalizing/i })).toBeDisabled();
+    });
+  });
+});

--- a/frontend/src/character-creation/__tests__/components/ReviewStage.test.tsx
+++ b/frontend/src/character-creation/__tests__/components/ReviewStage.test.tsx
@@ -28,8 +28,37 @@ import { Stage } from '../../types';
 vi.mock('../../api', () => ({
   submitDraftForReview: vi.fn(),
   addToRoster: vi.fn(),
+  finalizeDraftForTable: vi.fn(),
   getCGExplanations: vi.fn(),
 }));
+
+// ReviewStage now calls useTables() to gate the "Finalize for My Table"
+// button (#3268) — mock it so these tests don't hit the network. Individual
+// tests override the return value with vi.mocked(...).mockReturnValue(...)
+// where the GM-table gating matters.
+vi.mock('@/tables/queries', () => ({
+  useTables: vi.fn(() => ({ data: { count: 0, next: null, previous: null, results: [] } })),
+}));
+
+import { useTables } from '@/tables/queries';
+import type { GMTable } from '@/tables/types';
+
+function makeGMTable(overrides: Partial<GMTable> = {}): GMTable {
+  return {
+    id: 1,
+    gm: 10,
+    gm_username: 'gmUser',
+    name: 'Test Table',
+    description: '',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    archived_at: null,
+    member_count: 2,
+    story_count: 1,
+    viewer_role: 'gm',
+    ...overrides,
+  } as GMTable;
+}
 
 describe('ReviewStage', () => {
   const mockOnStageSelect = vi.fn();
@@ -438,6 +467,108 @@ describe('ReviewStage', () => {
       expect(
         screen.getByText(/review your character before submitting for approval/i)
       ).toBeInTheDocument();
+    });
+  });
+
+  describe('Finalize for My Table (#3268)', () => {
+    it('does not show the button when the account owns no active GM table', () => {
+      const queryClient = createTestQueryClient();
+
+      renderWithCharacterCreationProviders(
+        <ReviewStage draft={mockCompleteDraft} isStaff={false} onStageSelect={mockOnStageSelect} />,
+        { queryClient, account: mockPlayerAccount }
+      );
+
+      expect(
+        screen.queryByRole('button', { name: /finalize for my table/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('shows the button for a non-staff account that owns an active GM table', () => {
+      vi.mocked(useTables).mockReturnValue({
+        data: { count: 1, next: null, previous: null, results: [makeGMTable()] },
+      } as unknown as ReturnType<typeof useTables>);
+      const queryClient = createTestQueryClient();
+
+      renderWithCharacterCreationProviders(
+        <ReviewStage draft={mockCompleteDraft} isStaff={false} onStageSelect={mockOnStageSelect} />,
+        { queryClient, account: mockPlayerAccount }
+      );
+
+      expect(screen.getByRole('button', { name: /finalize for my table/i })).toBeInTheDocument();
+    });
+
+    it('is disabled when stages are incomplete (reuses the Submit condition)', () => {
+      vi.mocked(useTables).mockReturnValue({
+        data: { count: 1, next: null, previous: null, results: [makeGMTable()] },
+      } as unknown as ReturnType<typeof useTables>);
+      const queryClient = createTestQueryClient();
+
+      renderWithCharacterCreationProviders(
+        <ReviewStage
+          draft={mockIncompleteDraft}
+          isStaff={false}
+          onStageSelect={mockOnStageSelect}
+        />,
+        { queryClient, account: mockPlayerAccount }
+      );
+
+      expect(screen.getByRole('button', { name: /finalize for my table/i })).toBeDisabled();
+    });
+
+    it('ignores tables where the account is not the GM (viewer_role !== "gm")', () => {
+      vi.mocked(useTables).mockReturnValue({
+        data: {
+          count: 1,
+          next: null,
+          previous: null,
+          results: [makeGMTable({ viewer_role: 'member' })],
+        },
+      } as unknown as ReturnType<typeof useTables>);
+      const queryClient = createTestQueryClient();
+
+      renderWithCharacterCreationProviders(
+        <ReviewStage draft={mockCompleteDraft} isStaff={false} onStageSelect={mockOnStageSelect} />,
+        { queryClient, account: mockPlayerAccount }
+      );
+
+      expect(
+        screen.queryByRole('button', { name: /finalize for my table/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('does not show the button for staff even if they own a GM table', () => {
+      vi.mocked(useTables).mockReturnValue({
+        data: { count: 1, next: null, previous: null, results: [makeGMTable()] },
+      } as unknown as ReturnType<typeof useTables>);
+      const queryClient = createTestQueryClient();
+
+      renderWithCharacterCreationProviders(
+        <ReviewStage draft={mockCompleteDraft} isStaff={true} onStageSelect={mockOnStageSelect} />,
+        { queryClient, account: mockStaffAccount }
+      );
+
+      expect(
+        screen.queryByRole('button', { name: /finalize for my table/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it('opens the dialog on click', async () => {
+      vi.mocked(useTables).mockReturnValue({
+        data: { count: 1, next: null, previous: null, results: [makeGMTable()] },
+      } as unknown as ReturnType<typeof useTables>);
+      const user = userEvent.setup();
+      const queryClient = createTestQueryClient();
+
+      renderWithCharacterCreationProviders(
+        <ReviewStage draft={mockCompleteDraft} isStaff={false} onStageSelect={mockOnStageSelect} />,
+        { queryClient, account: mockPlayerAccount }
+      );
+
+      await user.click(screen.getByRole('button', { name: /finalize for my table/i }));
+
+      expect(screen.getByRole('dialog')).toBeInTheDocument();
+      expect(screen.getByText('Story Title *')).toBeInTheDocument();
     });
   });
 });

--- a/frontend/src/character-creation/api.ts
+++ b/frontend/src/character-creation/api.ts
@@ -253,6 +253,43 @@ export async function addToRoster(
   return res.json();
 }
 
+/** Body for POST .../drafts/{id}/finalize-gm/ (#3268). */
+export interface FinalizeForTablePayload {
+  target_table: number;
+  story_title: string;
+  story_description?: string;
+}
+
+/** 201 response from POST .../drafts/{id}/finalize-gm/. */
+export interface FinalizeForTableResponse {
+  character_id: number;
+  roster_entry_id: number;
+  story_id: number;
+  message: string;
+}
+
+/**
+ * POST /api/character-creation/drafts/{id}/finalize-gm/
+ * A player-GM finalizes their own completed draft directly onto the
+ * Available roster for a table they own, minting a story tied to it
+ * (#3268). Non-staff equivalent of `addToRoster` — errors surface a
+ * `{detail}` string (incomplete draft, missing table ownership, or a
+ * finalize-time validation failure), which the caller should render
+ * verbatim via `ApiError.detail`/`message`.
+ */
+export async function finalizeDraftForTable(
+  draftId: number,
+  payload: FinalizeForTablePayload
+): Promise<FinalizeForTableResponse> {
+  const res = await apiFetch(`${BASE_URL}/drafts/${draftId}/finalize-gm/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) await throwApiError(res, 'Failed to finalize character for your table');
+  return res.json();
+}
+
 export async function canCreateCharacter(): Promise<{ can_create: boolean; reason: string }> {
   const res = await apiFetch(`${BASE_URL}/can-create/`);
   if (!res.ok) {

--- a/frontend/src/character-creation/components/FinalizeForTableDialog.tsx
+++ b/frontend/src/character-creation/components/FinalizeForTableDialog.tsx
@@ -1,0 +1,188 @@
+/**
+ * FinalizeForTableDialog — a player-GM finalizes their own completed draft
+ * directly onto the Available roster for a table they own (#3268).
+ *
+ * Non-staff sibling of the staff "Add to Roster" button in `ReviewStage`:
+ * since `finalize-gm` also mints a `Story` tied to the target table, the GM
+ * picks which of their active GM-role tables to attach it to and names the
+ * story. On success, shows a panel naming the character and linking to the
+ * table instead of immediately redirecting — the player-GM stays in control
+ * of when the draft is cleared (see `useFinalizeDraftForTable`'s doc comment).
+ */
+
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { bulletinErrorsFrom, type BulletinFieldErrors } from '@/tables/bulletinErrors';
+import { FormErrors } from '@/tables/components/FieldError';
+import type { GMTable } from '@/tables/types';
+import type { FinalizeForTableResponse } from '../api';
+import { characterCreationKeys, useFinalizeDraftForTable } from '../queries';
+
+interface FinalizeForTableDialogProps {
+  draftId: number;
+  /** Active GM tables owned by the requesting account (`viewer_role === 'gm'`). */
+  tables: GMTable[];
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+export function FinalizeForTableDialog({
+  draftId,
+  tables,
+  open,
+  onOpenChange,
+}: FinalizeForTableDialogProps) {
+  const queryClient = useQueryClient();
+  const finalize = useFinalizeDraftForTable();
+
+  const [tableId, setTableId] = useState('');
+  const [storyTitle, setStoryTitle] = useState('');
+  const [storyDescription, setStoryDescription] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<BulletinFieldErrors>({});
+  const [result, setResult] = useState<FinalizeForTableResponse | null>(null);
+
+  function resetForm() {
+    setTableId('');
+    setStoryTitle('');
+    setStoryDescription('');
+    setFieldErrors({});
+    setResult(null);
+  }
+
+  /** Clears the finalized draft from cache once the player has seen the result. */
+  function clearFinalizedDraft() {
+    queryClient.setQueryData(characterCreationKeys.draft(), null);
+  }
+
+  function handleOpenChange(next: boolean) {
+    if (!next && result) {
+      clearFinalizedDraft();
+    }
+    onOpenChange(next);
+    if (!next) resetForm();
+  }
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setFieldErrors({});
+    finalize.mutate(
+      {
+        draftId,
+        payload: {
+          target_table: parseInt(tableId, 10),
+          story_title: storyTitle.trim(),
+          story_description: storyDescription.trim() || undefined,
+        },
+      },
+      {
+        onSuccess: (data) => setResult(data),
+        onError: (err: unknown) => setFieldErrors(bulletinErrorsFrom(err)),
+      }
+    );
+  }
+
+  const isValid = tableId !== '' && storyTitle.trim().length > 0;
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>Finalize for My Table</DialogTitle>
+          <DialogDescription>
+            Create this character directly on the Available roster for one of your GM tables, with a
+            new story tied to it.
+          </DialogDescription>
+        </DialogHeader>
+
+        {result ? (
+          <div className="space-y-4">
+            <p className="text-sm">{result.message}</p>
+            <DialogFooter>
+              <Button asChild onClick={clearFinalizedDraft}>
+                <Link to="/tables">Go to My Tables</Link>
+              </Button>
+            </DialogFooter>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-1">
+              <Label htmlFor="finalize-table">Table *</Label>
+              <Select value={tableId} onValueChange={setTableId}>
+                <SelectTrigger id="finalize-table">
+                  <SelectValue placeholder="Select a table" />
+                </SelectTrigger>
+                <SelectContent>
+                  {tables.map((table) => (
+                    <SelectItem key={table.id} value={String(table.id)}>
+                      {table.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+
+            <div className="space-y-1">
+              <Label htmlFor="finalize-story-title">Story Title *</Label>
+              <Input
+                id="finalize-story-title"
+                value={storyTitle}
+                onChange={(e) => setStoryTitle(e.target.value)}
+                placeholder="e.g. The Salt Road"
+                required
+                aria-describedby={
+                  fieldErrors.story_title ? 'finalize-story-title-error' : undefined
+                }
+              />
+            </div>
+
+            <div className="space-y-1">
+              <Label htmlFor="finalize-story-description">
+                Story Description{' '}
+                <span className="font-normal text-muted-foreground">(optional)</span>
+              </Label>
+              <Textarea
+                id="finalize-story-description"
+                value={storyDescription}
+                onChange={(e) => setStoryDescription(e.target.value)}
+                placeholder="What's this story about?"
+                rows={3}
+                className="resize-y"
+              />
+            </div>
+
+            <FormErrors errors={fieldErrors} />
+
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => handleOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={!isValid || finalize.isPending}>
+                {finalize.isPending ? 'Finalizing…' : 'Finalize for My Table'}
+              </Button>
+            </DialogFooter>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/character-creation/components/FinalizeForTableDialog.tsx
+++ b/frontend/src/character-creation/components/FinalizeForTableDialog.tsx
@@ -6,11 +6,12 @@
  * since `finalize-gm` also mints a `Story` tied to the target table, the GM
  * picks which of their active GM-role tables to attach it to and names the
  * story. On success, shows a panel naming the character and linking to the
- * table instead of immediately redirecting — the player-GM stays in control
- * of when the draft is cleared (see `useFinalizeDraftForTable`'s doc comment).
+ * specific table instead of immediately redirecting — the player-GM stays in
+ * control of when the draft is cleared (see `useFinalizeDraftForTable`'s doc
+ * comment and the unmount-cleanup effect below).
  */
 
-import { useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { useQueryClient } from '@tanstack/react-query';
 import { Button } from '@/components/ui/button';
@@ -61,6 +62,16 @@ export function FinalizeForTableDialog({
   const [fieldErrors, setFieldErrors] = useState<BulletinFieldErrors>({});
   const [result, setResult] = useState<FinalizeForTableResponse | null>(null);
 
+  // Mirrors `result` for the unmount-cleanup effect below, which needs a
+  // synchronous read of "did this finalize succeed" without depending on
+  // `result` (a dependency would re-run the effect, and re-subscribing an
+  // unmount handler on every render defeats the point — it must only ever
+  // run once, on the component's actual teardown).
+  const resultRef = useRef<FinalizeForTableResponse | null>(null);
+  useEffect(() => {
+    resultRef.current = result;
+  }, [result]);
+
   function resetForm() {
     setTableId('');
     setStoryTitle('');
@@ -81,6 +92,29 @@ export function FinalizeForTableDialog({
     onOpenChange(next);
     if (!next) resetForm();
   }
+
+  // Route-level safety net (#3268 review fix): this dialog stays mounted
+  // across open/close (its parent, `ReviewStage`, only toggles the `open`
+  // prop), so `handleOpenChange` above catches the in-dialog dismissal path
+  // (X button, Cancel, "Go to My Table"). But a player can also leave via
+  // browser Back or any other router nav that unmounts `ReviewStage` (and
+  // this dialog with it) without `handleOpenChange` ever running — e.g.
+  // right after a successful finalize, before they click through. Without
+  // this, the already-finalized draft stays cached (`staleTime` is 5 min —
+  // see `queryClient.ts`), and a return to /characters/create resurrects a
+  // phantom draft whose actions all 404 server-side. This effect's cleanup
+  // fires on every unmount path, so it clears the cache whenever the dialog
+  // goes away having actually finalized, regardless of how the player left.
+  // (`clearFinalizedDraft` intentionally omitted from deps: it must run its
+  // cleanup only on the component's final unmount, not on every re-render.)
+  useEffect(() => {
+    return () => {
+      if (resultRef.current) {
+        clearFinalizedDraft();
+      }
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
@@ -119,7 +153,7 @@ export function FinalizeForTableDialog({
             <p className="text-sm">{result.message}</p>
             <DialogFooter>
               <Button asChild onClick={clearFinalizedDraft}>
-                <Link to="/tables">Go to My Tables</Link>
+                <Link to={`/tables/${tableId}`}>Go to My Table</Link>
               </Button>
             </DialogFooter>
           </div>

--- a/frontend/src/character-creation/components/ReviewStage.tsx
+++ b/frontend/src/character-creation/components/ReviewStage.tsx
@@ -26,6 +26,8 @@ import {
 } from '@/components/ui/dialog';
 import { cn } from '@/lib/utils';
 import { motion } from 'framer-motion';
+import { useTables } from '@/tables/queries';
+import type { GMTable } from '@/tables/types';
 import {
   AlertCircle,
   Clock,
@@ -34,10 +36,12 @@ import {
   MessageSquare,
   Play,
   Send,
+  Sparkles,
   Undo2,
   UserPlus,
   XCircle,
 } from 'lucide-react';
+import { FinalizeForTableDialog } from './FinalizeForTableDialog';
 import {
   useAddToRoster,
   useCGExplanations,
@@ -69,9 +73,18 @@ export function ReviewStage({ draft, isStaff, onStageSelect }: ReviewStageProps)
 
   const cgPoints = useDraftCGPoints(draft.id);
 
+  // Active tables this (non-staff) account GMs — gates the "Finalize for My
+  // Table" flow (#3268). `useTables()` returns every table the requester has
+  // any relationship to; `viewer_role` narrows to ones they own as GM.
+  const tablesQuery = useTables({ status: 'active' });
+  const ownedGMTables: GMTable[] = (tablesQuery.data?.results ?? []).filter(
+    (table) => table.viewer_role === 'gm'
+  );
+
   const [submissionNotes, setSubmissionNotes] = useState('');
   const [resubmitComment, setResubmitComment] = useState('');
   const [showConversionModal, setShowConversionModal] = useState(false);
+  const [showFinalizeForTable, setShowFinalizeForTable] = useState(false);
 
   const stageCompletion = draft.stage_completion;
   const incompleteStages = Object.entries(stageCompletion)
@@ -320,6 +333,8 @@ export function ReviewStage({ draft, isStaff, onStageSelect }: ReviewStageProps)
           submitPending={submitDraft.isPending}
           onAddToRoster={() => addToRoster.mutate(draft.id)}
           addToRosterPending={addToRoster.isPending}
+          hasGMTable={ownedGMTables.length > 0}
+          onFinalizeForTable={() => setShowFinalizeForTable(true)}
         />
       )}
 
@@ -376,6 +391,16 @@ export function ReviewStage({ draft, isStaff, onStageSelect }: ReviewStageProps)
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Finalize for My Table (#3268) — player-GM direct-to-roster flow */}
+      {!isStaff && ownedGMTables.length > 0 && (
+        <FinalizeForTableDialog
+          draftId={draft.id}
+          tables={ownedGMTables}
+          open={showFinalizeForTable}
+          onOpenChange={setShowFinalizeForTable}
+        />
+      )}
     </motion.div>
   );
 }
@@ -512,6 +537,9 @@ interface NoApplicationActionsProps {
   submitPending: boolean;
   onAddToRoster: () => void;
   addToRosterPending: boolean;
+  /** Non-staff account owns at least one active GM-role table (#3268). */
+  hasGMTable: boolean;
+  onFinalizeForTable: () => void;
 }
 
 function NoApplicationActions({
@@ -523,6 +551,8 @@ function NoApplicationActions({
   submitPending,
   onAddToRoster,
   addToRosterPending,
+  hasGMTable,
+  onFinalizeForTable,
 }: NoApplicationActionsProps) {
   return (
     <div className="space-y-4">
@@ -569,6 +599,13 @@ function NoApplicationActions({
                 Add to Roster
               </>
             )}
+          </Button>
+        )}
+
+        {!isStaff && hasGMTable && (
+          <Button size="lg" variant="secondary" disabled={!canSubmit} onClick={onFinalizeForTable}>
+            <Sparkles className="mr-2 h-4 w-4" />
+            Finalize for My Table
           </Button>
         )}
       </div>

--- a/frontend/src/character-creation/components/index.ts
+++ b/frontend/src/character-creation/components/index.ts
@@ -2,6 +2,7 @@ export { ApplicationThread } from './ApplicationThread';
 export { AppearanceStage } from './AppearanceStage';
 export { AttributesStage } from './AttributesStage';
 export { DistinctionsStage } from './DistinctionsStage';
+export { FinalizeForTableDialog } from './FinalizeForTableDialog';
 export { FinalTouchesStage } from './FinalTouchesStage';
 export { FreePointsWidget } from './FreePointsWidget';
 export { GiftStage } from './GiftStage';

--- a/frontend/src/character-creation/queries.ts
+++ b/frontend/src/character-creation/queries.ts
@@ -297,7 +297,10 @@ export function useAddToRoster() {
  * shows a success panel naming the character before the player navigates
  * away, and nulling the draft here would unmount `ReviewStage` (and the
  * dialog with it) out from under that panel. The dialog clears the draft
- * cache itself once the player dismisses the success view.
+ * cache itself once the player dismisses the success view (X/Cancel/Link),
+ * plus a belt-and-suspenders unmount-cleanup effect for router navigation
+ * (e.g. browser Back) that unmounts the dialog without going through that
+ * dismissal path — see `FinalizeForTableDialog`'s effect for the full case.
  */
 export function useFinalizeDraftForTable() {
   return useMutation({

--- a/frontend/src/character-creation/queries.ts
+++ b/frontend/src/character-creation/queries.ts
@@ -8,6 +8,7 @@ import {
   addToRoster,
   canCreateCharacter,
   createDraft,
+  finalizeDraftForTable,
   getCGExplanations,
   getConsequencePoolCatalog,
   createGift,
@@ -61,6 +62,7 @@ import {
   updateTechnique,
   withdrawDraft,
 } from './api';
+import type { FinalizeForTablePayload } from './api';
 import type { CharacterDraft, CharacterDraftUpdate } from './types';
 
 export const characterCreationKeys = {
@@ -286,6 +288,21 @@ export function useAddToRoster() {
     onSuccess: () => {
       queryClient.setQueryData(characterCreationKeys.draft(), null);
     },
+  });
+}
+
+/**
+ * POST .../drafts/{id}/finalize-gm/ (#3268). Deliberately does NOT clear the
+ * draft cache on success (unlike `useAddToRoster`) — `FinalizeForTableDialog`
+ * shows a success panel naming the character before the player navigates
+ * away, and nulling the draft here would unmount `ReviewStage` (and the
+ * dialog with it) out from under that panel. The dialog clears the draft
+ * cache itself once the player dismisses the success view.
+ */
+export function useFinalizeDraftForTable() {
+  return useMutation({
+    mutationFn: ({ draftId, payload }: { draftId: number; payload: FinalizeForTablePayload }) =>
+      finalizeDraftForTable(draftId, payload),
   });
 }
 

--- a/frontend/src/stories/__tests__/GMDashboardPage.test.tsx
+++ b/frontend/src/stories/__tests__/GMDashboardPage.test.tsx
@@ -49,6 +49,8 @@ const mockDashboard = {
     beats_completed_by_risk: {},
     last_active_at: '2026-07-08T00:00:00Z',
   },
+  pending_applications: 3,
+  open_invites: 2,
 };
 
 describe('GMDashboardPage', () => {
@@ -65,6 +67,27 @@ describe('GMDashboardPage', () => {
     });
     expect(screen.getByText('Test Table')).toBeInTheDocument();
     expect(screen.getByText('gm')).toBeInTheDocument();
+  });
+
+  it('renders the pending applications and open invites tiles, linking to /tables (#3268)', async () => {
+    vi.mocked(apiFetch).mockResolvedValueOnce({
+      ok: true,
+      json: () => Promise.resolve(mockDashboard),
+    } as Response);
+
+    render(withProviders(<GMDashboardPage />));
+
+    await waitFor(() => {
+      expect(screen.getByText('GM Dashboard')).toBeInTheDocument();
+    });
+
+    const applicationsTile = screen.getByTestId('pending-applications-tile');
+    expect(applicationsTile).toHaveTextContent('3');
+    expect(applicationsTile).toHaveAttribute('href', '/tables');
+
+    const invitesTile = screen.getByTestId('open-invites-tile');
+    expect(invitesTile).toHaveTextContent('2');
+    expect(invitesTile).toHaveAttribute('href', '/tables');
   });
 
   it('renders not-a-GM message on 403', async () => {

--- a/frontend/src/stories/pages/GMDashboardPage.tsx
+++ b/frontend/src/stories/pages/GMDashboardPage.tsx
@@ -60,6 +60,10 @@ interface GMDashboardResponse {
   my_tables: GMDashboardTable[];
   pending_story_offers: GMDashboardOffer[];
   evidence_summary: GMDashboardEvidence;
+  /** Pending RosterApplications at this GM's tables (#3268). Reviewed from the per-table Recruitment tab. */
+  pending_applications: number;
+  /** This GM's unclaimed, unexpired roster invites (#3268). Managed from the per-table Recruitment tab. */
+  open_invites: number;
 }
 
 async function getGMDashboard(): Promise<GMDashboardResponse> {
@@ -220,6 +224,25 @@ function GMDashboardContent() {
           <p className="text-sm text-muted-foreground">Stories waiting on you</p>
           <p className="text-2xl font-bold">{data.waiting_for_gm.length}</p>
         </div>
+        {/* Pending applications + open invites (#3268) — GM-owned roster creation
+            surface. Both counts are reviewed/managed from the per-table
+            Recruitment tab, not this dashboard, so both link to /tables. */}
+        <Link
+          to="/tables"
+          className="rounded-lg border p-4 transition-colors hover:bg-accent"
+          data-testid="pending-applications-tile"
+        >
+          <p className="text-sm text-muted-foreground">Pending applications</p>
+          <p className="text-2xl font-bold">{data.pending_applications}</p>
+        </Link>
+        <Link
+          to="/tables"
+          className="rounded-lg border p-4 transition-colors hover:bg-accent"
+          data-testid="open-invites-tile"
+        >
+          <p className="text-sm text-muted-foreground">Open invites</p>
+          <p className="text-2xl font-bold">{data.open_invites}</p>
+        </Link>
       </section>
 
       {/* Pending story offers */}

--- a/frontend/src/tables/CLAUDE.md
+++ b/frontend/src/tables/CLAUDE.md
@@ -18,6 +18,11 @@ REST API client for `/api/gm/tables/` and `/api/gm/table-memberships/`.
 - **Table actions:** `archiveTable()`, `transferOwnership()`
 - **Membership reads:** `getTableMemberships()`
 - **Membership writes:** `inviteToTable()`, `removeMembership()`, `leaveTable()`
+- **GM roster recruitment (#3268):** `getTableInvites()`, `mintInvite()`, `revokeInvite()`,
+  `getGMQueue()`, `actionGMApplication()` (approve/deny) — the GM-facing side, rendered in
+  `RecruitmentTab` on `TableDetailPage`. `claimInvite(code)` is the player-facing side (any
+  authenticated account, not GM-scoped) — `POST /api/gm/invites/claim/`, rendered on
+  `ClaimInvitePage`.
 
 ### `queries.ts`
 
@@ -67,12 +72,17 @@ TypeScript types for the tables feature.
 
 ### `pages/`
 
-| File                  | Route         | Auth           |
-| --------------------- | ------------- | -------------- |
-| `TablesListPage.tsx`  | `/tables`     | ProtectedRoute |
-| `TableDetailPage.tsx` | `/tables/:id` | ProtectedRoute |
+| File                  | Route            | Auth           |
+| --------------------- | ---------------- | -------------- |
+| `TablesListPage.tsx`  | `/tables`        | ProtectedRoute |
+| `TableDetailPage.tsx` | `/tables/:id`    | ProtectedRoute |
+| `ClaimInvitePage.tsx` | `/invites/claim` | ProtectedRoute |
 
-Routes registered in `App.tsx` during Wave 14.
+Routes registered in `App.tsx` during Wave 14 (`ClaimInvitePage` added #3268). `ClaimInvitePage`
+reads the invite code from `?code=` (a GM-shared link pre-fills it) and posts to
+`GMInviteClaimView`; success creates a pending `RosterApplication` that surfaces in the target
+table's `RecruitmentTab` queue for the GM to approve/deny — this page doesn't itself await or
+poll for that outcome.
 
 ## Data Flow
 

--- a/frontend/src/tables/__tests__/ClaimInvitePage.test.tsx
+++ b/frontend/src/tables/__tests__/ClaimInvitePage.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * ClaimInvitePage Tests (#3268)
+ *
+ * Covers: the code input pre-fills from `?code=`, a successful claim shows
+ * the success panel, and a field error on `code` renders verbatim under the
+ * input.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { MemoryRouter } from 'react-router-dom';
+import { vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { ApiError } from '@/lib/errors';
+import { ClaimInvitePage } from '../pages/ClaimInvitePage';
+
+vi.mock('../queries', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../queries')>();
+  return {
+    ...actual,
+    useClaimInvite: vi.fn(),
+  };
+});
+
+import * as queries from '../queries';
+
+interface MutateOpts {
+  onSuccess?: (data: { application_id: number }) => void;
+  onError?: (err: unknown) => void;
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const client = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={client}>{children}</QueryClientProvider>;
+}
+
+function renderPage(initialEntries: string[] = ['/invites/claim']) {
+  return render(
+    <Wrapper>
+      <MemoryRouter initialEntries={initialEntries}>
+        <ClaimInvitePage />
+      </MemoryRouter>
+    </Wrapper>
+  );
+}
+
+describe('ClaimInvitePage', () => {
+  it('pre-fills the code input from ?code=', () => {
+    vi.mocked(queries.useClaimInvite).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useClaimInvite>);
+
+    renderPage(['/invites/claim?code=sunny-day-1']);
+
+    expect(screen.getByLabelText(/invite code/i)).toHaveValue('sunny-day-1');
+  });
+
+  it('leaves the code input blank with no ?code=', () => {
+    vi.mocked(queries.useClaimInvite).mockReturnValue({
+      mutate: vi.fn(),
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useClaimInvite>);
+
+    renderPage();
+
+    expect(screen.getByLabelText(/invite code/i)).toHaveValue('');
+  });
+
+  it('claims the entered code on submit', async () => {
+    const mutateFn = vi.fn();
+    vi.mocked(queries.useClaimInvite).mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useClaimInvite>);
+
+    const user = userEvent.setup();
+    renderPage();
+
+    await user.type(screen.getByLabelText(/invite code/i), 'sunny-day-1');
+    await user.click(screen.getByRole('button', { name: /claim invite/i }));
+
+    expect(mutateFn).toHaveBeenCalledWith('sunny-day-1', expect.any(Object));
+  });
+
+  it('shows a success panel on a successful claim', async () => {
+    const mutateFn = vi.fn((_code: string, opts: MutateOpts) => {
+      opts.onSuccess?.({ application_id: 42 });
+    });
+    vi.mocked(queries.useClaimInvite).mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useClaimInvite>);
+
+    const user = userEvent.setup();
+    renderPage(['/invites/claim?code=sunny-day-1']);
+
+    await user.click(screen.getByRole('button', { name: /claim invite/i }));
+
+    expect(await screen.findByText(/application submitted/i)).toBeInTheDocument();
+    expect(screen.queryByLabelText(/invite code/i)).not.toBeInTheDocument();
+  });
+
+  it('renders a code field error verbatim under the input', async () => {
+    const mutateFn = vi.fn((_code: string, opts: MutateOpts) => {
+      opts.onError?.(
+        new ApiError('Invalid invite code.', {
+          status: 400,
+          fieldErrors: { code: ['Invalid invite code.'] },
+        })
+      );
+    });
+    vi.mocked(queries.useClaimInvite).mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useClaimInvite>);
+
+    const user = userEvent.setup();
+    renderPage(['/invites/claim?code=bad-code']);
+
+    await user.click(screen.getByRole('button', { name: /claim invite/i }));
+
+    expect(await screen.findByText('Invalid invite code.')).toBeInTheDocument();
+    // The form stays up (not the success panel) so the player can retry.
+    expect(screen.getByLabelText(/invite code/i)).toBeInTheDocument();
+  });
+
+  it('renders a non_field_errors detail verbatim (e.g. an already-claimed invite)', async () => {
+    const mutateFn = vi.fn((_code: string, opts: MutateOpts) => {
+      opts.onError?.(
+        new ApiError('You already have a finalized application for this character.', {
+          status: 400,
+          fieldErrors: {
+            non_field_errors: ['You already have a finalized application for this character.'],
+          },
+        })
+      );
+    });
+    vi.mocked(queries.useClaimInvite).mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useClaimInvite>);
+
+    const user = userEvent.setup();
+    renderPage(['/invites/claim?code=claimed-code']);
+
+    await user.click(screen.getByRole('button', { name: /claim invite/i }));
+
+    expect(
+      await screen.findByText('You already have a finalized application for this character.')
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tables/api.ts
+++ b/frontend/src/tables/api.ts
@@ -18,8 +18,11 @@ import type {
   BulletinPostUpdateBody,
   BulletinReplyCreateBody,
   BulletinReplyUpdateBody,
+  GMApplicationAction,
   GMApplicationCreateBody,
   GMApplicationCreateResponse,
+  GMRosterInvite,
+  GMRosterInviteCreateBody,
   GMTable,
   GMTableCreateBody,
   GMTableMembership,
@@ -28,6 +31,8 @@ import type {
   GMTableUpdateBody,
   PaginatedBulletinPosts,
   PaginatedBulletinReplies,
+  PaginatedGMQueueApplications,
+  PaginatedGMRosterInvites,
   PaginatedMemberships,
   PaginatedTables,
   TableBulletinPost,
@@ -62,6 +67,8 @@ const MEMBERSHIPS_URL = '/api/gm/table-memberships';
 const BULLETIN_POSTS_URL = '/api/table-bulletin-posts';
 const BULLETIN_REPLIES_URL = '/api/table-bulletin-replies';
 const GM_APPLICATIONS_URL = '/api/gm/applications';
+const INVITES_URL = '/api/gm/invites';
+const QUEUE_URL = '/api/gm/queue';
 
 // ---------------------------------------------------------------------------
 // Tables CRUD
@@ -348,4 +355,75 @@ export async function createGMApplication(
   });
   if (!res.ok) await throwApiError(res, 'Failed to submit GM application');
   return res.json() as Promise<GMApplicationCreateResponse>;
+}
+
+// ---------------------------------------------------------------------------
+// GM roster invites (#3268)
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /api/gm/invites/
+ * Creator-scoped server-side (GMRosterInviteViewSet.get_queryset) — staff see
+ * all invites, GMs see only their own. No filter param needed.
+ */
+export async function getTableInvites(): Promise<PaginatedGMRosterInvites> {
+  const res = await apiFetch(`${INVITES_URL}/`);
+  if (!res.ok) await throwApiError(res, 'Failed to load invites');
+  return res.json() as Promise<PaginatedGMRosterInvites>;
+}
+
+/**
+ * POST /api/gm/invites/
+ * GM only; the serializer validates the requester oversees roster_entry's
+ * character at an active table.
+ */
+export async function mintInvite(data: GMRosterInviteCreateBody): Promise<GMRosterInvite> {
+  const res = await apiFetch(`${INVITES_URL}/`, {
+    method: 'POST',
+    headers: jsonHeaders(),
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) await throwApiError(res, 'Failed to mint invite');
+  return res.json() as Promise<GMRosterInvite>;
+}
+
+/**
+ * DELETE /api/gm/invites/{id}/
+ * Revokes an unclaimed invite. Claimed invites 400 (validated server-side).
+ */
+export async function revokeInvite(id: number): Promise<void> {
+  const res = await apiFetch(`${INVITES_URL}/${id}/`, { method: 'DELETE' });
+  if (!res.ok) await throwApiError(res, `Failed to revoke invite ${id}`);
+}
+
+// ---------------------------------------------------------------------------
+// GM application queue (#3268)
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /api/gm/queue/
+ * Pending RosterApplications for characters this GM (or staff) oversees.
+ */
+export async function getGMQueue(): Promise<PaginatedGMQueueApplications> {
+  const res = await apiFetch(`${QUEUE_URL}/`);
+  if (!res.ok) await throwApiError(res, 'Failed to load application queue');
+  return res.json() as Promise<PaginatedGMQueueApplications>;
+}
+
+/**
+ * POST /api/gm/queue/{id}/{action}/ where action is 'approve' | 'deny'.
+ * GM only (IsGM permission — staff without a GMProfile are rejected).
+ */
+export async function actionGMApplication(
+  id: number,
+  action: GMApplicationAction,
+  reviewNotes?: string
+): Promise<{ status: string }> {
+  const res = await apiFetch(`${QUEUE_URL}/${id}/${action}/`, {
+    method: 'POST',
+    headers: jsonHeaders(),
+    body: JSON.stringify({ review_notes: reviewNotes ?? '' }),
+  });
+  if (!res.ok) await throwApiError(res, `Failed to ${action} application ${id}`);
+  return res.json() as Promise<{ status: string }>;
 }

--- a/frontend/src/tables/api.ts
+++ b/frontend/src/tables/api.ts
@@ -21,6 +21,7 @@ import type {
   GMApplicationAction,
   GMApplicationCreateBody,
   GMApplicationCreateResponse,
+  GMInviteClaimResponse,
   GMRosterInvite,
   GMRosterInviteCreateBody,
   GMTable,
@@ -394,6 +395,23 @@ export async function mintInvite(data: GMRosterInviteCreateBody): Promise<GMRost
 export async function revokeInvite(id: number): Promise<void> {
   const res = await apiFetch(`${INVITES_URL}/${id}/`, { method: 'DELETE' });
   if (!res.ok) await throwApiError(res, `Failed to revoke invite ${id}`);
+}
+
+/**
+ * POST /api/gm/invites/claim/
+ * Any authenticated player claims an invite by code, creating (or reusing an
+ * existing pending) `RosterApplication` for the invited character. Field
+ * errors on `code` (invalid/claimed/expired/private-email-mismatch) — render
+ * verbatim via `ApiError.fieldErrors.code` / `.message`.
+ */
+export async function claimInvite(code: string): Promise<GMInviteClaimResponse> {
+  const res = await apiFetch(`${INVITES_URL}/claim/`, {
+    method: 'POST',
+    headers: jsonHeaders(),
+    body: JSON.stringify({ code }),
+  });
+  if (!res.ok) await throwApiError(res, 'Failed to claim invite');
+  return res.json() as Promise<GMInviteClaimResponse>;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/tables/components/MintInviteDialog.tsx
+++ b/frontend/src/tables/components/MintInviteDialog.tsx
@@ -1,0 +1,167 @@
+/**
+ * MintInviteDialog — GM mints a roster invite for a specific character (#3268).
+ *
+ * There is no existing search endpoint that scopes RosterEntry options to
+ * "characters this GM oversees at this table" (fetchRosterEntries only filters
+ * by roster/name/char_class/gender), so roster_entry is a plain numeric field —
+ * the GM already knows which roster entry they're inviting for from the
+ * table's story roster. The backend validates oversight server-side and
+ * surfaces a field error if the GM does not oversee the given entry.
+ */
+
+import { useState } from 'react';
+import { toast } from 'sonner';
+import { bulletinErrorsFrom, type BulletinFieldErrors } from '../bulletinErrors';
+import { FieldError, FormErrors } from './FieldError';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Switch } from '@/components/ui/switch';
+import { useMintInvite } from '../queries';
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+interface MintInviteDialogProps {
+  children: React.ReactNode;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function MintInviteDialog({ children }: MintInviteDialogProps) {
+  const [open, setOpen] = useState(false);
+  const [rosterEntryId, setRosterEntryId] = useState('');
+  const [isPublic, setIsPublic] = useState(false);
+  const [invitedEmail, setInvitedEmail] = useState('');
+  const [expiresAt, setExpiresAt] = useState('');
+  const [fieldErrors, setFieldErrors] = useState<BulletinFieldErrors>({});
+
+  const mintMutation = useMintInvite();
+
+  function resetForm() {
+    setRosterEntryId('');
+    setIsPublic(false);
+    setInvitedEmail('');
+    setExpiresAt('');
+    setFieldErrors({});
+  }
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) resetForm();
+  }
+
+  const parsedRosterEntryId = Number(rosterEntryId);
+  const isValid = rosterEntryId.trim() !== '' && Number.isInteger(parsedRosterEntryId);
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!isValid) return;
+    setFieldErrors({});
+
+    mintMutation.mutate(
+      {
+        roster_entry: parsedRosterEntryId,
+        is_public: isPublic,
+        invited_email: invitedEmail.trim() || undefined,
+        expires_at: expiresAt ? new Date(expiresAt).toISOString() : undefined,
+      },
+      {
+        onSuccess: (invite) => {
+          toast.success(`Invite minted: ${invite.code}`);
+          setOpen(false);
+        },
+        onError: (err: unknown) => {
+          setFieldErrors(bulletinErrorsFrom(err));
+        },
+      }
+    );
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>{children}</DialogTrigger>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Mint Invite</DialogTitle>
+          <DialogDescription>
+            Generate a claim code for a roster character you oversee at this table.
+          </DialogDescription>
+        </DialogHeader>
+
+        <form onSubmit={(e) => handleSubmit(e)} className="space-y-4">
+          {/* Roster entry */}
+          <div className="space-y-1">
+            <Label htmlFor="invite-roster-entry">Roster entry ID *</Label>
+            <Input
+              id="invite-roster-entry"
+              type="number"
+              min={1}
+              value={rosterEntryId}
+              onChange={(e) => setRosterEntryId(e.target.value)}
+              placeholder="e.g. 42"
+              required
+            />
+            <FieldError errors={fieldErrors} field="roster_entry" />
+          </div>
+
+          {/* Public toggle */}
+          <div className="flex items-center gap-3">
+            <Switch id="invite-public" checked={isPublic} onCheckedChange={setIsPublic} />
+            <Label htmlFor="invite-public">Public (anyone with the code can claim)</Label>
+          </div>
+
+          {/* Invited email (private invites) */}
+          <div className="space-y-1">
+            <Label htmlFor="invite-email">Invited email (optional)</Label>
+            <Input
+              id="invite-email"
+              type="email"
+              value={invitedEmail}
+              onChange={(e) => setInvitedEmail(e.target.value)}
+              placeholder="player@example.com"
+              disabled={isPublic}
+            />
+            <FieldError errors={fieldErrors} field="invited_email" />
+          </div>
+
+          {/* Expiry */}
+          <div className="space-y-1">
+            <Label htmlFor="invite-expires">Expires (optional)</Label>
+            <Input
+              id="invite-expires"
+              type="datetime-local"
+              value={expiresAt}
+              onChange={(e) => setExpiresAt(e.target.value)}
+            />
+            <FieldError errors={fieldErrors} field="expires_at" />
+          </div>
+
+          {/* Global errors */}
+          <FormErrors errors={fieldErrors} />
+
+          <DialogFooter>
+            <Button type="button" variant="outline" onClick={() => setOpen(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!isValid || mintMutation.isPending}>
+              {mintMutation.isPending ? 'Minting…' : 'Mint Invite'}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/src/tables/components/RecruitmentTab.test.tsx
+++ b/frontend/src/tables/components/RecruitmentTab.test.tsx
@@ -1,0 +1,322 @@
+/**
+ * RecruitmentTab Tests (#3268)
+ *
+ * Covers: invites + queue rendering from mocks, mint dialog POST payload,
+ * revoke DELETE, deny requires notes and sends `{review_notes}`, and that a
+ * non-GM staff viewer (account.is_gm === false) sees no action buttons.
+ */
+
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { configureStore } from '@reduxjs/toolkit';
+import { MemoryRouter } from 'react-router-dom';
+import { Provider } from 'react-redux';
+import { vi } from 'vitest';
+import type { ReactNode } from 'react';
+import { authSlice } from '@/store/authSlice';
+import { mockAccount } from '@/test/mocks/account';
+import { RecruitmentTab } from './RecruitmentTab';
+import type { GMQueueApplication, GMRosterInvite, GMTable } from '../types';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('../queries', () => ({
+  useInvites: vi.fn(),
+  useGMQueue: vi.fn(),
+  useMintInvite: vi.fn(),
+  useRevokeInvite: vi.fn(),
+  useActionGMApplication: vi.fn(),
+}));
+
+import * as queries from '../queries';
+
+// ---------------------------------------------------------------------------
+// Wrapper
+// ---------------------------------------------------------------------------
+
+/** isGM undefined = no account at all (logged-out-shaped, matches TablesListPage convention). */
+function createWrapper(isGM?: boolean) {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } });
+  const testStore = configureStore({ reducer: { auth: authSlice.reducer } });
+  if (isGM !== undefined) {
+    testStore.dispatch(authSlice.actions.setAccount({ ...mockAccount, is_gm: isGM }));
+  }
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return (
+      <Provider store={testStore}>
+        <QueryClientProvider client={qc}>
+          <MemoryRouter>{children}</MemoryRouter>
+        </QueryClientProvider>
+      </Provider>
+    );
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeTable(overrides: Partial<GMTable> = {}): GMTable {
+  return {
+    id: 1,
+    gm: 10,
+    gm_username: 'gmUser',
+    name: 'Test Table',
+    description: '',
+    status: 'active',
+    created_at: '2026-01-01T00:00:00Z',
+    archived_at: null,
+    member_count: 2,
+    story_count: 1,
+    viewer_role: 'gm',
+    ...overrides,
+  };
+}
+
+function makeInvite(overrides: Partial<GMRosterInvite> = {}): GMRosterInvite {
+  return {
+    id: 1,
+    roster_entry: 42,
+    code: 'abc123code',
+    created_by: 5,
+    created_at: '2026-08-01T00:00:00Z',
+    expires_at: null,
+    is_public: true,
+    invited_email: '',
+    claimed_at: null,
+    claimed_by: null,
+    claimed_username: null,
+    ...overrides,
+  };
+}
+
+function makeApplication(overrides: Partial<GMQueueApplication> = {}): GMQueueApplication {
+  return {
+    id: 7,
+    character: 99,
+    character_key: 'Alaric',
+    applicant_username: 'playerOne',
+    status: 'pending',
+    applied_date: '2026-08-10T00:00:00Z',
+    application_text: 'I would love to play Alaric.',
+    ...overrides,
+  };
+}
+
+function mockInvitesQuery(results: GMRosterInvite[] = []) {
+  vi.mocked(queries.useInvites).mockReturnValue({
+    data: { count: results.length, next: null, previous: null, results },
+    isLoading: false,
+  } as unknown as ReturnType<typeof queries.useInvites>);
+}
+
+function mockQueueQuery(results: GMQueueApplication[] = []) {
+  vi.mocked(queries.useGMQueue).mockReturnValue({
+    data: { count: results.length, next: null, previous: null, results },
+    isLoading: false,
+  } as unknown as ReturnType<typeof queries.useGMQueue>);
+}
+
+// ---------------------------------------------------------------------------
+// Setup
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.mocked(queries.useMintInvite).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof queries.useMintInvite>);
+  vi.mocked(queries.useRevokeInvite).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof queries.useRevokeInvite>);
+  vi.mocked(queries.useActionGMApplication).mockReturnValue({
+    mutate: vi.fn(),
+    isPending: false,
+  } as unknown as ReturnType<typeof queries.useActionGMApplication>);
+});
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+describe('RecruitmentTab rendering', () => {
+  it('renders invites from the mocked query', () => {
+    mockInvitesQuery([makeInvite({ code: 'sunny-day-1' })]);
+    mockQueueQuery([]);
+
+    render(<RecruitmentTab table={makeTable()} />, { wrapper: createWrapper(true) });
+
+    expect(screen.getByText('sunny-day-1')).toBeInTheDocument();
+    expect(screen.getByText('Public')).toBeInTheDocument();
+  });
+
+  it('renders queue applications from the mocked query', () => {
+    mockInvitesQuery([]);
+    mockQueueQuery([makeApplication({ character_key: 'Bramble' })]);
+
+    render(<RecruitmentTab table={makeTable()} />, { wrapper: createWrapper(true) });
+
+    expect(screen.getByText('Bramble')).toBeInTheDocument();
+    expect(screen.getByText(/playerOne/)).toBeInTheDocument();
+  });
+
+  it('shows the create-character callout linking to /characters/create', () => {
+    mockInvitesQuery([]);
+    mockQueueQuery([]);
+
+    render(<RecruitmentTab table={makeTable()} />, { wrapper: createWrapper(true) });
+
+    const link = screen.getByRole('link', { name: /create a character/i });
+    expect(link).toHaveAttribute('href', '/characters/create');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Mint invite
+// ---------------------------------------------------------------------------
+
+describe('Mint invite', () => {
+  it('POSTs the expected payload', async () => {
+    mockInvitesQuery([]);
+    mockQueueQuery([]);
+    const mutateFn = vi.fn();
+    vi.mocked(queries.useMintInvite).mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useMintInvite>);
+
+    const user = userEvent.setup();
+    render(<RecruitmentTab table={makeTable()} />, { wrapper: createWrapper(true) });
+
+    await user.click(screen.getByRole('button', { name: /mint invite/i }));
+    await user.type(screen.getByLabelText(/roster entry id/i), '42');
+    await user.click(screen.getByRole('button', { name: /^mint invite$/i }));
+
+    expect(mutateFn).toHaveBeenCalledWith(
+      expect.objectContaining({ roster_entry: 42, is_public: false }),
+      expect.any(Object)
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Revoke invite
+// ---------------------------------------------------------------------------
+
+describe('Revoke invite', () => {
+  it('calls DELETE via useRevokeInvite on confirm', async () => {
+    mockInvitesQuery([makeInvite({ id: 9, code: 'revokeme' })]);
+    mockQueueQuery([]);
+    const mutateFn = vi.fn();
+    vi.mocked(queries.useRevokeInvite).mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useRevokeInvite>);
+
+    const user = userEvent.setup();
+    render(<RecruitmentTab table={makeTable()} />, { wrapper: createWrapper(true) });
+
+    await user.click(screen.getByRole('button', { name: /revoke/i }));
+    const dialog = screen.getByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: /revoke invite/i }));
+
+    expect(mutateFn).toHaveBeenCalledWith(9, expect.any(Object));
+  });
+
+  it('does not show a Revoke button on a claimed invite', () => {
+    mockInvitesQuery([makeInvite({ claimed_at: '2026-08-11T00:00:00Z', claimed_username: 'p1' })]);
+    mockQueueQuery([]);
+
+    render(<RecruitmentTab table={makeTable()} />, { wrapper: createWrapper(true) });
+
+    expect(screen.queryByRole('button', { name: /revoke/i })).not.toBeInTheDocument();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Deny requires notes
+// ---------------------------------------------------------------------------
+
+describe('Deny application', () => {
+  it('requires notes and sends {review_notes} on submit', async () => {
+    mockInvitesQuery([]);
+    mockQueueQuery([makeApplication({ id: 12 })]);
+    const mutateFn = vi.fn();
+    vi.mocked(queries.useActionGMApplication).mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useActionGMApplication>);
+
+    const user = userEvent.setup();
+    render(<RecruitmentTab table={makeTable()} />, { wrapper: createWrapper(true) });
+
+    await user.click(screen.getByRole('button', { name: /^deny$/i }));
+
+    const denyButton = screen.getByRole('button', { name: /confirm deny/i });
+    expect(denyButton).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/denial notes/i), 'Not a fit for this table.');
+    expect(denyButton).not.toBeDisabled();
+
+    await user.click(denyButton);
+
+    expect(mutateFn).toHaveBeenCalledWith(
+      { id: 12, action: 'deny', reviewNotes: 'Not a fit for this table.' },
+      expect.any(Object)
+    );
+  });
+
+  it('approve sends no notes', async () => {
+    mockInvitesQuery([]);
+    mockQueueQuery([makeApplication({ id: 12 })]);
+    const mutateFn = vi.fn();
+    vi.mocked(queries.useActionGMApplication).mockReturnValue({
+      mutate: mutateFn,
+      isPending: false,
+    } as unknown as ReturnType<typeof queries.useActionGMApplication>);
+
+    const user = userEvent.setup();
+    render(<RecruitmentTab table={makeTable()} />, { wrapper: createWrapper(true) });
+
+    await user.click(screen.getByRole('button', { name: /^approve$/i }));
+
+    expect(mutateFn).toHaveBeenCalledWith({ id: 12, action: 'approve' }, expect.any(Object));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Non-GM staff viewer (Decision 6)
+// ---------------------------------------------------------------------------
+
+describe('Non-GM staff viewer', () => {
+  it('sees no Approve/Deny/Mint/Revoke action buttons, and a pointer link', async () => {
+    mockInvitesQuery([makeInvite()]);
+    mockQueueQuery([makeApplication()]);
+
+    render(<RecruitmentTab table={makeTable({ viewer_role: 'staff' })} />, {
+      wrapper: createWrapper(false),
+    });
+
+    expect(screen.queryByRole('button', { name: /^approve$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^deny$/i })).not.toBeInTheDocument();
+
+    const link = screen.getByRole('link', { name: /review roster applications/i });
+    expect(link).toHaveAttribute('href', '/staff/roster-applications');
+  });
+
+  it('still shows Mint invite and Revoke for a staff viewer (invites are not GM-gated)', () => {
+    mockInvitesQuery([makeInvite()]);
+    mockQueueQuery([]);
+
+    render(<RecruitmentTab table={makeTable({ viewer_role: 'staff' })} />, {
+      wrapper: createWrapper(false),
+    });
+
+    expect(screen.getByRole('button', { name: /mint invite/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /revoke/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/tables/components/RecruitmentTab.test.tsx
+++ b/frontend/src/tables/components/RecruitmentTab.test.tsx
@@ -308,7 +308,7 @@ describe('Non-GM staff viewer', () => {
     expect(link).toHaveAttribute('href', '/staff/roster-applications');
   });
 
-  it('still shows Mint invite and Revoke for a staff viewer (invites are not GM-gated)', () => {
+  it('hides Mint invite but still shows Revoke for a staff viewer (mint requires a GMProfile; revoke staff-bypasses)', () => {
     mockInvitesQuery([makeInvite()]);
     mockQueueQuery([]);
 
@@ -316,7 +316,7 @@ describe('Non-GM staff viewer', () => {
       wrapper: createWrapper(false),
     });
 
-    expect(screen.getByRole('button', { name: /mint invite/i })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /mint invite/i })).not.toBeInTheDocument();
     expect(screen.getByRole('button', { name: /revoke/i })).toBeInTheDocument();
   });
 });

--- a/frontend/src/tables/components/RecruitmentTab.tsx
+++ b/frontend/src/tables/components/RecruitmentTab.tsx
@@ -10,6 +10,13 @@
  * action endpoint requires a GMProfile (`IsGM` permission), so staff viewing
  * a table they don't personally GM would only get a 403 from those buttons.
  * They instead see read-only rows plus a pointer to the staff review page.
+ *
+ * Mint Invite is gated on `account.is_gm` the same way: `GMRosterInviteSerializer
+ * .validate` (world/gm/serializers.py) hard-requires `request.user.gm_profile`,
+ * so a staff account without a GMProfile would only get a 400 "GM profile
+ * required." from that button. Revoke stays visible to any staff viewer —
+ * `GMInviteRevokeSerializer.validate` genuinely bypasses for `request.user
+ * .is_staff` — so it is not gated here.
  */
 
 import { useState } from 'react';
@@ -161,7 +168,7 @@ function RevokeInviteDialog({
   );
 }
 
-function InvitesSection() {
+function InvitesSection({ isGM }: { isGM: boolean }) {
   const { data, isLoading } = useInvites();
   const [revokeTarget, setRevokeTarget] = useState<GMRosterInvite | null>(null);
 
@@ -174,9 +181,11 @@ function InvitesSection() {
           <CardTitle className="text-base">Invites</CardTitle>
           <CardDescription>Claim codes for characters you oversee.</CardDescription>
         </div>
-        <MintInviteDialog>
-          <Button size="sm">Mint invite</Button>
-        </MintInviteDialog>
+        {isGM && (
+          <MintInviteDialog>
+            <Button size="sm">Mint invite</Button>
+          </MintInviteDialog>
+        )}
       </CardHeader>
       <CardContent>
         {isLoading ? (
@@ -388,7 +397,7 @@ export function RecruitmentTab({ table: _table }: RecruitmentTabProps) {
   return (
     <div className="space-y-6">
       <CreateCharacterCallout />
-      <InvitesSection />
+      <InvitesSection isGM={isGM} />
       <QueueSection isGM={isGM} />
     </div>
   );

--- a/frontend/src/tables/components/RecruitmentTab.tsx
+++ b/frontend/src/tables/components/RecruitmentTab.tsx
@@ -1,0 +1,395 @@
+/**
+ * RecruitmentTab — invites + application queue for a GM table (#3268).
+ *
+ * Mounted only for GM/staff viewers (same gate as TableDetailPage's admin row).
+ * Both `/api/gm/invites/` and `/api/gm/queue/` are scoped to the requesting
+ * GM's account across ALL their tables (staff see everything), not to this
+ * one table — there is no `table` filter on either endpoint (world/gm/views.py).
+ *
+ * Approve/Deny render only when `account.is_gm` (Decision 6): the queue
+ * action endpoint requires a GMProfile (`IsGM` permission), so staff viewing
+ * a table they don't personally GM would only get a 403 from those buttons.
+ * They instead see read-only rows plus a pointer to the staff review page.
+ */
+
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { useSelector } from 'react-redux';
+import { toast } from 'sonner';
+import type { RootState } from '@/store/store';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Textarea } from '@/components/ui/textarea';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { MintInviteDialog } from './MintInviteDialog';
+import { useActionGMApplication, useGMQueue, useInvites, useRevokeInvite } from '../queries';
+import type { GMQueueApplication, GMRosterInvite, GMTable } from '../types';
+
+// ---------------------------------------------------------------------------
+// Callout — create a character for this table
+// ---------------------------------------------------------------------------
+
+function CreateCharacterCallout() {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Create a character for this table</CardTitle>
+        <CardDescription>
+          Author a new roster character through the character creator, then mint an invite once
+          it&rsquo;s ready. Character creation uses the same shared single-draft slot as any other
+          character you create, so finish or discard an existing draft first.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Button asChild variant="outline" size="sm">
+          <Link to="/characters/create">Create a character</Link>
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Invites section
+// ---------------------------------------------------------------------------
+
+function formatExpiry(expiresAt: string | null): string {
+  if (!expiresAt) return 'No expiry';
+  return new Date(expiresAt).toLocaleString();
+}
+
+function InviteRow({
+  invite,
+  onRevoke,
+}: {
+  invite: GMRosterInvite;
+  onRevoke: (invite: GMRosterInvite) => void;
+}) {
+  function handleCopy() {
+    navigator.clipboard?.writeText(invite.code);
+    toast.success('Invite code copied.');
+  }
+
+  return (
+    <div className="flex flex-wrap items-center justify-between gap-2 py-3">
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex flex-wrap items-center gap-2">
+          <code className="rounded bg-muted px-2 py-0.5 text-sm">{invite.code}</code>
+          <Button type="button" variant="ghost" size="sm" onClick={handleCopy}>
+            Copy
+          </Button>
+          <Badge variant={invite.is_public ? 'outline' : 'secondary'}>
+            {invite.is_public ? 'Public' : 'Private'}
+          </Badge>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {formatExpiry(invite.expires_at)} &middot; Claimed by {invite.claimed_username ?? '-'}
+        </p>
+      </div>
+      {!invite.claimed_at && (
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          className="text-destructive hover:bg-destructive/10"
+          onClick={() => onRevoke(invite)}
+        >
+          Revoke
+        </Button>
+      )}
+    </div>
+  );
+}
+
+function RevokeInviteDialog({
+  invite,
+  open,
+  onOpenChange,
+}: {
+  invite: GMRosterInvite | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const revokeMutation = useRevokeInvite();
+
+  function handleConfirm() {
+    if (!invite) return;
+    revokeMutation.mutate(invite.id, {
+      onSuccess: () => {
+        toast.success('Invite revoked.');
+        onOpenChange(false);
+      },
+      onError: () => {
+        toast.error('Failed to revoke invite.');
+      },
+    });
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Revoke Invite</DialogTitle>
+          <DialogDescription>
+            Revoke invite <strong>{invite?.code}</strong>? This cannot be undone.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter>
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={revokeMutation.isPending}
+          >
+            {revokeMutation.isPending ? 'Revoking…' : 'Revoke Invite'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+function InvitesSection() {
+  const { data, isLoading } = useInvites();
+  const [revokeTarget, setRevokeTarget] = useState<GMRosterInvite | null>(null);
+
+  const invites = data?.results ?? [];
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between gap-2">
+        <div>
+          <CardTitle className="text-base">Invites</CardTitle>
+          <CardDescription>Claim codes for characters you oversee.</CardDescription>
+        </div>
+        <MintInviteDialog>
+          <Button size="sm">Mint invite</Button>
+        </MintInviteDialog>
+      </CardHeader>
+      <CardContent>
+        {isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </div>
+        ) : invites.length === 0 ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">No invites minted yet.</p>
+        ) : (
+          <div className="divide-y">
+            {invites.map((invite) => (
+              <InviteRow key={invite.id} invite={invite} onRevoke={setRevokeTarget} />
+            ))}
+          </div>
+        )}
+      </CardContent>
+
+      <RevokeInviteDialog
+        invite={revokeTarget}
+        open={revokeTarget !== null}
+        onOpenChange={(next) => {
+          if (!next) setRevokeTarget(null);
+        }}
+      />
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Application queue section
+// ---------------------------------------------------------------------------
+
+function QueueRow({ application, isGM }: { application: GMQueueApplication; isGM: boolean }) {
+  const [expanded, setExpanded] = useState(false);
+  const [denying, setDenying] = useState(false);
+  const [denyNotes, setDenyNotes] = useState('');
+  const actionMutation = useActionGMApplication();
+
+  function handleApprove() {
+    actionMutation.mutate(
+      { id: application.id, action: 'approve' },
+      {
+        onSuccess: () => toast.success(`${application.character_key} approved.`),
+        onError: () => toast.error('Failed to approve application.'),
+      }
+    );
+  }
+
+  function handleDenySubmit() {
+    if (!denyNotes.trim()) return;
+    actionMutation.mutate(
+      { id: application.id, action: 'deny', reviewNotes: denyNotes.trim() },
+      {
+        onSuccess: () => {
+          toast.success(`${application.character_key} denied.`);
+          setDenying(false);
+          setDenyNotes('');
+        },
+        onError: () => toast.error('Failed to deny application.'),
+      }
+    );
+  }
+
+  return (
+    <div className="space-y-2 py-3">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <div>
+          <p className="font-medium">{application.character_key}</p>
+          <p className="text-xs text-muted-foreground">
+            Applicant {application.applicant_username} &middot;{' '}
+            {new Date(application.applied_date).toLocaleDateString()}
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button type="button" variant="ghost" size="sm" onClick={() => setExpanded((v) => !v)}>
+            {expanded ? 'Hide application' : 'View application'}
+          </Button>
+          {isGM && !denying && (
+            <>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={handleApprove}
+                disabled={actionMutation.isPending}
+              >
+                Approve
+              </Button>
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="text-destructive hover:bg-destructive/10"
+                onClick={() => setDenying(true)}
+                disabled={actionMutation.isPending}
+              >
+                Deny
+              </Button>
+            </>
+          )}
+        </div>
+      </div>
+
+      {expanded && (
+        <p className="whitespace-pre-wrap rounded-md bg-muted p-3 text-sm">
+          {application.application_text}
+        </p>
+      )}
+
+      {isGM && denying && (
+        <div className="space-y-2 rounded-md border p-3">
+          <label className="text-sm font-medium" htmlFor={`deny-notes-${application.id}`}>
+            Denial notes *
+          </label>
+          <Textarea
+            id={`deny-notes-${application.id}`}
+            value={denyNotes}
+            onChange={(e) => setDenyNotes(e.target.value)}
+            placeholder="Let the applicant know why this application was denied."
+            rows={3}
+            required
+          />
+          <div className="flex justify-end gap-2">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => {
+                setDenying(false);
+                setDenyNotes('');
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              variant="destructive"
+              size="sm"
+              onClick={handleDenySubmit}
+              disabled={!denyNotes.trim() || actionMutation.isPending}
+            >
+              {actionMutation.isPending ? 'Denying…' : 'Confirm Deny'}
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function QueueSection({ isGM }: { isGM: boolean }) {
+  const { data, isLoading } = useGMQueue();
+  const applications = data?.results ?? [];
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Application Queue</CardTitle>
+        <CardDescription>Pending applications for characters you oversee.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {!isGM && (
+          <p className="mb-3 text-sm text-muted-foreground">
+            You can view but not act on applications here.{' '}
+            <Link to="/staff/roster-applications" className="underline">
+              Review roster applications
+            </Link>
+            .
+          </p>
+        )}
+        {isLoading ? (
+          <div className="space-y-2">
+            <Skeleton className="h-16 w-full" />
+            <Skeleton className="h-16 w-full" />
+          </div>
+        ) : applications.length === 0 ? (
+          <p className="py-4 text-center text-sm text-muted-foreground">No pending applications.</p>
+        ) : (
+          <div className="divide-y">
+            {applications.map((application) => (
+              <QueueRow key={application.id} application={application} isGM={isGM} />
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+interface RecruitmentTabProps {
+  /**
+   * Unused today: neither /api/gm/invites/ nor /api/gm/queue/ take a `table`
+   * filter (both are GM-account-scoped, world/gm/views.py — see module docblock).
+   * Kept for signature parity with the other table-detail tabs (TableBulletin,
+   * TableStoryRoster, TableMemberRoster all take `{ table }`) and in case a
+   * table-scoped filter is added later.
+   */
+  table: GMTable;
+}
+
+export function RecruitmentTab({ table: _table }: RecruitmentTabProps) {
+  const isGM = useSelector((state: RootState) => state.auth.account?.is_gm ?? false);
+
+  return (
+    <div className="space-y-6">
+      <CreateCharacterCallout />
+      <InvitesSection />
+      <QueueSection isGM={isGM} />
+    </div>
+  );
+}

--- a/frontend/src/tables/pages/ClaimInvitePage.tsx
+++ b/frontend/src/tables/pages/ClaimInvitePage.tsx
@@ -1,0 +1,86 @@
+/**
+ * ClaimInvitePage — /invites/claim (#3268)
+ *
+ * A player follows a GM-minted invite link (`/invites/claim?code=...`) to
+ * apply for the invited character. Claiming creates (or reuses an existing
+ * pending) RosterApplication; the actual approve/deny still runs through the
+ * normal GM queue (`RecruitmentTab`) — this page only submits the code.
+ *
+ * `GMInviteClaimView`'s response is just `{application_id}` — the claimed
+ * roster entry/character aren't echoed back, so the success panel links
+ * somewhere generic (the roster) rather than the specific entry.
+ */
+
+import { useState } from 'react';
+import { Link, useSearchParams } from 'react-router-dom';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { bulletinErrorsFrom, type BulletinFieldErrors } from '../bulletinErrors';
+import { FieldError, FormErrors } from '../components/FieldError';
+import { useClaimInvite } from '../queries';
+
+export function ClaimInvitePage() {
+  const [searchParams] = useSearchParams();
+  const [code, setCode] = useState(searchParams.get('code') ?? '');
+  const [fieldErrors, setFieldErrors] = useState<BulletinFieldErrors>({});
+  const [applicationId, setApplicationId] = useState<number | null>(null);
+
+  const claimInvite = useClaimInvite();
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setFieldErrors({});
+    claimInvite.mutate(code.trim(), {
+      onSuccess: (data) => setApplicationId(data.application_id),
+      onError: (err: unknown) => setFieldErrors(bulletinErrorsFrom(err)),
+    });
+  }
+
+  return (
+    <div className="mx-auto max-w-md space-y-6 p-6">
+      <Card>
+        <CardHeader>
+          <CardTitle>Claim Your Invite</CardTitle>
+          <CardDescription>
+            Enter the invite code a GM shared with you to apply for that character.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {applicationId !== null ? (
+            <div className="space-y-4">
+              <p className="text-sm">
+                Application submitted. The table&apos;s GM will review it from their queue.
+              </p>
+              <Button asChild>
+                <Link to="/roster">Browse the Roster</Link>
+              </Button>
+            </div>
+          ) : (
+            <form onSubmit={handleSubmit} className="space-y-4">
+              <div className="space-y-1">
+                <Label htmlFor="invite-code">Invite Code</Label>
+                <Input
+                  id="invite-code"
+                  value={code}
+                  onChange={(e) => setCode(e.target.value)}
+                  placeholder="e.g. sunny-day-1"
+                  required
+                  aria-describedby={fieldErrors.code ? 'invite-code-error' : undefined}
+                />
+                <FieldError errors={fieldErrors} field="code" id="invite-code-error" />
+              </div>
+
+              <FormErrors errors={fieldErrors} />
+
+              <Button type="submit" disabled={code.trim().length === 0 || claimInvite.isPending}>
+                {claimInvite.isPending ? 'Claiming…' : 'Claim Invite'}
+              </Button>
+            </form>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/tables/pages/TableDetailPage.tsx
+++ b/frontend/src/tables/pages/TableDetailPage.tsx
@@ -7,6 +7,7 @@
  *  - Stories: role-aware story list
  *  - Members: role-aware member roster
  *  - Bulletin: placeholder ("Bulletin board coming soon")
+ *  - Recruitment (GM/staff only, #3268): roster invites + application queue
  *
  * GM/staff viewers see all content + admin actions.
  * Member/guest viewers see scoped content and no admin actions.
@@ -30,6 +31,7 @@ import { RemoveFromTableDialog } from '../components/RemoveFromTableDialog';
 import { LeaveTableDialog } from '../components/LeaveTableDialog';
 import { ArchiveTableDialog } from '../components/ArchiveTableDialog';
 import { TableBulletin } from '../components/TableBulletin';
+import { RecruitmentTab } from '../components/RecruitmentTab';
 
 // ---------------------------------------------------------------------------
 // Inner detail (inside error boundary)
@@ -161,6 +163,7 @@ function TableDetailInner({ tableId }: { tableId: number }) {
             <TabsTrigger value="stories">Stories</TabsTrigger>
             <TabsTrigger value="members">Members</TabsTrigger>
             <TabsTrigger value="bulletin">Bulletin</TabsTrigger>
+            {isGMOrStaff && <TabsTrigger value="recruitment">Recruitment</TabsTrigger>}
           </TabsList>
         </div>
 
@@ -198,6 +201,12 @@ function TableDetailInner({ tableId }: { tableId: number }) {
         <TabsContent value="bulletin" className="mt-4">
           <TableBulletin table={table} />
         </TabsContent>
+
+        {isGMOrStaff && (
+          <TabsContent value="recruitment" className="mt-4">
+            <RecruitmentTab table={table} />
+          </TabsContent>
+        )}
       </Tabs>
 
       {/* Dialogs */}

--- a/frontend/src/tables/queries.ts
+++ b/frontend/src/tables/queries.ts
@@ -357,6 +357,17 @@ export function useRevokeInvite() {
   });
 }
 
+/**
+ * POST /api/gm/invites/claim/ (#3268). No cache to invalidate — the invites
+ * list is creator-scoped (the claimant isn't the invite's creator) and the
+ * new `RosterApplication` isn't surfaced by any query this claimant can see.
+ */
+export function useClaimInvite() {
+  return useMutation({
+    mutationFn: (code: string) => api.claimInvite(code),
+  });
+}
+
 // ---------------------------------------------------------------------------
 // GM application queue hooks (#3268)
 // ---------------------------------------------------------------------------

--- a/frontend/src/tables/queries.ts
+++ b/frontend/src/tables/queries.ts
@@ -18,7 +18,9 @@ import type {
   BulletinPostUpdateBody,
   BulletinReplyCreateBody,
   BulletinReplyUpdateBody,
+  GMApplicationAction,
   GMApplicationCreateBody,
+  GMRosterInviteCreateBody,
   GMTableCreateBody,
   GMTableMembershipCreateBody,
   GMTableTransferBody,
@@ -61,6 +63,8 @@ export const tablesKeys = {
     params === undefined
       ? ([...TABLES_ROOT, 'bulletin-replies'] as const)
       : ([...TABLES_ROOT, 'bulletin-replies', params] as const),
+  invites: () => [...TABLES_ROOT, 'invites'] as const,
+  gmQueue: () => [...TABLES_ROOT, 'gm-queue'] as const,
 };
 
 // ---------------------------------------------------------------------------
@@ -318,5 +322,67 @@ export function useDeleteBulletinReply() {
 export function useCreateGMApplication() {
   return useMutation({
     mutationFn: (data: GMApplicationCreateBody) => api.createGMApplication(data),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// GM roster invite hooks (#3268)
+// ---------------------------------------------------------------------------
+
+export function useInvites() {
+  return useQuery({
+    queryKey: tablesKeys.invites(),
+    queryFn: () => api.getTableInvites(),
+    throwOnError: true,
+  });
+}
+
+export function useMintInvite() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (data: GMRosterInviteCreateBody) => api.mintInvite(data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: tablesKeys.invites() }).catch(() => {});
+    },
+  });
+}
+
+export function useRevokeInvite() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (id: number) => api.revokeInvite(id),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: tablesKeys.invites() }).catch(() => {});
+    },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// GM application queue hooks (#3268)
+// ---------------------------------------------------------------------------
+
+export function useGMQueue() {
+  return useQuery({
+    queryKey: tablesKeys.gmQueue(),
+    queryFn: () => api.getGMQueue(),
+    throwOnError: true,
+  });
+}
+
+export function useActionGMApplication() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({
+      id,
+      action,
+      reviewNotes,
+    }: {
+      id: number;
+      action: GMApplicationAction;
+      reviewNotes?: string;
+    }) => api.actionGMApplication(id, action, reviewNotes),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: tablesKeys.gmQueue() }).catch(() => {});
+    },
   });
 }

--- a/frontend/src/tables/types.ts
+++ b/frontend/src/tables/types.ts
@@ -226,6 +226,16 @@ export interface PaginatedGMRosterInvites {
   results: GMRosterInvite[];
 }
 
+/**
+ * 201 response from POST /api/gm/invites/claim/ — mirrors
+ * `GMInviteClaimView`. Only the new `RosterApplication`'s pk; the claimed
+ * roster entry/character aren't echoed back, so a claim success view can
+ * only link somewhere generic (e.g. `/roster`), not the specific entry.
+ */
+export interface GMInviteClaimResponse {
+  application_id: number;
+}
+
 // ---------------------------------------------------------------------------
 // GM application queue (#3268) — hand-defined; mirrors
 // GMApplicationQueueSerializer. RosterApplication status values are

--- a/frontend/src/tables/types.ts
+++ b/frontend/src/tables/types.ts
@@ -188,3 +188,68 @@ export interface BulletinReplyCreateBody {
 export interface BulletinReplyUpdateBody {
   body: string;
 }
+
+// ---------------------------------------------------------------------------
+// GM roster invites (#3268) — hand-defined because the generated schema does
+// not yet reflect GMRosterInviteSerializer's shape.
+// Mirrors world/gm/serializers.py's GMRosterInviteSerializer.
+// ---------------------------------------------------------------------------
+
+export interface GMRosterInvite {
+  readonly id: number;
+  /** PK of the RosterEntry this invite grants. */
+  roster_entry: number;
+  readonly code: string;
+  /** PK of the creating GMProfile. */
+  readonly created_by: number;
+  readonly created_at: string;
+  expires_at: string | null;
+  is_public: boolean;
+  invited_email: string;
+  readonly claimed_at: string | null;
+  /** PK of the claiming AccountDB, or null if unclaimed. */
+  readonly claimed_by: number | null;
+  readonly claimed_username: string | null;
+}
+
+export interface GMRosterInviteCreateBody {
+  roster_entry: number;
+  expires_at?: string | null;
+  is_public?: boolean;
+  invited_email?: string;
+}
+
+export interface PaginatedGMRosterInvites {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: GMRosterInvite[];
+}
+
+// ---------------------------------------------------------------------------
+// GM application queue (#3268) — hand-defined; mirrors
+// GMApplicationQueueSerializer. RosterApplication status values are
+// pending/approved/denied/withdrawn (world/roster/models/choices.py's
+// ApplicationStatus), but the queue endpoint only ever returns pending rows.
+// ---------------------------------------------------------------------------
+
+export interface GMQueueApplication {
+  readonly id: number;
+  /** PK of the character (ObjectDB) applied for. */
+  readonly character: number;
+  readonly character_key: string;
+  readonly applicant_username: string;
+  readonly status: string;
+  readonly applied_date: string;
+  readonly application_text: string;
+}
+
+export interface PaginatedGMQueueApplications {
+  count: number;
+  next: string | null;
+  previous: string | null;
+  results: GMQueueApplication[];
+}
+
+/** action is validated server-side against GMApplicationActionSerializer.APPROVE/DENY. */
+export type GMApplicationAction = 'approve' | 'deny';

--- a/src/world/character_creation/services.py
+++ b/src/world/character_creation/services.py
@@ -76,6 +76,26 @@ class DraftExpiredError(CharacterCreationError):
     """Raised when attempting to use an expired draft."""
 
 
+def require_draft_complete(draft: CharacterDraft) -> None:
+    """Raise DraftIncompleteError unless every non-Review stage is complete.
+
+    Shared completeness gate for the direct-finalize paths that skip the normal
+    application review process (staff add-to-roster, player-GM finalize, #3268).
+
+    Raises:
+        DraftIncompleteError: If required stages are not complete.
+    """
+    if draft.can_submit():
+        return
+    incomplete = [
+        CharacterDraft.Stage(stage).label
+        for stage, complete in draft.get_stage_completion().items()
+        if not complete and stage != CharacterDraft.Stage.REVIEW
+    ]
+    msg = f"Cannot finalize: incomplete stages: {', '.join(incomplete)}"
+    raise DraftIncompleteError(msg)
+
+
 @transaction.atomic
 def finalize_character(
     draft: CharacterDraft,
@@ -108,14 +128,7 @@ def finalize_character(
         msg = "This character draft has expired due to inactivity."
         raise DraftExpiredError(msg)
 
-    if not draft.can_submit():
-        incomplete = [
-            CharacterDraft.Stage(stage).label
-            for stage, complete in draft.get_stage_completion().items()
-            if not complete and stage != CharacterDraft.Stage.REVIEW
-        ]
-        msg = f"Cannot finalize: incomplete stages: {', '.join(incomplete)}"
-        raise DraftIncompleteError(msg)
+    require_draft_complete(draft)
 
     # Build character name
     full_name = _build_character_full_name(draft)

--- a/src/world/character_creation/tests/finalization_fixtures.py
+++ b/src/world/character_creation/tests/finalization_fixtures.py
@@ -1,0 +1,194 @@
+"""Shared test fixtures for character-finalization tests (#3268).
+
+Extracted from ``test_services.py`` so both the service-level finalization
+tests and the GM-finalize view tests (``test_gm_finalize_view.py``) can build
+a submittable ``CharacterDraft`` without hand-rolling a second complete-draft
+fixture.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from world.character_creation.models import Beginnings, CharacterDraft, StartingArea
+from world.character_sheets.models import Gender
+from world.classes.factories import PathFactory
+from world.classes.models import PathStage
+from world.forms.models import Build, HeightBand
+from world.magic.factories import (
+    EffectTypeFactory,
+    GiftFactory,
+    PathGiftGrantFactory,
+    ResonanceFactory,
+    TechniqueFactory,
+    TraditionFactory,
+    TraditionGiftGrantFactory,
+)
+from world.realms.models import Realm
+from world.roster.seeds import ensure_rosters
+from world.skills.factories import SkillFactory
+from world.species.models import Species
+from world.tarot.constants import ArcanaType
+from world.tarot.models import TarotCard
+from world.traits.models import CharacterTraitValue, Trait, TraitType
+
+# Shared stats dict used by all finalization tests (12 stats, 1-5 scale, sum=24)
+DEFAULT_STATS = {
+    "strength": 2,
+    "agility": 2,
+    "stamina": 2,
+    "charm": 2,
+    "presence": 2,
+    "composure": 2,
+    "intellect": 2,
+    "wits": 2,
+    "stability": 2,
+    "luck": 2,
+    "perception": 2,
+    "willpower": 2,
+}
+
+
+class FinalizationTestMixin:
+    """Shared setup and helpers for character finalization test classes."""
+
+    @staticmethod
+    def _flush_common_caches() -> None:
+        """Flush SharedMemoryModel caches to prevent test pollution."""
+        CharacterTraitValue.flush_instance_cache()
+        Trait.flush_instance_cache()
+
+    @staticmethod
+    def _setup_finalization_base(
+        target: object, *, prefix: str, height_min: int, height_max: int
+    ) -> None:
+        """Create common CG prerequisites on target (cls or self).
+
+        Sets: realm, area, species, gender, tarot_card, beginnings,
+        height_band, build, path, effect_type, resonance, tradition.
+        """
+        slug = prefix.lower().replace(" ", "_")
+
+        # finalize_character()/approve_application() now look up seeded rosters by
+        # roster_type (Roster.objects.get — #2728) instead of lazily creating them
+        # via ensure_rosters(). Seed all seven shelves here so any finalization test
+        # can add_to_roster=True/False or approve without a Roster.DoesNotExist.
+        ensure_rosters()
+
+        target.realm = Realm.objects.create(name=f"{prefix} Realm", description="Test")
+        target.area = StartingArea.objects.create(
+            name=f"{prefix} Area",
+            description="Test",
+            realm=target.realm,
+            access_level=StartingArea.AccessLevel.ALL,
+        )
+        target.species = Species.objects.create(name=f"{prefix} Species", description="Test")
+        target.gender, _ = Gender.objects.get_or_create(
+            key=f"{slug}_gender", defaults={"display_name": f"{prefix} Gender"}
+        )
+        target.tarot_card = TarotCard.objects.create(
+            name=f"{prefix} Fool",
+            arcana_type=ArcanaType.MAJOR,
+            rank=0,
+            latin_name="Fatui",
+        )
+        target.beginnings = Beginnings.objects.create(
+            name=f"{prefix} Beginnings",
+            description="Test",
+            starting_area=target.area,
+            trust_required=0,
+            is_active=True,
+            family_known=False,
+        )
+        target.beginnings.allowed_species.add(target.species)
+        target.height_band = HeightBand.objects.create(
+            name=f"{slug}_band",
+            display_name=f"{prefix} Band",
+            min_inches=height_min,
+            max_inches=height_max,
+            weight_min=None,
+            weight_max=None,
+            is_cg_selectable=True,
+        )
+        target.build = Build.objects.create(
+            name=f"{slug}_build",
+            display_name=f"{prefix} Build",
+            weight_factor=Decimal("1.0"),
+            is_cg_selectable=True,
+        )
+        for stat_name in DEFAULT_STATS:
+            Trait.objects.get_or_create(
+                name=stat_name,
+                defaults={"trait_type": TraitType.STAT, "description": stat_name},
+            )
+        target.path = PathFactory(name=f"{prefix} Path", stage=PathStage.PROSPECT, minimum_level=1)
+        target.effect_type = EffectTypeFactory()
+        target.resonance = ResonanceFactory()
+        target.tradition = TraditionFactory()
+
+        # Gift-stage validator fixtures (#2426): a gift available for (tradition, path)
+        # with a pool technique, plus a Skill for the anima check.
+        target.gift = GiftFactory(name=f"{prefix} Gift")
+        path_grant = PathGiftGrantFactory(path=target.path, gift=target.gift)
+        target.technique = TechniqueFactory(gift=target.gift, effect_type=target.effect_type)
+        path_grant.starter_techniques.set([target.technique])
+        TraditionGiftGrantFactory(tradition=target.tradition, gift=target.gift)
+        target.skill = SkillFactory()
+        target.stat_trait = Trait.objects.get(name="strength")
+
+    def _create_complete_magic(self, draft: CharacterDraft) -> None:
+        """Create complete magic data for a draft (Gift-stage validators, #2426).
+
+        Populates the keys ``compute_magic_errors`` requires so ``draft.can_submit()``
+        (the finalize gate) passes.
+        """
+        draft.draft_data["selected_gift_id"] = self.gift.id
+        draft.draft_data["selected_technique_ids"] = [self.technique.id]
+        draft.draft_data["selected_gift_resonance_id"] = self.resonance.id
+        draft.draft_data["anima_check_stat_id"] = self.stat_trait.id
+        draft.draft_data["anima_check_skill_id"] = self.skill.id
+        draft.save(update_fields=["draft_data"])
+
+    def _create_base_draft(
+        self,
+        *,
+        first_name: str = "Test",
+        height_inches: int | None = None,
+        **extra_draft_data: object,
+    ) -> CharacterDraft:
+        """Create a complete draft for finalization testing.
+
+        Override draft_data fields via extra_draft_data kwargs (e.g., stats=..., quote=...).
+        """
+        if height_inches is None:
+            height_inches = (self.height_band.min_inches + self.height_band.max_inches) // 2
+
+        base_data = {
+            "first_name": first_name,
+            "description": "A test character",
+            "stats": DEFAULT_STATS,
+            "lineage_is_orphan": True,
+            "tarot_card_name": self.tarot_card.name,
+            "tarot_reversed": False,
+            "traits_complete": True,
+        }
+        base_data.update(extra_draft_data)
+
+        draft = CharacterDraft.objects.create(
+            account=self.account,
+            selected_area=self.area,
+            selected_beginnings=self.beginnings,
+            selected_species=self.species,
+            selected_gender=self.gender,
+            selected_path=self.path,
+            selected_tradition=self.tradition,
+            age=25,
+            birthday_month=6,
+            birthday_day=12,
+            height_band=self.height_band,
+            height_inches=height_inches,
+            build=self.build,
+            draft_data=base_data,
+        )
+        self._create_complete_magic(draft)
+        return draft

--- a/src/world/character_creation/tests/test_gm_finalize_view.py
+++ b/src/world/character_creation/tests/test_gm_finalize_view.py
@@ -1,4 +1,4 @@
-"""Endpoint tests for the GM character-finalize flow (#1506).
+"""Endpoint tests for the GM character-finalize flow (#1506, hardened #3268).
 
 POST /api/character-creation/drafts/<pk>/finalize-gm/ — a player-GM finalizes a draft
 onto the Available roster for a table they own, stamped with GM_TABLE provenance.
@@ -6,36 +6,36 @@ onto the Available roster for a table they own, stamped with GM_TABLE provenance
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from world.character_creation.factories import CharacterDraftFactory
+from world.character_creation.models import CharacterDraft
+from world.character_creation.tests.finalization_fixtures import FinalizationTestMixin
 from world.gm.factories import GMProfileFactory, GMTableFactory
-from world.magic.factories import TraditionFactory
+from world.magic.exceptions import GiftResonanceUnresolvable
 from world.roster.models import RosterEntry
 from world.roster.models.choices import CreationProvenance, RosterType
-from world.roster.seeds import ensure_rosters
 
 
-class GMFinalizeViewTests(APITestCase):
+class GMFinalizeViewTests(FinalizationTestMixin, APITestCase):
     @classmethod
     def setUpTestData(cls) -> None:
-        # finalize_gm_character() looks up a seeded roster by roster_type (#2728).
-        ensure_rosters()
+        cls._setup_finalization_base(cls, prefix="GM Finalize", height_min=700, height_max=800)
         cls.gm = GMProfileFactory()
         cls.table = GMTableFactory(gm=cls.gm)
 
     def _url(self, draft) -> str:
         return f"/api/character-creation/drafts/{draft.pk}/finalize-gm/"
 
-    def _draft(self, account=None):
-        return CharacterDraftFactory(
-            account=account or self.gm.account,
-            # CharacterTradition creation is unconditional in finalize_magic_data
-            # (#2426) — a tradition is required even for GM-created drafts.
-            selected_tradition=TraditionFactory(),
-            draft_data={"first_name": "Aurelius"},
-        )
+    def _draft(self, account=None, **extra_draft_data):
+        # _create_base_draft (FinalizationTestMixin) builds a fully submittable
+        # draft, reusing the same CG prerequisites/tradition/gift/technique/resonance
+        # fixtures the service-level finalization tests use (#3268 Decision 3) —
+        # finalize_gm now gates on draft.can_submit() same as add_to_roster.
+        self.account = account or self.gm.account
+        return self._create_base_draft(first_name="Aurelius", **extra_draft_data)
 
     def test_owner_finalizes_with_gm_table_provenance(self) -> None:
         draft = self._draft()
@@ -83,3 +83,59 @@ class GMFinalizeViewTests(APITestCase):
             format="json",
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_incomplete_draft_returns_400_with_incomplete_stages_detail(self) -> None:
+        """An incomplete draft is rejected before any mutation (#3268) — mirrors the
+        completeness gate finalize_character (and thus add_to_roster) already enforces.
+        """
+        draft = CharacterDraft.objects.create(
+            account=self.gm.account,
+            selected_area=self.area,
+            selected_beginnings=self.beginnings,
+            selected_species=self.species,
+            selected_gender=self.gender,
+            age=25,
+            birthday_month=6,
+            birthday_day=12,
+            height_band=self.height_band,
+            height_inches=750,
+            build=self.build,
+            draft_data={
+                "first_name": "Half Finished",
+                "lineage_is_orphan": True,
+                "tarot_card_name": self.tarot_card.name,
+                "tarot_reversed": False,
+                "path_skills_complete": True,
+                "traits_complete": True,
+                "magic_complete": True,
+                # No stats field - attributes stage incomplete
+            },
+        )
+        self.client.force_authenticate(user=self.gm.account)
+        response = self.client.post(
+            self._url(draft),
+            {"target_table": self.table.pk, "story_title": "Unfinished Business"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.assertIn("incomplete stages", response.data["detail"])
+
+    def test_unresolvable_gift_resonance_returns_400_not_500(self) -> None:
+        """A GiftResonanceUnresolvable from finalize_gm_character must not surface as an
+        unhandled 500 — mirrors add_to_roster's #2971 handling exactly.
+        """
+        draft = self._draft()
+        self.client.force_authenticate(user=self.gm.account)
+
+        with patch(
+            "world.character_creation.services.finalize_gm_character",
+            side_effect=GiftResonanceUnresolvable,
+        ):
+            response = self.client.post(
+                self._url(draft),
+                {"target_table": self.table.pk, "story_title": "Unresolvable Resonance"},
+                format="json",
+            )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.content)
+        self.assertEqual(response.data["detail"], "Character creation failed.")

--- a/src/world/character_creation/tests/test_services.py
+++ b/src/world/character_creation/tests/test_services.py
@@ -11,31 +11,29 @@ from django.test import TestCase, override_settings
 from django.test.utils import CaptureQueriesContext
 from evennia.accounts.models import AccountDB
 
-from world.character_creation.models import Beginnings, CharacterDraft, StartingArea
+from world.character_creation.models import CharacterDraft, StartingArea
 from world.character_creation.services import (
     DraftIncompleteError,
     can_create_character,
     finalize_character,
     get_accessible_starting_areas,
 )
-from world.character_sheets.models import CharacterSheet, Gender
-from world.classes.factories import PathFactory
-from world.classes.models import PathStage
+from world.character_creation.tests.finalization_fixtures import (
+    DEFAULT_STATS,
+    FinalizationTestMixin,
+)
+from world.character_sheets.models import CharacterSheet
 from world.forms.factories import FormTraitFactory, FormTraitOptionFactory
 from world.forms.models import Build, HeightBand
 from world.magic.factories import (
-    EffectTypeFactory,
     GiftFactory,
-    PathGiftGrantFactory,
     ResonanceFactory,
     TechniqueFactory,
     TraditionFactory,
     TraditionGiftGrantFactory,
 )
-from world.realms.models import Realm
 from world.roster.seeds import ensure_rosters
 from world.skills.factories import SkillFactory
-from world.species.models import Species
 from world.tarot.constants import ArcanaType
 from world.tarot.models import TarotCard
 from world.traits.models import (
@@ -45,167 +43,6 @@ from world.traits.models import (
     TraitChangeSource,
     TraitType,
 )
-
-# Shared stats dict used by all finalization tests (12 stats, 1-5 scale, sum=24)
-DEFAULT_STATS = {
-    "strength": 2,
-    "agility": 2,
-    "stamina": 2,
-    "charm": 2,
-    "presence": 2,
-    "composure": 2,
-    "intellect": 2,
-    "wits": 2,
-    "stability": 2,
-    "luck": 2,
-    "perception": 2,
-    "willpower": 2,
-}
-
-
-class FinalizationTestMixin:
-    """Shared setup and helpers for character finalization test classes."""
-
-    @staticmethod
-    def _flush_common_caches() -> None:
-        """Flush SharedMemoryModel caches to prevent test pollution."""
-        CharacterTraitValue.flush_instance_cache()
-        Trait.flush_instance_cache()
-
-    @staticmethod
-    def _setup_finalization_base(
-        target: object, *, prefix: str, height_min: int, height_max: int
-    ) -> None:
-        """Create common CG prerequisites on target (cls or self).
-
-        Sets: realm, area, species, gender, tarot_card, beginnings,
-        height_band, build, path, effect_type, resonance, tradition.
-        """
-        slug = prefix.lower().replace(" ", "_")
-
-        # finalize_character()/approve_application() now look up seeded rosters by
-        # roster_type (Roster.objects.get — #2728) instead of lazily creating them
-        # via ensure_rosters(). Seed all seven shelves here so any finalization test
-        # can add_to_roster=True/False or approve without a Roster.DoesNotExist.
-        ensure_rosters()
-
-        target.realm = Realm.objects.create(name=f"{prefix} Realm", description="Test")
-        target.area = StartingArea.objects.create(
-            name=f"{prefix} Area",
-            description="Test",
-            realm=target.realm,
-            access_level=StartingArea.AccessLevel.ALL,
-        )
-        target.species = Species.objects.create(name=f"{prefix} Species", description="Test")
-        target.gender, _ = Gender.objects.get_or_create(
-            key=f"{slug}_gender", defaults={"display_name": f"{prefix} Gender"}
-        )
-        target.tarot_card = TarotCard.objects.create(
-            name=f"{prefix} Fool",
-            arcana_type=ArcanaType.MAJOR,
-            rank=0,
-            latin_name="Fatui",
-        )
-        target.beginnings = Beginnings.objects.create(
-            name=f"{prefix} Beginnings",
-            description="Test",
-            starting_area=target.area,
-            trust_required=0,
-            is_active=True,
-            family_known=False,
-        )
-        target.beginnings.allowed_species.add(target.species)
-        target.height_band = HeightBand.objects.create(
-            name=f"{slug}_band",
-            display_name=f"{prefix} Band",
-            min_inches=height_min,
-            max_inches=height_max,
-            weight_min=None,
-            weight_max=None,
-            is_cg_selectable=True,
-        )
-        target.build = Build.objects.create(
-            name=f"{slug}_build",
-            display_name=f"{prefix} Build",
-            weight_factor=Decimal("1.0"),
-            is_cg_selectable=True,
-        )
-        for stat_name in DEFAULT_STATS:
-            Trait.objects.get_or_create(
-                name=stat_name,
-                defaults={"trait_type": TraitType.STAT, "description": stat_name},
-            )
-        target.path = PathFactory(name=f"{prefix} Path", stage=PathStage.PROSPECT, minimum_level=1)
-        target.effect_type = EffectTypeFactory()
-        target.resonance = ResonanceFactory()
-        target.tradition = TraditionFactory()
-
-        # Gift-stage validator fixtures (#2426): a gift available for (tradition, path)
-        # with a pool technique, plus a Skill for the anima check.
-        target.gift = GiftFactory(name=f"{prefix} Gift")
-        path_grant = PathGiftGrantFactory(path=target.path, gift=target.gift)
-        target.technique = TechniqueFactory(gift=target.gift, effect_type=target.effect_type)
-        path_grant.starter_techniques.set([target.technique])
-        TraditionGiftGrantFactory(tradition=target.tradition, gift=target.gift)
-        target.skill = SkillFactory()
-        target.stat_trait = Trait.objects.get(name="strength")
-
-    def _create_complete_magic(self, draft: CharacterDraft) -> None:
-        """Create complete magic data for a draft (Gift-stage validators, #2426).
-
-        Populates the keys ``compute_magic_errors`` requires so ``draft.can_submit()``
-        (the finalize gate) passes.
-        """
-        draft.draft_data["selected_gift_id"] = self.gift.id
-        draft.draft_data["selected_technique_ids"] = [self.technique.id]
-        draft.draft_data["selected_gift_resonance_id"] = self.resonance.id
-        draft.draft_data["anima_check_stat_id"] = self.stat_trait.id
-        draft.draft_data["anima_check_skill_id"] = self.skill.id
-        draft.save(update_fields=["draft_data"])
-
-    def _create_base_draft(
-        self,
-        *,
-        first_name: str = "Test",
-        height_inches: int | None = None,
-        **extra_draft_data: object,
-    ) -> CharacterDraft:
-        """Create a complete draft for finalization testing.
-
-        Override draft_data fields via extra_draft_data kwargs (e.g., stats=..., quote=...).
-        """
-        if height_inches is None:
-            height_inches = (self.height_band.min_inches + self.height_band.max_inches) // 2
-
-        base_data = {
-            "first_name": first_name,
-            "description": "A test character",
-            "stats": DEFAULT_STATS,
-            "lineage_is_orphan": True,
-            "tarot_card_name": self.tarot_card.name,
-            "tarot_reversed": False,
-            "traits_complete": True,
-        }
-        base_data.update(extra_draft_data)
-
-        draft = CharacterDraft.objects.create(
-            account=self.account,
-            selected_area=self.area,
-            selected_beginnings=self.beginnings,
-            selected_species=self.species,
-            selected_gender=self.gender,
-            selected_path=self.path,
-            selected_tradition=self.tradition,
-            age=25,
-            birthday_month=6,
-            birthday_day=12,
-            height_band=self.height_band,
-            height_inches=height_inches,
-            build=self.build,
-            draft_data=base_data,
-        )
-        self._create_complete_magic(draft)
-        return draft
 
 
 class CharacterFinalizationTests(FinalizationTestMixin, TestCase):
@@ -460,7 +297,6 @@ class CharacterFinalizationTests(FinalizationTestMixin, TestCase):
 
     def test_finalize_populates_physical_stats(self):
         """Test that finalization populates height, build, and weight on CharacterSheet."""
-        from world.forms.models import Build, HeightBand
 
         # Create height band and build for physical stats directly to avoid factory issues
         # Use unique height range outside all default bands (default bands end at 600)
@@ -678,7 +514,7 @@ class FinalizeCharacterSkillsTests(FinalizationTestMixin, TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        from world.skills.factories import SkillFactory, SpecializationFactory
+        from world.skills.factories import SpecializationFactory
         from world.skills.models import CharacterSkillValue, CharacterSpecializationValue
 
         CharacterSkillValue.flush_instance_cache()
@@ -1153,7 +989,6 @@ class FinalizeCharacterDistinctionResonanceTests(FinalizationTestMixin, TestCase
         from world.magic.factories import (
             AffinityFactory,
             DistinctionResonanceGrantFactory,
-            ResonanceFactory,
         )
         from world.mechanics.constants import RESONANCE_CATEGORY_NAME
         from world.mechanics.factories import ModifierCategoryFactory, ModifierTargetFactory
@@ -1288,8 +1123,6 @@ class FinalizeGiftAndTechniquesTests(TestCase):
     @classmethod
     def setUpTestData(cls) -> None:
         from world.magic.factories import (
-            GiftFactory,
-            ResonanceFactory,
             TechniqueFactory,
             TraditionFactory,
         )
@@ -2045,8 +1878,6 @@ class FinalizeRitualKnowledgeTests(FinalizationTestMixin, TestCase):
 
     @classmethod
     def setUpTestData(cls):
-        from world.skills.factories import SkillFactory
-
         cls._setup_finalization_base(
             cls, prefix="Ritual Knowledge Test", height_min=3100, height_max=3200
         )
@@ -2449,7 +2280,6 @@ class GetAccessibleStartingAreasTrustRequiredTests(TestCase):
     def test_trust_required_area_excluded_for_normal_account(self):
         from evennia_extensions.factories import AccountFactory
         from world.character_creation.factories import StartingAreaFactory
-        from world.character_creation.models import StartingArea
 
         open_area = StartingAreaFactory(name="Open Area", access_level=StartingArea.AccessLevel.ALL)
         gated_area = StartingAreaFactory(
@@ -2467,7 +2297,6 @@ class GetAccessibleStartingAreasTrustRequiredTests(TestCase):
     def test_trust_required_area_included_for_staff(self):
         from evennia_extensions.factories import AccountFactory
         from world.character_creation.factories import StartingAreaFactory
-        from world.character_creation.models import StartingArea
 
         gated_area = StartingAreaFactory(
             name="Gated Area Staff",

--- a/src/world/character_creation/views.py
+++ b/src/world/character_creation/views.py
@@ -73,6 +73,7 @@ from world.character_creation.serializers import (
 )
 from world.character_creation.services import (
     CharacterCreationError,
+    DraftIncompleteError,
     add_application_comment,
     approve_application,
     can_create_character,
@@ -81,6 +82,7 @@ from world.character_creation.services import (
     finalize_character,
     get_accessible_starting_areas,
     request_revisions,
+    require_draft_complete,
     resubmit_draft,
     submit_draft_for_review,
     unsubmit_draft,
@@ -749,6 +751,15 @@ class CharacterDraftViewSet(viewsets.ModelViewSet):
             )
 
         draft = self.get_object()
+
+        try:
+            require_draft_complete(draft)
+        except DraftIncompleteError as exc:
+            return Response(
+                {"detail": exc.reason},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
         draft.is_gm_creation = True
         draft.target_table = table
         draft.story_title = story_title
@@ -759,11 +770,13 @@ class CharacterDraftViewSet(viewsets.ModelViewSet):
 
         try:
             entry, story = finalize_gm_character(draft)
-        except DjangoValidationError as exc:
-            return Response(
-                {"detail": "; ".join(exc.messages)},
-                status=status.HTTP_400_BAD_REQUEST,
-            )
+        except (DjangoValidationError, GiftResonanceUnresolvable) as exc:
+            if isinstance(exc, DjangoValidationError):
+                detail = "; ".join(exc.messages)
+            else:
+                logger.exception("GM character finalize failed while resolving gift resonance.")
+                detail = "Character creation failed."
+            return Response({"detail": detail}, status=status.HTTP_400_BAD_REQUEST)
         return Response(
             {
                 "character_id": entry.character_sheet.pk,

--- a/src/world/gm/tests/test_gm_dashboard.py
+++ b/src/world/gm/tests/test_gm_dashboard.py
@@ -1,11 +1,17 @@
-"""Tests for GET /api/gm/dashboard/ — the GM dashboard aggregation (#2004)."""
+"""Tests for GET /api/gm/dashboard/ — the GM dashboard aggregation (#2004, #3268)."""
+
+from datetime import timedelta
 
 from django.urls import reverse
+from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APITestCase
 
 from evennia_extensions.factories import AccountFactory
-from world.gm.factories import GMProfileFactory, GMTableFactory
+from world.gm.factories import GMProfileFactory, GMRosterInviteFactory, GMTableFactory
+from world.roster.factories import RosterApplicationFactory, RosterEntryFactory
+from world.stories.factories import StoryFactory
+from world.stories.models import StoryParticipation
 
 
 class GMDashboardViewTest(APITestCase):
@@ -34,6 +40,8 @@ class GMDashboardViewTest(APITestCase):
             "my_tables",
             "pending_story_offers",
             "evidence_summary",
+            "pending_applications",
+            "open_invites",
         ]:
             self.assertIn(key, data)
         # The GM's table appears in my_tables.
@@ -41,6 +49,47 @@ class GMDashboardViewTest(APITestCase):
         self.assertIn(self.gm_table.pk, table_ids)
         # Evidence summary carries the GM's level.
         self.assertEqual(data["evidence_summary"]["level"], self.gm_profile.level)
+        # No applications/invites yet.
+        self.assertEqual(data["pending_applications"], 0)
+        self.assertEqual(data["open_invites"], 0)
+
+    def test_pending_applications_counts_queue_at_own_tables(self) -> None:
+        """pending_applications mirrors gm_application_queue(profile).count() (#3268)."""
+        entry = RosterEntryFactory()
+        story = StoryFactory(primary_table=self.gm_table)
+        StoryParticipation.objects.create(
+            story=story,
+            character=entry.character_sheet,
+            is_active=True,
+        )
+        RosterApplicationFactory(character=entry.character_sheet)
+
+        self.client.force_authenticate(user=self.gm_account)
+        url = reverse("gm:gm-dashboard")
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data["pending_applications"], 1)
+
+    def test_open_invites_excludes_claimed_and_expired(self) -> None:
+        """open_invites counts only this GM's unclaimed, unexpired invites (#3268)."""
+        # Open invite: unclaimed, not yet expired.
+        GMRosterInviteFactory(created_by=self.gm_profile)
+        # Claimed invite: excluded.
+        GMRosterInviteFactory(created_by=self.gm_profile, claimed_at=timezone.now())
+        # Expired invite: excluded.
+        GMRosterInviteFactory(
+            created_by=self.gm_profile,
+            expires_at=timezone.now() - timedelta(days=1),
+        )
+        # Another GM's open invite: excluded.
+        other_gm = GMProfileFactory()
+        GMRosterInviteFactory(created_by=other_gm)
+
+        self.client.force_authenticate(user=self.gm_account)
+        url = reverse("gm:gm-dashboard")
+        resp = self.client.get(url)
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.data["open_invites"], 1)
 
     def test_non_gm_rejected(self) -> None:
         self.client.force_authenticate(user=self.non_gm_account)

--- a/src/world/gm/views.py
+++ b/src/world/gm/views.py
@@ -560,6 +560,17 @@ class GMDashboardView(APIView):
         # Evidence summary (self-view of what staff sees).
         evidence = gm_evidence_summary(gm_profile)
 
+        # Pending applications at this GM's tables (#3268 — GM-owned roster creation
+        # dashboard surface).
+        pending_applications = gm_application_queue(gm_profile).count()
+
+        # This GM's roster invites that haven't been claimed and haven't expired yet.
+        open_invites = GMRosterInvite.objects.filter(
+            created_by=gm_profile,
+            claimed_at__isnull=True,
+            expires_at__gt=timezone.now(),
+        ).count()
+
         return Response(
             {
                 "episodes_ready_to_run": buckets.episodes_ready,
@@ -575,6 +586,8 @@ class GMDashboardView(APIView):
                     "beats_completed_by_risk": evidence.beats_completed_by_risk,
                     "last_active_at": evidence.last_active_at,
                 },
+                "pending_applications": pending_applications,
+                "open_invites": open_invites,
             }
         )
 


### PR DESCRIPTION
Closes #3268

## Summary

Frontend for GM-owned roster creation, closing the Phase 3/5 roadmap leftover: a Recruitment tab on the table page (invite mint/copy/revoke + the table application queue with GM-gated approve/deny), a Finalize-for-my-table dialog at the CG Review stage, an invite claim page at /invites/claim, and GM dashboard attention counts. Rides along: finalize-gm now gates on draft completeness (same DraftIncompleteError shape as add-to-roster) and catches GiftResonanceUnresolvable as 400 not 500; dashboard payload gains pending_applications/open_invites. MERGE ORDER: after PR #3270 - the Recruitment tab's staff pointer links the /staff/roster-applications route that PR adds.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #3268 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased cleanly onto latest origin/main (6 commits); no conflicts; no migrations on this branch.

<!-- last-addressed-comment: 0 -->