### PR TITLE
Technique combat-power evaluator and Techniques panel on the tuning dashboard

### DIFF
--- a/docs/adr/0223-technique-combat-power-in-damage-equivalents.md
+++ b/docs/adr/0223-technique-combat-power-in-damage-equivalents.md
@@ -1,0 +1,41 @@
+# ADR-0223: Technique combat power is measured in damage-equivalents against a reference matchup, with parsed (not probed) mitigation
+
+**Status:** Accepted (2026-08-20, #3279)
+
+**Decision.** The tuning instrument for technique balance values every technique payload
+in one currency: expected damage-equivalent (DE) per cast, an expectation over the SL
+distribution of a reference matchup. Non-damage effects convert via a reference frame:
+buffs = priced percent x reference outgoing DPR x expected duration; hard control =
+enemy rounds denied x incoming DPR; mitigation = parsed reduction x incoming DPR x
+duration; healing = damage undone, capped. Reference DPR is self-anchoring (the median
+baseline attack DE of the authored corpus at the chosen context), never a hand-tuned
+constant. Covenant-role amplification is reported as a second number per technique
+(fully-matched anchor at a chosen thread level) computed by the same pure helpers the
+live covenant power terms call, so the instrument cannot drift from combat. Mitigation
+magnitudes are extracted by parsing MODIFY_PAYLOAD reactive-trigger flow steps
+(`protective_magnitude`), not by an empirical run of the damage pipeline; every
+valuation carries a provenance flag and unparseable shapes surface as UNPRICEABLE
+authoring gaps rather than silent zeros.
+
+**Why.** Techniques were tuned blind: `price_design` budgets inputs (intensity, authored
+base damage), not outcomes, and nothing compared "18 expected damage" against "+30% team
+damage for 3 rounds" or "x0.5 incoming for 2 rounds". A single contestable exchange rate,
+stated openly and computed from live formulas, beats per-category metrics nobody can
+trade off. Self-anchoring DPR re-anchors buff/mitigation values automatically as the
+attack corpus is retuned.
+
+**Rejected alternatives.** (a) Per-category scores with no conversion: never answers "is
+this buff overpowered". (b) Sim-derived marginal win-rate value: truthful but slow,
+noisy, unexplainable, and requires simulated parties to cast techniques first. (c) An
+empirical mitigation probe (apply condition to a scratch target, run
+`apply_damage_to_participant` with/without): the most drift-proof option and the original
+recommendation, but it demands a no-DB-writes, no-idmapper-pollution harness around the
+damage pipeline; ruled heavier than the need (Tehom, 2026-08-20: best guesses fine).
+Parsing covers all shipped defensive content (Defend's multiply-0.5 is a regression
+test); the provenance system leaves a clean seam to add a probe if trigger shapes
+proliferate beyond the parser.
+
+**Consequences.** Phase 2 (outcome-denominated authoring budgets) and phase 3
+(simulation that casts techniques) consume the same evaluator. Enhancement techniques
+(`enhances_effect_type`, whole runtime payload = flat +2 power) will visibly value near
+zero: that is the instrument reporting a design gap, not a bug to paper over.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -228,6 +228,7 @@ treat those names as hints to confirm, not gospel.
 - [0220 — Canvas deletion gates on `exported_at`, not fixture-key presence](0220-deletion-gates-on-exported-at-not-fixture-key.md) (#3269; refines ADR-0140)
 - [0221 — Codex containers hide when their subtree is empty; knowledge is an account-wide union](0221-codex-containers-hide-when-empty-knowledge-is-account-union.md) (#3276)
 - [0222 - Perspective attribution lives on the grant row, viewer-only](0222-perspective-attribution-on-the-grant-row.md) (#3277)
+- [0223 - Technique combat power is measured in damage-equivalents against a reference matchup, with parsed (not probed) mitigation](0223-technique-combat-power-in-damage-equivalents.md) (#3279)
 
 ### Gift & resonance economy
 - [0050 — Gifts are Major or Minor; species abilities are a species-granted Minor Gift](0050-gifts-are-major-or-minor-species-abilities-are-minor-gifts.md)

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -7299,12 +7299,24 @@ Production-callable seed layer for populating sane defaults on a fresh dev insta
 ### Game Tuning & Game Ops Dashboards (#1220 / #1221)
 Admin-hosted, superuser-only HTMX dashboards for difficulty tuning/simulation and live-game analytics.
 
-- **Game Tuning** (`/admin/_tuning/`, `admin_tuning`) — four HTMX-fragment panels: checks
+- **Game Tuning** (`/admin/_tuning/`, `admin_tuning`) — five HTMX-fragment panels: checks
   probability distributions (`web/admin/tuning/checks_analytics.py` —
   `compute_chart_distributions`, `compute_matchup`), consequence-pool inspector
   (`consequence_analytics.py` — `inspect_pool`, `list_pools`), condition danger ranking
-  (`condition_analytics.py` — `compute_condition_danger`), and a Monte Carlo
-  party-vs-boss simulation form (`SimulationRunForm` in `web/admin/tuning/views.py`).
+  (`condition_analytics.py` — `compute_condition_danger`), a Monte Carlo
+  party-vs-boss simulation form (`SimulationRunForm` in `web/admin/tuning/views.py`),
+  and a technique combat-power league table (#3279: `technique_analytics.py` —
+  `build_technique_panel`, over
+  `world.magic.services.technique_power_eval.evaluate_all_with_reference(EvalContext) ->
+  (list[TechniquePowerReport], ReferenceFrame)`; types in
+  `world/magic/types/technique_power.py`). The evaluator prices every technique payload
+  family in expected damage-equivalent per cast (ADR-0223) with per-valuation provenance
+  (FORMULA/PARSED/ESTIMATE/UNPRICED_DISPEL/UNPRICEABLE/INERT_PAYLOAD), a baseline vs
+  matched-anchor covenant-role band via the shared pure helpers
+  `blend_power_contribution`/`specialty_power_contribution`
+  (`world/magic/services/power_terms.py`), and mitigation magnitudes parsed from
+  MODIFY_PAYLOAD reactive triggers via `protective_magnitude`
+  (`world/magic/services/targeting.py`).
 - **Simulator:** `world.combat.simulation.run_party_vs_boss_simulation(SimulationParams) -> SimulationReport`
   drives the real `world.combat.services.resolve_round` pipeline through synthetic,
   locationless encounters inside nested transaction savepoints that are always rolled

--- a/docs/systems/tuning.md
+++ b/docs/systems/tuning.md
@@ -10,7 +10,7 @@ admin-hosted with vanilla `django-htmx` instead of `django-unfold` or a React st
 Read+preview only — sliders/forms re-render fragments via `hx-get`; nothing here writes
 game config except the Monte Carlo run (which itself writes nothing persistent, see
 below). Edits to the underlying config models still go through the normal admin change
-forms. Four panels, each its own HTMX fragment endpoint loaded with `hx-trigger="load"`
+forms. Five panels, each its own HTMX fragment endpoint loaded with `hx-trigger="load"`
 from `src/web/templates/admin/tuning/dashboard.html`:
 
 | Panel | Fragment view | URL name | Analytics module |
@@ -19,6 +19,7 @@ from `src/web/templates/admin/tuning/dashboard.html`:
 | Consequences | `tuning_consequences_fragment` | `admin_tuning_consequences` | `consequence_analytics.py` |
 | Conditions | `tuning_conditions_fragment` | `admin_tuning_conditions` | `condition_analytics.py` |
 | Simulation | `tuning_simulation_fragment` | `admin_tuning_simulation` | `world.combat.simulation` |
+| Techniques | `tuning_techniques_fragment` | `admin_tuning_techniques` | `technique_analytics.py` + `world.magic.services.technique_power_eval` |
 
 All views live in `src/web/admin/tuning/views.py` and are wrapped in `superuser_required`
 (defined there), which mirrors `game_setup_views.py`'s gate: `@staff_member_required` plus
@@ -156,6 +157,51 @@ persisted):
    scaling config exists — including a GM's live tuning edits — this module never
    overwrites it, so the preview tool can't silently reset the very tuning it's
    supposed to be previewing.
+
+### Techniques panel — technique combat-power league table (#3279)
+
+Answers "what does this technique contribute to combat power" in one currency: **expected
+damage-equivalent (DE) per cast** against a reference matchup, so attacks, buffs,
+mitigation, control, and healing are comparable on one axis (see ADR-0223 for the
+currency decision). The evaluator lives in `world.magic` (not the web layer) so it reuses
+live combat formulas and stays importable by future budget/simulation phases:
+
+- `world/magic/services/technique_power_eval.py` —
+  `evaluate_all_with_reference(EvalContext) -> (list[TechniquePowerReport], ReferenceFrame)`
+  (and the `evaluate_all` wrapper). Types in `world/magic/types/technique_power.py`.
+- **SL distribution:** rolls 1..100 enumerated against the context's
+  roller-points/target-difficulty matchup (same math as the Checks panel; local
+  re-implementation over `world.traits` models because `world` services must not import
+  `web` code). Every valuation is an expectation over those bands.
+- **Two power contexts per technique:** baseline (the technique's own `intensity`,
+  equal to `_derive_power(character=None)`) and a fully-matched-anchor amplification at
+  the context's thread level, computed by the SAME pure helpers the live covenant power
+  terms call (`blend_power_contribution` / `specialty_power_contribution` in
+  `services/power_terms.py`) — retuning `CovenantRoleBlendConfig` moves the panel.
+- **Valuators by payload family:** damage profiles through `compute_damage_budget` and
+  the `DamageSuccessLevelMultiplier` table; team-damage-lane buffs through the priced
+  percent path times reference DPR times expected duration; other modifier conditions as
+  the DE shift of a synthetic reference attack; DoT and stat debuffs sign-flipped; hard
+  control (HOLD/FEAR/DISTRACTION function tags) as enemy rounds denied times incoming
+  DPR; mitigation via `protective_magnitude` (flow-step parse of MODIFY_PAYLOAD triggers,
+  e.g. Defend's multiply-0.5); treatments as capped healing. Dispel is deliberately
+  unpriced; capability grants are valued 0 (no cast seam exists).
+- **Provenance on every valuation:** FORMULA / PARSED / ESTIMATE / UNPRICED_DISPEL /
+  UNPRICEABLE / INERT_PAYLOAD — the panel shows per-corpus provenance counts, and
+  UNPRICEABLE rows double as an authoring-gap worklist.
+- **Reference DPR is self-anchoring:** the median baseline attack DE of the corpus at the
+  chosen context (labeled "median-attack estimate"); no hand-maintained constant.
+
+Panel mechanics mirror the Simulation panel: a param form (level, thread level, matchup
+knobs, sort) POSTs a recompute cached 24h under an exact-param key with a
+`tuning-tech-power:last` pointer; `technique_analytics.py` adds an inner cache keyed on
+the analytics knobs only (excluding `sort`) so header-sort clicks never re-run the
+evaluator. The league table sorts by baseline DE, anchor DE, DE-per-anima, name, or
+level (whitelisted); each row has a `<details>` drill-down showing every valuation line
+(kind, label, value, provenance, arithmetic detail). Below the table: the zero/unpriced
+bucket and provenance summary. Weapon-scaled damage profiles are flagged
+(`weapon_scaled`), not weapon-augmented; execute ramps are flagged, not folded into the
+headline; windup techniques divide DE by `1 + windup_rounds`.
 
 ## Game Ops — `/admin/_ops/` (`admin_ops`)
 

--- a/src/web/admin/tests/test_tuning_technique_panel.py
+++ b/src/web/admin/tests/test_tuning_technique_panel.py
@@ -1,0 +1,249 @@
+"""Tests for the Techniques combat-power panel view (#3279 Task 3).
+
+Evaluating the whole technique catalog is real DB work (see
+`technique_analytics.py`'s module docstring), so every test here patches
+`web.admin.tuning.technique_analytics.build_technique_panel` at its origin with a
+canned, distinctive `TechniquePanelData` and asserts the mock was actually invoked
+(or not) rather than exercising the real evaluator - mirrors
+`test_tuning_simulation_view.py`'s patching discipline.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import TestCase
+from django.urls import reverse
+from evennia.accounts.models import AccountDB
+
+from web.admin.tuning.technique_analytics import (
+    TechniqueAnalyticsParams,
+    TechniquePanelData,
+    TechniqueRow,
+)
+from world.magic.types.technique_power import (
+    PayloadValuation,
+    ReferenceFrame,
+    TechniquePowerReport,
+    ValuationProvenance,
+)
+
+_PATCH_TARGET = "web.admin.tuning.technique_analytics.build_technique_panel"
+
+
+def _canned_report(**overrides: Any) -> TechniquePowerReport:
+    defaults: dict[str, Any] = {
+        "technique_id": 1,
+        "name": "Distinctive Firebolt",
+        "gift_name": "Pyromancy",
+        "level": 4,
+        "tier": 1,
+        "category": "Attack",
+        "baseline_power": 4,
+        "amplified_power": 6,
+        "baseline_de": 11.0,
+        "amplified_de": 16.5,
+        "valuations": (
+            PayloadValuation(
+                kind="damage",
+                label="fire",
+                value=11.0,
+                provenance=ValuationProvenance.FORMULA,
+                detail="E[budget x mult] over SL bands = 11.00",
+            ),
+        ),
+        "effective_anima": 5,
+        "de_per_anima": 2.2,
+        "flags": (),
+    }
+    defaults.update(overrides)
+    return TechniquePowerReport(**defaults)
+
+
+def _canned_panel(**overrides: Any) -> TechniquePanelData:
+    params = overrides.pop("params", None) or TechniqueAnalyticsParams()
+    report = overrides.pop("report", None) or _canned_report()
+    rows = overrides.pop("rows", [TechniqueRow(report=report, amplification_ratio=1.5)])
+    defaults: dict[str, Any] = {
+        "rows": rows,
+        "zero_bucket": [],
+        "provenance_summary": {"FORMULA": 1},
+        "params": params,
+        "reference": ReferenceFrame(
+            outgoing_dpr=9.5, incoming_dpr=9.5, source_label="median-attack estimate"
+        ),
+    }
+    defaults.update(overrides)
+    return TechniquePanelData(**defaults)
+
+
+class TestTechniqueFragmentView(TestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.super = AccountDB.objects.create_superuser(
+            "roottechadmin", "roottech@example.com", "pw-123456"
+        )
+        cls.staff = AccountDB.objects.create_user("techstaffer", "ts@example.com", "pw-123456")
+        cls.staff.is_staff = True
+        cls.staff.save()
+
+    def setUp(self) -> None:
+        cache.clear()
+        self.addCleanup(cache.clear)
+
+    def _post_data(self, **overrides: Any) -> dict[str, Any]:
+        data: dict[str, Any] = {
+            "level": 10,
+            "thread_level": 3,
+            "roller_points": 25,
+            "target_difficulty": 25,
+            "roll_modifier": 0,
+            "sort": "baseline_de",
+        }
+        data.update(overrides)
+        return data
+
+    def test_anonymous_get_redirected_to_login(self) -> None:
+        resp = self.client.get(reverse("admin_tuning_techniques"))
+        self.assertEqual(resp.status_code, 302)
+
+    def test_staff_non_superuser_get_forbidden(self) -> None:
+        self.client.force_login(self.staff)
+        resp = self.client.get(reverse("admin_tuning_techniques"))
+        self.assertEqual(resp.status_code, 403)
+
+    def test_get_with_no_cache_renders_empty_state(self) -> None:
+        self.client.force_login(self.super)
+        resp = self.client.get(reverse("admin_tuning_techniques"))
+        self.assertEqual(resp.status_code, 200)
+        body = resp.content.decode()
+        self.assertIn('id="panel-techniques-form"', body)
+        self.assertIn("No evaluation has been run yet", body)
+
+    @patch(_PATCH_TARGET)
+    def test_post_valid_superuser_builds_panel_and_renders_rows(self, mock_build: Any) -> None:
+        mock_build.return_value = _canned_panel()
+        self.client.force_login(self.super)
+        resp = self.client.post(reverse("admin_tuning_techniques"), self._post_data())
+
+        self.assertEqual(resp.status_code, 200)
+        mock_build.assert_called_once()
+
+        called_params = mock_build.call_args.args[0]
+        self.assertIsInstance(called_params, TechniqueAnalyticsParams)
+        self.assertEqual(called_params.level, 10)
+        self.assertEqual(called_params.thread_level, 3)
+        self.assertEqual(called_params.roller_points, 25)
+        self.assertEqual(called_params.target_difficulty, 25)
+        self.assertEqual(called_params.roll_modifier, 0)
+        self.assertEqual(called_params.sort, "baseline_de")
+
+        body = resp.content.decode()
+        self.assertIn("Distinctive Firebolt", body)
+        self.assertIn("Pyromancy", body)
+
+    @patch(_PATCH_TARGET)
+    def test_get_after_post_returns_cached_result_without_rebuilding(self, mock_build: Any) -> None:
+        mock_build.return_value = _canned_panel()
+        self.client.force_login(self.super)
+
+        post_resp = self.client.post(reverse("admin_tuning_techniques"), self._post_data())
+        self.assertEqual(post_resp.status_code, 200)
+
+        get_resp = self.client.get(reverse("admin_tuning_techniques"))
+        self.assertEqual(get_resp.status_code, 200)
+
+        mock_build.assert_called_once()
+        body = get_resp.content.decode()
+        self.assertIn("Distinctive Firebolt", body)
+
+    @patch(_PATCH_TARGET)
+    def test_get_with_unknown_sort_falls_back_to_baseline_de(self, mock_build: Any) -> None:
+        mock_build.return_value = _canned_panel(params=TechniqueAnalyticsParams(sort="baseline_de"))
+        self.client.force_login(self.super)
+
+        self.client.post(reverse("admin_tuning_techniques"), self._post_data())
+        resp = self.client.get(reverse("admin_tuning_techniques"), {"sort": "not-a-real-key"})
+
+        self.assertEqual(resp.status_code, 200)
+        # An unrecognized sort resolves to the same "baseline_de" the cached
+        # panel was already built with, so no second build is triggered.
+        mock_build.assert_called_once()
+        body = resp.content.decode()
+        self.assertIn("Distinctive Firebolt", body)
+
+    @patch(_PATCH_TARGET)
+    def test_get_with_different_known_sort_rebuilds_panel(self, mock_build: Any) -> None:
+        mock_build.side_effect = [
+            _canned_panel(params=TechniqueAnalyticsParams(sort="baseline_de")),
+            _canned_panel(params=TechniqueAnalyticsParams(sort="name")),
+        ]
+        self.client.force_login(self.super)
+
+        self.client.post(reverse("admin_tuning_techniques"), self._post_data())
+        resp = self.client.get(reverse("admin_tuning_techniques"), {"sort": "name"})
+
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(mock_build.call_count, 2)
+        second_call_params = mock_build.call_args.args[0]
+        self.assertEqual(second_call_params.sort, "name")
+
+    @patch(_PATCH_TARGET)
+    def test_post_out_of_range_level_is_clamped_not_rejected(self, mock_build: Any) -> None:
+        mock_build.return_value = _canned_panel()
+        self.client.force_login(self.super)
+        resp = self.client.post(
+            reverse("admin_tuning_techniques"),
+            self._post_data(level=999, thread_level=-5),
+        )
+
+        self.assertEqual(resp.status_code, 200)
+        mock_build.assert_called_once()
+        called_params = mock_build.call_args.args[0]
+        self.assertEqual(called_params.level, 30)
+        self.assertEqual(called_params.thread_level, 0)
+
+    @patch(_PATCH_TARGET)
+    def test_post_invalid_sort_choice_rerenders_form_errors_without_building(
+        self, mock_build: Any
+    ) -> None:
+        self.client.force_login(self.super)
+        resp = self.client.post(
+            reverse("admin_tuning_techniques"), self._post_data(sort="not-a-real-key")
+        )
+        self.assertEqual(resp.status_code, 200)
+        body = resp.content.decode()
+        self.assertIn("errorlist", body)
+        mock_build.assert_not_called()
+
+    @patch(_PATCH_TARGET)
+    def test_zero_bucket_and_provenance_summary_render(self, mock_build: Any) -> None:
+        inert_report = _canned_report(
+            technique_id=2,
+            name="Inert Placeholder",
+            baseline_de=0.0,
+            amplified_de=0.0,
+            valuations=(
+                PayloadValuation(
+                    kind="capability",
+                    label="Latent Spark",
+                    value=0.0,
+                    provenance=ValuationProvenance.INERT_PAYLOAD,
+                    detail="no capability-grant cast seam exists",
+                ),
+            ),
+            de_per_anima=0.0,
+        )
+        mock_build.return_value = _canned_panel(
+            zero_bucket=[inert_report],
+            provenance_summary={"FORMULA": 1, "INERT_PAYLOAD": 1},
+        )
+        self.client.force_login(self.super)
+        resp = self.client.post(reverse("admin_tuning_techniques"), self._post_data())
+
+        self.assertEqual(resp.status_code, 200)
+        body = resp.content.decode()
+        self.assertIn("Inert Placeholder", body)
+        self.assertIn("INERT_PAYLOAD", body)

--- a/src/web/admin/tuning/technique_analytics.py
+++ b/src/web/admin/tuning/technique_analytics.py
@@ -1,0 +1,204 @@
+"""Technique combat-power analytics for the Game Tuning dashboard (#3279 Task 3).
+
+Wraps `world.magic.services.technique_power_eval.evaluate_all_with_reference` - the
+DE (damage-equivalent per cast) evaluator built in Tasks 1-2 - into the shapes the
+Techniques panel renders: a sortable league table, a bucket for unpriced/zero-value
+techniques, and a provenance-count summary. See
+`docs/plans/3279-technique-power-eval-plan.md` for the full currency spec this
+panel surfaces.
+
+**Two-tier caching.** Evaluating ~270 techniques with DB lookups per cast band is
+too slow to run on every page load or every header-sort click, so the expensive
+step (:func:`_evaluate_corpus`, everything but `sort`) is cached independently of
+`sort` via Django's cache - a sort-only re-render (a GET carrying a new `?sort=`)
+reuses the cached corpus and only re-buckets/re-sorts, which is cheap. The VIEW
+(`web.admin.tuning.views.tuning_techniques_fragment`) layers its own exact-param
+cache on top of the full `TechniquePanelData` this module returns, mirroring the
+simulation panel's cache-key/last-key-pointer contract - see that view's docstring.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from django.core.cache import cache
+
+from world.magic.services import technique_power_eval
+from world.magic.types.technique_power import (
+    EvalContext,
+    ReferenceFrame,
+    TechniquePowerReport,
+)
+
+#: Sort-key identifiers, named constants (not bare string literals) so the
+#: comparisons in `_sort_value` don't trip `tools/lint_string_literal.py`.
+SORT_BASELINE_DE = "baseline_de"
+SORT_AMPLIFIED_DE = "amplified_de"
+SORT_DE_PER_ANIMA = "de_per_anima"
+SORT_NAME = "name"
+SORT_LEVEL = "level"
+
+#: Whitelisted `sort` values - anything else falls back to `DEFAULT_SORT` rather
+#: than erroring, since a header-link GET has no error-feedback surface.
+SORT_KEYS = frozenset(
+    {SORT_BASELINE_DE, SORT_AMPLIFIED_DE, SORT_DE_PER_ANIMA, SORT_NAME, SORT_LEVEL}
+)
+DEFAULT_SORT = SORT_BASELINE_DE
+
+_LEVEL_DEFAULT = 10
+_THREAD_LEVEL_DEFAULT = 3
+_ROLLER_POINTS_DEFAULT = 25
+_TARGET_DIFFICULTY_DEFAULT = 25
+_ROLL_MODIFIER_DEFAULT = 0
+
+#: 24h - matches `_SIMULATION_CACHE_TIMEOUT` in `web.admin.tuning.views`; a
+#: catalog-wide evaluation run should outlive a single admin session.
+_CORPUS_CACHE_TIMEOUT = 60 * 60 * 24
+
+
+def resolve_sort_key(sort: str) -> str:
+    """Whitelist-or-fallback for a `sort` value (query param or form input)."""
+    return sort if sort in SORT_KEYS else DEFAULT_SORT
+
+
+@dataclass(frozen=True, slots=True)
+class TechniqueAnalyticsParams:
+    """Panel knobs for the Techniques tuning panel (#3279 Task 3).
+
+    Mirrors `SimulationParams` (`world.combat.simulation`) - a plain, unvalidated
+    value object. Clamping/whitelisting happens at the form boundary
+    (`web.admin.tuning.views.TechniqueAnalyticsForm`) and, for `sort` specifically,
+    also in :func:`resolve_sort_key` (reused for the header-link GET path, which
+    never touches the form).
+    """
+
+    level: int = _LEVEL_DEFAULT
+    thread_level: int = _THREAD_LEVEL_DEFAULT
+    roller_points: int = _ROLLER_POINTS_DEFAULT
+    target_difficulty: int = _TARGET_DIFFICULTY_DEFAULT
+    roll_modifier: int = _ROLL_MODIFIER_DEFAULT
+    sort: str = DEFAULT_SORT
+
+
+@dataclass(frozen=True, slots=True)
+class TechniqueRow:
+    """One league-table row: a report plus its derived amplification ratio."""
+
+    report: TechniquePowerReport
+    #: `amplified_de / baseline_de`, or `None` when `baseline_de` is 0 (undefined).
+    amplification_ratio: float | None
+
+
+@dataclass(frozen=True, slots=True)
+class TechniquePanelData:
+    """Everything the `_techniques_panel.html` fragment renders (#3279 Task 3)."""
+
+    rows: list[TechniqueRow]
+    #: Reports with `baseline_de == 0` and every valuation zero - unpriced/inert
+    #: content (UNPRICEABLE/INERT_PAYLOAD-only techniques, or ones with no
+    #: `ResultChart` to roll against at all).
+    zero_bucket: list[TechniquePowerReport]
+    #: `ValuationProvenance.value -> count`, across every valuation in the corpus
+    #: (both `rows` and `zero_bucket`).
+    provenance_summary: dict[str, int]
+    params: TechniqueAnalyticsParams
+    reference: ReferenceFrame
+
+
+def _corpus_cache_key(params: TechniqueAnalyticsParams) -> str:
+    """Cache key for the expensive evaluator run - deliberately excludes `sort`."""
+    return (
+        f"tuning-tech-power-corpus:{params.level}:{params.thread_level}:"
+        f"{params.roller_points}:{params.target_difficulty}:{params.roll_modifier}"
+    )
+
+
+def _evaluate_corpus(
+    params: TechniqueAnalyticsParams,
+) -> tuple[list[TechniquePowerReport], ReferenceFrame]:
+    """Run (or reuse a cached) `evaluate_all_with_reference` for *params* (#3279).
+
+    Called via the module object (`technique_power_eval.evaluate_all_with_reference`,
+    never a bare `from ... import`) so tests can patch it at its origin and still
+    intercept this call.
+    """
+    key = _corpus_cache_key(params)
+    cached = cache.get(key)
+    if cached is not None:
+        return cached
+
+    context = EvalContext(
+        level=params.level,
+        thread_level=params.thread_level,
+        roller_points=params.roller_points,
+        target_difficulty=params.target_difficulty,
+        roll_modifier=params.roll_modifier,
+    )
+    result = technique_power_eval.evaluate_all_with_reference(context)
+    cache.set(key, result, _CORPUS_CACHE_TIMEOUT)
+    return result
+
+
+def _is_zero_value(report: TechniquePowerReport) -> bool:
+    """True when a report has nothing priced: baseline_de is 0 and every valuation is 0."""
+    return report.baseline_de == 0 and all(v.value == 0 for v in report.valuations)
+
+
+def _amplification_ratio(report: TechniquePowerReport) -> float | None:
+    if report.baseline_de > 0:
+        return report.amplified_de / report.baseline_de
+    return None
+
+
+def _sort_value(row: TechniqueRow, sort: str) -> object:
+    """Sort key for one row - numeric sorts descending (best first), name ascending."""
+    report = row.report
+    if sort == SORT_NAME:
+        return report.name.lower()
+    if sort == SORT_LEVEL:
+        return -report.level
+    if sort == SORT_AMPLIFIED_DE:
+        return -report.amplified_de
+    if sort == SORT_DE_PER_ANIMA:
+        return -report.de_per_anima
+    return -report.baseline_de
+
+
+def _provenance_summary(reports: list[TechniquePowerReport]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for report in reports:
+        for valuation in report.valuations:
+            key = valuation.provenance.value
+            counts[key] = counts.get(key, 0) + 1
+    return counts
+
+
+def build_technique_panel(params: TechniqueAnalyticsParams) -> TechniquePanelData:
+    """Build the full Techniques panel payload for *params* (#3279 Task 3).
+
+    Splits the evaluated corpus into priced rows (sorted per
+    `resolve_sort_key(params.sort)`) and the zero/unpriced bucket, and tallies
+    valuation provenance across the whole corpus. The expensive evaluator run
+    itself is cached independently of `sort` - see :func:`_evaluate_corpus`.
+    """
+    reports, reference = _evaluate_corpus(params)
+
+    rows: list[TechniqueRow] = []
+    zero_bucket: list[TechniquePowerReport] = []
+    for report in reports:
+        if _is_zero_value(report):
+            zero_bucket.append(report)
+        else:
+            ratio = _amplification_ratio(report)
+            rows.append(TechniqueRow(report=report, amplification_ratio=ratio))
+
+    sort = resolve_sort_key(params.sort)
+    rows.sort(key=lambda row: _sort_value(row, sort))
+
+    return TechniquePanelData(
+        rows=rows,
+        zero_bucket=zero_bucket,
+        provenance_summary=_provenance_summary(reports),
+        params=params,
+        reference=reference,
+    )

--- a/src/web/admin/tuning/views.py
+++ b/src/web/admin/tuning/views.py
@@ -1,18 +1,21 @@
-"""Game Tuning dashboard — superuser-only difficulty analytics + simulation (#1221).
+"""Game Tuning dashboard - superuser-only difficulty analytics + simulation (#1221).
 
-The dashboard page (`tuning_dashboard`) renders a skeleton of four panels, each
+The dashboard page (`tuning_dashboard`) renders a skeleton of five panels, each
 an HTMX fragment loaded on page load. Task 2 replaced the checks-panel stub
 with `tuning_checks_fragment` (real analytics, see `checks_analytics.py`). Task 3
 replaced the consequences-panel stub with `tuning_consequences_fragment` (see
 `consequence_analytics.py`). Task 4 replaced the conditions-panel stub with
 `tuning_conditions_fragment` (see `condition_analytics.py`). Task 6 replaced the
 simulation-panel stub with `tuning_simulation_fragment` (Monte Carlo party-vs-boss
-batches over the real engine, see `world.combat.simulation`).
+batches over the real engine, see `world.combat.simulation`). #3279 Task 3 added a
+fifth panel, `tuning_techniques_fragment` (technique combat-power league table,
+see `technique_analytics.py`).
 """
 
 from __future__ import annotations
 
 from collections.abc import Callable
+from dataclasses import replace
 from functools import wraps
 from typing import Any
 
@@ -24,6 +27,7 @@ from django.http import HttpRequest, HttpResponse
 from django.shortcuts import render
 
 from actions.models.consequence_pools import ConsequencePool
+from web.admin.tuning import technique_analytics
 from web.admin.tuning.checks_analytics import compute_chart_distributions, compute_matchup
 from web.admin.tuning.condition_analytics import compute_condition_danger
 from web.admin.tuning.consequence_analytics import inspect_pool, list_pools
@@ -35,7 +39,7 @@ _DEFAULT_ROLLER_POINTS = 25
 _DEFAULT_TARGET_DIFFICULTY = 25
 _DEFAULT_CONDITION_SEVERITY = 5
 
-# 24h — a simulation batch is expensive (dozens of full combat rounds), so a
+# 24h - a simulation batch is expensive (dozens of full combat rounds), so a
 # cached report should outlive a single admin session by a wide margin.
 _SIMULATION_CACHE_TIMEOUT = 60 * 60 * 24
 # Fixed pointer key: GET renders "the most recently cached result" by looking
@@ -69,7 +73,7 @@ def superuser_required(view: Callable[..., HttpResponse]) -> Callable[..., HttpR
 
 @superuser_required
 def tuning_dashboard(request: HttpRequest) -> HttpResponse:
-    """Game Tuning dashboard skeleton: four HTMX-loaded panels."""
+    """Game Tuning dashboard skeleton: five HTMX-loaded panels."""
     context = {"title": "Game Tuning"}
     return render(request, "admin/tuning/dashboard.html", context)
 
@@ -147,10 +151,10 @@ def _clamp(value: int, minimum: int, maximum: int) -> int:
 class SimulationRunForm(forms.Form):
     """Validates enum membership; clamps numeric ranges (#1221 Task 6).
 
-    `tier`/`risk_level` are `ChoiceField`s — an unrecognized value is a real
+    `tier`/`risk_level` are `ChoiceField`s - an unrecognized value is a real
     form error (there's no sane way to "clamp" a string into an enum member).
     The numeric fields are silently clamped into range instead of erroring, per
-    the brief ("clamps iterations to 1..500 via the form") — a GM fat-fingering
+    the brief ("clamps iterations to 1..500 via the form") - a GM fat-fingering
     9999 iterations should get the capped run, not a rejected form.
     """
 
@@ -209,7 +213,7 @@ def tuning_simulation_fragment(request: HttpRequest) -> HttpResponse:
     """Monte Carlo simulation panel: run + cache party-vs-boss batches (#1221 Task 6).
 
     GET renders the form (seeded with `SimulationParams` defaults) plus the most
-    recently cached result, if any — tracked via the fixed `_SIMULATION_LAST_KEY`
+    recently cached result, if any - tracked via the fixed `_SIMULATION_LAST_KEY`
     pointer so a plain page reload doesn't lose the last run. POST validates and
     clamps inputs through `SimulationRunForm`, runs the batch synchronously, and
     caches the report under both the exact-param key and the last-key pointer
@@ -219,7 +223,7 @@ def tuning_simulation_fragment(request: HttpRequest) -> HttpResponse:
     `from world.combat.simulation import run_party_vs_boss_simulation` directly)
     so tests can patch the real function at its origin
     (`world.combat.simulation.run_party_vs_boss_simulation`) and still intercept
-    this call — a bare `from ... import f` would bind a name here that patching
+    this call - a bare `from ... import f` would bind a name here that patching
     the origin module wouldn't reach.
     """
     report: SimulationReport | None = None
@@ -250,3 +254,123 @@ def tuning_simulation_fragment(request: HttpRequest) -> HttpResponse:
         "histogram": _round_count_histogram(report.round_counts) if report else [],
     }
     return render(request, "admin/tuning/_simulation_panel.html", context)
+
+
+# 24h - mirrors `_SIMULATION_CACHE_TIMEOUT`; a full technique-catalog evaluation
+# run should outlive a single admin session by a wide margin.
+_TECHNIQUE_CACHE_TIMEOUT = 60 * 60 * 24
+# Fixed pointer key, mirroring `_SIMULATION_LAST_KEY` - GET renders "the most
+# recently cached result" via whichever exact-param key was last written here.
+_TECHNIQUE_LAST_KEY = "tuning-tech-power:last"
+
+
+class TechniqueAnalyticsForm(forms.Form):
+    """Validates `sort` enum membership; clamps `level`/`thread_level` (#3279 Task 3).
+
+    Mirrors `SimulationRunForm`'s contract: `sort` is a `ChoiceField` (an
+    unrecognized value is a real form error on submit - but the header-link GET
+    re-render never goes through this form; it resolves `sort` via
+    `technique_analytics.resolve_sort_key` instead, which silently falls back).
+    `level`/`thread_level` are clamped rather than rejected, per the currency
+    spec's stated ranges; `roller_points`/`target_difficulty`/`roll_modifier` are
+    plain ints with no authored range to clamp to.
+    """
+
+    level = forms.IntegerField()
+    thread_level = forms.IntegerField()
+    roller_points = forms.IntegerField()
+    target_difficulty = forms.IntegerField()
+    roll_modifier = forms.IntegerField()
+    sort = forms.ChoiceField(choices=[(key, key) for key in sorted(technique_analytics.SORT_KEYS)])
+
+    def clean_level(self) -> int:
+        return _clamp(self.cleaned_data["level"], 1, 30)
+
+    def clean_thread_level(self) -> int:
+        return _clamp(self.cleaned_data["thread_level"], 0, 30)
+
+
+def _technique_form_defaults() -> dict[str, Any]:
+    """Initial values for a fresh GET form, mirroring `TechniqueAnalyticsParams` defaults."""
+    defaults = technique_analytics.TechniqueAnalyticsParams()
+    return {
+        "level": defaults.level,
+        "thread_level": defaults.thread_level,
+        "roller_points": defaults.roller_points,
+        "target_difficulty": defaults.target_difficulty,
+        "roll_modifier": defaults.roll_modifier,
+        "sort": defaults.sort,
+    }
+
+
+def _technique_cache_key(params: technique_analytics.TechniqueAnalyticsParams) -> str:
+    """Exact-param cache key (every knob, including `sort`) for the built panel."""
+    return (
+        f"tuning-tech-power:{params.level}:{params.thread_level}:{params.roller_points}:"
+        f"{params.target_difficulty}:{params.roll_modifier}:{params.sort}"
+    )
+
+
+def _cache_technique_panel(
+    params: technique_analytics.TechniqueAnalyticsParams,
+    panel: technique_analytics.TechniquePanelData,
+) -> None:
+    cache_key = _technique_cache_key(params)
+    cache.set(cache_key, panel, _TECHNIQUE_CACHE_TIMEOUT)
+    cache.set(_TECHNIQUE_LAST_KEY, cache_key, _TECHNIQUE_CACHE_TIMEOUT)
+
+
+@superuser_required
+def tuning_techniques_fragment(request: HttpRequest) -> HttpResponse:
+    """Techniques combat-power panel: league table of every technique's DE (#3279 Task 3).
+
+    GET renders the form (seeded with `TechniqueAnalyticsParams` defaults) plus the
+    most recently cached result, if any - tracked via the fixed
+    `_TECHNIQUE_LAST_KEY` pointer, mirroring the simulation panel. POST validates
+    and clamps inputs through `TechniqueAnalyticsForm`, builds the panel
+    synchronously, and caches it under both the exact-param key and the last-key
+    pointer (24h timeout).
+
+    The header league-table links re-render via a plain `hx-get` carrying only
+    `?sort=<key>` - evaluating the whole catalog is too slow to redo on every sort
+    click, so a GET whose resolved `sort` differs from the cached panel's own
+    rebuilds via `technique_analytics.build_technique_panel` (which reuses its own
+    independently-cached corpus, see that module) rather than re-running the
+    evaluator end to end.
+
+    Calls `technique_analytics.build_technique_panel` via the module object (never
+    a bare `from ... import`) so tests can patch it at its origin and still
+    intercept this call - same discipline as `tuning_simulation_fragment`.
+    """
+    panel: technique_analytics.TechniquePanelData | None = None
+
+    if request.method == "POST":
+        form = TechniqueAnalyticsForm(request.POST)
+        if form.is_valid():
+            params = technique_analytics.TechniqueAnalyticsParams(
+                level=form.cleaned_data["level"],
+                thread_level=form.cleaned_data["thread_level"],
+                roller_points=form.cleaned_data["roller_points"],
+                target_difficulty=form.cleaned_data["target_difficulty"],
+                roll_modifier=form.cleaned_data["roll_modifier"],
+                sort=form.cleaned_data["sort"],
+            )
+            panel = technique_analytics.build_technique_panel(params)
+            _cache_technique_panel(params, panel)
+    else:
+        form = TechniqueAnalyticsForm(initial=_technique_form_defaults())
+        last_key = cache.get(_TECHNIQUE_LAST_KEY)
+        cached_panel = cache.get(last_key) if last_key else None
+        if cached_panel is not None:
+            requested_sort = technique_analytics.resolve_sort_key(
+                request.GET.get("sort", cached_panel.params.sort)
+            )
+            if requested_sort != cached_panel.params.sort:
+                params = replace(cached_panel.params, sort=requested_sort)
+                panel = technique_analytics.build_technique_panel(params)
+                _cache_technique_panel(params, panel)
+            else:
+                panel = cached_panel
+
+    context = {"form": form, "panel": panel}
+    return render(request, "admin/tuning/_techniques_panel.html", context)

--- a/src/web/admin/urls.py
+++ b/src/web/admin/urls.py
@@ -51,6 +51,7 @@ from web.admin.tuning.views import (
     tuning_consequences_fragment,
     tuning_dashboard,
     tuning_simulation_fragment,
+    tuning_techniques_fragment,
 )
 from web.admin.views import (
     export_data,
@@ -136,6 +137,7 @@ urlpatterns = [
     path("_tuning/consequences/", tuning_consequences_fragment, name="admin_tuning_consequences"),
     path("_tuning/conditions/", tuning_conditions_fragment, name="admin_tuning_conditions"),
     path("_tuning/simulation/", tuning_simulation_fragment, name="admin_tuning_simulation"),
+    path("_tuning/techniques/", tuning_techniques_fragment, name="admin_tuning_techniques"),
     path("_ops/", ops_dashboard, name="admin_ops"),
     path("_ops/progression/", ops_progression_fragment, name="admin_ops_progression"),
     path("_ops/economy/", ops_economy_fragment, name="admin_ops_economy"),

--- a/src/web/templates/admin/tuning/_techniques_panel.html
+++ b/src/web/templates/admin/tuning/_techniques_panel.html
@@ -1,0 +1,236 @@
+{% load i18n %}
+<style>
+  #panel-techniques .tuning-form {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: flex-end;
+    gap: 1.5rem;
+    margin-bottom: 1rem;
+  }
+  #panel-techniques .tuning-field {
+    display: flex;
+    flex-direction: column;
+    min-width: 9rem;
+  }
+  #panel-techniques .tuning-field label {
+    font-size: 0.85rem;
+    margin-bottom: 0.25rem;
+  }
+  #panel-techniques table.tuning-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 1rem;
+  }
+  #panel-techniques table.tuning-table th,
+  #panel-techniques table.tuning-table td {
+    border-bottom: 1px solid var(--hairline-color);
+    padding: 0.4rem 0.5rem;
+    text-align: left;
+    vertical-align: middle;
+  }
+  #panel-techniques table.tuning-table th a {
+    color: inherit;
+    text-decoration: underline dotted;
+  }
+  #panel-techniques .badge {
+    display: inline-block;
+    font-size: 0.75rem;
+    padding: 0.1rem 0.4rem;
+    border-radius: 2px;
+    border: 1px solid var(--hairline-color);
+    color: var(--body-quiet-color);
+    margin-right: 0.25rem;
+  }
+  #panel-techniques .valuation-lines {
+    margin: 0.4rem 0 0.6rem 1rem;
+    font-size: 0.85rem;
+  }
+  #panel-techniques .valuation-lines li {
+    margin-bottom: 0.15rem;
+  }
+  #panel-techniques .provenance-summary {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    font-size: 0.85rem;
+    color: var(--body-quiet-color);
+  }
+  #panel-techniques .zero-bucket-list {
+    font-size: 0.85rem;
+    margin: 0 0 1rem 1rem;
+  }
+  #panel-techniques .zero-bucket-list li {
+    margin-bottom: 0.15rem;
+  }
+  #panel-techniques .errorlist {
+    color: var(--error-fg);
+    font-size: 0.8rem;
+    margin: 0.2rem 0 0;
+    padding-left: 1rem;
+  }
+</style>
+
+<h2>{% translate "Technique Combat Power" %}</h2>
+<p>
+  {% translate "Prices every authored technique's combat payloads into DE (damage-equivalent per cast in a reference matchup) and compares baseline power to a fully-matched covenant anchor at the chosen thread level." %}
+</p>
+
+<form id="panel-techniques-form" class="tuning-form" method="post"
+      hx-post="{% url 'admin_tuning_techniques' %}" hx-target="#panel-techniques">
+  <div class="tuning-field">
+    <label for="{{ form.level.id_for_label }}">{% translate "Level" %}</label>
+    {{ form.level }}
+    {{ form.level.errors }}
+  </div>
+  <div class="tuning-field">
+    <label for="{{ form.thread_level.id_for_label }}">{% translate "Thread level" %}</label>
+    {{ form.thread_level }}
+    {{ form.thread_level.errors }}
+  </div>
+  <div class="tuning-field">
+    <label for="{{ form.roller_points.id_for_label }}">{% translate "Roller points" %}</label>
+    {{ form.roller_points }}
+    {{ form.roller_points.errors }}
+  </div>
+  <div class="tuning-field">
+    <label for="{{ form.target_difficulty.id_for_label }}">{% translate "Target difficulty" %}</label>
+    {{ form.target_difficulty }}
+    {{ form.target_difficulty.errors }}
+  </div>
+  <div class="tuning-field">
+    <label for="{{ form.roll_modifier.id_for_label }}">{% translate "Roll modifier" %}</label>
+    {{ form.roll_modifier }}
+    {{ form.roll_modifier.errors }}
+  </div>
+  <div class="tuning-field">
+    <label for="{{ form.sort.id_for_label }}">{% translate "Sort" %}</label>
+    {{ form.sort }}
+    {{ form.sort.errors }}
+  </div>
+  <div class="tuning-field">
+    <button type="submit">{% translate "Evaluate catalog" %}</button>
+  </div>
+</form>
+
+{% if panel %}
+<p>
+  {% translate "Reference DPR" %}:
+  <strong>{{ panel.reference.outgoing_dpr|floatformat:2 }}</strong>
+  ({{ panel.reference.source_label }})
+</p>
+
+<table class="tuning-table">
+  <thead>
+    <tr>
+      <th>
+        <a href="{% url 'admin_tuning_techniques' %}?sort=name"
+           hx-get="{% url 'admin_tuning_techniques' %}?sort=name" hx-target="#panel-techniques">
+          {% translate "Technique" %}
+        </a>
+      </th>
+      <th>{% translate "Gift" %}</th>
+      <th>
+        <a href="{% url 'admin_tuning_techniques' %}?sort=level"
+           hx-get="{% url 'admin_tuning_techniques' %}?sort=level" hx-target="#panel-techniques">
+          {% translate "Lvl/Tier" %}
+        </a>
+      </th>
+      <th>{% translate "Category" %}</th>
+      <th>
+        <a href="{% url 'admin_tuning_techniques' %}?sort=baseline_de"
+           hx-get="{% url 'admin_tuning_techniques' %}?sort=baseline_de" hx-target="#panel-techniques">
+          {% translate "Base DE" %}
+        </a>
+      </th>
+      <th>
+        <a href="{% url 'admin_tuning_techniques' %}?sort=amplified_de"
+           hx-get="{% url 'admin_tuning_techniques' %}?sort=amplified_de" hx-target="#panel-techniques">
+          {% translate "Anchor DE" %}
+        </a>
+      </th>
+      <th>{% translate "Amp x" %}</th>
+      <th>{% translate "Anima" %}</th>
+      <th>
+        <a href="{% url 'admin_tuning_techniques' %}?sort=de_per_anima"
+           hx-get="{% url 'admin_tuning_techniques' %}?sort=de_per_anima" hx-target="#panel-techniques">
+          {% translate "DE/Anima" %}
+        </a>
+      </th>
+      <th>{% translate "Flags" %}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in panel.rows %}
+    <tr>
+      <td>
+        <details>
+          <summary>{{ row.report.name }}</summary>
+          <ul class="valuation-lines">
+            {% for valuation in row.report.valuations %}
+            <li>
+              <strong>{{ valuation.kind }}</strong> &middot; {{ valuation.label }} &middot;
+              {{ valuation.value|floatformat:2 }} &middot;
+              <span class="badge">{{ valuation.provenance }}</span>
+              {{ valuation.detail }}
+            </li>
+            {% empty %}
+            <li>{% translate "No priced valuations." %}</li>
+            {% endfor %}
+          </ul>
+        </details>
+      </td>
+      <td>{{ row.report.gift_name }}</td>
+      <td>{{ row.report.level }}/{{ row.report.tier }}</td>
+      <td>{{ row.report.category }}</td>
+      <td>{{ row.report.baseline_de|floatformat:2 }}</td>
+      <td>{{ row.report.amplified_de|floatformat:2 }}</td>
+      <td>
+        {% if row.amplification_ratio is not None %}
+        {{ row.amplification_ratio|floatformat:2 }}x
+        {% else %}
+        n/a
+        {% endif %}
+      </td>
+      <td>{{ row.report.effective_anima }}</td>
+      <td>{{ row.report.de_per_anima|floatformat:3 }}</td>
+      <td>
+        {% for flag in row.report.flags %}
+        <span class="badge">{{ flag }}</span>
+        {% endfor %}
+      </td>
+    </tr>
+    {% empty %}
+    <tr><td colspan="10">{% translate "No priced techniques at these parameters." %}</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+
+<h3>{% translate "Unpriced or zero-value" %}</h3>
+{% if panel.zero_bucket %}
+<ul class="zero-bucket-list">
+  {% for report in panel.zero_bucket %}
+  <li>
+    {{ report.name }} ({{ report.gift_name }}) &middot;
+    {% if report.flags %}
+    {% for flag in report.flags %}<span class="badge">{{ flag }}</span>{% endfor %}
+    {% else %}
+    <span class="badge">{% translate "no priced payload" %}</span>
+    {% endif %}
+  </li>
+  {% endfor %}
+</ul>
+{% else %}
+<p>{% translate "Every technique in the catalog priced at least one payload." %}</p>
+{% endif %}
+
+<h3>{% translate "Valuation provenance" %}</h3>
+<p class="provenance-summary">
+  {% for provenance, count in panel.provenance_summary.items %}
+  <span>{{ provenance }}: {{ count }}</span>
+  {% empty %}
+  <span>{% translate "No valuations to summarize." %}</span>
+  {% endfor %}
+</p>
+{% else %}
+<p>{% translate "No evaluation has been run yet - set parameters above and evaluate the catalog." %}</p>
+{% endif %}

--- a/src/web/templates/admin/tuning/dashboard.html
+++ b/src/web/templates/admin/tuning/dashboard.html
@@ -26,6 +26,11 @@
            hx-get="{% url 'admin_tuning_simulation' %}" hx-trigger="load">
     <p>Loading simulation&hellip;</p>
   </section>
+
+  <section class="tuning-panel" id="panel-techniques"
+           hx-get="{% url 'admin_tuning_techniques' %}" hx-trigger="load">
+    <p>Loading technique combat-power analytics&hellip;</p>
+  </section>
 </div>
 <script src="{% static 'admin/js/vendor/htmx.min.js' %}" defer></script>
 {% endblock %}

--- a/src/world/magic/services/power_terms.py
+++ b/src/world/magic/services/power_terms.py
@@ -13,11 +13,10 @@ from __future__ import annotations
 
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from decimal import Decimal
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from decimal import Decimal
-
     from world.character_sheets.models import CharacterSheet
     from world.magic.models import (
         AuraPowerConfig,
@@ -284,6 +283,22 @@ def get_covenant_role_blend_config() -> CovenantRoleBlendConfig:
     return config
 
 
+def blend_power_contribution(
+    thread_level: int, blend_weight: Decimal, multiplier_tenths: int
+) -> Decimal:
+    """Per-role blend arithmetic (#2529, extracted #3279): thread_level x
+    blend_weight x multiplier_tenths / 10.
+
+    Pure helper shared by the live ``covenant_role_blend_power_term`` provider
+    (summed over every engaged role, then int-truncated) and the technique
+    combat-power evaluator (``world.magic.services.technique_power_eval``),
+    which calls this with ``blend_weight=Decimal(1)`` — the "fully matched
+    anchor" case — to compute the amplified-power comparison. Never
+    duplicate this formula elsewhere; both callers must go through here.
+    """
+    return Decimal(thread_level) * blend_weight * multiplier_tenths / 10
+
+
 def covenant_role_blend_power_term(ctx: PowerTermContext) -> int:
     """Baseline blend boost for engaged covenant roles (#2529, Layer 1).
 
@@ -295,8 +310,6 @@ def covenant_role_blend_power_term(ctx: PowerTermContext) -> int:
     (#2536's presentation contract). PRIMARY-only (#2641): a secondary vow
     never contributes to the combat-identity blend — this is the chassis.
     """
-    from decimal import Decimal  # noqa: PLC0415
-
     from world.magic.services.threads import (  # noqa: PLC0415
         total_thread_level_across_all_kinds,
     )
@@ -319,7 +332,7 @@ def covenant_role_blend_power_term(ctx: PowerTermContext) -> int:
         weight = role.blend_weight_for(alignment)
         if not weight:
             continue
-        total += Decimal(total_threads) * weight * config.multiplier_tenths / 10
+        total += blend_power_contribution(total_threads, weight, config.multiplier_tenths)
     return int(total)
 
 
@@ -345,14 +358,27 @@ def _scale_secondary_contribution(secondary_total: Decimal) -> Decimal:
     .potency_tenths / 10`` (#2641) — a no-op (zero query) when the total is zero, so
     the common all-primary case costs nothing extra.
     """
-    from decimal import Decimal  # noqa: PLC0415
-
     if not secondary_total:
         return secondary_total
     from world.covenants.services import secondary_vow_config  # noqa: PLC0415
 
     potency_tenths = secondary_vow_config().potency_tenths
     return secondary_total * Decimal(potency_tenths) / 10
+
+
+def specialty_power_contribution(thread_level: int, multiplier_tenths: int) -> Decimal:
+    """Per-row specialty arithmetic (#2443, extracted #3279): thread_level x
+    multiplier_tenths / 10.
+
+    Pure helper shared by the live ``covenant_role_specialty_power_term``
+    provider (summed over every matching specialty row, secondary-scaled,
+    then int-truncated) and the technique combat-power evaluator
+    (``world.magic.services.technique_power_eval``), which calls this with
+    ``multiplier_tenths=10`` (x1.0, primary side only) for the amplified-power
+    comparison. Never duplicate this formula elsewhere; both callers must go
+    through here.
+    """
+    return Decimal(thread_level) * multiplier_tenths / 10
 
 
 def covenant_role_specialty_power_term(ctx: PowerTermContext) -> int:
@@ -376,8 +402,6 @@ def covenant_role_specialty_power_term(ctx: PowerTermContext) -> int:
     BEFORE being added to the primary-side sum and int-truncated — a secondary
     vow's specialty reward is real but always situational, never raw.
     """
-    from decimal import Decimal  # noqa: PLC0415
-
     from world.covenants.models import CovenantRoleTechniqueSpecialty  # noqa: PLC0415
     from world.magic.services.threads import (  # noqa: PLC0415
         total_thread_level_across_all_kinds,
@@ -406,7 +430,7 @@ def covenant_role_specialty_power_term(ctx: PowerTermContext) -> int:
     primary_total = Decimal(0)
     secondary_total = Decimal(0)
     for row in rows:
-        contribution = Decimal(total_threads) * row.multiplier_tenths / 10
+        contribution = specialty_power_contribution(total_threads, row.multiplier_tenths)
         if row.covenant_role_id in secondary_role_ids:
             secondary_total += contribution
         else:

--- a/src/world/magic/services/targeting.py
+++ b/src/world/magic/services/targeting.py
@@ -7,6 +7,8 @@ cast routing downstream.
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 from django.core.exceptions import ValidationError
 from django.db.models import Prefetch
 
@@ -257,6 +259,86 @@ def protective_flavor(technique: Technique) -> str | None:
     """
     resolved = protective_condition_and_flavor(technique)
     return resolved[1] if resolved is not None else None
+
+
+#: ProtectiveMagnitude.mode values (#3279) — named constants, not bare strings, so
+#: callers (e.g. technique_power_eval's mitigation valuator) compare against an
+#: identifier.
+PROTECTIVE_MAGNITUDE_MULTIPLY = "multiply"
+PROTECTIVE_MAGNITUDE_FLAT = "flat"
+
+#: The MODIFY_PAYLOAD step shape :func:`protective_magnitude` recognizes — the same
+#: field/op vocabulary ``world.combat.defend_content.ensure_defend_content`` seeds
+#: for the shipped Defend technique and
+#: ``flows.models.flows.FlowStepDefinition._execute_modify_payload`` interprets.
+_MODIFY_PAYLOAD_AMOUNT_FIELD = "amount"
+_MODIFY_PAYLOAD_OP_MULTIPLY = "multiply"
+_MODIFY_PAYLOAD_OP_ADD = "add"
+
+
+@dataclass(frozen=True, slots=True)
+class ProtectiveMagnitude:
+    """A parsed damage-mitigation magnitude extracted from a protective condition (#3279).
+
+    ``mode=PROTECTIVE_MAGNITUDE_MULTIPLY`` carries ``factor`` (e.g. Defend's 0.5
+    halves incoming damage); ``mode=PROTECTIVE_MAGNITUDE_FLAT`` carries ``amount``
+    (a flat per-hit reduction). Exactly one of ``factor``/``amount`` is populated
+    per mode — the other stays ``None``.
+    """
+
+    mode: str
+    factor: float | None = None
+    amount: int | None = None
+
+
+def protective_magnitude(condition_template: ConditionTemplate) -> ProtectiveMagnitude | None:
+    """Extract a parseable damage-mitigation magnitude from a protective condition (#3279).
+
+    Sibling to :func:`protective_flavor` for the technique combat-power evaluator's
+    mitigation valuator (``world.magic.services.technique_power_eval``): walks
+    *condition_template*'s ``reactive_triggers -> flow_definition -> steps`` looking
+    for a ``MODIFY_PAYLOAD`` step on the ``"amount"`` field (the shape
+    ``world.combat.defend_content.ensure_defend_content`` seeds for the shipped
+    Defend technique — ``{"field": "amount", "op": "multiply", "value": 0.5}``):
+
+    - ``op == "multiply"`` -> ``ProtectiveMagnitude(mode="multiply", factor=value)``
+      (percentage mitigation — Defend's 0.5 halves incoming damage).
+    - ``op == "add"`` with a negative ``value`` -> ``ProtectiveMagnitude(mode="flat",
+      amount=abs(value))`` (a flat per-hit reduction — ``modify_payload``'s op
+      vocabulary has no literal "subtract", so a flat reduction is authored as an
+      add of a negative amount, see ``flows.models.flows.FlowStepDefinition
+      ._execute_modify_payload``).
+
+    Returns the FIRST matching step across every trigger (authored protective
+    conditions carry at most one in practice). Any other shape — a
+    ``CALL_SERVICE_FUNCTION`` handler (the barrier/blink/reflect families
+    :func:`protective_flavor` classifies), a ``MODIFY_PAYLOAD`` step on a
+    different field, or an unrecognized op — returns ``None``: an authoring-gap
+    bucket for the evaluator's UNPRICEABLE provenance, not an error.
+    """
+    triggers = condition_template.reactive_triggers.select_related(
+        "flow_definition"
+    ).prefetch_related(
+        Prefetch(
+            "flow_definition__steps",
+            queryset=FlowStepDefinition.objects.filter(action=FlowActionChoices.MODIFY_PAYLOAD),
+            to_attr="cached_modify_payload_steps",
+        )
+    )
+    for trigger in triggers:
+        for step in trigger.flow_definition.cached_modify_payload_steps:
+            params = step.parameters or {}
+            if params.get("field") != _MODIFY_PAYLOAD_AMOUNT_FIELD:
+                continue
+            op = params.get("op")
+            value = params.get("value")
+            if not isinstance(value, (int, float)):
+                continue
+            if op == _MODIFY_PAYLOAD_OP_MULTIPLY:
+                return ProtectiveMagnitude(mode=PROTECTIVE_MAGNITUDE_MULTIPLY, factor=float(value))
+            if op == _MODIFY_PAYLOAD_OP_ADD and value < 0:
+                return ProtectiveMagnitude(mode=PROTECTIVE_MAGNITUDE_FLAT, amount=int(abs(value)))
+    return None
 
 
 #: Reactive-trigger handler families that consume a caster-declared position PAIR

--- a/src/world/magic/services/technique_power_eval.py
+++ b/src/world/magic/services/technique_power_eval.py
@@ -872,15 +872,23 @@ def evaluate_technique(
     )
 
 
-def evaluate_all(context: EvalContext) -> list[TechniquePowerReport]:
-    """Evaluate every technique in the catalog, two-pass (#3279).
+def evaluate_all_with_reference(
+    context: EvalContext,
+) -> tuple[list[TechniquePowerReport], ReferenceFrame]:
+    """Evaluate every technique in the catalog, two-pass, exposing the reference (#3279).
 
     Pass 1 computes baseline attack DE for every technique carrying at least one
     damage-profile row; the median of those figures becomes the reference frame's
-    ``outgoing_dpr``/``incoming_dpr`` (self-anchoring — derived from the game's own
+    ``outgoing_dpr``/``incoming_dpr`` (self-anchoring - derived from the game's own
     content, not an authored constant). Pass 2 evaluates every technique in the
     catalog against that reference. A run shares one matchup-band computation and
     one damage-multiplier cache across both passes and every technique.
+
+    ``evaluate_all`` (below) is the pre-#3279-Task-3 signature every existing caller
+    and test still uses; this wrapper is the one that also hands back the
+    ``ReferenceFrame`` the two-pass bootstrap computed, for the Techniques tuning
+    panel's "Reference DPR" line (`web.admin.tuning.technique_analytics`) - the only
+    consumer of the reference frame outside this module.
     """
     multiplier_cache: dict[int, Decimal] = {}
     bands = _matchup_bands(context)
@@ -917,9 +925,21 @@ def evaluate_all(context: EvalContext) -> list[TechniquePowerReport]:
         )
 
     all_techniques = Technique.objects.all().select_related("gift", "effect_type")
-    return [
+    reports = [
         evaluate_technique(
             technique, context, reference, _multiplier_cache=multiplier_cache, _bands=bands
         )
         for technique in all_techniques
     ]
+    return reports, reference
+
+
+def evaluate_all(context: EvalContext) -> list[TechniquePowerReport]:
+    """Evaluate every technique in the catalog, two-pass (#3279).
+
+    Thin wrapper over :func:`evaluate_all_with_reference` that drops the
+    ``ReferenceFrame`` - kept as the stable pre-Task-3 signature for existing
+    callers/tests that only want the reports.
+    """
+    reports, _reference = evaluate_all_with_reference(context)
+    return reports

--- a/src/world/magic/services/technique_power_eval.py
+++ b/src/world/magic/services/technique_power_eval.py
@@ -1,0 +1,361 @@
+"""Technique combat-power evaluator (#3279).
+
+Prices every authored technique's combat payloads into DE (damage-equivalent per
+cast in a reference matchup) and compares its baseline power (``technique.intensity``
+alone) to an "amplified" anchor (a caster with a fully-matched engaged covenant
+role/specialty at the panel's thread level). Drives the Game Tuning "Techniques"
+panel (a later task); this module has no view/admin dependency of its own.
+
+Only the damage payload valuator is implemented here (Task 1 of #3279's plan,
+``docs/plans/3279-technique-power-eval-plan.md``) — buffs, debuffs, control,
+mitigation, heals, dispel, and capability grants all return an empty valuation
+list for now and are picked up by the follow-on task. Power/anima plumbing (the
+baseline-vs-amplified power comparison, effective anima cost, windup division) is
+complete in this task.
+
+**Layering note:** the currency spec calls for
+``web.admin.tuning.checks_analytics.compute_matchup`` to derive the per-cast
+success-level distribution. ``world`` code must never import from ``web`` (web
+depends on world, not the reverse — no other `world` *service* module does this;
+the handful of existing `world -> web` imports are all thin view/admin-layer
+plumbing, not business logic). ``compute_matchup`` itself is pure Django ORM over
+``world.traits`` models with no web dependency of its own, so ``_matchup_bands``
+below is a local, byte-for-byte-equivalent replica of its ~40-line roll
+enumeration over the same tables — see that function's docstring.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+import statistics
+from typing import TYPE_CHECKING
+
+from world.magic.models.techniques import Technique
+from world.magic.services.power_terms import (
+    blend_power_contribution,
+    get_covenant_role_blend_config,
+    specialty_power_contribution,
+)
+from world.magic.types.technique_power import (
+    EvalContext,
+    PayloadValuation,
+    ReferenceFrame,
+    TechniquePowerReport,
+    ValuationProvenance,
+)
+
+if TYPE_CHECKING:
+    from world.magic.models.techniques import AbstractDamageProfile
+
+#: A caster whose sole engaged role is a fully-matched anchor (blend_weight=1.0,
+#: specialty multiplier_tenths=10 => x1.0) — the amplified-power comparison point.
+_ANCHOR_BLEND_WEIGHT = Decimal(1)
+_ANCHOR_SPECIALTY_MULTIPLIER_TENTHS = 10
+
+#: current_anima passed to calculate_effective_anima_cost — large enough that no
+#: technique in the catalog could ever hit the ``lethal`` overburn floor, so the
+#: figure returned is always the pure delta-formula cost, never a deficit-clamped one.
+_ANIMA_HEADROOM = 1_000_000
+
+
+@dataclass(frozen=True, slots=True)
+class _MatchupBand:
+    """One outcome's share of the 1-100 roll space (#3279).
+
+    Local stand-in for ``web.admin.tuning.checks_analytics.OutcomeBand`` — only
+    the two fields this evaluator reads (``success_level``, ``probability``).
+    """
+
+    success_level: int
+    probability: float
+
+
+def _matchup_bands(context: EvalContext) -> list[_MatchupBand]:
+    """Replicate ``checks_analytics.compute_matchup`` locally (see module docstring).
+
+    Derives the roller-minus-target rank difference exactly as
+    ``world.checks.services._compute_check_breakdown`` does (a missing rank —
+    below every ``CheckRank.min_points`` — contributes 0), selects the nearest
+    seeded ``ResultChart`` for that difference, then walks every possible roll
+    1..100 applying the same clamp the check engine applies
+    (``effective = max(1, min(100, roll + roll_modifier))``) and tallies which
+    ``ResultChartOutcome`` row each lands in. Returns ``[]`` when no
+    ``ResultChart`` has been seeded at all (no rank difference to fall back to).
+    """
+    from world.traits.models import CheckRank, ResultChart, ResultChartOutcome  # noqa: PLC0415
+
+    roller_rank = CheckRank.get_rank_for_points(context.roller_points)
+    target_rank = CheckRank.get_rank_for_points(context.target_difficulty)
+    rank_difference = (roller_rank.rank if roller_rank else 0) - (
+        target_rank.rank if target_rank else 0
+    )
+
+    chart = ResultChart.get_chart_for_difference(rank_difference)
+    if chart is None:
+        return []
+
+    outcome_rows = list(
+        ResultChartOutcome.objects.filter(chart=chart)
+        .select_related("outcome")
+        .order_by("min_roll")
+    )
+
+    counts: dict[int, int] = {}
+    levels: dict[int, int] = {}
+    for roll in range(1, 101):
+        effective = max(1, min(100, roll + context.roll_modifier))
+        matched = next(
+            (row for row in outcome_rows if row.min_roll <= effective <= row.max_roll),
+            None,
+        )
+        if matched is None:
+            continue
+        key = matched.outcome_id
+        counts[key] = counts.get(key, 0) + 1
+        levels[key] = matched.outcome.success_level
+
+    return [
+        _MatchupBand(success_level=levels[key], probability=count / 100.0)
+        for key, count in counts.items()
+    ]
+
+
+def _amplified_power_delta(context: EvalContext) -> int:
+    """Power gained going from baseline to the "fully matched anchor" (#3279).
+
+    Sums the two role-band pure helpers (extracted from ``power_terms.py`` in
+    this same task) at ``context.thread_level``, each int-truncated separately
+    before summing — mirroring how ``_derive_power``'s TERM stage truncates
+    every provider's contribution independently before adding it to the
+    ledger total.
+    """
+    config = get_covenant_role_blend_config()
+    blend = int(
+        blend_power_contribution(
+            context.thread_level, _ANCHOR_BLEND_WEIGHT, config.multiplier_tenths
+        )
+    )
+    specialty = int(
+        specialty_power_contribution(context.thread_level, _ANCHOR_SPECIALTY_MULTIPLIER_TENTHS)
+    )
+    return blend + specialty
+
+
+def _cached_damage_multiplier(success_level: int, cache: dict[int, Decimal]) -> Decimal:
+    """DB-backed ``get_damage_multiplier`` lookup, memoized per evaluation run.
+
+    ``cache`` is owned by the caller (fresh per ``evaluate_all`` run, or per
+    standalone ``evaluate_technique`` call) so a staff tuning edit to
+    ``DamageSuccessLevelMultiplier`` is always picked up by the NEXT run —
+    never stale across runs, only de-duplicated within one.
+    """
+    if success_level not in cache:
+        from world.conditions.services import get_damage_multiplier  # noqa: PLC0415
+
+        cache[success_level] = get_damage_multiplier(success_level)
+    return cache[success_level]
+
+
+def _damage_row_valuation(
+    row: AbstractDamageProfile,
+    *,
+    power: int,
+    bands: list[_MatchupBand],
+    multiplier_cache: dict[int, Decimal],
+) -> PayloadValuation:
+    """Expected DE for one ``TechniqueDamageProfile`` row at a given power.
+
+    ``expected = Σ over bands with sl >= row.minimum_success_level of
+    P(sl) x row.compute_damage_budget(power, sl) x get_damage_multiplier(sl)``
+    — the currency spec's attack formula.
+    """
+    expected = 0.0
+    for band in bands:
+        if band.success_level < row.minimum_success_level:
+            continue
+        budget = row.compute_damage_budget(effective_power=power, success_level=band.success_level)
+        multiplier = _cached_damage_multiplier(band.success_level, multiplier_cache)
+        expected += band.probability * float(budget) * float(multiplier)
+
+    label = row.damage_type.name if row.damage_type_id else "untyped damage"
+    return PayloadValuation(
+        kind="damage",
+        label=label,
+        value=expected,
+        provenance=ValuationProvenance.FORMULA,
+        detail=f"E[budget x mult] over SL bands = {expected:.2f}",
+    )
+
+
+def _damage_valuations(
+    technique: Technique,
+    *,
+    power: int,
+    bands: list[_MatchupBand],
+    multiplier_cache: dict[int, Decimal],
+) -> list[PayloadValuation]:
+    """One ``PayloadValuation`` per damage-profile row, at the given power."""
+    return [
+        _damage_row_valuation(row, power=power, bands=bands, multiplier_cache=multiplier_cache)
+        for row in technique.cached_damage_profiles
+    ]
+
+
+def _effective_anima(technique: Technique) -> int:
+    """Effective anima cost at the technique's own (unmodified) intensity/control."""
+    from world.magic.services.techniques import calculate_effective_anima_cost  # noqa: PLC0415
+
+    result = calculate_effective_anima_cost(
+        base_cost=technique.anima_cost,
+        runtime_intensity=technique.intensity,
+        runtime_control=technique.control,
+        current_anima=_ANIMA_HEADROOM,
+        lethal=True,
+    )
+    return result.effective_cost
+
+
+def evaluate_technique(
+    technique: Technique,
+    context: EvalContext,
+    reference: ReferenceFrame,  # noqa: ARG001 — reserved for Task 2's buff/mitigation/dispel
+    # valuators, which value against reference.outgoing_dpr/incoming_dpr; the damage
+    # valuator built in this task doesn't need it.
+    *,
+    _multiplier_cache: dict[int, Decimal] | None = None,
+    _bands: list[_MatchupBand] | None = None,
+) -> TechniquePowerReport:
+    """Full combat-power report for one technique at one evaluation context (#3279).
+
+    Baseline power is ``technique.intensity`` alone — the same figure
+    ``_derive_power(character=None)`` returns
+    (``world/magic/services/techniques.py:394``, ``PowerLedgerBuilder(base=max(0,
+    channeled_intensity)).build()`` when there is no character to derive
+    contributions from). Amplified power adds ``_amplified_power_delta`` on top —
+    the "fully matched anchor" comparison point.
+
+    ``_multiplier_cache``/``_bands`` let ``evaluate_all`` share one damage-
+    multiplier cache and one matchup-band computation across every technique in
+    a run; a standalone caller computes its own (fresh per call) when omitted.
+    """
+    if _multiplier_cache is None:
+        _multiplier_cache = {}
+    if _bands is None:
+        _bands = _matchup_bands(context)
+
+    baseline_power = technique.intensity
+    amplified_power = baseline_power + _amplified_power_delta(context)
+    effective_anima = _effective_anima(technique)
+
+    if not _bands:
+        return TechniquePowerReport(
+            technique_id=technique.pk,
+            name=technique.name,
+            gift_name=technique.gift.name,
+            level=technique.level,
+            tier=technique.tier,
+            category=technique.effect_type.category,
+            baseline_power=baseline_power,
+            amplified_power=amplified_power,
+            baseline_de=0.0,
+            amplified_de=0.0,
+            valuations=(),
+            effective_anima=effective_anima,
+            de_per_anima=0.0,
+            flags=("no_result_charts",),
+        )
+
+    valuations = _damage_valuations(
+        technique, power=baseline_power, bands=_bands, multiplier_cache=_multiplier_cache
+    )
+    amplified_valuations = _damage_valuations(
+        technique, power=amplified_power, bands=_bands, multiplier_cache=_multiplier_cache
+    )
+    baseline_de = sum(v.value for v in valuations)
+    amplified_de = sum(v.value for v in amplified_valuations)
+
+    flags: list[str] = []
+    damage_profiles = technique.cached_damage_profiles
+    if any(row.uses_equipped_weapon for row in damage_profiles):
+        flags.append("weapon_scaled")
+    if any(row.execute_missing_health_multiplier for row in damage_profiles):
+        flags.append("execute_ramp")
+
+    if technique.windup_rounds > 0:
+        divisor = 1 + technique.windup_rounds
+        baseline_de /= divisor
+        amplified_de /= divisor
+        flags.append(f"windup:{technique.windup_rounds}")
+
+    de_per_anima = baseline_de / max(1, effective_anima)
+
+    return TechniquePowerReport(
+        technique_id=technique.pk,
+        name=technique.name,
+        gift_name=technique.gift.name,
+        level=technique.level,
+        tier=technique.tier,
+        category=technique.effect_type.category,
+        baseline_power=baseline_power,
+        amplified_power=amplified_power,
+        baseline_de=baseline_de,
+        amplified_de=amplified_de,
+        valuations=tuple(valuations),
+        effective_anima=effective_anima,
+        de_per_anima=de_per_anima,
+        flags=tuple(flags),
+    )
+
+
+def evaluate_all(context: EvalContext) -> list[TechniquePowerReport]:
+    """Evaluate every technique in the catalog, two-pass (#3279).
+
+    Pass 1 computes baseline attack DE for every technique carrying at least one
+    damage-profile row; the median of those figures becomes the reference frame's
+    ``outgoing_dpr``/``incoming_dpr`` (self-anchoring — derived from the game's own
+    content, not an authored constant). Pass 2 evaluates every technique in the
+    catalog against that reference. A run shares one matchup-band computation and
+    one damage-multiplier cache across both passes and every technique.
+    """
+    multiplier_cache: dict[int, Decimal] = {}
+    bands = _matchup_bands(context)
+
+    attack_techniques = (
+        Technique.objects.filter(damage_profiles__isnull=False)
+        .distinct()
+        .select_related("gift", "effect_type")
+    )
+    placeholder_reference = ReferenceFrame(
+        outgoing_dpr=0.0, incoming_dpr=0.0, source_label="pending"
+    )
+    baseline_des = [
+        evaluate_technique(
+            technique,
+            context,
+            placeholder_reference,
+            _multiplier_cache=multiplier_cache,
+            _bands=bands,
+        ).baseline_de
+        for technique in attack_techniques
+    ]
+
+    if baseline_des:
+        median = statistics.median(baseline_des)
+        reference = ReferenceFrame(
+            outgoing_dpr=median,
+            incoming_dpr=median,
+            source_label="median-attack estimate",
+        )
+    else:
+        reference = ReferenceFrame(
+            outgoing_dpr=0.0, incoming_dpr=0.0, source_label="no attack techniques"
+        )
+
+    all_techniques = Technique.objects.all().select_related("gift", "effect_type")
+    return [
+        evaluate_technique(
+            technique, context, reference, _multiplier_cache=multiplier_cache, _bands=bands
+        )
+        for technique in all_techniques
+    ]

--- a/src/world/magic/services/technique_power_eval.py
+++ b/src/world/magic/services/technique_power_eval.py
@@ -6,12 +6,19 @@ alone) to an "amplified" anchor (a caster with a fully-matched engaged covenant
 role/specialty at the panel's thread level). Drives the Game Tuning "Techniques"
 panel (a later task); this module has no view/admin dependency of its own.
 
-Only the damage payload valuator is implemented here (Task 1 of #3279's plan,
-``docs/plans/3279-technique-power-eval-plan.md``) — buffs, debuffs, control,
-mitigation, heals, dispel, and capability grants all return an empty valuation
-list for now and are picked up by the follow-on task. Power/anima plumbing (the
-baseline-vs-amplified power comparison, effective anima cost, windup division) is
-complete in this task.
+Task 1 built the damage payload valuator, the power/anima plumbing (baseline-vs-
+amplified power comparison, effective anima cost, windup division), and the
+two-pass reference-DPR bootstrap. Task 2 (this module, still) adds every other
+payload valuator: ALLY/SELF applied-condition buffs (the bounded team-damage-
+percent lane plus a generic roll-modifier-shift estimate for other
+``ConditionModifierEffect``-carrying conditions), ENEMY applied-condition
+debuffs (damage-over-time, the same generic modifier-shift estimate, and a
+technique-level hard-control estimate for HOLD/FEAR/DISTRACTION function
+tags), a mitigation valuator that PARSES a protective condition's reactive-
+trigger flow steps (see ``world.magic.services.targeting.protective_magnitude``)
+rather than probing empirically, treatment heals, an unpriced dispel flag, and
+an explicitly-zero INERT_PAYLOAD row per capability grant (no cast seam exists
+for technique capability grants — see this app's CLAUDE.md).
 
 **Layering note:** the currency spec calls for
 ``web.admin.tuning.checks_analytics.compute_matchup`` to derive the per-cast
@@ -26,12 +33,17 @@ enumeration over the same tables — see that function's docstring.
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from decimal import Decimal
 import statistics
 from typing import TYPE_CHECKING
 
-from world.magic.models.techniques import Technique
+from world.magic.constants import (
+    PCT_PER_POWER_TENTHS,
+    TEAM_BUFF_LANE_CAP_PERCENT,
+    TechniqueFunction,
+)
+from world.magic.models.techniques import ConditionTargetKind, Technique
 from world.magic.services.power_terms import (
     blend_power_contribution,
     get_covenant_role_blend_config,
@@ -46,7 +58,12 @@ from world.magic.types.technique_power import (
 )
 
 if TYPE_CHECKING:
-    from world.magic.models.techniques import AbstractDamageProfile
+    from world.conditions.models import ConditionTemplate
+    from world.magic.models.techniques import (
+        AbstractAppliedCondition,
+        AbstractDamageProfile,
+        TechniqueTreatment,
+    )
 
 #: A caster whose sole engaged role is a fully-matched anchor (blend_weight=1.0,
 #: specialty multiplier_tenths=10 => x1.0) — the amplified-power comparison point.
@@ -57,6 +74,24 @@ _ANCHOR_SPECIALTY_MULTIPLIER_TENTHS = 10
 #: technique in the catalog could ever hit the ``lethal`` overburn floor, so the
 #: figure returned is always the pure delta-formula cost, never a deficit-clamped one.
 _ANIMA_HEADROOM = 1_000_000
+
+#: TechniqueFunction tags that a "hard control" valuation (#3279 Task 2) is priced
+#: for — a technique landing any of these on an ENEMY-targeted applied condition is
+#: valued as locking the target down for the condition's expected duration.
+_HARD_CONTROL_FUNCTIONS = frozenset(
+    {TechniqueFunction.HOLD, TechniqueFunction.FEAR, TechniqueFunction.DISTRACTION}
+)
+
+#: The synthetic "reference attack" profile used by the generic-modifier SL-shift
+#: valuator (#3279 Task 2) to measure how much a non-team-lane
+#: ``ConditionModifierEffect`` moves a nominal attack's expected damage when its
+#: ``roll_modifier`` shifts by the condition's expected severity. A fixed synthetic
+#: profile (rather than the technique's own, possibly non-attack, payload) avoids
+#: circularity — see ``_reference_attack_de``.
+_MITIGATION_REFERENCE_BASE_DAMAGE = 5
+_MITIGATION_REFERENCE_MULTIPLIER = Decimal("1.00")
+_MITIGATION_REFERENCE_PER_EXTRA_SL = 2
+_MITIGATION_REFERENCE_MIN_SL = 1
 
 
 @dataclass(frozen=True, slots=True)
@@ -202,6 +237,527 @@ def _damage_valuations(
     ]
 
 
+def _expected_duration_rounds(
+    row: AbstractAppliedCondition,
+    *,
+    power: int,
+    bands: list[_MatchupBand],
+) -> float:
+    """Band-weighted expected duration (rounds) for an applied-condition row.
+
+    Mirrors the damage valuator's SL-band expectation: sums ``P(sl) *
+    row.compute_duration_rounds(power, sl)`` over bands with
+    ``sl >= row.minimum_success_level``. ``compute_duration_rounds`` can return
+    ``None`` (only when a condition template's ``default_duration_value`` is
+    itself null); treated as 0 rounds.
+    """
+    total = 0.0
+    for band in bands:
+        if band.success_level < row.minimum_success_level:
+            continue
+        duration = row.compute_duration_rounds(
+            effective_power=power, success_level=band.success_level
+        )
+        total += band.probability * (duration or 0)
+    return total
+
+
+def _expected_severity(
+    row: AbstractAppliedCondition,
+    *,
+    power: int,
+    bands: list[_MatchupBand],
+) -> float:
+    """Band-weighted expected severity for an applied-condition row (mirrors duration)."""
+    total = 0.0
+    for band in bands:
+        if band.success_level < row.minimum_success_level:
+            continue
+        total += band.probability * row.compute_severity(
+            effective_power=power, success_level=band.success_level
+        )
+    return total
+
+
+def _is_team_lane_condition(condition: ConditionTemplate) -> bool:
+    """True if *condition* rides the bounded team-damage-percent lane (#2643).
+
+    Byte-identical detection to ``world.magic.services.condition_application``'s
+    own check — a condition whose template carries a
+    ``ConditionModifierEffect(modifier_target__name="team_damage_percent",
+    scales_with_severity=True)`` row prices its severity via
+    ``priced_percent_severity`` instead of its own authored formula.
+    """
+    from world.conditions.models import ConditionModifierEffect  # noqa: PLC0415
+    from world.mechanics.constants import TEAM_DAMAGE_PERCENT_TARGET_NAME  # noqa: PLC0415
+
+    return ConditionModifierEffect.objects.filter(
+        condition=condition,
+        modifier_target__name=TEAM_DAMAGE_PERCENT_TARGET_NAME,
+        scales_with_severity=True,
+    ).exists()
+
+
+def _team_lane_percent(power: int, context: EvalContext) -> int:
+    """Local replica of ``world.conditions.services.priced_percent_severity`` (#3279).
+
+    That function resolves its ``target_level`` by looking up a real ``ObjectDB``
+    (a ``CharacterSheet`` or ``CombatOpponent``) — this evaluator has no concrete
+    target, so it substitutes ``context.level`` for ``target_level`` directly, per
+    the currency spec. Same clamp: ``max(1, min(TEAM_BUFF_LANE_CAP_PERCENT, ...))``.
+    """
+    raw = power * PCT_PER_POWER_TENTHS / 10 / max(1, context.level)
+    return max(1, min(TEAM_BUFF_LANE_CAP_PERCENT, round(raw)))
+
+
+def _team_lane_valuation(
+    row: AbstractAppliedCondition,
+    *,
+    power: int,
+    context: EvalContext,
+    duration: float,
+    reference: ReferenceFrame,
+) -> PayloadValuation:
+    """Value a team-damage-percent-lane applied-condition row (#3279 Task 2).
+
+    ALLY/SELF: a team-wide damage buff, priced against ``reference.outgoing_dpr``.
+    ENEMY: the same bounded lane debuffing the target's own output, priced against
+    ``reference.incoming_dpr`` (damage the caster prevents by landing it).
+    """
+    percent = _team_lane_percent(power, context)
+    is_enemy = row.target_kind == ConditionTargetKind.ENEMY
+    dpr = reference.incoming_dpr if is_enemy else reference.outgoing_dpr
+    value = (percent / 100.0) * dpr * duration
+    return PayloadValuation(
+        kind="debuff" if is_enemy else "buff",
+        label=row.condition.name,
+        value=value,
+        provenance=ValuationProvenance.FORMULA,
+        detail=f"team_damage_percent {percent}% x dpr x {duration:.2f} expected rounds",
+    )
+
+
+def _reference_attack_de(
+    bands: list[_MatchupBand],
+    *,
+    effective_power: int,
+    multiplier_cache: dict[int, Decimal],
+) -> float:
+    """DE of the synthetic nominal reference-attack profile at *bands* (#3279 Task 2).
+
+    ``base_damage=5, multiplier=1, per_extra_sl=2, min_sl=1`` — the same
+    ``_scale_by_power_and_sl``-shaped formula the damage valuator uses, inlined
+    here (rather than a real ``TechniqueDamageProfile`` row) so the generic-
+    modifier valuator can measure a roll_modifier shift's DE impact without
+    depending on the technique's own (possibly non-attack) payload.
+    """
+    expected = 0.0
+    for band in bands:
+        if band.success_level < _MITIGATION_REFERENCE_MIN_SL:
+            continue
+        budget = (
+            _MITIGATION_REFERENCE_BASE_DAMAGE
+            + int(_MITIGATION_REFERENCE_MULTIPLIER * effective_power)
+            + _MITIGATION_REFERENCE_PER_EXTRA_SL
+            * max(0, band.success_level - _MITIGATION_REFERENCE_MIN_SL)
+        )
+        multiplier = _cached_damage_multiplier(band.success_level, multiplier_cache)
+        expected += band.probability * float(budget) * float(multiplier)
+    return expected
+
+
+def _generic_modifier_valuation(  # noqa: PLR0913 - cohesive per-row valuation params
+    row: AbstractAppliedCondition,
+    *,
+    power: int,
+    bands: list[_MatchupBand],
+    context: EvalContext,
+    duration: float,
+    multiplier_cache: dict[int, Decimal],
+) -> PayloadValuation | None:
+    """Value a non-team-lane, ``ConditionModifierEffect``-carrying applied-condition row.
+
+    Estimates the row's expected roll_modifier shift (severity-weighted, banded)
+    then measures its DE impact on the synthetic reference attack
+    (:func:`_reference_attack_de`) by re-running the matchup with ``roll_modifier``
+    shifted. ALLY/SELF: the shift is assumed to buff the caster's own attack
+    (``shifted - base``). ENEMY: the shift is assumed to debuff the target's
+    attack against the caster, so the value is the DAMAGE PREVENTED
+    (``base - shifted``) — a sign flip from the buff case, per the currency spec.
+
+    Returns ``None`` when *row*'s condition carries no (non-team-lane)
+    ``ConditionModifierEffect`` row — the caller falls through to the mitigation
+    parse (SELF/ALLY) or leaves the row for the caller's own fallback (ENEMY).
+    """
+    from world.conditions.models import ConditionModifierEffect  # noqa: PLC0415
+    from world.mechanics.constants import TEAM_DAMAGE_PERCENT_TARGET_NAME  # noqa: PLC0415
+
+    effects = list(
+        ConditionModifierEffect.objects.filter(condition=row.condition).exclude(
+            modifier_target__name=TEAM_DAMAGE_PERCENT_TARGET_NAME
+        )
+    )
+    if not effects:
+        return None
+
+    expected_shift = 0.0
+    for band in bands:
+        if band.success_level < row.minimum_success_level:
+            continue
+        severity = row.compute_severity(effective_power=power, success_level=band.success_level)
+        total = sum(
+            (effect.value * severity if effect.scales_with_severity else effect.value)
+            for effect in effects
+        )
+        expected_shift += band.probability * total
+
+    shifted_roll_modifier = context.roll_modifier + round(expected_shift)
+    shifted_context = replace(context, roll_modifier=shifted_roll_modifier)
+    shifted_bands = _matchup_bands(shifted_context)
+    base_de = _reference_attack_de(
+        bands, effective_power=context.level, multiplier_cache=multiplier_cache
+    )
+    shifted_de = _reference_attack_de(
+        shifted_bands, effective_power=context.level, multiplier_cache=multiplier_cache
+    )
+
+    is_enemy = row.target_kind == ConditionTargetKind.ENEMY
+    if is_enemy:
+        value = (base_de - shifted_de) * duration
+        kind = "debuff"
+    else:
+        value = (shifted_de - base_de) * duration
+        kind = "buff" if expected_shift >= 0 else "debuff"
+
+    return PayloadValuation(
+        kind=kind,
+        label=row.condition.name,
+        value=value,
+        provenance=ValuationProvenance.ESTIMATE,
+        detail=(
+            f"E[roll_modifier shift]={expected_shift:.2f} -> DE delta "
+            f"{shifted_de - base_de:.2f} x {duration:.2f} expected rounds"
+        ),
+    )
+
+
+def _dot_valuation(
+    row: AbstractAppliedCondition,
+    *,
+    power: int,
+    bands: list[_MatchupBand],
+    duration: float,
+) -> PayloadValuation | None:
+    """Value an ENEMY applied-condition row whose condition carries damage-over-time.
+
+    ``dot_per_round`` mirrors ``web.admin.tuning.condition_analytics
+    .compute_condition_danger``'s own formula: ``base_damage * (severity if
+    scales_with_severity else 1) * (row.stack_count if scales_with_stacks else 1)``,
+    summed over every ``ConditionDamageOverTime`` row attached directly to the
+    condition template (stage-specific DoT rows are not walked — a deliberate
+    best-guess simplification; most authored DoT lives at the condition level).
+    Returns ``None`` when the condition carries no such row.
+    """
+    from world.conditions.models import ConditionDamageOverTime  # noqa: PLC0415
+
+    dot_rows = list(ConditionDamageOverTime.objects.filter(condition=row.condition))
+    if not dot_rows:
+        return None
+
+    expected_severity = _expected_severity(row, power=power, bands=bands)
+    per_round = sum(
+        dot.base_damage
+        * (expected_severity if dot.scales_with_severity else 1)
+        * (row.stack_count if dot.scales_with_stacks else 1)
+        for dot in dot_rows
+    )
+    value = per_round * duration
+    return PayloadValuation(
+        kind="debuff",
+        label=row.condition.name,
+        value=value,
+        provenance=ValuationProvenance.FORMULA,
+        detail=f"dot_per_round={per_round:.2f} x {duration:.2f} expected rounds",
+    )
+
+
+def _mitigation_valuation(
+    row: AbstractAppliedCondition,
+    *,
+    duration: float,
+    reference: ReferenceFrame,
+) -> PayloadValuation | None:
+    """Value a SELF/ALLY applied-condition row via the protective-magnitude PARSE.
+
+    Delegates the flow-step walk to
+    ``world.magic.services.targeting.protective_magnitude``. ``multiply`` mode:
+    ``(1 - factor) * reference.incoming_dpr * duration``. ``flat`` mode:
+    ``amount * duration``, capped at ``reference.incoming_dpr * duration`` (a flat
+    reduction can't logically mitigate more than the reference hit itself would
+    have dealt). Returns ``None`` when the condition's protective family (if any)
+    isn't a recognized MODIFY_PAYLOAD shape — the caller falls back to UNPRICEABLE.
+    """
+    from world.magic.services import targeting  # noqa: PLC0415
+
+    magnitude = targeting.protective_magnitude(row.condition)
+    if magnitude is None:
+        return None
+
+    if magnitude.mode == targeting.PROTECTIVE_MAGNITUDE_MULTIPLY:
+        value = (1 - magnitude.factor) * reference.incoming_dpr * duration
+        detail = f"(1 - {magnitude.factor}) x incoming_dpr x {duration:.2f} expected rounds"
+    else:
+        cap = reference.incoming_dpr * duration
+        raw = magnitude.amount * duration
+        value = min(raw, cap) if cap > 0 else raw
+        detail = f"{magnitude.amount} x {duration:.2f} expected rounds, capped at {cap:.2f}"
+
+    return PayloadValuation(
+        kind="mitigation",
+        label=row.condition.name,
+        value=value,
+        provenance=ValuationProvenance.PARSED,
+        detail=detail,
+    )
+
+
+def _unpriceable_valuation(*, label: str, kind: str) -> PayloadValuation:
+    """An authoring-gap bucket row: the payload's mechanism could not be classified."""
+    return PayloadValuation(
+        kind=kind,
+        label=label,
+        value=0.0,
+        provenance=ValuationProvenance.UNPRICEABLE,
+        detail="unrecognized payload shape",
+    )
+
+
+def _condition_application_valuations(  # noqa: PLR0913 - cohesive per-technique valuation params
+    technique: Technique,
+    *,
+    power: int,
+    bands: list[_MatchupBand],
+    context: EvalContext,
+    reference: ReferenceFrame,
+    multiplier_cache: dict[int, Decimal],
+) -> list[PayloadValuation]:
+    """Value every ``TechniqueAppliedCondition`` row plus the technique-level control
+    estimate (#3279 Task 2).
+
+    Per-row routing (see module docstring + ``docs/plans/3279-technique-power-eval-
+    plan.md``):
+
+    - Team-damage-percent lane (any target_kind) -> :func:`_team_lane_valuation`.
+    - ENEMY + damage-over-time -> :func:`_dot_valuation`.
+    - Non-team-lane ``ConditionModifierEffect`` (any target_kind) ->
+      :func:`_generic_modifier_valuation`.
+    - SELF/ALLY with none of the above -> :func:`_mitigation_valuation`, else
+      UNPRICEABLE.
+    - ENEMY with none of the above -> UNPRICEABLE.
+
+    Separately, ONE technique-level "hard control" row is appended when the
+    technique carries a HOLD/FEAR/DISTRACTION function tag AND at least one
+    ENEMY applied-condition row exists — valued at the longest expected duration
+    among the technique's ENEMY rows times ``reference.incoming_dpr`` (#3279's
+    currency spec; deliberately per-technique, not per-row).
+    """
+    valuations: list[PayloadValuation] = []
+    enemy_durations: list[float] = []
+
+    for row in technique.cached_condition_applications:
+        duration = _expected_duration_rounds(row, power=power, bands=bands)
+        is_enemy = row.target_kind == ConditionTargetKind.ENEMY
+        if is_enemy:
+            enemy_durations.append(duration)
+
+        if _is_team_lane_condition(row.condition):
+            valuations.append(
+                _team_lane_valuation(
+                    row, power=power, context=context, duration=duration, reference=reference
+                )
+            )
+            continue
+
+        if is_enemy:
+            dot = _dot_valuation(row, power=power, bands=bands, duration=duration)
+            if dot is not None:
+                valuations.append(dot)
+                continue
+
+        modifier = _generic_modifier_valuation(
+            row,
+            power=power,
+            bands=bands,
+            context=context,
+            duration=duration,
+            multiplier_cache=multiplier_cache,
+        )
+        if modifier is not None:
+            valuations.append(modifier)
+            continue
+
+        if not is_enemy:
+            mitigation = _mitigation_valuation(row, duration=duration, reference=reference)
+            if mitigation is not None:
+                valuations.append(mitigation)
+                continue
+
+        valuations.append(
+            _unpriceable_valuation(
+                label=row.condition.name, kind="mitigation" if not is_enemy else "debuff"
+            )
+        )
+
+    has_hard_control_tag = any(
+        tag.function in _HARD_CONTROL_FUNCTIONS for tag in technique.cached_function_tags
+    )
+    if has_hard_control_tag and enemy_durations:
+        control_duration = max(enemy_durations)
+        value = control_duration * reference.incoming_dpr
+        valuations.append(
+            PayloadValuation(
+                kind="control",
+                label="hard control",
+                value=value,
+                provenance=ValuationProvenance.ESTIMATE,
+                detail=(
+                    f"{control_duration:.2f} expected rounds x incoming_dpr (HOLD/FEAR/DISTRACTION)"
+                ),
+            )
+        )
+
+    return valuations
+
+
+def _treatment_valuations(
+    technique: Technique,
+    *,
+    bands: list[_MatchupBand],
+    reference: ReferenceFrame,
+) -> list[PayloadValuation]:
+    """Value every ``TechniqueTreatment`` row (#3279 Task 2).
+
+    ``TechniqueTreatment`` carries no SL-scaling columns of its own — the healed
+    amount lives on its ``TreatmentTemplate`` as three outcome-tier flat amounts
+    (``mend_on_crit``/``mend_on_success``/``mend_on_partial``, keyed to the
+    treatment's own internal check outcome, not this evaluator's cast SL bands).
+    Best-guess mapping (documented deliberately, not hidden): reuse the cast's own
+    SL bands and rank each band's success_level against the treatment's own tiers
+    (``>= 3`` -> crit, ``== 2`` -> success, ``== 1`` -> partial) — bands below
+    ``row.minimum_success_level`` are skipped, same SL gate the damage valuator uses.
+    Capped at ``reference.incoming_dpr`` — ``TechniqueTreatment`` has no duration
+    field of its own (a heal is instant, not a rounds-long window), so the
+    currency spec's ``max(1, expected_duration_rounds if it has one else 1)``
+    window is always 1 here.
+    """
+    rows: list[TechniqueTreatment] = list(technique.treatments.select_related("treatment_template"))
+    valuations: list[PayloadValuation] = []
+    for row in rows:
+        template = row.treatment_template
+        expected = 0.0
+        for band in bands:
+            if band.success_level < row.minimum_success_level:
+                continue
+            if band.success_level >= 3:  # noqa: PLR2004 - treatment outcome-tier threshold
+                mend = template.mend_on_crit
+            elif band.success_level == 2:  # noqa: PLR2004 - treatment outcome-tier threshold
+                mend = template.mend_on_success
+            else:
+                mend = template.mend_on_partial
+            expected += band.probability * mend
+
+        cap = reference.incoming_dpr
+        value = min(expected, cap) if cap > 0 else expected
+        valuations.append(
+            PayloadValuation(
+                kind="heal",
+                label=template.name,
+                value=value,
+                provenance=ValuationProvenance.FORMULA,
+                detail=f"E[heal]={expected:.2f}, capped at incoming_dpr={cap:.2f}",
+            )
+        )
+    return valuations
+
+
+def _dispel_valuation(technique: Technique) -> PayloadValuation | None:
+    """One technique-level dispel row (#3279 Task 2) — never priced (v1).
+
+    ``TechniqueRemovedCondition`` payloads are deliberately not valued: dispel's
+    combat impact depends entirely on what the target happened to have applied,
+    which this evaluator has no visibility into. One row per technique (not per
+    removed-condition row), value 0, naming every condition the technique removes.
+    """
+    rows = technique.cached_removed_conditions
+    if not rows:
+        return None
+    names = ", ".join(sorted({row.condition.name for row in rows}))
+    return PayloadValuation(
+        kind="dispel",
+        label="dispel",
+        value=0.0,
+        provenance=ValuationProvenance.UNPRICED_DISPEL,
+        detail=f"removes: {names}",
+    )
+
+
+def _capability_grant_valuations(technique: Technique) -> list[PayloadValuation]:
+    """One INERT_PAYLOAD row per capability grant (#3279 Task 2) — explicitly zero.
+
+    No technique/capability-grant cast seam exists anywhere in the codebase yet
+    (see this app's CLAUDE.md, "Signature Motif Bonus" section's "Deferred" note,
+    which documents the same gap for the sibling ``SignatureMotifBonusCapabilityGrant``
+    payload) — valued 0 explicitly rather than silently dropped, so the report
+    never implies a capability grant is combat-inert by omission.
+    """
+    return [
+        PayloadValuation(
+            kind="capability",
+            label=grant.capability.name,
+            value=0.0,
+            provenance=ValuationProvenance.INERT_PAYLOAD,
+            detail="no capability-grant cast seam exists (see src/world/magic/CLAUDE.md)",
+        )
+        for grant in technique.cached_capability_grants
+    ]
+
+
+def _all_payload_valuations(  # noqa: PLR0913 - cohesive per-technique valuation params
+    technique: Technique,
+    *,
+    power: int,
+    bands: list[_MatchupBand],
+    context: EvalContext,
+    reference: ReferenceFrame,
+    multiplier_cache: dict[int, Decimal],
+) -> list[PayloadValuation]:
+    """Every payload valuation for *technique* at *power* (#3279 Task 2).
+
+    Damage (Task 1) + applied-condition buffs/debuffs/control/mitigation +
+    treatment heals + the one dispel row (if any) + one capability-grant row per
+    grant (if any).
+    """
+    valuations = list(
+        _damage_valuations(technique, power=power, bands=bands, multiplier_cache=multiplier_cache)
+    )
+    valuations.extend(
+        _condition_application_valuations(
+            technique,
+            power=power,
+            bands=bands,
+            context=context,
+            reference=reference,
+            multiplier_cache=multiplier_cache,
+        )
+    )
+    valuations.extend(_treatment_valuations(technique, bands=bands, reference=reference))
+    dispel = _dispel_valuation(technique)
+    if dispel is not None:
+        valuations.append(dispel)
+    valuations.extend(_capability_grant_valuations(technique))
+    return valuations
+
+
 def _effective_anima(technique: Technique) -> int:
     """Effective anima cost at the technique's own (unmodified) intensity/control."""
     from world.magic.services.techniques import calculate_effective_anima_cost  # noqa: PLC0415
@@ -219,9 +775,7 @@ def _effective_anima(technique: Technique) -> int:
 def evaluate_technique(
     technique: Technique,
     context: EvalContext,
-    reference: ReferenceFrame,  # noqa: ARG001 — reserved for Task 2's buff/mitigation/dispel
-    # valuators, which value against reference.outgoing_dpr/incoming_dpr; the damage
-    # valuator built in this task doesn't need it.
+    reference: ReferenceFrame,
     *,
     _multiplier_cache: dict[int, Decimal] | None = None,
     _bands: list[_MatchupBand] | None = None,
@@ -266,11 +820,21 @@ def evaluate_technique(
             flags=("no_result_charts",),
         )
 
-    valuations = _damage_valuations(
-        technique, power=baseline_power, bands=_bands, multiplier_cache=_multiplier_cache
+    valuations = _all_payload_valuations(
+        technique,
+        power=baseline_power,
+        bands=_bands,
+        context=context,
+        reference=reference,
+        multiplier_cache=_multiplier_cache,
     )
-    amplified_valuations = _damage_valuations(
-        technique, power=amplified_power, bands=_bands, multiplier_cache=_multiplier_cache
+    amplified_valuations = _all_payload_valuations(
+        technique,
+        power=amplified_power,
+        bands=_bands,
+        context=context,
+        reference=reference,
+        multiplier_cache=_multiplier_cache,
     )
     baseline_de = sum(v.value for v in valuations)
     amplified_de = sum(v.value for v in amplified_valuations)

--- a/src/world/magic/tests/test_technique_power_eval.py
+++ b/src/world/magic/tests/test_technique_power_eval.py
@@ -1,0 +1,181 @@
+"""Tests for the technique combat-power evaluator (#3279 Task 1).
+
+Covers the damage payload valuator, the baseline-vs-amplified power comparison
+(via the pure helpers extracted from ``power_terms.py`` in this same task),
+windup division, the ``weapon_scaled`` flag, effective-anima-cost-driven
+``de_per_anima``, and a regression guard on the extracted pure helpers
+themselves. Buffs/debuffs/control/mitigation/heals/dispel/capability payloads
+are Task 2's scope — not covered here.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from django.test import TestCase
+
+from world.conditions.factories import DamageSuccessLevelMultiplierFactory
+from world.magic.factories import TechniqueDamageProfileFactory, TechniqueFactory
+from world.magic.services.power_terms import (
+    blend_power_contribution,
+    get_covenant_role_blend_config,
+    specialty_power_contribution,
+)
+from world.magic.services.technique_power_eval import evaluate_technique
+from world.magic.services.techniques import calculate_effective_anima_cost
+from world.magic.types.technique_power import EvalContext, ReferenceFrame
+from world.traits.factories import (
+    CheckOutcomeFactory,
+    CheckRankFactory,
+    ResultChartFactory,
+    ResultChartOutcomeFactory,
+)
+from world.traits.models import ResultChart
+
+_PLACEHOLDER_REFERENCE = ReferenceFrame(outgoing_dpr=0.0, incoming_dpr=0.0, source_label="test")
+
+
+class TechniquePowerEvalDamageTests(TestCase):
+    """Damage valuator + power/anima plumbing (#3279 Task 1)."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        # A single CheckRank at rank=0/min_points=0 puts EvalContext's default
+        # roller_points=25 and target_difficulty=25 at the same rank, so the
+        # derived rank_difference is 0 — matching the chart below.
+        CheckRankFactory(rank=0, min_points=0)
+
+        # Two-band, even-split chart at rank_difference=0 (mirrors
+        # web/admin/tests/test_checks_analytics.py's setup pattern): SL 1 on
+        # rolls 1-50, SL 3 on rolls 51-100 -> P=0.5 each.
+        cls.sl1 = CheckOutcomeFactory(name="Partial", success_level=1)
+        cls.sl3 = CheckOutcomeFactory(name="Full", success_level=3)
+        chart = ResultChartFactory(rank_difference=0, name="Even")
+        ResultChartOutcomeFactory(chart=chart, outcome=cls.sl1, min_roll=1, max_roll=50)
+        ResultChartOutcomeFactory(chart=chart, outcome=cls.sl3, min_roll=51, max_roll=100)
+
+        # One multiplier row covering both bands (SL >= 1 -> x1.00) keeps the
+        # hand-computed expectation in test_one below simple.
+        DamageSuccessLevelMultiplierFactory(min_success_level=1, multiplier=Decimal("1.00"))
+
+    def setUp(self) -> None:
+        # ResultChart._chart_cache is a process-level dict, not
+        # transaction-scoped — clear it so this class's own chart wins.
+        ResultChart.clear_cache()
+
+    def _technique(self, **kwargs):
+        kwargs.setdefault("intensity", 4)
+        kwargs.setdefault("damage_profile", False)
+        return TechniqueFactory(**kwargs)
+
+    def test_one_damage_profile_matches_hand_computed_expectation(self) -> None:
+        """budget(SL1)=9, budget(SL3)=13; E[DE] = 0.5*9 + 0.5*13 = 11.0 (mult x1.00)."""
+        technique = self._technique(intensity=4)
+        TechniqueDamageProfileFactory(
+            technique=technique,
+            base_damage=5,
+            damage_intensity_multiplier=Decimal("1.00"),
+            damage_per_extra_sl=2,
+            minimum_success_level=1,
+        )
+
+        report = evaluate_technique(technique, EvalContext(), _PLACEHOLDER_REFERENCE)
+
+        budget_sl1 = 5 + int(Decimal("1.00") * 4) + 2 * max(0, 1 - 1)
+        budget_sl3 = 5 + int(Decimal("1.00") * 4) + 2 * max(0, 3 - 1)
+        expected_de = 0.5 * budget_sl1 * 1.0 + 0.5 * budget_sl3 * 1.0
+
+        self.assertEqual(report.baseline_power, 4)
+        self.assertAlmostEqual(report.baseline_de, expected_de, places=9)
+        self.assertEqual(len(report.valuations), 1)
+        self.assertEqual(report.valuations[0].kind, "damage")
+
+    def test_amplified_power_matches_role_band_pure_helpers(self) -> None:
+        """amplified_power - baseline_power == int(blend) + int(specialty) at thread_level."""
+        technique = self._technique(intensity=4)
+        TechniqueDamageProfileFactory(technique=technique, base_damage=5, minimum_success_level=1)
+        context = EvalContext(thread_level=3)
+
+        report = evaluate_technique(technique, context, _PLACEHOLDER_REFERENCE)
+
+        config = get_covenant_role_blend_config()
+        expected_blend = int(
+            blend_power_contribution(context.thread_level, Decimal(1), config.multiplier_tenths)
+        )
+        expected_specialty = int(specialty_power_contribution(context.thread_level, 10))
+
+        self.assertEqual(
+            report.amplified_power - report.baseline_power,
+            expected_blend + expected_specialty,
+        )
+
+    def test_windup_divides_de_and_weapon_scaled_flag_set(self) -> None:
+        technique = self._technique(intensity=4, windup_rounds=2)
+        TechniqueDamageProfileFactory(
+            technique=technique,
+            base_damage=5,
+            damage_intensity_multiplier=Decimal("1.00"),
+            damage_per_extra_sl=2,
+            minimum_success_level=1,
+            uses_equipped_weapon=True,
+        )
+
+        report = evaluate_technique(technique, EvalContext(), _PLACEHOLDER_REFERENCE)
+
+        budget_sl1 = 5 + int(Decimal("1.00") * 4) + 2 * max(0, 1 - 1)
+        budget_sl3 = 5 + int(Decimal("1.00") * 4) + 2 * max(0, 3 - 1)
+        raw_de = 0.5 * budget_sl1 * 1.0 + 0.5 * budget_sl3 * 1.0
+        expected_de = raw_de / 3  # divided by (1 + windup_rounds)
+
+        self.assertAlmostEqual(report.baseline_de, expected_de, places=9)
+        self.assertIn("windup:2", report.flags)
+        self.assertIn("weapon_scaled", report.flags)
+
+    def test_de_per_anima_uses_effective_control_delta_cost(self) -> None:
+        technique = self._technique(intensity=4, control=6, anima_cost=10)
+        TechniqueDamageProfileFactory(technique=technique, base_damage=5, minimum_success_level=1)
+
+        report = evaluate_technique(technique, EvalContext(), _PLACEHOLDER_REFERENCE)
+
+        effective = calculate_effective_anima_cost(
+            base_cost=10,
+            runtime_intensity=4,
+            runtime_control=6,
+            current_anima=1_000_000,
+            lethal=True,
+        )
+
+        self.assertEqual(report.effective_anima, effective.effective_cost)
+        self.assertAlmostEqual(
+            report.de_per_anima,
+            report.baseline_de / max(1, effective.effective_cost),
+            places=9,
+        )
+
+
+class PowerTermPureHelperExtractionTests(TestCase):
+    """Regression guard: extracted helpers reproduce the pre-refactor inline arithmetic (#3279)."""
+
+    def test_blend_power_contribution_matches_inline_formula(self) -> None:
+        thread_level, blend_weight, multiplier_tenths = 7, Decimal("0.5"), 20
+        expected = Decimal(thread_level) * blend_weight * multiplier_tenths / 10
+        self.assertEqual(
+            blend_power_contribution(thread_level, blend_weight, multiplier_tenths), expected
+        )
+
+    def test_blend_power_contribution_second_sample(self) -> None:
+        thread_level, blend_weight, multiplier_tenths = 12, Decimal(1), 15
+        expected = Decimal(thread_level) * blend_weight * multiplier_tenths / 10
+        self.assertEqual(
+            blend_power_contribution(thread_level, blend_weight, multiplier_tenths), expected
+        )
+
+    def test_specialty_power_contribution_matches_inline_formula(self) -> None:
+        thread_level, multiplier_tenths = 7, 15
+        expected = Decimal(thread_level) * multiplier_tenths / 10
+        self.assertEqual(specialty_power_contribution(thread_level, multiplier_tenths), expected)
+
+    def test_specialty_power_contribution_second_sample(self) -> None:
+        thread_level, multiplier_tenths = 20, 10
+        expected = Decimal(thread_level) * multiplier_tenths / 10
+        self.assertEqual(specialty_power_contribution(thread_level, multiplier_tenths), expected)

--- a/src/world/magic/tests/test_technique_power_eval_valuators.py
+++ b/src/world/magic/tests/test_technique_power_eval_valuators.py
@@ -1,0 +1,317 @@
+"""Tests for the technique combat-power evaluator's remaining valuators (#3279 Task 2).
+
+Covers the buff/control/mitigation/heal/dispel/capability valuators Task 1 left
+unimplemented: the team-damage-percent buff lane, the technique-level hard-control
+estimate, the mitigation PARSE (regression-tested against the real shipped Defend
+content — the plan's "key regression tripwire"), treatment healing (capped),
+dispel/capability-grant zero-valued rows, and the UNPRICEABLE fallback for an
+unrecognized protective family. The damage valuator + power/anima plumbing are
+covered by ``test_technique_power_eval.py`` (Task 1) and are not repeated here.
+"""
+
+from __future__ import annotations
+
+from django.test import TestCase
+
+from flows.constants import EventName
+from flows.consts import FlowActionChoices
+from flows.factories import (
+    FlowDefinitionFactory,
+    FlowStepDefinitionFactory,
+    TriggerDefinitionFactory,
+)
+from world.combat.defend_content import DEFEND_PASSIVE_NAME, ensure_defend_content
+from world.conditions.factories import (
+    ConditionModifierEffectFactory,
+    ConditionTemplateFactory,
+    DamageSuccessLevelMultiplierFactory,
+    TreatmentTemplateFactory,
+)
+from world.magic.constants import (
+    PCT_PER_POWER_TENTHS,
+    TEAM_BUFF_LANE_CAP_PERCENT,
+    TechniqueFunction,
+)
+from world.magic.factories import (
+    TechniqueAppliedConditionFactory,
+    TechniqueCapabilityGrantFactory,
+    TechniqueFactory,
+    TechniqueFunctionTagFactory,
+    TechniqueRemovedConditionFactory,
+)
+from world.magic.models.techniques import ConditionTargetKind, Technique, TechniqueTreatment
+from world.magic.services.targeting import protective_magnitude
+from world.magic.services.technique_power_eval import evaluate_technique
+from world.magic.types.technique_power import EvalContext, ReferenceFrame, ValuationProvenance
+from world.mechanics.factories import TeamDamagePercentTargetFactory
+from world.traits.factories import (
+    CheckOutcomeFactory,
+    CheckRankFactory,
+    ResultChartFactory,
+    ResultChartOutcomeFactory,
+)
+from world.traits.models import ResultChart
+
+# PayloadValuation.kind values this suite filters on (a free string field, not a
+# TextChoices — named constants here per the string-literal lint rule).
+_KIND_BUFF = "buff"
+_KIND_CONTROL = "control"
+_KIND_MITIGATION = "mitigation"
+_KIND_HEAL = "heal"
+_KIND_DISPEL = "dispel"
+_KIND_CAPABILITY = "capability"
+
+
+class TechniquePowerEvalValuatorTestCase(TestCase):
+    """Shared even-split SL1/SL3 matchup chart, mirroring Task 1's test setup."""
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        # rank=0/min_points=0 puts EvalContext's default roller_points=25 and
+        # target_difficulty=25 at the same rank -> rank_difference=0.
+        CheckRankFactory(rank=0, min_points=0)
+
+        cls.sl1 = CheckOutcomeFactory(name="Partial", success_level=1)
+        cls.sl3 = CheckOutcomeFactory(name="Full", success_level=3)
+        chart = ResultChartFactory(rank_difference=0, name="Even")
+        ResultChartOutcomeFactory(chart=chart, outcome=cls.sl1, min_roll=1, max_roll=50)
+        ResultChartOutcomeFactory(chart=chart, outcome=cls.sl3, min_roll=51, max_roll=100)
+
+        DamageSuccessLevelMultiplierFactory(min_success_level=1, multiplier=1)
+
+    def setUp(self) -> None:
+        # ResultChart._chart_cache is a process-level dict, not transaction-scoped.
+        ResultChart.clear_cache()
+
+    def _technique(self, **kwargs) -> Technique:
+        kwargs.setdefault("intensity", 4)
+        kwargs.setdefault("damage_profile", False)
+        return TechniqueFactory(**kwargs)
+
+
+class TeamDamagePercentLaneTests(TechniquePowerEvalValuatorTestCase):
+    """1a: the bounded team-damage-percent buff lane (#3279)."""
+
+    def test_ally_buff_matches_hand_computed_percent_x_outgoing_dpr_x_duration(self) -> None:
+        technique = self._technique(intensity=40)
+        condition = ConditionTemplateFactory(default_duration_value=3)
+        ConditionModifierEffectFactory(
+            condition=condition,
+            modifier_target=TeamDamagePercentTargetFactory(),
+            scales_with_severity=True,
+        )
+        TechniqueAppliedConditionFactory(
+            technique=technique,
+            condition=condition,
+            target_kind=ConditionTargetKind.ALLY,
+            minimum_success_level=1,
+        )
+        context = EvalContext(level=10)
+        reference = ReferenceFrame(outgoing_dpr=20.0, incoming_dpr=15.0, source_label="test")
+
+        report = evaluate_technique(technique, context, reference)
+
+        # Hand-computed: raw = power * PCT_PER_POWER_TENTHS / 10 / level; clamp 1..cap.
+        raw = technique.intensity * PCT_PER_POWER_TENTHS / 10 / context.level
+        percent = max(1, min(TEAM_BUFF_LANE_CAP_PERCENT, round(raw)))
+        # duration is constant (base_duration_rounds=None -> condition default, no
+        # power/SL scaling authored) across both bands, whose probabilities sum to 1.
+        expected_duration = condition.default_duration_value
+        expected_value = (percent / 100.0) * reference.outgoing_dpr * expected_duration
+
+        buff_rows = [v for v in report.valuations if v.kind == _KIND_BUFF]
+        self.assertEqual(len(buff_rows), 1)
+        self.assertAlmostEqual(buff_rows[0].value, expected_value, places=6)
+        self.assertEqual(buff_rows[0].provenance, ValuationProvenance.FORMULA)
+
+
+class HardControlTests(TechniquePowerEvalValuatorTestCase):
+    """2b: HOLD/FEAR/DISTRACTION hard-control estimate, once per technique (#3279)."""
+
+    def test_hold_tag_values_expected_duration_x_incoming_dpr(self) -> None:
+        technique = self._technique(intensity=5)
+        TechniqueFunctionTagFactory(technique=technique, function=TechniqueFunction.HOLD)
+        condition = ConditionTemplateFactory(default_duration_value=4)
+        TechniqueAppliedConditionFactory(
+            technique=technique,
+            condition=condition,
+            target_kind=ConditionTargetKind.ENEMY,
+            minimum_success_level=1,
+        )
+        context = EvalContext()
+        reference = ReferenceFrame(outgoing_dpr=10.0, incoming_dpr=12.0, source_label="test")
+
+        report = evaluate_technique(technique, context, reference)
+
+        control_rows = [v for v in report.valuations if v.kind == _KIND_CONTROL]
+        self.assertEqual(len(control_rows), 1)
+        expected_value = condition.default_duration_value * reference.incoming_dpr
+        self.assertAlmostEqual(control_rows[0].value, expected_value, places=6)
+        self.assertEqual(control_rows[0].provenance, ValuationProvenance.ESTIMATE)
+
+        # The underlying ENEMY row itself carries no DoT/modifier -> UNPRICEABLE,
+        # separate from (in addition to) the technique-level control row.
+        unpriceable_rows = [
+            v for v in report.valuations if v.provenance == ValuationProvenance.UNPRICEABLE
+        ]
+        self.assertEqual(len(unpriceable_rows), 1)
+
+    def test_no_control_row_without_function_tag(self) -> None:
+        technique = self._technique(intensity=5)
+        condition = ConditionTemplateFactory(default_duration_value=4)
+        TechniqueAppliedConditionFactory(
+            technique=technique,
+            condition=condition,
+            target_kind=ConditionTargetKind.ENEMY,
+            minimum_success_level=1,
+        )
+        context = EvalContext()
+        reference = ReferenceFrame(outgoing_dpr=10.0, incoming_dpr=12.0, source_label="test")
+
+        report = evaluate_technique(technique, context, reference)
+
+        self.assertFalse([v for v in report.valuations if v.kind == _KIND_CONTROL])
+
+
+class MitigationParseTests(TechniquePowerEvalValuatorTestCase):
+    """3: mitigation PARSE, regression-tested against the shipped Defend content."""
+
+    def test_defend_content_parses_to_multiply_half_regression(self) -> None:
+        """THE key regression tripwire: shipped Defend content must parse as 0.5x."""
+        ensure_defend_content()
+        technique = Technique.objects.get(name=DEFEND_PASSIVE_NAME)
+        row = technique.condition_applications.get()
+
+        magnitude = protective_magnitude(row.condition)
+
+        self.assertIsNotNone(magnitude)
+        self.assertEqual(magnitude.mode, "multiply")
+        self.assertEqual(magnitude.factor, 0.5)
+
+    def test_defend_content_values_as_50_percent_mitigation(self) -> None:
+        ensure_defend_content()
+        technique = Technique.objects.get(name=DEFEND_PASSIVE_NAME)
+        context = EvalContext()
+        reference = ReferenceFrame(outgoing_dpr=0.0, incoming_dpr=30.0, source_label="test")
+
+        report = evaluate_technique(technique, context, reference)
+
+        mitigation_rows = [v for v in report.valuations if v.kind == _KIND_MITIGATION]
+        self.assertEqual(len(mitigation_rows), 1)
+        self.assertEqual(mitigation_rows[0].provenance, ValuationProvenance.PARSED)
+        # Shielded's default_duration_value=1, no power/SL scaling authored -> duration
+        # is constant 1 across both bands, whose probabilities sum to 1.
+        expected_value = 0.5 * reference.incoming_dpr * 1
+        self.assertAlmostEqual(mitigation_rows[0].value, expected_value, places=6)
+        # Defend carries no damage profile, so baseline_de is exactly the mitigation.
+        self.assertAlmostEqual(report.baseline_de, expected_value, places=6)
+
+    def test_unrecognized_protective_family_is_unpriceable(self) -> None:
+        condition = ConditionTemplateFactory()
+        flow = FlowDefinitionFactory()
+        FlowStepDefinitionFactory(
+            flow=flow,
+            action=FlowActionChoices.CALL_SERVICE_FUNCTION,
+            variable_name="world.magic.services.effect_handlers.absorb_pool",
+            parameters={},
+        )
+        trigger = TriggerDefinitionFactory(flow_definition=flow, event_name=EventName.EXAMINED)
+        condition.reactive_triggers.add(trigger)
+
+        self.assertIsNone(protective_magnitude(condition))
+
+        technique = self._technique(intensity=4)
+        TechniqueAppliedConditionFactory(
+            technique=technique,
+            condition=condition,
+            target_kind=ConditionTargetKind.SELF,
+            minimum_success_level=1,
+        )
+        context = EvalContext()
+        reference = ReferenceFrame(outgoing_dpr=10.0, incoming_dpr=10.0, source_label="test")
+
+        report = evaluate_technique(technique, context, reference)
+
+        matching = [v for v in report.valuations if v.label == condition.name]
+        self.assertEqual(len(matching), 1)
+        self.assertEqual(matching[0].provenance, ValuationProvenance.UNPRICEABLE)
+        self.assertEqual(matching[0].value, 0.0)
+
+
+class DispelAndCapabilityGrantTests(TechniquePowerEvalValuatorTestCase):
+    """5 + 6: dispel is never priced; capability grants are explicitly inert."""
+
+    def test_dispel_row_is_unpriced_and_names_removed_conditions(self) -> None:
+        technique = self._technique(intensity=3)
+        removed = ConditionTemplateFactory(name="Charmed")
+        TechniqueRemovedConditionFactory(technique=technique, condition=removed)
+        context = EvalContext()
+        reference = ReferenceFrame(outgoing_dpr=1.0, incoming_dpr=1.0, source_label="test")
+
+        report = evaluate_technique(technique, context, reference)
+
+        dispel_rows = [v for v in report.valuations if v.kind == _KIND_DISPEL]
+        self.assertEqual(len(dispel_rows), 1)
+        self.assertEqual(dispel_rows[0].value, 0.0)
+        self.assertEqual(dispel_rows[0].provenance, ValuationProvenance.UNPRICED_DISPEL)
+        self.assertIn("Charmed", dispel_rows[0].detail)
+
+    def test_capability_grant_is_inert_payload(self) -> None:
+        technique = self._technique(intensity=3)
+        TechniqueCapabilityGrantFactory(technique=technique)
+        context = EvalContext()
+        reference = ReferenceFrame(outgoing_dpr=1.0, incoming_dpr=1.0, source_label="test")
+
+        report = evaluate_technique(technique, context, reference)
+
+        capability_rows = [v for v in report.valuations if v.kind == _KIND_CAPABILITY]
+        self.assertEqual(len(capability_rows), 1)
+        self.assertEqual(capability_rows[0].value, 0.0)
+        self.assertEqual(capability_rows[0].provenance, ValuationProvenance.INERT_PAYLOAD)
+
+
+class TreatmentHealingTests(TechniquePowerEvalValuatorTestCase):
+    """4: treatment healing, capped at reference.incoming_dpr."""
+
+    def test_treatment_healing_is_capped_at_incoming_dpr(self) -> None:
+        technique = self._technique(intensity=5)
+        treatment_template = TreatmentTemplateFactory(
+            mend_on_crit=10, mend_on_success=6, mend_on_partial=2
+        )
+        TechniqueTreatment.objects.create(
+            technique=technique,
+            treatment_template=treatment_template,
+            target_kind=ConditionTargetKind.ALLY,
+            minimum_success_level=1,
+        )
+        context = EvalContext()
+        reference = ReferenceFrame(outgoing_dpr=0.0, incoming_dpr=5.0, source_label="test")
+
+        report = evaluate_technique(technique, context, reference)
+
+        # Uncapped E[heal] = 0.5*mend_on_partial(sl1) + 0.5*mend_on_crit(sl3) = 1 + 5 = 6.
+        # Capped at reference.incoming_dpr = 5.0.
+        heal_rows = [v for v in report.valuations if v.kind == _KIND_HEAL]
+        self.assertEqual(len(heal_rows), 1)
+        self.assertEqual(heal_rows[0].value, 5.0)
+        self.assertEqual(heal_rows[0].provenance, ValuationProvenance.FORMULA)
+
+    def test_treatment_healing_uncapped_below_incoming_dpr(self) -> None:
+        technique = self._technique(intensity=5)
+        treatment_template = TreatmentTemplateFactory(
+            mend_on_crit=10, mend_on_success=6, mend_on_partial=2
+        )
+        TechniqueTreatment.objects.create(
+            technique=technique,
+            treatment_template=treatment_template,
+            target_kind=ConditionTargetKind.ALLY,
+            minimum_success_level=1,
+        )
+        context = EvalContext()
+        reference = ReferenceFrame(outgoing_dpr=0.0, incoming_dpr=100.0, source_label="test")
+
+        report = evaluate_technique(technique, context, reference)
+
+        heal_rows = [v for v in report.valuations if v.kind == _KIND_HEAL]
+        self.assertEqual(len(heal_rows), 1)
+        self.assertAlmostEqual(heal_rows[0].value, 6.0, places=6)

--- a/src/world/magic/types/technique_power.py
+++ b/src/world/magic/types/technique_power.py
@@ -1,0 +1,118 @@
+"""Technique combat-power evaluator types (#3279).
+
+Shared shapes for ``world.magic.services.technique_power_eval`` — the panel-driving
+evaluator that prices every authored technique's combat payloads into DE (damage
+equivalent per cast in a reference matchup) and compares its baseline power to a
+"fully matched anchor" (a caster with an engaged covenant role/specialty at the
+panel's thread level). See ``docs/plans/3279-technique-power-eval-plan.md`` for the
+full currency spec.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import Enum
+
+
+class ValuationProvenance(str, Enum):
+    """How confident a ``PayloadValuation``'s ``value`` figure is (#3279).
+
+    FORMULA
+        Derived directly from an authored formula (a damage budget, a priced
+        percent severity) with no approximation.
+    PARSED
+        Derived by walking authored structure (a mitigation flow step's
+        MODIFY_PAYLOAD factor) rather than reading one formula field.
+    ESTIMATE
+        A deliberate approximation where no exact formula exists (hard
+        control's expected-duration x reference incoming DPR).
+    UNPRICED_DISPEL
+        A ``TechniqueRemovedCondition`` payload — not priced in v1; listed
+        value is always 0.
+    UNPRICEABLE
+        The payload's mechanism could not be classified at all — an
+        authoring-gap bucket row, value 0.
+    INERT_PAYLOAD
+        A capability grant with no cast seam yet — valued 0 explicitly, not
+        silently dropped.
+    """
+
+    FORMULA = "FORMULA"
+    PARSED = "PARSED"
+    ESTIMATE = "ESTIMATE"
+    UNPRICED_DISPEL = "UNPRICED_DISPEL"
+    UNPRICEABLE = "UNPRICEABLE"
+    INERT_PAYLOAD = "INERT_PAYLOAD"
+
+
+@dataclass(frozen=True, slots=True)
+class EvalContext:
+    """Panel knobs driving one technique-power evaluation run (#3279).
+
+    ``roller_points``/``target_difficulty``/``roll_modifier`` mirror the
+    checks-analytics tuning panel's own matchup knobs
+    (``web.admin.tuning.checks_analytics.compute_matchup``). ``level`` and
+    ``thread_level`` drive the role-band comparison: baseline power is the
+    technique's own intensity; amplified power adds the blend + specialty
+    pure-helper contributions at ``thread_level`` for a "fully matched
+    anchor" caster.
+    """
+
+    level: int = 10
+    thread_level: int = 3
+    roller_points: int = 25
+    target_difficulty: int = 25
+    roll_modifier: int = 0
+
+
+@dataclass(frozen=True, slots=True)
+class ReferenceFrame:
+    """Self-anchoring reference DPR for one evaluation run (#3279).
+
+    Built by ``evaluate_all``'s pass 1: both DPR figures default to the
+    median baseline attack DE across every technique carrying damage-profile
+    rows, so the reference is derived from the game's own authored content
+    rather than a hand-picked constant. ``source_label`` documents where the
+    number came from for the panel drill-down (e.g. "median-attack estimate",
+    or "no attack techniques" when pass 1 found nothing to median).
+    """
+
+    outgoing_dpr: float
+    incoming_dpr: float
+    source_label: str
+
+
+@dataclass(frozen=True, slots=True)
+class PayloadValuation:
+    """One priced payload line inside a technique's combat-power report (#3279)."""
+
+    #: "damage" / "buff" / "debuff" / "control" / "mitigation" / "heal" /
+    #: "dispel" / "capability".
+    kind: str
+    label: str
+    value: float
+    provenance: ValuationProvenance
+    #: Human-readable arithmetic, e.g. "E[budget x mult] over SL bands = 14.2".
+    detail: str
+
+
+@dataclass(frozen=True, slots=True)
+class TechniquePowerReport:
+    """Full combat-power report for one technique at one evaluation context (#3279)."""
+
+    technique_id: int
+    name: str
+    gift_name: str
+    level: int
+    tier: int
+    category: str
+    baseline_power: int
+    amplified_power: int
+    baseline_de: float
+    amplified_de: float
+    #: Priced payload lines for the BASELINE context (power=baseline_power).
+    valuations: tuple[PayloadValuation, ...]
+    effective_anima: int
+    de_per_anima: float
+    #: e.g. "weapon_scaled", "windup:2", "passive", "no_result_charts".
+    flags: tuple[str, ...]

--- a/src/world/magic/types/technique_power.py
+++ b/src/world/magic/types/technique_power.py
@@ -56,6 +56,15 @@ class EvalContext:
     technique's own intensity; amplified power adds the blend + specialty
     pure-helper contributions at ``thread_level`` for a "fully matched
     anchor" caster.
+
+    ``passive`` (#3279 Task 2) flags that the technique is being evaluated as a
+    passive-applied payload (no roll — combat applies it at
+    ``effective_power=intensity``, ``success_level=row.minimum_success_level``,
+    see ``world/combat/services.py:5889`` ``_apply_passive_technique``). v1 does
+    NOT attempt to auto-detect passive-ness from a technique's authored data —
+    that requires combat-slot context this evaluator doesn't have — so this
+    field exists as a documented seam only; it defaults False and nothing reads
+    it yet.
     """
 
     level: int = 10
@@ -63,6 +72,7 @@ class EvalContext:
     roller_points: int = 25
     target_difficulty: int = 25
     roll_modifier: int = 0
+    passive: bool = False
 
 
 @dataclass(frozen=True, slots=True)


### PR DESCRIPTION
Closes #3279

## Summary

Adds a technique combat-power measurement instrument (#3279): a world.magic evaluator that prices every technique payload family in expected damage-equivalent per cast against a reference matchup (SL-distribution expectations over the real damage/severity/duration formulas), reports a baseline vs matched-covenant-anchor power band via pure helpers shared with the live covenant power terms, parses mitigation magnitudes from MODIFY_PAYLOAD reactive triggers (Defend x0.5 is a regression test), and tags every valuation with provenance (FORMULA/PARSED/ESTIMATE/UNPRICED_DISPEL/UNPRICEABLE/INERT_PAYLOAD). Surfaces it as a fifth Techniques panel on the Game Tuning dashboard: cached, sortable league table (base DE, anchor DE, amplification, DE-per-anima) with per-row valuation drill-down, zero/unpriced buckets, and provenance counts. Docs: tuning.md section, INDEX entry, ADR-0223. No models, no migrations.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #3279 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Rebased onto fcb1685aa; one conflict in docs/adr/README.md (ADR number race with #3278's ADR-0222) resolved by renumbering this PR's ADR to 0223.

<!-- last-addressed-comment: 0 -->