### PR TITLE
World builder field feedback: staff character mint, hierarchy breadcrumbs, full-page room editor

### DIFF
--- a/docs/roadmap/tooling.md
+++ b/docs/roadmap/tooling.md
@@ -3,6 +3,25 @@
 **Status:** in-progress
 **Depends on:** Areas, Items, Combat, Stories (for GM tools)
 
+## Built (2026-08-20, #3283 — field feedback: staff mint, breadcrumbs, room editor page)
+
+First real authoring session on the deployed builder produced three fixes.
+**Staff character mint**: `POST /api/world-builder/areas/mint-builder-character/`
+(`world.roster.services.staff_characters.mint_staff_character`) creates the
+whole working set — character + sheet + PRIMARY persona + NPC-shelf roster
+entry + active tenure — in one transaction, skipping the CG wizard entirely;
+the world-builder actor banner grew the create form, and actor resolution
+falls back to the account's first owned character (dispatch checks ownership,
+not puppeting), so the minted character works immediately. Player-GM OOC
+characters ride the same service gated on GMProfile later; sheet free-editing
+stays on the admin. **Hierarchy at a glance**: the manager payload and
+room-detail endpoint carry an `ancestors` breadcrumb chain, rendered on the
+canvas header and the room editor. **Full-page room editor**:
+`/staff/world-builder/rooms/:id` gives one room the full width (identity +
+every authoring section in responsive columns), deep-linkable via the
+self-sufficient room-detail payload; the canvas side panel keeps an "Open
+full editor" link for quick jumps.
+
 ## Built (2026-08-18, #3269 Phases B+C — full room authoring + area metadata)
 
 Rooms are no longer hollow: the staff panel gained sections for ambient stats

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -87,6 +87,11 @@ const WorldBuilderPage = lazy(() =>
     default: m.WorldBuilderPage,
   }))
 );
