### PR TITLE
Fix nav dropdowns opening at a fixed spot instead of under their trigger

### DIFF
--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -9,7 +9,6 @@ import {
   NavigationMenuItem,
   NavigationMenuTrigger,
   NavigationMenuContent,
-  NavigationMenuViewport,
 } from './ui/navigation-menu';
 import { Sheet, SheetTrigger, SheetContent } from './ui/sheet';
 import { Button } from './ui/button';
@@ -151,7 +150,6 @@ export function Header() {
               <UserNav />
             </NavigationMenuItem>
           </NavigationMenuList>
-          <NavigationMenuViewport />
         </NavigationMenu>
         <div className="md:hidden">
           <Sheet>

--- a/frontend/src/components/__tests__/Header.test.tsx
+++ b/frontend/src/components/__tests__/Header.test.tsx
@@ -89,6 +89,25 @@ describe('Header', () => {
     expect(screen.getByRole('link', { name: /threads/i })).toBeInTheDocument();
   });
 
+  it('renders dropdown content inside its own nav item so it opens under the trigger', async () => {
+    const { user } = setupUser();
+    render(
+      <Wrapper>
+        <Header />
+      </Wrapper>
+    );
+
+    const trigger = screen.getByRole('button', { name: /characters/i });
+    await user.click(trigger);
+
+    // The panel must be a descendant of the trigger's list item — a shared
+    // viewport outside the item renders every dropdown at the same spot on
+    // the page instead of under its trigger (unclickable on hover-out).
+    const item = trigger.closest('li');
+    expect(item).not.toBeNull();
+    expect(item).toContainElement(screen.getByRole('link', { name: /roster/i }));
+  });
+
   it('renders Story dropdown links when opened', async () => {
     const { user } = setupUser();
     render(

--- a/frontend/src/components/ui/navigation-menu.tsx
+++ b/frontend/src/components/ui/navigation-menu.tsx
@@ -30,7 +30,13 @@ const NavigationMenuList = React.forwardRef<
 ));
 NavigationMenuList.displayName = NavigationMenuPrimitive.List.displayName;
 
-const NavigationMenuItem = NavigationMenuPrimitive.Item;
+const NavigationMenuItem = React.forwardRef<
+  React.ElementRef<typeof NavigationMenuPrimitive.Item>,
+  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Item>
+>(({ className, ...props }, ref) => (
+  <NavigationMenuPrimitive.Item ref={ref} className={cn('relative', className)} {...props} />
+));
+NavigationMenuItem.displayName = NavigationMenuPrimitive.Item.displayName;
 
 const NavigationMenuLink = NavigationMenuPrimitive.Link;
 
@@ -53,30 +59,13 @@ const NavigationMenuContent = React.forwardRef<
   <NavigationMenuPrimitive.Content
     ref={ref}
     className={cn(
-      'left-0 top-0 w-full data-[motion=from-end]:animate-in data-[motion=from-start]:animate-in data-[motion=to-end]:animate-out data-[motion=to-start]:animate-out data-[motion=from-end]:slide-in-from-right-52 data-[motion=from-start]:slide-in-from-left-52 data-[motion=to-end]:slide-out-to-right-52 data-[motion=to-start]:slide-out-to-left-52 md:absolute md:w-auto',
+      'absolute left-0 top-full z-50 mt-1.5 w-auto min-w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95',
       className
     )}
     {...props}
   />
 ));
 NavigationMenuContent.displayName = NavigationMenuPrimitive.Content.displayName;
-
-const NavigationMenuViewport = React.forwardRef<
-  React.ElementRef<typeof NavigationMenuPrimitive.Viewport>,
-  React.ComponentPropsWithoutRef<typeof NavigationMenuPrimitive.Viewport>
->(({ className, ...props }, ref) => (
-  <div className="absolute left-0 top-full flex justify-center">
-    <NavigationMenuPrimitive.Viewport
-      ref={ref}
-      className={cn(
-        'origin-top-center relative mt-1 h-[var(--radix-navigation-menu-viewport-height)] w-full overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-90 sm:w-[var(--radix-navigation-menu-viewport-width)]',
-        className
-      )}
-      {...props}
-    />
-  </div>
-));
-NavigationMenuViewport.displayName = NavigationMenuPrimitive.Viewport.displayName;
 
 const NavigationMenuIndicator = React.forwardRef<
   React.ElementRef<typeof NavigationMenuPrimitive.Indicator>,
@@ -102,6 +91,5 @@ export {
   NavigationMenuLink,
   NavigationMenuContent,
   NavigationMenuTrigger,
-  NavigationMenuViewport,
   NavigationMenuIndicator,
 };


### PR DESCRIPTION
## Problem

Hovering Characters, Story, or World in the nav bar opened the dropdown at the same fixed place on the page (anchored to the left edge of the menu) instead of under the hovered item. Because the panel appeared away from its trigger, moving the pointer toward it left the hover area and Radix closed the menu — the links were nearly impossible to click.

## Root cause

The shadcn `NavigationMenu` wrapper rendered every `NavigationMenuContent` into one shared `NavigationMenuViewport`, positioned `absolute left-0 top-full` on the menu root — one spot for all three dropdowns.

## Fix

Drop the shared viewport (its only consumer was `Header`) and position each `NavigationMenuContent` absolutely beneath its own now-`relative` `NavigationMenuItem` — the shadcn `viewport={false}` pattern. Each dropdown now opens directly under its trigger, so hover continuity holds and the links are clickable.

## Testing

- New regression test asserts the open panel is a DOM descendant of its trigger's `<li>` (fails against the shared-viewport implementation).
- `pnpm vitest run src/components/__tests__/Header.test.tsx` — 5 passed.
- `pnpm typecheck`, `pnpm lint` (0 errors), `pnpm build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)