+const RoomEditorPage = lazy(() =>
+  import('@/world-builder/pages/RoomEditorPage').then((m) => ({
+    default: m.RoomEditorPage,
+  }))
+);
 const StoryBuilderPage = lazy(() =>
   import('@/story-builder/pages/StoryBuilderPage').then((m) => ({
     default: m.StoryBuilderPage,
@@ -569,6 +574,16 @@ function App() {
               <StaffRoute>
                 <Suspense fallback={<Skeleton className="h-64 w-full" />}>
                   <WorldBuilderPage />
+                </Suspense>
+              </StaffRoute>
+            }
+          />
+          <Route
+            path="/staff/world-builder/rooms/:roomId"
+            element={
+              <StaffRoute>
+                <Suspense fallback={<Skeleton className="h-64 w-full" />}>
+                  <RoomEditorPage />
                 </Suspense>
               </StaffRoute>
             }

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -21877,6 +21877,29 @@ export interface paths {
     patch?: never;
     trace?: never;
   };
+  '/api/world-builder/areas/mint-builder-character/': {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    get?: never;
+    put?: never;
+    /**
+     * @description POST /api/world-builder/areas/mint-builder-character/ (#3283).
+     *
+     *     Mints an OOC staff character (character + sheet + persona + NPC-shelf
+     *     roster entry + active tenure on the requesting account) so staff never
+     *     touch the CG wizard for a working builder character.
+     */
+    post: operations['world_builder_areas_mint_builder_character_create'];
+    delete?: never;
+    options?: never;
+    head?: never;
+    patch?: never;
+    trace?: never;
+  };
   '/api/world-builder/areas/room-detail/': {
     parameters: {
       query?: never;
@@ -29077,6 +29100,15 @@ export interface components {
      * @enum {string}
      */
     MinRiskEnum: 'none' | 'low' | 'moderate' | 'high' | 'extreme';
+    /** @description POST body for the #3283 staff-character mint. */
+    MintBuilderCharacterRequestRequest: {
+      name: string;
+    };
+    /** @description Result of the #3283 staff-character mint. */
+    MintBuilderCharacterResult: {
+      character_id: number;
+      name: string;
+    };
     /** @description Staff-facing miracle catalog serializer (#2360). */
     Miracle: {
       readonly id: number;
@@ -39423,6 +39455,7 @@ export interface components {
     StoryAreaManager: {
       area: components['schemas']['WorldBuilderArea'];
       catalogs: components['schemas']['WorldBuilderCatalogs'];
+      breadcrumb: components['schemas']['WorldBuilderBreadcrumb'][];
       rooms: components['schemas']['StoryRoom'][];
       exits: components['schemas']['WorldBuilderExit'][];
     };
@@ -41835,8 +41868,15 @@ export interface components {
     WorldBuilderAreaManager: {
       area: components['schemas']['WorldBuilderArea'];
       catalogs: components['schemas']['WorldBuilderCatalogs'];
+      breadcrumb: components['schemas']['WorldBuilderBreadcrumb'][];
       rooms: components['schemas']['WorldBuilderRoom'][];
       exits: components['schemas']['WorldBuilderExit'][];
+    };
+    /** @description One ancestor link in the area hierarchy chain (#3283). */
+    WorldBuilderBreadcrumb: {
+      id: number;
+      name: string;
+      level_display: string;
     };
     /** @description Panel pick-lists (#3269). */
     WorldBuilderCatalogs: {
@@ -41962,6 +42002,9 @@ export interface components {
     /** @description Selection-time room detail (#3269): exit profiles + comfort breakdown. */
     WorldBuilderRoomDetail: {
       id: number;
+      room: components['schemas']['WorldBuilderRoom'];
+      catalogs: components['schemas']['WorldBuilderCatalogs'];
+      breadcrumb: components['schemas']['WorldBuilderBreadcrumb'][];
       exits: components['schemas']['WorldBuilderExitDetail'][];
       comfort: components['schemas']['WorldBuilderComfort'];
       ambient_lines: components['schemas']['WorldBuilderAmbientLine'][];
@@ -72615,6 +72658,29 @@ export interface operations {
         };
         content: {
           'application/json': components['schemas']['WorldBuilderAreaManager'];
+        };
+      };
+    };
+  };
+  world_builder_areas_mint_builder_character_create: {
+    parameters: {
+      query?: never;
+      header?: never;
+      path?: never;
+      cookie?: never;
+    };
+    requestBody: {
+      content: {
+        'application/json': components['schemas']['MintBuilderCharacterRequestRequest'];
+      };
+    };
+    responses: {
+      201: {
+        headers: {
+          [name: string]: unknown;
+        };
+        content: {
+          'application/json': components['schemas']['MintBuilderCharacterResult'];
         };
       };
     };

--- a/frontend/src/world-builder/api.ts
+++ b/frontend/src/world-builder/api.ts
@@ -44,6 +44,19 @@ export function fetchAreaManager(areaId: number): Promise<WorldBuilderAreaManage
   return getJson(`/api/world-builder/areas/${areaId}/manager/`, 'Failed to load the area map.');
 }
 
+/** Mint an OOC staff builder character (#3283). */
+export async function mintBuilderCharacter(
+  name: string
+): Promise<{ character_id: number; name: string }> {
+  const res = await apiFetch('/api/world-builder/areas/mint-builder-character/', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ name }),
+  });
+  if (!res.ok) await throwApiError(res, 'Failed to create the character.');
+  return (await res.json()) as { character_id: number; name: string };
+}
+
 /** Selection-time room detail (#3269): exit profiles, comfort, ambient rows. */
 export function fetchRoomDetail(roomId: number): Promise<WorldBuilderRoomDetail> {
   const qs = new URLSearchParams({ room_id: String(roomId) }).toString();

--- a/frontend/src/world-builder/components/RoomDetailPanel.tsx
+++ b/frontend/src/world-builder/components/RoomDetailPanel.tsx
@@ -40,6 +40,8 @@ import { Textarea } from '@/components/ui/textarea';
 
 import { ROOM_ENCLOSURES } from '../types';
 import type { WorldBuilderAreaManager, WorldBuilderExit, WorldBuilderRoom } from '../types';
+import { Link } from 'react-router-dom';
+
 import { RoomAuthoringSections } from './RoomAuthoringSections';
 import { PlaceClueDialog } from './PlaceClueDialog';
 import { PlacePortalAnchorDialog } from './PlacePortalAnchorDialog';
@@ -356,6 +358,12 @@ export function RoomDetailPanel({
             </AlertDialogContent>
           </AlertDialog>
         </div>
+      )}
+
+      {!isStory && (
+        <Button asChild size="sm" variant="outline" className="self-start">
+          <Link to={`/staff/world-builder/rooms/${room.id}`}>Open full editor</Link>
+        </Button>
       )}
 
       {!isStory && catalogs && (

--- a/frontend/src/world-builder/pages/RoomEditorPage.tsx
+++ b/frontend/src/world-builder/pages/RoomEditorPage.tsx
@@ -1,0 +1,74 @@
+/**
+ * RoomEditorPage — /staff/world-builder/rooms/:roomId (#3283).
+ *
+ * Nearly all authoring work happens on a room, and the canvas page's 320px
+ * side panel compressed it badly. This page gives one room the full width:
+ * hierarchy breadcrumb on top (building › neighborhood › city, at a glance),
+ * then the identity panel and every authoring section flowing in responsive
+ * columns. Self-sufficient on the room-detail endpoint (which carries the
+ * room row, catalogs, and breadcrumb), so it deep-links and survives reloads.
+ */
+import { Link, useNavigate, useParams } from 'react-router-dom';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Skeleton } from '@/components/ui/skeleton';
+
+import { RoomDetailPanel } from '../components/RoomDetailPanel';
+import { useRoomDetailQuery, useWorldBuilderAction } from '../queries';
+import { useWorldBuilderActor } from '../useWorldBuilderActor';
+import type { WorldBuilderActionKey } from '../types';
+
+export function RoomEditorPage() {
+  const { roomId } = useParams();
+  const navigate = useNavigate();
+  const characterId = useWorldBuilderActor();
+  const parsedRoomId = roomId ? Number(roomId) : null;
+  const { data: detail, isLoading } = useRoomDetailQuery(parsedRoomId);
+  const { mutate: runMutation } = useWorldBuilderAction(
+    characterId ?? 0,
+    detail?.room.area_id ?? null
+  );
+
+  const runAction = (key: string, kwargs: Record<string, unknown>) => {
+    if (characterId == null) {
+      toast.error('You need a character to build as — mint one from the World Builder page.');
+      return;
+    }
+    runMutation({ key: key as WorldBuilderActionKey, kwargs });
+  };
+
+  if (isLoading || !detail) {
+    return <Skeleton className="m-4 h-64 w-full" />;
+  }
+
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-3 p-4" data-testid="room-editor-page">
+      <div className="flex items-center gap-2">
+        <Button size="sm" variant="ghost" onClick={() => navigate('/staff/world-builder')}>
+          ← Canvas
+        </Button>
+        <nav className="text-sm text-muted-foreground" data-testid="room-editor-breadcrumb">
+          {detail.breadcrumb.map((crumb) => (
+            <span key={crumb.id}>
+              <Link to="/staff/world-builder" className="hover:underline">
+                {crumb.name}
+              </Link>
+              <span className="mx-1">›</span>
+            </span>
+          ))}
+          <span className="font-medium text-foreground">{detail.room.name}</span>
+        </nav>
+      </div>
+      <div className="columns-1 gap-4 lg:columns-2 xl:columns-3 [&>*]:mb-4 [&>*]:break-inside-avoid">
+        <RoomDetailPanel
+          room={detail.room}
+          catalogs={detail.catalogs}
+          exits={[]}
+          runAction={runAction}
+          onLinkRooms={() => navigate('/staff/world-builder')}
+        />
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/world-builder/pages/WorldBuilderPage.tsx
+++ b/frontend/src/world-builder/pages/WorldBuilderPage.tsx
@@ -22,11 +22,12 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import type { GhostCell } from '@/map-canvas/ghosts';
-import { useMyRosterEntriesQuery } from '@/roster/queries';
-import { useAppSelector } from '@/store/hooks';
+import { useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
 import { AreaArrangeCanvas } from '../components/AreaArrangeCanvas';
+import { useWorldBuilderActor } from '../useWorldBuilderActor';
+import { mintBuilderCharacter } from '../api';
 import { AreaTreePanel } from '../components/AreaTreePanel';
 import { EditAreaDialog } from '../components/EditAreaDialog';
 import { CreateAreaDialog } from '../components/CreateAreaDialog';
@@ -44,12 +45,7 @@ import {
 import type { WorldBuilderActionKey } from '../types';
 
 export function WorldBuilderPage() {
-  const activeCharacterName = useAppSelector((state) => state.game.active);
-  const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
-  const characterId = useMemo(
-    () => myRosterEntries.find((entry) => entry.name === activeCharacterName)?.character_id ?? null,
-    [myRosterEntries, activeCharacterName]
-  );
+  const characterId = useWorldBuilderActor();
 
   const [selectedAreaId, setSelectedAreaId] = useState<number | null>(null);
   const [selectedRoomId, setSelectedRoomId] = useState<number | null>(null);
@@ -63,6 +59,9 @@ export function WorldBuilderPage() {
   // #3269 place-mode: an unplaced room awaiting a ghost-cell click.
   const [placeModeRoomId, setPlaceModeRoomId] = useState<number | null>(null);
   const [searchTerm, setSearchTerm] = useState('');
+  const [mintName, setMintName] = useState('');
+  const [minting, setMinting] = useState(false);
+  const queryClient = useQueryClient();
   const [arrangeMode, setArrangeMode] = useState(false);
   const [editAreaOpen, setEditAreaOpen] = useState(false);
   const { data: childAreasPage } = useWorldBuilderAreasQuery(
@@ -119,6 +118,15 @@ export function WorldBuilderPage() {
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <h1 className="text-lg font-semibold">World Builder</h1>
+          {manager && (manager.breadcrumb?.length ?? 0) > 1 && (
+            <span className="text-xs text-muted-foreground" data-testid="area-breadcrumb">
+              {manager.breadcrumb
+                .slice(0, -1)
+                .map((crumb) => crumb.name)
+                .join(' › ')}{' '}
+              ›
+            </span>
+          )}
           {manager && <PromoteAreaButton area={manager.area} runAction={runAction} />}
           {manager && (
             <Button size="sm" variant="outline" onClick={() => setEditAreaOpen(true)}>
@@ -183,11 +191,40 @@ export function WorldBuilderPage() {
       </div>
       {characterId == null && (
         <div
-          className="rounded border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-sm"
+          className="flex items-center gap-2 rounded border border-amber-500/50 bg-amber-500/10 px-3 py-2 text-sm"
           data-testid="world-builder-actor-banner"
         >
-          Select a character to build as - builder actions dispatch through your played character,
-          so every control is inert until you are playing one.
+          <span className="flex-1">
+            You need a character to build as. Staff can mint an OOC builder character here — no
+            character creation required.
+          </span>
+          <Input
+            className="h-8 w-48"
+            value={mintName}
+            onChange={(event) => setMintName(event.target.value)}
+            placeholder="Builder name"
+            data-testid="mint-name-input"
+          />
+          <Button
+            size="sm"
+            disabled={!mintName.trim() || minting}
+            data-testid="mint-submit"
+            onClick={async () => {
+              setMinting(true);
+              try {
+                const made = await mintBuilderCharacter(mintName.trim());
+                toast.success(`${made.name} created - you can build as them immediately.`);
+                setMintName('');
+                await queryClient.invalidateQueries({ queryKey: ['my-roster-entries'] });
+              } catch (error) {
+                toast.error(error instanceof Error ? error.message : 'Mint failed.');
+              } finally {
+                setMinting(false);
+              }
+            }}
+          >
+            Create staff character
+          </Button>
         </div>
       )}
       {placeModeRoomId != null && (

--- a/frontend/src/world-builder/types.ts
+++ b/frontend/src/world-builder/types.ts
@@ -55,8 +55,17 @@ export type WorldBuilderActionKey =
   | 'staff_remove_portal_anchor';
 
 /** Selection-time room detail (#3269) — mirrors WorldBuilderRoomDetailSerializer. */
+export interface WorldBuilderBreadcrumbEntry {
+  id: number;
+  name: string;
+  level_display: string;
+}
+
 export interface WorldBuilderRoomDetail {
   id: number;
+  room: WorldBuilderRoom;
+  catalogs: WorldBuilderAreaManager['catalogs'];
+  breadcrumb: WorldBuilderBreadcrumbEntry[];
   exits: {
     id: number;
     name: string;

--- a/frontend/src/world-builder/useWorldBuilderActor.ts
+++ b/frontend/src/world-builder/useWorldBuilderActor.ts
@@ -1,0 +1,20 @@
+/**
+ * useWorldBuilderActor (#3283) — the account's acting character for staff
+ * builder dispatch. Ownership (IsCharacterOwner), not puppeting, is what the
+ * dispatch endpoint checks, so this prefers the actively played character
+ * but falls back to the account's first owned character — which makes a
+ * freshly minted staff builder character usable without entering the game.
+ */
+import { useMemo } from 'react';
+
+import { useMyRosterEntriesQuery } from '@/roster/queries';
+import { useAppSelector } from '@/store/hooks';
+
+export function useWorldBuilderActor(): number | null {
+  const activeCharacterName = useAppSelector((state) => state.game.active);
+  const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
+  return useMemo(() => {
+    const active = myRosterEntries.find((entry) => entry.name === activeCharacterName);
+    return active?.character_id ?? myRosterEntries[0]?.character_id ?? null;
+  }, [myRosterEntries, activeCharacterName]);
+}

--- a/src/schema.json
+++ b/src/schema.json
@@ -35665,6 +35665,32 @@ paths:
               schema:
                 $ref: '#/components/schemas/WorldBuilderAreaManager'
           description: ''
+  /api/world-builder/areas/mint-builder-character/:
+    post:
+      operationId: world_builder_areas_mint_builder_character_create
+      description: |-
+        POST /api/world-builder/areas/mint-builder-character/ (#3283).
+
+        Mints an OOC staff character (character + sheet + persona + NPC-shelf
+        roster entry + active tenure on the requesting account) so staff never
+        touch the CG wizard for a working builder character.
+      tags:
+      - world-builder
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MintBuilderCharacterRequestRequest'
+        required: true
+      security:
+      - cookieAuth: []
+      responses:
+        '201':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MintBuilderCharacterResult'
+          description: ''
   /api/world-builder/areas/room-detail/:
     get:
       operationId: world_builder_areas_room_detail_retrieve
@@ -51007,6 +51033,27 @@ components:
         * `moderate` - Moderate
         * `high` - High
         * `extreme` - Extreme
+    MintBuilderCharacterRequestRequest:
+      type: object
+      description: 'POST body for the #3283 staff-character mint.'
+      properties:
+        name:
+          type: string
+          minLength: 1
+          maxLength: 80
+      required:
+      - name
+    MintBuilderCharacterResult:
+      type: object
+      description: 'Result of the #3283 staff-character mint.'
+      properties:
+        character_id:
+          type: integer
+        name:
+          type: string
+      required:
+      - character_id
+      - name
     Miracle:
       type: object
       description: Staff-facing miracle catalog serializer (#2360).
@@ -69972,6 +70019,10 @@ components:
           $ref: '#/components/schemas/WorldBuilderArea'
         catalogs:
           $ref: '#/components/schemas/WorldBuilderCatalogs'
+        breadcrumb:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorldBuilderBreadcrumb'
         rooms:
           type: array
           items:
@@ -69982,6 +70033,7 @@ components:
             $ref: '#/components/schemas/WorldBuilderExit'
       required:
       - area
+      - breadcrumb
       - catalogs
       - exits
       - rooms
@@ -74782,6 +74834,10 @@ components:
           $ref: '#/components/schemas/WorldBuilderArea'
         catalogs:
           $ref: '#/components/schemas/WorldBuilderCatalogs'
+        breadcrumb:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorldBuilderBreadcrumb'
         rooms:
           type: array
           items:
@@ -74792,9 +74848,24 @@ components:
             $ref: '#/components/schemas/WorldBuilderExit'
       required:
       - area
+      - breadcrumb
       - catalogs
       - exits
       - rooms
+    WorldBuilderBreadcrumb:
+      type: object
+      description: One ancestor link in the area hierarchy chain (#3283).
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+        level_display:
+          type: string
+      required:
+      - id
+      - level_display
+      - name
     WorldBuilderCatalogs:
       type: object
       description: Panel pick-lists (#3269).
@@ -75156,6 +75227,14 @@ components:
       properties:
         id:
           type: integer
+        room:
+          $ref: '#/components/schemas/WorldBuilderRoom'
+        catalogs:
+          $ref: '#/components/schemas/WorldBuilderCatalogs'
+        breadcrumb:
+          type: array
+          items:
+            $ref: '#/components/schemas/WorldBuilderBreadcrumb'
         exits:
           type: array
           items:
@@ -75173,9 +75252,12 @@ components:
       required:
       - ambient_emits
       - ambient_lines
+      - breadcrumb
+      - catalogs
       - comfort
       - exits
       - id
+      - room
     WorldBuilderRoomFeature:
       type: object
       description: The room's active feature, if any (#3269).

--- a/src/world/areas/builder_views.py
+++ b/src/world/areas/builder_views.py
@@ -34,6 +34,8 @@ from world.areas.filters import AreaFilter
 from world.areas.grid_services import exits_from_rooms
 from world.areas.models import Area
 from world.areas.serializers import (
+    MintBuilderCharacterRequestSerializer,
+    MintBuilderCharacterResultSerializer,
     WorldBuilderAreaManagerSerializer,
     WorldBuilderAreaSerializer,
     WorldBuilderRoomDetailSerializer,
@@ -284,6 +286,67 @@ def _authoring_catalogs() -> dict:
     }
 
 
+def _room_rows(profiles: list[RoomProfile]) -> list[dict]:
+    """The per-room payload dicts (#3283) — single source for the area
+    manager payload and the full-page room editor's one-room fetch."""
+    room_ids = [p.objectdb_id for p in profiles]
+    descriptions = {
+        row.object_id: row.permanent_description
+        for row in ObjectDisplayData.objects.filter(object_id__in=room_ids)
+    }
+    occupant_counts = _occupant_counts(room_ids)
+    stats_by_room = _stat_sidecars(profiles)
+    authoring = _authoring_sidecars(profiles)
+    clues_by_room, triggers_by_room, anchors_by_room = _clue_and_anchor_sidecars(room_ids)
+    return [
+        {
+            "id": p.objectdb_id,
+            "name": p.objectdb.db_key,
+            "description": descriptions.get(p.objectdb_id, ""),
+            "is_public": p.is_public,
+            "is_social_hub": p.is_social_hub,
+            "is_outdoor": p.is_outdoor,
+            "enclosure": p.enclosure,
+            "size_name": p.size.name if p.size_id else None,
+            "grid_x": p.grid_x,
+            "grid_y": p.grid_y,
+            "floor": p.floor,
+            "fixture_key": p.fixture_key,
+            "origin": p.origin,
+            "exported_at": p.exported_at,
+            "needs_prose": _needs_prose(descriptions.get(p.objectdb_id, "")),
+            "stats": stats_by_room.get(p.objectdb_id, []),
+            "area_id": p.area_id,
+            "size_units": p.size.units if p.size_id else None,
+            "default_blueprint": (p.default_blueprint.name if p.default_blueprint_id else None),
+            "places": authoring["places"].get(p.objectdb_id, []),
+            "feature": authoring["feature"].get(p.objectdb_id),
+            "functionaries": authoring["functionaries"].get(p.objectdb_id, []),
+            "ambient_counts": authoring["ambient_counts"].get(
+                p.objectdb_id, {"lines": 0, "emits": 0}
+            ),
+            "travel_hub": authoring["travel_hub"].get(p.objectdb_id),
+            "starting_bindings": authoring["starting_bindings"].get(p.objectdb_id, []),
+            "occupant_count": occupant_counts.get(p.objectdb_id, 0),
+            "clues": clues_by_room.get(p.objectdb_id, []),
+            "clue_triggers": triggers_by_room.get(p.objectdb_id, []),
+            "portal_anchors": anchors_by_room.get(p.objectdb_id, []),
+        }
+        for p in profiles
+    ]
+
+
+def _area_breadcrumb(area: Area | None) -> list[dict]:
+    """Ancestor chain, outermost first (#3283): World > City > Ward > ..."""
+    chain: list[dict] = []
+    node = area
+    while node is not None:
+        chain.append({"id": node.pk, "name": node.name, "level_display": node.get_level_display()})
+        node = node.parent
+    chain.reverse()
+    return chain
+
+
 def area_manager_payload(area: Area) -> dict:
     """Area + all rooms + exits for the world-builder/story-builder manager canvas.
 
@@ -299,14 +362,7 @@ def area_manager_payload(area: Area) -> dict:
         )
     )
     room_ids = [p.objectdb_id for p in profiles]
-    descriptions = {
-        row.object_id: row.permanent_description
-        for row in ObjectDisplayData.objects.filter(object_id__in=room_ids)
-    }
-    occupant_counts = _occupant_counts(room_ids)
-    stats_by_room = _stat_sidecars(profiles)
-    authoring = _authoring_sidecars(profiles)
-    clues_by_room, triggers_by_room, anchors_by_room = _clue_and_anchor_sidecars(room_ids)
+    rooms_data = _room_rows(profiles)
 
     exits = list(exits_from_rooms(set(room_ids)).select_related("db_destination"))
     destination_ids = {e.db_destination_id for e in exits if e.db_destination_id is not None}
@@ -319,42 +375,8 @@ def area_manager_payload(area: Area) -> dict:
     return {
         "area": area,
         "catalogs": _authoring_catalogs(),
-        "rooms": [
-            {
-                "id": p.objectdb_id,
-                "name": p.objectdb.db_key,
-                "description": descriptions.get(p.objectdb_id, ""),
-                "is_public": p.is_public,
-                "is_social_hub": p.is_social_hub,
-                "is_outdoor": p.is_outdoor,
-                "enclosure": p.enclosure,
-                "size_name": p.size.name if p.size_id else None,
-                "grid_x": p.grid_x,
-                "grid_y": p.grid_y,
-                "floor": p.floor,
-                "fixture_key": p.fixture_key,
-                "origin": p.origin,
-                "exported_at": p.exported_at,
-                "needs_prose": _needs_prose(descriptions.get(p.objectdb_id, "")),
-                "stats": stats_by_room.get(p.objectdb_id, []),
-                "area_id": p.area_id,
-                "size_units": p.size.units if p.size_id else None,
-                "default_blueprint": (p.default_blueprint.name if p.default_blueprint_id else None),
-                "places": authoring["places"].get(p.objectdb_id, []),
-                "feature": authoring["feature"].get(p.objectdb_id),
-                "functionaries": authoring["functionaries"].get(p.objectdb_id, []),
-                "ambient_counts": authoring["ambient_counts"].get(
-                    p.objectdb_id, {"lines": 0, "emits": 0}
-                ),
-                "travel_hub": authoring["travel_hub"].get(p.objectdb_id),
-                "starting_bindings": authoring["starting_bindings"].get(p.objectdb_id, []),
-                "occupant_count": occupant_counts.get(p.objectdb_id, 0),
-                "clues": clues_by_room.get(p.objectdb_id, []),
-                "clue_triggers": triggers_by_room.get(p.objectdb_id, []),
-                "portal_anchors": anchors_by_room.get(p.objectdb_id, []),
-            }
-            for p in profiles
-        ],
+        "rooms": rooms_data,
+        "breadcrumb": _area_breadcrumb(area),
         "exits": [
             {
                 "id": e.pk,
@@ -417,6 +439,36 @@ class WorldBuilderViewSet(viewsets.ReadOnlyModelViewSet):
             for p in hits
         ]
         return Response(WorldBuilderRoomHitSerializer(payload, many=True).data)
+
+    @extend_schema(
+        request=MintBuilderCharacterRequestSerializer,
+        responses={201: MintBuilderCharacterResultSerializer},
+    )
+    @action(detail=False, methods=["post"], url_path="mint-builder-character")
+    def mint_builder_character(self, request: Request) -> Response:
+        """POST /api/world-builder/areas/mint-builder-character/ (#3283).
+
+        Mints an OOC staff character (character + sheet + persona + NPC-shelf
+        roster entry + active tenure on the requesting account) so staff never
+        touch the CG wizard for a working builder character.
+        """
+        from world.roster.services.staff_characters import (  # noqa: PLC0415
+            StaffMintError,
+            mint_staff_character,
+        )
+
+        body = MintBuilderCharacterRequestSerializer(data=request.data)
+        body.is_valid(raise_exception=True)
+        try:
+            character = mint_staff_character(request.user, body.validated_data["name"])
+        except StaffMintError as exc:
+            return Response({"detail": exc.user_message}, status=400)
+        return Response(
+            MintBuilderCharacterResultSerializer(
+                {"character_id": character.pk, "name": character.db_key}
+            ).data,
+            status=201,
+        )
 
     @extend_schema(responses={200: WorldBuilderRoomDetailSerializer})
     @action(detail=False, methods=["get"], url_path="room-detail")
@@ -508,6 +560,9 @@ class WorldBuilderViewSet(viewsets.ReadOnlyModelViewSet):
         ]
         payload = {
             "id": profile.objectdb_id,
+            "room": _room_rows([profile])[0],
+            "catalogs": _authoring_catalogs(),
+            "breadcrumb": _area_breadcrumb(profile.area),
             "exits": exits,
             "comfort": comfort,
             "ambient_lines": ambient_lines,

--- a/src/world/areas/serializers.py
+++ b/src/world/areas/serializers.py
@@ -247,14 +247,25 @@ class WorldBuilderCatalogsSerializer(serializers.Serializer):
     beginnings = WorldBuilderIdNameSerializer(many=True)
 
 
-class WorldBuilderRoomDetailSerializer(serializers.Serializer):
-    """Selection-time room detail (#3269): exit profiles + comfort breakdown."""
+class MintBuilderCharacterRequestSerializer(serializers.Serializer):
+    """POST body for the #3283 staff-character mint."""
+
+    name = serializers.CharField(max_length=80)
+
+
+class MintBuilderCharacterResultSerializer(serializers.Serializer):
+    """Result of the #3283 staff-character mint."""
+
+    character_id = serializers.IntegerField()
+    name = serializers.CharField()
+
+
+class WorldBuilderBreadcrumbSerializer(serializers.Serializer):
+    """One ancestor link in the area hierarchy chain (#3283)."""
 
     id = serializers.IntegerField()
-    exits = WorldBuilderExitDetailSerializer(many=True)
-    comfort = WorldBuilderComfortSerializer()
-    ambient_lines = WorldBuilderAmbientLineSerializer(many=True)
-    ambient_emits = WorldBuilderAmbientEmitSerializer(many=True)
+    name = serializers.CharField()
+    level_display = serializers.CharField()
 
 
 class WorldBuilderRoomSerializer(serializers.Serializer):
@@ -312,10 +323,24 @@ class WorldBuilderExitSerializer(serializers.Serializer):
     to_area_id = serializers.IntegerField(allow_null=True)
 
 
+class WorldBuilderRoomDetailSerializer(serializers.Serializer):
+    """Selection-time room detail (#3269): exit profiles + comfort breakdown."""
+
+    id = serializers.IntegerField()
+    room = WorldBuilderRoomSerializer()
+    catalogs = WorldBuilderCatalogsSerializer()
+    breadcrumb = WorldBuilderBreadcrumbSerializer(many=True)
+    exits = WorldBuilderExitDetailSerializer(many=True)
+    comfort = WorldBuilderComfortSerializer()
+    ambient_lines = WorldBuilderAmbientLineSerializer(many=True)
+    ambient_emits = WorldBuilderAmbientEmitSerializer(many=True)
+
+
 class WorldBuilderAreaManagerSerializer(serializers.Serializer):
     """The full staff-only area-manager payload: area header + rooms + exits."""
 
     area = WorldBuilderAreaSerializer()
     catalogs = WorldBuilderCatalogsSerializer()
+    breadcrumb = WorldBuilderBreadcrumbSerializer(many=True)
     rooms = WorldBuilderRoomSerializer(many=True)
     exits = WorldBuilderExitSerializer(many=True)

--- a/src/world/roster/services/staff_characters.py
+++ b/src/world/roster/services/staff_characters.py
@@ -1,0 +1,70 @@
+"""Staff/GM OOC character minting (#3283).
+
+The world builder (and every staff action surface) dispatches through a
+character the account owns, but an OOC staff tool character has no business
+going through the CG wizard — none of CG's output matters for it, and CG's
+content gates (species/beginnings eligibility) can block it entirely on a
+fresh deploy. This service mints the whole working set in one transaction:
+Character + CharacterSheet + PRIMARY Persona (via the blessed
+``create_character_with_sheet``), a RosterEntry on the NPC shelf (staff-side;
+never publicly listed), and an active RosterTenure binding it to the
+requesting account — which is exactly what ``IsCharacterOwner`` and the
+builder's actor resolution key on.
+
+Follow-on (deliberately not built): the same mint gated on ``GMProfile`` for
+player GMs' OOC characters; free-form sheet editing rides the Django admin.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from django.db import transaction
+from django.utils import timezone
+
+if TYPE_CHECKING:
+    from evennia.accounts.models import AccountDB
+    from evennia.objects.models import ObjectDB
+
+
+class StaffMintError(Exception):
+    """Raised on an invalid mint; carries a player-safe message."""
+
+    def __init__(self, message: str) -> None:
+        super().__init__(message)
+        self.user_message = message
+
+
+@transaction.atomic
+def mint_staff_character(account: AccountDB, name: str) -> ObjectDB:
+    """Mint an OOC staff character bound to ``account``; returns the character."""
+    from evennia.objects.models import ObjectDB  # noqa: PLC0415
+
+    from evennia_extensions.models import PlayerData  # noqa: PLC0415
+    from world.character_sheets.services import create_character_with_sheet  # noqa: PLC0415
+    from world.roster.models import Roster, RosterEntry, RosterTenure  # noqa: PLC0415
+    from world.roster.models.choices import RosterType  # noqa: PLC0415
+
+    name = (name or "").strip()
+    if not name:
+        msg = "Name the character."
+        raise StaffMintError(msg)
+    if ObjectDB.objects.filter(db_key__iexact=name).exists():
+        msg = "A character by that name already exists."
+        raise StaffMintError(msg)
+
+    character, sheet, _persona = create_character_with_sheet(
+        character_key=name, primary_persona_name=name
+    )
+    roster, _ = Roster.objects.get_or_create(name="NPC", defaults={"roster_type": RosterType.NPC})
+    entry = RosterEntry.objects.create(character_sheet=sheet, roster=roster)
+    player_data, _ = PlayerData.objects.get_or_create(account=account)
+    RosterTenure.objects.create(
+        player_data=player_data,
+        roster_entry=entry,
+        player_number=1,
+        start_date=timezone.now(),
+        approved_date=timezone.now(),
+        approved_by=player_data,
+    )
+    return character

--- a/src/world/roster/tests/test_staff_characters.py
+++ b/src/world/roster/tests/test_staff_characters.py
@@ -1,0 +1,63 @@
+"""Staff OOC character mint (#3283) — service + endpoint."""
+
+from __future__ import annotations
+
+from django.test import TestCase
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory
+from world.roster.models import RosterEntry, RosterTenure
+from world.roster.services.staff_characters import StaffMintError, mint_staff_character
+
+
+class MintStaffCharacterServiceTests(TestCase):
+    def test_mint_creates_full_working_set(self) -> None:
+        account = AccountFactory(username="staffer", is_staff=True)
+        character = mint_staff_character(account, "Apostate Builder")
+        assert character.db_key == "Apostate Builder"
+        sheet = character.sheet_data
+        entry = RosterEntry.objects.get(character_sheet=sheet)
+        assert entry.roster.name == "NPC"
+        tenure = RosterTenure.objects.get(roster_entry=entry)
+        assert tenure.player_data.account_id == account.pk
+        assert tenure.approved_date is not None
+
+    def test_duplicate_name_refused(self) -> None:
+        account = AccountFactory(username="staffer2", is_staff=True)
+        mint_staff_character(account, "Twin Name")
+        with self.assertRaises(StaffMintError) as caught:
+            mint_staff_character(account, "twin name")
+        assert "already exists" in caught.exception.user_message
+
+    def test_blank_name_refused(self) -> None:
+        account = AccountFactory(username="staffer3", is_staff=True)
+        with self.assertRaises(StaffMintError):
+            mint_staff_character(account, "   ")
+
+
+class MintBuilderCharacterEndpointTests(APITestCase):
+    def test_staff_mints_via_endpoint(self) -> None:
+        account = AccountFactory(username="endpoint_staff", is_staff=True)
+        self.client.force_authenticate(user=account)
+        response = self.client.post(
+            "/api/world-builder/areas/mint-builder-character/",
+            {"name": "Endpoint Builder"},
+            format="json",
+        )
+        assert response.status_code == 201, response.content
+        assert response.data["name"] == "Endpoint Builder"
+        entry = RosterEntry.objects.get(character_sheet_id=response.data["character_id"])
+        assert entry.roster.name == "NPC"
+
+    def test_non_staff_rejected(self) -> None:
+        account = AccountFactory(username="endpoint_player", is_staff=False)
+        self.client.force_authenticate(user=account)
+        response = self.client.post(
+            "/api/world-builder/areas/mint-builder-character/",
+            {"name": "Sneaky Builder"},
+            format="json",
+        )
+        assert response.status_code in (403, 404)
+        assert not RosterEntry.objects.filter(
+            character_sheet__character__db_key="Sneaky Builder"
+        ).exists()


### PR DESCRIPTION
Closes #3283

## Summary

Field feedback from the first live authoring session (#3283): (1) Staff character mint — mint_staff_character creates character + sheet + PRIMARY persona + NPC-shelf roster entry + active tenure in one transaction via a new IsAdminUser endpoint; the world-builder actor banner grew the create form, and actor resolution now falls back to the account's first owned character (dispatch checks ownership, not puppeting), so the minted character builds immediately with zero CG involvement. Player-GM OOC characters ride the same service gated on GMProfile later. (2) Hierarchy at a glance — manager payload and room-detail carry an ancestors breadcrumb chain, rendered on the canvas header and the room editor. (3) Full-page room editor — /staff/world-builder/rooms/:id gives one room the full width (identity + every authoring section in responsive columns), deep-linkable via the self-sufficient room-detail payload; the cramped side panel keeps an Open-full-editor link. No migrations.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #3283 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branched from current main; no drift, no migrations in this PR (main tip 0161 untouched).

<!-- last-addressed-comment: 0 -->