### PR TITLE
Arx I archival: freeze/upload scripts, basic-auth static archive vhost, on-demand content sync (ADR-0225)

### DIFF
--- a/.github/workflows/standup.yml
+++ b/.github/workflows/standup.yml
@@ -23,6 +23,11 @@ on:
         required: false
         type: boolean
         default: false
+      run_arx1_archive_sync:
+        description: 'Also pull the static Arx I archive export from the backups bucket onto the box (rare — expected roughly once; see docs/operations/arx1-archival.md)'
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -65,6 +70,9 @@ jobs:
           # only appends `--tags all,content_repo` to the ansible-playbook
           # invocation when this arrives as the literal string "true".
           ARXII_RUN_CONTENT_REFRESH: ${{ inputs.run_content_refresh }}
+          # Arx I archive sync — same on-demand idiom as the line above
+          # (standup.sh adds `arx1_archive` to the --tags list on "true").
+          ARXII_RUN_ARX1_ARCHIVE_SYNC: ${{ inputs.run_arx1_archive_sync }}
           # Provisioning (operator/CI-only; revoke at provider after run):
           LINODE_TOKEN: ${{ secrets.TF_LINODE_TOKEN }}
           CLOUDFLARE_API_TOKEN: ${{ secrets.TF_CLOUDFLARE_API_TOKEN }}
@@ -116,6 +124,12 @@ jobs:
           # entirely (settings.py only calls sentry_sdk.init() when
           # SENTRY_DSN is non-empty); not in standup.sh's REQUIRED_ARXII.
           ARXII_SENTRY_DSN: ${{ secrets.ARXII_SENTRY_DSN }}
+          # Optional — empty/unset means roles/caddy renders NO Arx I archive
+          # vhost (a clean converge, not a refused one); not in REQUIRED_ARXII
+          # and never on-box (caddy-step-only, like the DNS token below —
+          # read via lookup('env', ...) in roles/caddy/defaults). Set it (a
+          # bcrypt hash from `caddy hash-password`) to roll the archive out.
+          ARXII_ARX1_ARCHIVE_BASICAUTH_HASH: ${{ secrets.ARXII_ARX1_ARCHIVE_BASICAUTH_HASH }}
           ARXII_CADDY_CF_DNS_TOKEN: ${{ secrets.ARXII_CADDY_CF_DNS_TOKEN }}
           # #3153: ansible-step-only, deliberately never in secrets_map (see
           # secrets.env.example) — the content_repo role's clone task reads

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -35,7 +35,7 @@ jobs:
         run: |
           set -euo pipefail
           shopt -s nullglob
-          files=(infra/scripts/*.sh)
+          files=(infra/scripts/*.sh infra/scripts/arx1/*.sh)
           if [ ${#files[@]} -eq 0 ]; then echo "no shell scripts yet — skip"; exit 0; fi
           sudo apt-get update -qq && sudo apt-get install -y shellcheck
           shellcheck "${files[@]}"
@@ -139,14 +139,22 @@ jobs:
 
           for cf in "${cfs[@]}"; do
             echo "== $cf =="
-            # The repo ships a Jinja TEMPLATE; Caddy cannot parse `{{ ... }}`.
-            # Every Caddyfile* template here has no Jinja control flow (only
-            # simple substitutions), so stub every `{{ ... }}` with a
-            # placeholder host to get a syntactically real Caddyfile.
-            # Caddy-native single-brace placeholders ({env.X}, {remote_host})
-            # are intentionally left intact.
+            # The repo ships a Jinja TEMPLATE; Caddy cannot parse `{{ ... }}`
+            # or `{% ... %}`. Render a syntactically real Caddyfile by (1)
+            # DROPPING Jinja control-flow lines — `{% if %}`/`{% endif %}`
+            # sit ALONE on their own lines in these templates (a contract
+            # the templates' own comments state) — so conditionally-rendered
+            # blocks like the Arx I archive vhost are ALWAYS validated, and
+            # (2) stubbing each `{{ ... }}` with a UNIQUE placeholder host:
+            # two site blocks stubbed to the SAME host would be an
+            # ambiguous-site adapt error, a stub artifact rather than a real
+            # config problem. A unique hostname is simultaneously a valid
+            # site address, reverse_proxy upstream, root path token, and
+            # basic_auth hash string at adapt time (adapt parses; it does
+            # not provision hashes). Caddy-native single-brace placeholders
+            # ({env.X}, {remote_host}) are intentionally left intact.
             rendered="/tmp/$(basename "$cf").rendered"
-            sed -E 's/\{\{[^}]*\}\}/placeholder.example.com/g' "$cf" > "$rendered"
+            perl -ne 'next if /^\s*\{%.*%\}\s*$/; s/\{\{[^}]*\}\}/"placeholder".(++$i).".example.com"/ge; print' "$cf" > "$rendered"
             # Dispatch on CONTENT (#2236 review), not filename: a "does the
             # filename contain the word rehearsal" substring match trusts a
             # naming convention that can drift (a renamed/new template

--- a/docs/adr/0225-arx1-archived-to-object-storage-static-site.md
+++ b/docs/adr/0225-arx1-archived-to-object-storage-static-site.md
@@ -11,8 +11,14 @@ the Arx I website (crawled through Django's test client as staff, so
 login-gated content renders) served by the Arx II box's Caddy at
 `archive.<domain>` behind basic auth: previously-private content should not be
 stranger-readable or crawlable, but anyone WITH archive access may see
-anything - spoilers included. The GM/OOC logs are the one exception: backup
-only, never served (player OOC information, not merely spoilers). The
+anything that was written with the intent of being read by staff - black
+journals, secrets, clues, actions, events, spoilers included (all were
+always staff-viewable and explicitly known to be so). The boundary is IC
+communication players did NOT intend staff to read: messengers
+(player-to-player mail) carried an expectation of privacy, illusory or not,
+and are never surfaced - they have no web view in arxcode, so they exist
+only inside the private sqlite backup, alongside the GM/OOC event logs
+(also backup-only, never served). The
 basic-auth hash secret doubles as the vhost's enable switch (optional-secret
 posture); content delivery is an on-demand `never`-tagged role, mirroring
 content_repo. **Rejected:** keeping Arx I playable/running on the new box (a

--- a/docs/adr/0225-arx1-archived-to-object-storage-static-site.md
+++ b/docs/adr/0225-arx1-archived-to-object-storage-static-site.md
@@ -1,0 +1,22 @@
+# ADR-0225: Arx I is archived to object storage + a static basic-auth site, not kept running
+
+**Status:** Accepted (2026-08-21, Tehom in-session).
+
+The Arx I Linode ($50/month) is retired. Its durable data - the sqlite database,
+the rpevent logs (public and GM/OOC variants), and a "resurrection kit" (code,
+venv, configs) - becomes checksummed zstd artifacts under the `arx1/` prefix in
+BOTH existing backup buckets (Linode primary + R2 offsite), verified by
+re-download before the box dies. History stays browsable as a STATIC export of
+the Arx I website (crawled through Django's test client as staff, so
+login-gated content renders) served by the Arx II box's Caddy at
+`archive.<domain>` behind basic auth: previously-private content should not be
+stranger-readable or crawlable, but anyone WITH archive access may see
+anything - spoilers included. The GM/OOC logs are the one exception: backup
+only, never served (player OOC information, not merely spoilers). The
+basic-auth hash secret doubles as the vhost's enable switch (optional-secret
+posture); content delivery is an on-demand `never`-tagged role, mirroring
+content_repo. **Rejected:** keeping Arx I playable/running on the new box (a
+zombie service competing for attention and RAM during the Arx II push - the
+resurrection kit preserves the option at zero standing cost), and a
+public/unauthenticated archive (crawlers + strangers reading formerly gated
+content).

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -230,6 +230,7 @@ treat those names as hints to confirm, not gospel.
 - [0222 - Perspective attribution lives on the grant row, viewer-only](0222-perspective-attribution-on-the-grant-row.md) (#3277)
 - [0223 - Technique combat power is measured in damage-equivalents against a reference matchup, with parsed (not probed) mitigation](0223-technique-combat-power-in-damage-equivalents.md) (#3279)
 - [0224 - The CG shop window serves perspective content ungated](0224-cg-shop-window-serves-perspective-content-ungated.md) (#3281; extends ADR-0222)
+- [0225 - Arx I is archived to object storage + a static basic-auth site, not kept running](0225-arx1-archived-to-object-storage-static-site.md)
 
 ### Gift & resonance economy
 - [0050 — Gifts are Major or Minor; species abilities are a species-granted Minor Gift](0050-gifts-are-major-or-minor-species-abilities-are-minor-gifts.md)

--- a/docs/operations/arx1-archival.md
+++ b/docs/operations/arx1-archival.md
@@ -77,17 +77,40 @@ touching) the Arx II `db/` and `media/` objects.
 ## Step 3 - build and upload the static site export
 
 `arx1_static_export.py` is a DRAFT crawler: it walks the Arx I site through
-Django's test client logged in as a staff account, so login-gated pages render
-with full content, and writes a plain-HTML tree. Test it against the real data
-before trusting it (expect to tune `DEFAULT_SEEDS` and `SKIP_PATTERNS` against
-arxcode's actual urls.py; the run summary prints errors and skips to guide
-that). It can run on the old box before retirement, or later anywhere the
-resurrection kit + db snapshot are restored - so this step does NOT block
-Step 5.
+Django's test client (no webserver involved - it renders views directly
+against the sqlite DB) logged in as an account you choose, and writes a
+plain-HTML tree. Its seeds and skip rules were written against arxcode's
+actual urls.py, so coverage includes the big lore surfaces: rosters and
+character sheets (every roster state, so departed characters too), **actions**
+(`/character/sheet/<id>/actions/` lists + per-action pages, force-enqueued
+for every discovered sheet rather than trusting the sheet template's links),
+**journals** (`/comms/journals/list/`, paginated - entries render inline in
+the list), events, crises, boards, help topics, and news. Still test a run
+against real data before trusting it; the summary prints errors and skipped
+URLs to guide tuning.
+
+Two things to decide/know before running:
+
+- **The crawl account decides the content.** A staff account sees secrets,
+  clues, GM notes - AND every **black (private) journal**, because the
+  journal list shows all journals the viewer is permitted. A fresh non-staff
+  account gets white journals only but loses the sheet secrets/clues too.
+  There is no URL-level way to split the difference; pick via `--username`.
+- **Runtime: hours, plan for overnight.** Six years of data is plausibly
+  50k-150k pages at ~100-500ms each, single-threaded. The exporter streams
+  every page to disk immediately (flat memory) and supports `--resume`
+  (re-parses already-saved files for links instead of re-rendering), so run
+  it under `tmux`/`screen` and an interruption costs minutes, not the run.
+
+It runs wherever the Arx I Django environment exists: on the old box before
+retirement (easiest - SSH in, tmux, run), or later anywhere the resurrection
+kit + db snapshot are restored - so this step does NOT block Step 5. It does
+NOT run on the Arx II box, which never gets Arx I code; the Arx II box only
+receives the finished tarball in Step 4.
 
 ```sh
 cd <arx1 game dir>
-<venv>/bin/python arx1_static_export.py --out ~/arx1-site
+<venv>/bin/python arx1_static_export.py --out ~/arx1-site --resume
 # spot-check ~/arx1-site in a browser (python -m http.server), then pack:
 tar -C ~/arx1-site -cf - . | zstd -19 --long=27 -T0 -o arx1-site-export.tar.zst
 sha256sum arx1-site-export.tar.zst > arx1-site-export.tar.zst.sha256

--- a/docs/operations/arx1-archival.md
+++ b/docs/operations/arx1-archival.md
@@ -92,9 +92,14 @@ character sheets (every roster state, so departed characters too), **actions**
 (`/character/sheet/<id>/actions/` lists + per-action pages, force-enqueued
 for every discovered sheet rather than trusting the sheet template's links),
 **journals** (`/comms/journals/list/`, paginated - entries render inline in
-the list), events, crises, boards, help topics, and news. Still test a run
-against real data before trusting it; the summary prints errors and skipped
-URLs to guide tuning.
+the list), events, crises, boards, help topics, and news. It also writes a
+**synthetic `/lore/` appendix rendered straight from the DB** (ruled in
+2026-08-21): all mysteries, revelations, and clues - never-discovered ones
+and gm_notes included - because none of that had a crawlable surface in
+Arx I (telnet investigation commands + Django admin only). Skippable with
+`--skip-lore-appendix` for tuning runs. Still test a run against real data
+before trusting it; the summary prints errors and skipped URLs to guide
+tuning.
 
 Two things to know before running:
 

--- a/docs/operations/arx1-archival.md
+++ b/docs/operations/arx1-archival.md
@@ -12,11 +12,18 @@ Linode backups bucket the Arx II box already pays for, plus Cloudflare R2
 costs the Arx II box only disk and an extra Caddy vhost. The $50/month Arx I
 Linode goes away entirely.
 
-Decision record: ADR-0225. Rulings baked in: spoilers/secrets/clues may all
-appear in the archive (anyone with archive access may see anything), the site
-is basic-auth gated (previously-private content should not be crawlable or
-stranger-readable), and the GM/OOC rpevent logs are backup-only - they contain
-player OOC information and are NEVER served, not even behind the auth gate.
+Decision record: ADR-0225. Content policy (ruled 2026-08-21): **everything
+written with the intent of being read by staff is fair game for the archive**
+- black journals, secrets, clues, actions, events, spoilers - all were always
+staff-viewable and explicitly known to be so. **The boundary is IC
+communication players did not intend staff to read: messengers**
+(player-to-player mail) carried an expectation of privacy and are never
+surfaced. Verified: messengers have no web view in arxcode (model + telnet
+handler + Django admin only, and the crawler skips /admin), so they exist
+only inside the private sqlite backup - if anyone ever builds NEW archive
+surfaces from that DB, messengers stay excluded. The GM/OOC rpevent logs are
+likewise backup-only (player OOC information). The site is basic-auth gated
+so previously login-gated content is not crawlable or stranger-readable.
 
 ## Moving parts (all in this repo)
 
@@ -89,13 +96,14 @@ the list), events, crises, boards, help topics, and news. Still test a run
 against real data before trusting it; the summary prints errors and skipped
 URLs to guide tuning.
 
-Two things to decide/know before running:
+Two things to know before running:
 
-- **The crawl account decides the content.** A staff account sees secrets,
-  clues, GM notes - AND every **black (private) journal**, because the
-  journal list shows all journals the viewer is permitted. A fresh non-staff
-  account gets white journals only but loses the sheet secrets/clues too.
-  There is no URL-level way to split the difference; pick via `--username`.
+- **Crawl as a staff account** (the default: first superuser). Ruled
+  2026-08-21: black journals, secrets, clues, and GM notes all belong in the
+  archive - everything staff-intended is in (see the content policy above).
+  The staff journal list includes every black journal because a fresh
+  account has read nothing, so its "unread" list is the full permitted set.
+  Messengers cannot leak in regardless: they have no web view.
 - **Runtime: hours, plan for overnight.** Six years of data is plausibly
   50k-150k pages at ~100-500ms each, single-threaded. The exporter streams
   every page to disk immediately (flat memory) and supports `--resume`

--- a/docs/operations/arx1-archival.md
+++ b/docs/operations/arx1-archival.md
@@ -1,0 +1,147 @@
+# Arx I archival and Linode retirement
+
+End state (ruled 2026-08-21): the Arx I Linode is deleted; its data survives as
+checksummed, twice-replicated archives in object storage; a read-only static
+copy of the Arx I website is served from the Arx II box behind basic auth at
+`archive.<domain>`; and making Arx I *playable* again someday stays possible via
+a "resurrection kit" - without keeping any zombie process running today.
+
+Cost after retirement: ~$0/month. The compressed archive rides the flat-rate
+Linode backups bucket the Arx II box already pays for, plus Cloudflare R2
+(10 GB-month free tier, $0.015/GB-month past it, zero egress). The static site
+costs the Arx II box only disk and an extra Caddy vhost. The $50/month Arx I
+Linode goes away entirely.
+
+Decision record: ADR-0225. Rulings baked in: spoilers/secrets/clues may all
+appear in the archive (anyone with archive access may see anything), the site
+is basic-auth gated (previously-private content should not be crawlable or
+stranger-readable), and the GM/OOC rpevent logs are backup-only - they contain
+player OOC information and are NEVER served, not even behind the auth gate.
+
+## Moving parts (all in this repo)
+
+| Piece | Where | Runs on |
+| --- | --- | --- |
+| Freeze script | `infra/scripts/arx1/arx1-freeze.sh` | the Arx I box |
+| Upload + verify script | `infra/scripts/arx1/arx1-upload.sh` | the Arx I box |
+| Static-site exporter (DRAFT) | `infra/scripts/arx1/arx1_static_export.py` | the Arx I venv |
+| Archive vhost (basic auth, TLS) | `roles/caddy` (`caddy_archive_*` vars) | Arx II box, every converge |
+| Content sync (bucket -> web root) | `roles/arx1_archive` (`--tags arx1_archive`) | Arx II box, on demand |
+| DNS record `archive.<domain>` | `terraform/modules/cloudflare_dns` | tofu apply (the button) |
+
+## Step 1 - freeze the data (on the Arx I box)
+
+Copy `infra/scripts/arx1/arx1-freeze.sh` to the Arx I host and run it there:
+
+```sh
+ARX1_GAME_DIR=/path/to/game \
+ARX1_LOG_DIR=/path/to/rpevent/logs \
+ARX1_VENV=/path/to/venv \
+ARX1_GM_LOG_GLOB='*_gm*' \
+bash arx1-freeze.sh
+```
+
+Check `ARX1_GM_LOG_GLOB` against the real filenames FIRST - a wrong glob
+silently misfiles GM logs into the public tarball. The script warns loudly if
+the glob matches nothing.
+
+It produces, under `~/arx1-freeze`: a vacuumed + integrity-checked sqlite
+snapshot, separate public and GM rpevent tarballs, a resurrection kit (game dir
+including the venv, pip freeze, python/uname versions, crontab, webserver and
+service configs), `SHA256SUMS`, and a `README.txt` manifest. Everything is
+zstd level 19 with a long match window; decompression therefore needs
+`zstd -d --long=27` (recorded in the manifest).
+
+## Step 2 - upload to both buckets and byte-verify
+
+On the same box (install rclone's static binary first -
+https://rclone.org/install.sh - it runs on any distro vintage):
+
+```sh
+LINODE_BUCKET=... LINODE_ENDPOINT=... LINODE_ACCESS_KEY=... LINODE_SECRET_KEY=... \
+R2_BUCKET=... R2_ENDPOINT=... R2_ACCESS_KEY=... R2_SECRET_KEY=... \
+bash arx1-upload.sh
+```
+
+Bucket names and endpoints are the `backups_bucket`/`backups_s3_endpoint` and
+`r2_offsite_bucket`/`r2_s3_endpoint` tofu outputs. For keys, either reuse the
+existing pairs or mint fresh ones in each dashboard (Linode: bucket-scoped
+key; Cloudflare: R2 API token scoped to the offsite bucket) and revoke after.
+The script re-checks `SHA256SUMS` locally before anything leaves the box, then
+`rclone check --download`s every object from BOTH remotes - actual bytes, not
+etags. That re-download IS the "verified before the Linode dies" gate.
+
+Everything lands under the `arx1/` prefix in both buckets, beside (never
+touching) the Arx II `db/` and `media/` objects.
+
+## Step 3 - build and upload the static site export
+
+`arx1_static_export.py` is a DRAFT crawler: it walks the Arx I site through
+Django's test client logged in as a staff account, so login-gated pages render
+with full content, and writes a plain-HTML tree. Test it against the real data
+before trusting it (expect to tune `DEFAULT_SEEDS` and `SKIP_PATTERNS` against
+arxcode's actual urls.py; the run summary prints errors and skips to guide
+that). It can run on the old box before retirement, or later anywhere the
+resurrection kit + db snapshot are restored - so this step does NOT block
+Step 5.
+
+```sh
+cd <arx1 game dir>
+<venv>/bin/python arx1_static_export.py --out ~/arx1-site
+# spot-check ~/arx1-site in a browser (python -m http.server), then pack:
+tar -C ~/arx1-site -cf - . | zstd -19 --long=27 -T0 -o arx1-site-export.tar.zst
+sha256sum arx1-site-export.tar.zst > arx1-site-export.tar.zst.sha256
+```
+
+Upload both files to the PRIMARY bucket as `arx1/arx1-site-export.tar.zst` and
+`...tar.zst.sha256` (rclone as in Step 2; copy them to R2 too for safety). The
+sync role expects `index.html` at the tarball ROOT and refuses a tree without
+it.
+
+## Step 4 - serve it from the Arx II box
+
+1. Generate the shared credential's hash: `caddy hash-password` (any machine
+   with caddy; the password itself goes wherever you share such things).
+2. Set the gated `prod` Environment secret `ARXII_ARX1_ARCHIVE_BASICAUTH_HASH`
+   to that hash. This secret is the vhost's enable switch: while it is unset,
+   converges render no archive vhost at all (optional posture, like
+   `ARXII_SENTRY_DSN` - a clean converge, not a refused one).
+3. Press the button ("Stand up infra") with **Also pull the static Arx I
+   archive export** checked. The tofu step creates the `archive.<domain>` DNS
+   records; the caddy role renders the basic-auth vhost (login `archive`,
+   password per the hash) and issues its cert; the `arx1_archive` role pulls
+   the export from the bucket, verifies its checksum, and installs it at
+   `/srv/arx1-archive`.
+4. Browse `https://archive.<domain>/`, authenticate, spot-check an event page.
+
+Re-running after a re-uploaded export: press the button with the same checkbox
+again (the sync is a re-runnable oneshot). The vhost itself needs no checkbox;
+it converges every deploy once the secret exists.
+
+## Step 5 - retire the Arx I Linode
+
+Gate deletion on ALL of:
+
+- [ ] `arx1-upload.sh` finished green (both remotes byte-verified), and the
+      objects are visible in both dashboards under `arx1/`.
+- [ ] The GM tarball's file list was eyeballed (`zstd -dc --long=27 <gm>.tar.zst
+      | tar -tf - | head`) and really is the GM set, and the public tarball
+      really is the public set.
+- [ ] Optionally: a third copy pulled to a personal machine (a full 3-2-1 for
+      data that will never change again).
+
+Then: power the Linode off, wait a short grace window if wanted (a powered-off
+Linode still bills - keep it short or skip it; the verified copies are the real
+safety), and delete the instance. Cancel any Arx I-only ancillary services
+(its backups add-on, orphaned volumes/IPs).
+
+## Making it playable again someday (deliberately deferred)
+
+The resurrection kit preserves the option without keeping anything running:
+game code + venv (actual bytes, not just a pip freeze that trusts PyPI
+forever), interpreter version, service/webserver configs, crontab, plus the db
+snapshot and logs beside it. Standing it back up means: restore kit + db onto
+any box (the Arx II host has headroom - mind the port map), point its settings
+at the restored sqlite, run it read-only or live. No part of the archive
+pipeline needs to be undone first. If people actually start playing there
+again, revisit backups - "frozen forever" stops being true at that point.

--- a/infra/README.md
+++ b/infra/README.md
@@ -174,6 +174,12 @@ disables the feature, never refuses the converge — `secrets_vault`'s
   `SENTRY_ENVIRONMENT` (prod: `production`; rehearsal: `rehearsal`) and
   `SENTRY_RELEASE` (the deployed commit SHA, stamped by `app_deploy` after
   checkout) are derived on-box, not operator-supplied.
+- `ARXII_ARX1_ARCHIVE_BASICAUTH_HASH` — bcrypt hash (from `caddy
+  hash-password`) of the shared password for the read-only Arx I archive
+  site. Caddy-step-only: read via `lookup('env', ...)` in `roles/caddy`'s
+  defaults, never written on-box (it configures Caddy, not the app). Unset
+  means the `archive.<domain>` vhost is simply not rendered. See "Arx I
+  archive" below and `docs/operations/arx1-archival.md`.
 
 **Pre-stored by the operator — ansible-step-only, never written to the app's
 own EnvironmentFile (#3153; a third category alongside "on-box runtime"
@@ -683,6 +689,26 @@ recovery-only, so:
   rehearsal" above).
 - Watched by the off-box heartbeat (`roles/offbox_alerting`) alongside
   `arxii-backup.service`/`arxii-offsite.service`.
+
+## Arx I archive (`archive.<domain>`, read-only, basic auth)
+
+The retired Arx I game's history lives in both backup buckets under the
+`arx1/` prefix (sqlite snapshot, rpevent logs, resurrection kit — uploaded
+and byte-verified by `infra/scripts/arx1/`), and a static export of its
+website is served by the Arx II box's Caddy behind basic auth. Two levers:
+
+- **Vhost**: `roles/caddy` renders the `archive.<domain>` site block only
+  when the optional `ARXII_ARX1_ARCHIVE_BASICAUTH_HASH` gated-Environment
+  secret is set (a bcrypt hash from `caddy hash-password`) — unset means no
+  vhost, a clean converge (same posture as `ARXII_SENTRY_DSN`).
+- **Content**: `roles/arx1_archive` (`never`-tagged, like content_repo)
+  pulls `arx1/arx1-site-export.tar.zst` from the primary bucket, verifies
+  its checksum, and installs it at `/srv/arx1-archive` — the button's
+  "Also pull the static Arx I archive export" checkbox.
+
+The GM/OOC rpevent logs are backup-only and never served. Full runbook
+(freeze, upload, export, serve, Linode teardown):
+`docs/operations/arx1-archival.md`; decision: ADR-0225.
 
 ## Known gap: Object Lock
 

--- a/infra/ansible/group_vars/secrets.env.example
+++ b/infra/ansible/group_vars/secrets.env.example
@@ -45,6 +45,15 @@
 #   ARXII_SENTRY_DSN  (Sentry error/performance monitoring DSN; settings.py
 #                      only calls sentry_sdk.init() when this is non-empty)
 #
+# CADDY-STEP-ONLY, OPTIONAL — read directly via lookup('env', ...) in
+# roles/caddy/defaults (never in secrets_map, never in /etc/arxii/arxii.env:
+# it configures Caddy, not the app). Missing/empty means the Arx I archive
+# vhost is simply not rendered — a clean converge, not a refused one. Set it
+# to roll the archive out (docs/operations/arx1-archival.md):
+#   ARXII_ARX1_ARCHIVE_BASICAUTH_HASH  (bcrypt hash of the shared archive
+#                                       password, from `caddy hash-password`
+#                                       — the HASH, never the password)
+#
 # ANSIBLE-STEP-ONLY, NEVER ON-BOX (#3153) — reaches the ansible-playbook
 # step's env exactly like the ON-BOX set above, but is deliberately NEVER
 # written into secrets_map/the box's own EnvironmentFile (/etc/arxii/

--- a/infra/ansible/roles/arx1_archive/defaults/main.yml
+++ b/infra/ansible/roles/arx1_archive/defaults/main.yml
@@ -1,0 +1,30 @@
+---
+# On-demand (site.yml tags this role `never` + `arx1_archive`, like
+# content_repo): it runs only when an operator explicitly passes
+# `--tags arx1_archive` — standup.yml's `run_arx1_archive_sync` input, via
+# standup.sh. The Arx I archive is a one-time historical import, not an
+# every-deploy concern; see docs/operations/arx1-archival.md for the whole
+# freeze -> upload -> serve pipeline this is the last leg of.
+#
+# Kept impossible in rehearsal even if `--tags arx1_archive` were passed
+# there by mistake: the source bucket + its writer credential are
+# prod-adjacent (same reasoning content_repo_enabled documents for the
+# GitHub PAT). rehearse.sh's generated group_vars never sets this true...
+# and does not need to set it false either — the `never` tag already keeps
+# the role dormant; this var is the belt to that suspender.
+arx1_archive_enabled: true
+
+# Where the site lands. Must match roles/caddy's caddy_archive_root (the
+# vhost's file_server root) — both default to the same path on purpose.
+arx1_archive_root: /srv/arx1-archive
+
+# Source object: the static-site export tarball the Arx I freeze pipeline
+# uploaded (infra/scripts/arx1/ + the runbook). Lives in the PRIMARY backups
+# bucket under its own prefix; the R2 copy of the same object is the offsite
+# backup, not this sync's source. Bucket/endpoint/region reuse the backups
+# group_vars standup.sh already generates — same bucket, same on-box writer
+# credential (BACKUP_WRITER_* in /etc/arxii/arxii.env).
+arx1_archive_bucket: "{{ backups_bucket }}"
+arx1_archive_s3_endpoint: "{{ backups_s3_endpoint }}"
+arx1_archive_region: "{{ backups_region }}"
+arx1_archive_object: "arx1/arx1-site-export.tar.zst"

--- a/infra/ansible/roles/arx1_archive/handlers/main.yml
+++ b/infra/ansible/roles/arx1_archive/handlers/main.yml
@@ -1,0 +1,4 @@
+---
+- name: Reload systemd
+  ansible.builtin.systemd_service:
+    daemon_reload: true

--- a/infra/ansible/roles/arx1_archive/meta/main.yml
+++ b/infra/ansible/roles/arx1_archive/meta/main.yml
@@ -1,0 +1,11 @@
+---
+galaxy_info:
+  role_name: arx1_archive
+  author: Arx II
+  description: One-shot pull of the static Arx I archive site from the backups bucket onto the box (Caddy serves it; roles/caddy owns the vhost).
+  license: proprietary
+  min_ansible_version: "2.15"
+  platforms:
+    - name: Ubuntu
+      versions: [noble]
+dependencies: []

--- a/infra/ansible/roles/arx1_archive/tasks/main.yml
+++ b/infra/ansible/roles/arx1_archive/tasks/main.yml
@@ -1,0 +1,55 @@
+---
+# On-demand one-shot (see defaults/main.yml): pull the static Arx I archive
+# export out of the primary backups bucket, verify its checksum, and install
+# it under the Caddy vhost's web root. The vhost itself (basic auth, TLS,
+# headers) belongs to roles/caddy; this role only delivers content. Full
+# pipeline: docs/operations/arx1-archival.md.
+
+- name: Zstd present (the archive tarball is .tar.zst)
+  ansible.builtin.apt:
+    name: [zstd]
+    state: present
+    update_cache: true
+    cache_valid_time: 3600
+    lock_timeout: 600
+
+- name: Install the sync script
+  ansible.builtin.template:
+    src: arx1-archive-sync.sh.j2
+    dest: /usr/local/sbin/arx1-archive-sync
+    owner: root
+    group: root
+    mode: "0750"
+
+# A oneshot unit rather than running the script straight from Ansible: the
+# bucket credential lives in the vault EnvironmentFile, and a systemd
+# EnvironmentFile is the established way creds reach a job on this box (see
+# roles/backups) — the key never transits Ansible's process environment.
+- name: Install the sync service (reads the EnvironmentFile for creds)
+  ansible.builtin.copy:
+    dest: /etc/systemd/system/arx1-archive-sync.service
+    owner: root
+    group: root
+    mode: "0644"
+    content: |
+      [Unit]
+      Description=Arx I static archive - pull + verify + install from the backups bucket
+      [Service]
+      Type=oneshot
+      EnvironmentFile={{ secrets_env_file | default('/etc/arxii/arxii.env') }}
+      ExecStart=/usr/local/sbin/arx1-archive-sync
+  notify: Reload systemd
+
+- name: Reload systemd before starting (the unit may be new this run)
+  ansible.builtin.meta: flush_handlers
+
+# Starting a Type=oneshot unit (no RemainAfterExit) BLOCKS until the job
+# exits and propagates its failure, so this task IS the sync, not a
+# fire-and-forget. Re-running the role re-runs the sync — that is the
+# point of invoking `--tags arx1_archive` again after re-uploading a
+# corrected export.
+- name: Run the sync (blocks until the oneshot exits; fails loudly)
+  ansible.builtin.systemd_service:
+    name: arx1-archive-sync.service
+    state: started
+  changed_when: true

--- a/infra/ansible/roles/arx1_archive/templates/arx1-archive-sync.sh.j2
+++ b/infra/ansible/roles/arx1_archive/templates/arx1-archive-sync.sh.j2
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Managed by Ansible (arx1_archive). One-shot: pull the static Arx I archive
+# site export from the primary backups bucket, verify its checksum, and swap
+# it into the Caddy-served web root. Read-only against the bucket — never
+# deletes remote objects. Safe to re-run: the end state is the freshly
+# verified export, whatever was there before.
+set -euo pipefail
+
+# Creds come from the systemd unit's EnvironmentFile (/etc/arxii/arxii.env):
+# the on-box bucket-scoped writer key the backups job already uses.
+export AWS_ACCESS_KEY_ID="${BACKUP_WRITER_ACCESS_KEY:?BACKUP_WRITER_ACCESS_KEY missing from environment}"
+export AWS_SECRET_ACCESS_KEY="${BACKUP_WRITER_SECRET_KEY:?BACKUP_WRITER_SECRET_KEY missing from environment}"
+
+endpoint="{{ arx1_archive_s3_endpoint }}"
+region="{{ arx1_archive_region }}"
+src="s3://{{ arx1_archive_bucket }}/{{ arx1_archive_object }}"
+dest="{{ arx1_archive_root }}"
+obj="$(basename "{{ arx1_archive_object }}")"
+
+# /var/tmp, not /tmp: /tmp may be tmpfs, and the extracted site should not
+# have to fit in RAM.
+work="$(mktemp -d /var/tmp/arx1-archive-sync.XXXXXX)"
+trap 'rm -rf "${work}"' EXIT
+
+aws --endpoint-url "${endpoint}" --region "${region}" s3 cp "${src}" "${work}/${obj}"
+aws --endpoint-url "${endpoint}" --region "${region}" s3 cp "${src}.sha256" "${work}/${obj}.sha256"
+(cd "${work}" && sha256sum -c "${obj}.sha256")
+
+mkdir "${work}/site"
+# The tarball root IS the site root (index.html at top level) — the freeze
+# pipeline's export step packs it that way; see the runbook. --long=27
+# mirrors the compression side (infra/scripts/arx1/): long-window zstd
+# frames refuse to decompress without it ("Frame requires too much memory").
+zstd -dc --long=27 "${work}/${obj}" | tar -xf - -C "${work}/site"
+if [ ! -e "${work}/site/index.html" ]; then
+  echo "extracted tree has no top-level index.html — refusing to install" >&2
+  exit 1
+fi
+chmod -R a+rX "${work}/site"
+
+# Swap. ${work} may sit on a different filesystem, so stage the tree beside
+# the destination first; the two mv renames are then atomic each, and the
+# only transient state a concurrent request can see is "site briefly absent"
+# (a 404), never a half-written mix. The old-tree mv must come first — mv
+# onto an EXISTING directory would move the new tree INSIDE it instead of
+# replacing it.
+rm -rf "${dest}.new" "${dest}.old"
+cp -a "${work}/site" "${dest}.new"
+if [ -e "${dest}" ]; then mv "${dest}" "${dest}.old"; fi
+mv "${dest}.new" "${dest}"
+rm -rf "${dest}.old"
+
+echo "arx1 archive installed at ${dest} ($(du -sh "${dest}" | cut -f1))"

--- a/infra/ansible/roles/caddy/defaults/main.yml
+++ b/infra/ansible/roles/caddy/defaults/main.yml
@@ -19,10 +19,10 @@ caddy_backend: "127.0.0.1:4001"         # localhost-bound Django/web app backend
 # Evennia portal websocket, localhost-bound. Templated into the Caddyfile's
 # @ws route exactly like caddy_backend above (a single whole-address token,
 # not "host:{{ var }}" split across a literal host and a templated port) —
-# CI's validate.yml stubs every WHOLE `{{ ... }}` substitution with one
-# hostname placeholder (`placeholder.example.com`) before running `caddy
-# adapt`, and a bare hostname is itself a valid reverse_proxy upstream (no
-# port = Caddy's default), so this form survives that stub. The old
+# CI's validate.yml stubs every WHOLE `{{ ... }}` substitution with a
+# unique placeholder hostname (`placeholderN.example.com`) before running
+# `caddy adapt`, and a bare hostname is itself a valid reverse_proxy
+# upstream (no port = Caddy's default), so this form survives that stub. The old
 # "port-only var, hardcoded host" split would NOT have survived it (that's
 # why it used to be informational-only) — keep this as a whole address.
 caddy_ws_backend: "127.0.0.1:4002"
@@ -38,6 +38,30 @@ caddy_static_root: "/opt/arxii/current/src/server/.static"
 # DNS-edit-scoped Cloudflare token supplied via env (CADDY_CF_DNS_TOKEN),
 # which is a NEW on-box secret to add to the gated-Environment contract.
 caddy_acme_email: "ops@example"
+# --- Arx I static archive vhost (docs/operations/arx1-archival.md) ----------
+# A second, static-only site block: the read-only Arx I historical archive,
+# served straight from disk behind basic auth. Enabled only when ALL of:
+# not rehearsal (the hash secret is prod-adjacent), the fqdn is wired
+# (standup.sh writes it from `tofu output archive_fqdn`), and the operator
+# has set the ARXII_ARX1_ARCHIVE_BASICAUTH_HASH gated-Environment secret
+# (a bcrypt hash from `caddy hash-password`). A missing secret means
+# "archive not rolled out yet" — a clean converge with no archive vhost,
+# NOT a refused one. This is deliberately the secrets_map_optional posture
+# (see roles/secrets_vault), not the fail-closed secrets_map one, and the
+# var is read here directly (like the DNS-01 token) because it configures
+# Caddy, never the app — it has no business in /etc/arxii/arxii.env.
+# NOTE: consume caddy_archive_enabled with `| bool` — the folded expression
+# renders to the STRING "True"/"False", and a bare `{% if %}` on a non-empty
+# string is always truthy.
+caddy_archive_fqdn: "" # = tofu output archive_fqdn (via generated group_vars)
+caddy_archive_root: /srv/arx1-archive
+caddy_archive_basicauth_user: archive
+caddy_archive_basicauth_hash: "{{ lookup('env', 'ARXII_ARX1_ARCHIVE_BASICAUTH_HASH') }}"
+caddy_archive_enabled: >-
+  {{ (not caddy_rehearsal_mode)
+     and (caddy_archive_fqdn | length > 0)
+     and (caddy_archive_basicauth_hash | length > 0) }}
+
 # #2236 Phase 3 P1 (dress rehearsal). When true: deploy Caddyfile.rehearsal.j2
 # (local_certs, no DNS-01) instead of Caddyfile.j2, and skip the
 # caddy-dns/cloudflare plugin steps below (not needed without acme_dns —

--- a/infra/ansible/roles/caddy/tasks/main.yml
+++ b/infra/ansible/roles/caddy/tasks/main.yml
@@ -166,6 +166,21 @@
   notify: Restart caddy
   when: not caddy_rehearsal_mode
 
+# --- Arx I static archive web root ------------------------------------------
+# The archive site block (rendered only when caddy_archive_enabled — see
+# defaults) points file_server at this root, so it must exist before the
+# Caddyfile deploys. CONTENT arrives separately, via the on-demand
+# arx1_archive role (`--tags arx1_archive`), not here — a converge before
+# the first content sync just serves authenticated 404s, which is fine.
+- name: Arx I archive web root exists (content arrives via arx1_archive)
+  ansible.builtin.file:
+    path: "{{ caddy_archive_root }}"
+    state: directory
+    owner: root
+    group: root
+    mode: "0755"
+  when: caddy_archive_enabled | bool
+
 - name: Deploy Caddyfile (validated before reload)
   ansible.builtin.template:
     # `caddy validate` PROVISIONS modules, it does not merely parse — the

--- a/infra/ansible/roles/caddy/templates/Caddyfile.j2
+++ b/infra/ansible/roles/caddy/templates/Caddyfile.j2
@@ -31,11 +31,12 @@
 		# whole-address token (roles/caddy/defaults/main.yml's
 		# caddy_ws_backend) exactly like the plain-handle block's
 		# caddy_backend below — CI's validate.yml stubs each entire Jinja
-		# substitution with one hostname placeholder before running caddy
-		# adapt, and a bare hostname is a valid reverse_proxy upstream on its
-		# own, so this survives that stub (a split host-colon-templated-port
-		# form would not have). Caddy handles the Upgrade handshake
-		# automatically; no extra config needed for the WS proxy.
+		# substitution with a unique placeholder hostname before running
+		# caddy adapt, and a bare hostname is a valid reverse_proxy upstream
+		# on its own, so this survives that stub (a split
+		# host-colon-templated-port form would not have). Caddy handles the
+		# Upgrade handshake automatically; no extra config needed for the WS
+		# proxy.
 		reverse_proxy {{ caddy_ws_backend }} {
 			# Trust only Cloudflare (the firewall only admits Cloudflare to
 			# 80/443) — {remote_host} would always be the CF edge IP, never
@@ -61,3 +62,31 @@
 		}
 	}
 }
+{% if caddy_archive_enabled | bool %}
+
+# Arx I static archive — read-only historical pages rendered from the Arx I
+# sqlite DB (docs/operations/arx1-archival.md), served straight from disk:
+# no backend, no websocket, no Django. basic_auth because much of this
+# content was login-gated on the original site; X-Robots-Tag keeps crawlers
+# out even if the credential ever leaks into a URL. Jinja control-flow lines
+# in this template must sit ALONE on their own lines — CI's validate.yml
+# drops such lines wholesale before `caddy adapt`, so this block is always
+# validated. (`| bool` is load-bearing: caddy_archive_enabled renders as the
+# STRING "True"/"False" — see roles/caddy/defaults/main.yml.)
+{{ caddy_archive_fqdn }} {
+	encode zstd gzip
+	header {
+		Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		X-Robots-Tag "noindex, nofollow"
+		-Server
+	}
+	basic_auth {
+		{{ caddy_archive_basicauth_user }} {{ caddy_archive_basicauth_hash }}
+	}
+	root * {{ caddy_archive_root }}
+	file_server
+}
+{% endif %}

--- a/infra/ansible/roles/caddy/templates/Caddyfile.rehearsal.j2
+++ b/infra/ansible/roles/caddy/templates/Caddyfile.rehearsal.j2
@@ -38,9 +38,9 @@
 		# Evennia portal websocket, localhost-bound. Templated as a single
 		# whole-address token exactly like the plain-handle block's
 		# caddy_backend below — CI's validate.yml stubs each entire Jinja
-		# substitution with one hostname placeholder before running caddy
-		# adapt, and a bare hostname is a valid reverse_proxy upstream on its
-		# own, so this survives that stub.
+		# substitution with a unique placeholder hostname before running
+		# caddy adapt, and a bare hostname is a valid reverse_proxy upstream
+		# on its own, so this survives that stub.
 		reverse_proxy {{ caddy_ws_backend }} {
 			# No Cloudflare in front during rehearsal — smoke.sh runs ON the
 			# stage box itself (over SSH, host_firewall's Cloudflare-only
@@ -65,3 +65,30 @@
 		}
 	}
 }
+{% if caddy_archive_enabled | bool %}
+
+# Arx I static archive — kept in lockstep with Caddyfile.j2 (see its block
+# comment). Never actually rendered in rehearsal: caddy_archive_enabled is
+# hard-false there (its defaults expression includes `not
+# caddy_rehearsal_mode`, and the stage box holds no
+# ARXII_ARX1_ARCHIVE_BASICAUTH_HASH secret anyway — prod-adjacent, by the
+# isolation doctrine). Present so the two templates stay the same site set,
+# and CI's validate.yml (which drops control-flow lines before adapt) still
+# validates this block's shape against the stock binary.
+{{ caddy_archive_fqdn }} {
+	encode zstd gzip
+	header {
+		Strict-Transport-Security "max-age=31536000; includeSubDomains; preload"
+		X-Content-Type-Options "nosniff"
+		X-Frame-Options "DENY"
+		Referrer-Policy "strict-origin-when-cross-origin"
+		X-Robots-Tag "noindex, nofollow"
+		-Server
+	}
+	basic_auth {
+		{{ caddy_archive_basicauth_user }} {{ caddy_archive_basicauth_hash }}
+	}
+	root * {{ caddy_archive_root }}
+	file_server
+}
+{% endif %}

--- a/infra/ansible/site.yml
+++ b/infra/ansible/site.yml
@@ -36,6 +36,14 @@
     # `never`-tagged role simply doesn't run unless asked for, so ordinary
     # deploys (and every other role above/below) are completely unaffected.
     - { role: content_repo, when: content_repo_enabled, tags: [content_repo, never] }
+    # Arx I static-archive content sync — same on-demand idiom as
+    # content_repo above (`never` tag; runs only with `--tags arx1_archive`,
+    # standup.yml's `run_arx1_archive_sync` input): a one-time historical
+    # import, not an every-deploy concern. The vhost that SERVES the content
+    # is roles/caddy's (every deploy, gated on the basic-auth hash secret);
+    # this role only pulls the export out of the backups bucket. See
+    # docs/operations/arx1-archival.md.
+    - { role: arx1_archive, when: arx1_archive_enabled, tags: [arx1_archive, never] }
     - backups
     # #2236 Phase 3 P1: skipped entirely in rehearsal (offsite_enabled: false
     # — the R2 credential is prod-adjacent; see roles/offsite_replication's

--- a/infra/scripts/arx1/arx1-freeze.sh
+++ b/infra/scripts/arx1/arx1-freeze.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# arx1-freeze.sh — one-time freeze of the Arx I game data into durable,
+# checksummed archive artifacts. Runs ON the Arx I host (copy this file
+# there), NOT on the Arx II box and not in a devcontainer. Produces, under
+# $ARX1_OUT:
+#
+#   arx1-final-<date>.sqlite3.zst          consistent, vacuumed sqlite snapshot
+#   arx1-rpevents-public-<date>.tar.zst    public rpevent logs
+#   arx1-rpevents-gm-<date>.tar.zst        GM/OOC rpevent logs — PRIVATE:
+#                                          backup-only, never served from the
+#                                          archive site
+#   arx1-resurrection-kit-<date>.tar.zst   game dir (venv included) + configs +
+#                                          pip freeze + service/cron state:
+#                                          everything needed to ever run the
+#                                          game again
+#   SHA256SUMS, README.txt
+#
+# Compression is LOSSLESS at every level — max settings cost CPU once, never
+# fidelity. Separate tarballs on purpose: corruption in one compressed
+# stream cannot take the others with it, and the GM set can never ship
+# accidentally with anything public-facing.
+#
+# Companion: arx1-upload.sh pushes the lot to both buckets and verifies.
+# Full runbook: docs/operations/arx1-archival.md.
+set -euo pipefail
+
+: "${ARX1_GAME_DIR:?set ARX1_GAME_DIR to the Arx I game directory (the evennia game dir)}"
+: "${ARX1_LOG_DIR:?set ARX1_LOG_DIR to the directory holding the rpevent logs}"
+ARX1_DB="${ARX1_DB:-${ARX1_GAME_DIR}/server/evennia.db3}"
+# Filename pattern (a `find -name` glob, matched within ARX1_LOG_DIR) that
+# identifies the GM/OOC variant of each event log. Everything else in the
+# log dir counts as public. CHECK THIS against the real filenames before
+# running — a wrong glob silently misfiles GM logs as public.
+ARX1_GM_LOG_GLOB="${ARX1_GM_LOG_GLOB:-*_gm*}"
+ARX1_VENV="${ARX1_VENV:-}" # optional: the game's virtualenv, for pip freeze
+ARX1_OUT="${ARX1_OUT:-${HOME}/arx1-freeze}"
+
+# -19: max practical level. --long=27: 128MB match window — event logs
+# repeat heavily across files, and a long window lets zstd deduplicate
+# across the whole tar stream. NOTE: decompression needs the same flag
+# (`zstd -d --long=27`), recorded in README.txt below.
+ZSTD_ARGS=(-19 --long=27 -T0)
+
+for tool in sqlite3 zstd tar sha256sum; do
+  command -v "${tool}" >/dev/null 2>&1 || {
+    echo "required tool '${tool}' not found — install it first (apt install ${tool})" >&2
+    exit 1
+  }
+done
+[ -f "${ARX1_DB}" ] || { echo "ARX1_DB not found: ${ARX1_DB}" >&2; exit 1; }
+[ -d "${ARX1_LOG_DIR}" ] || { echo "ARX1_LOG_DIR not found: ${ARX1_LOG_DIR}" >&2; exit 1; }
+
+date_tag="$(date +%Y%m%d)"
+mkdir -p "${ARX1_OUT}"
+cd "${ARX1_OUT}"
+
+echo "== 1/4 sqlite snapshot =="
+# .backup uses sqlite's online-backup API: a CONSISTENT copy even if the
+# game is still running (a raw `cp` of a live db is not). VACUUM then drops
+# years of free pages from the copy before compression even starts.
+db_snap="arx1-final-${date_tag}.sqlite3"
+rm -f "${db_snap}"
+sqlite3 "${ARX1_DB}" ".backup '${ARX1_OUT}/${db_snap}'"
+sqlite3 "${ARX1_OUT}/${db_snap}" "VACUUM;"
+integrity="$(sqlite3 "${ARX1_OUT}/${db_snap}" "PRAGMA integrity_check;")"
+[ "${integrity}" = "ok" ] || { echo "sqlite integrity_check failed: ${integrity}" >&2; exit 1; }
+zstd "${ZSTD_ARGS[@]}" --rm -f "${db_snap}" -o "${db_snap}.zst"
+echo "   ${db_snap}.zst ($(du -h "${db_snap}.zst" | cut -f1))"
+
+echo "== 2/4 rpevent logs (public / gm split) =="
+gm_list="${ARX1_OUT}/gm-files.txt"
+public_list="${ARX1_OUT}/public-files.txt"
+(cd "${ARX1_LOG_DIR}" && find . -type f -name "${ARX1_GM_LOG_GLOB}" | sort) > "${gm_list}"
+(cd "${ARX1_LOG_DIR}" && find . -type f ! -name "${ARX1_GM_LOG_GLOB}" | sort) > "${public_list}"
+gm_count="$(wc -l < "${gm_list}")"
+public_count="$(wc -l < "${public_list}")"
+echo "   ${public_count} public files, ${gm_count} gm files (glob: ${ARX1_GM_LOG_GLOB})"
+if [ "${gm_count}" -eq 0 ]; then
+  echo "   WARNING: the GM glob matched NOTHING — if GM logs exist under a" >&2
+  echo "   different naming scheme they are about to land in the PUBLIC" >&2
+  echo "   tarball. Verify ARX1_GM_LOG_GLOB before trusting this run." >&2
+fi
+tar -C "${ARX1_LOG_DIR}" -cf - -T "${public_list}" \
+  | zstd "${ZSTD_ARGS[@]}" -o "arx1-rpevents-public-${date_tag}.tar.zst" -f
+if [ "${gm_count}" -gt 0 ]; then
+  tar -C "${ARX1_LOG_DIR}" -cf - -T "${gm_list}" \
+    | zstd "${ZSTD_ARGS[@]}" -o "arx1-rpevents-gm-${date_tag}.tar.zst" -f
+fi
+
+echo "== 3/4 resurrection kit =="
+# Everything needed to make Arx I PLAYABLE again someday, without
+# archaeology. The venv is included deliberately: pip freeze alone assumes
+# every pinned wheel still exists on PyPI years from now; the venv's actual
+# bytes make no such bet. The db and event logs are excluded — they are the
+# other artifacts.
+kit_extra="${ARX1_OUT}/kit-extra"
+rm -rf "${kit_extra}"
+mkdir -p "${kit_extra}"
+python_bin="python"
+if [ -n "${ARX1_VENV}" ] && [ -x "${ARX1_VENV}/bin/python" ]; then
+  python_bin="${ARX1_VENV}/bin/python"
+  "${ARX1_VENV}/bin/pip" freeze > "${kit_extra}/pip-freeze.txt" || true
+fi
+"${python_bin}" --version > "${kit_extra}/python-version.txt" 2>&1 || true
+crontab -l > "${kit_extra}/crontab.txt" 2>/dev/null || true
+uname -a > "${kit_extra}/uname.txt"
+# Grab whichever webserver/service configs this box actually has.
+for conf_dir in /etc/nginx /etc/apache2 /etc/systemd/system /etc/init.d; do
+  if [ -d "${conf_dir}" ]; then
+    mkdir -p "${kit_extra}/etc"
+    cp -a "${conf_dir}" "${kit_extra}/etc/" 2>/dev/null || true
+  fi
+done
+tar -cf - \
+  --exclude="$(basename "${ARX1_DB}")" \
+  --exclude='*.db3-journal' \
+  -C "$(dirname "${ARX1_GAME_DIR}")" "$(basename "${ARX1_GAME_DIR}")" \
+  -C "${ARX1_OUT}" kit-extra \
+  | zstd "${ZSTD_ARGS[@]}" -o "arx1-resurrection-kit-${date_tag}.tar.zst" -f
+rm -rf "${kit_extra}"
+
+echo "== 4/4 checksums + manifest =="
+cat > README.txt <<EOF
+Arx I archive freeze — generated ${date_tag} on $(hostname) by arx1-freeze.sh.
+
+Contents:
+  arx1-final-${date_tag}.sqlite3.zst        the game database (sqlite,
+                                            .backup + VACUUM + integrity_check ok)
+  arx1-rpevents-public-${date_tag}.tar.zst  public rpevent logs (${public_count} files)
+  arx1-rpevents-gm-${date_tag}.tar.zst      GM/OOC rpevent logs (${gm_count} files) —
+                                            PRIVATE, backup-only, never serve
+  arx1-resurrection-kit-${date_tag}.tar.zst game dir incl. venv, pip freeze,
+                                            python/uname versions, crontab,
+                                            /etc service+webserver configs
+
+To decompress (the --long flag is REQUIRED — these are long-window frames):
+  zstd -d --long=27 <file>.zst
+  zstd -dc --long=27 <file>.tar.zst | tar -xf -
+
+Verify before trusting anything:
+  sha256sum -c SHA256SUMS
+
+Log paths inside the rpevent tarballs are relative to: ${ARX1_LOG_DIR}
+Game dir was: ${ARX1_GAME_DIR}
+GM-vs-public split used the filename glob: ${ARX1_GM_LOG_GLOB}
+EOF
+rm -f SHA256SUMS
+sha256sum ./*.zst README.txt > SHA256SUMS
+
+echo
+echo "Freeze complete in ${ARX1_OUT}:"
+du -h ./*.zst | sed 's/^/   /'
+echo "Next: arx1-upload.sh (see docs/operations/arx1-archival.md)."

--- a/infra/scripts/arx1/arx1-upload.sh
+++ b/infra/scripts/arx1/arx1-upload.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# arx1-upload.sh — push the arx1-freeze.sh artifacts to BOTH buckets (the
+# primary Linode backups bucket and the independent R2 offsite copy) under
+# the arx1/ prefix, then verify every object by re-downloading and comparing
+# bytes. Runs wherever the freeze artifacts are (the Arx I host, or a
+# machine you rsync'd them to). Never deletes remote objects.
+#
+# Uses rclone: a single static binary that runs on any distro vintage
+# (https://rclone.org/install.sh), configured entirely from env vars below —
+# no rclone.conf on disk, so no credential is ever written to the old box.
+#
+# Credentials: create/scoped per docs/operations/arx1-archival.md — the
+# Linode pair must reach only the backups bucket; the R2 pair only the
+# offsite bucket. Both already exist for the Arx II box; for this one-time
+# push either reuse them or mint a fresh pair and revoke after.
+set -euo pipefail
+
+ARX1_OUT="${ARX1_OUT:-${HOME}/arx1-freeze}"
+: "${LINODE_BUCKET:?e.g. the tofu output backups_bucket}"
+: "${LINODE_ENDPOINT:?e.g. https://us-east-1.linodeobjects.com (tofu output backups_s3_endpoint)}"
+: "${LINODE_ACCESS_KEY:?bucket-scoped access key}"
+: "${LINODE_SECRET_KEY:?bucket-scoped secret key}"
+: "${R2_BUCKET:?e.g. the tofu output r2_offsite_bucket}"
+: "${R2_ENDPOINT:?https://<account-id>.r2.cloudflarestorage.com (tofu output r2_s3_endpoint)}"
+: "${R2_ACCESS_KEY:?R2 S3 access key}"
+: "${R2_SECRET_KEY:?R2 S3 secret key}"
+
+command -v rclone >/dev/null 2>&1 || {
+  echo "rclone not found — install the static binary first: https://rclone.org/install.sh" >&2
+  exit 1
+}
+[ -f "${ARX1_OUT}/SHA256SUMS" ] || {
+  echo "no SHA256SUMS in ${ARX1_OUT} — run arx1-freeze.sh first" >&2
+  exit 1
+}
+
+# Local self-check before anything leaves the box: never upload artifacts
+# that do not match their own manifest.
+(cd "${ARX1_OUT}" && sha256sum -c SHA256SUMS)
+
+# Env-var remote config (rclone reads RCLONE_CONFIG_<NAME>_<KEY>).
+export RCLONE_CONFIG_LINODE_TYPE=s3
+export RCLONE_CONFIG_LINODE_PROVIDER=Other
+export RCLONE_CONFIG_LINODE_ENDPOINT="${LINODE_ENDPOINT}"
+export RCLONE_CONFIG_LINODE_ACCESS_KEY_ID="${LINODE_ACCESS_KEY}"
+export RCLONE_CONFIG_LINODE_SECRET_ACCESS_KEY="${LINODE_SECRET_KEY}"
+export RCLONE_CONFIG_R2_TYPE=s3
+export RCLONE_CONFIG_R2_PROVIDER=Cloudflare
+export RCLONE_CONFIG_R2_ENDPOINT="${R2_ENDPOINT}"
+export RCLONE_CONFIG_R2_ACCESS_KEY_ID="${R2_ACCESS_KEY}"
+export RCLONE_CONFIG_R2_SECRET_ACCESS_KEY="${R2_SECRET_KEY}"
+
+for remote in "linode:${LINODE_BUCKET}/arx1" "r2:${R2_BUCKET}/arx1"; do
+  echo "== upload -> ${remote%%:*} =="
+  rclone copy --progress "${ARX1_OUT}" "${remote}"
+  # --download: re-fetch every object and compare actual bytes, not just
+  # S3 etags (multipart etags are not md5s, so etag comparison can lie).
+  # This IS the "verify by re-download before the Linode dies" step.
+  echo "== verify (byte-for-byte re-download) <- ${remote%%:*} =="
+  rclone check --download "${ARX1_OUT}" "${remote}"
+done
+
+echo
+echo "Both copies uploaded and byte-verified under arx1/."
+echo "The old box is now safe to retire once the archive site export is"
+echo "also up (see docs/operations/arx1-archival.md)."

--- a/infra/scripts/arx1/arx1_static_export.py
+++ b/infra/scripts/arx1/arx1_static_export.py
@@ -65,7 +65,7 @@ from urllib.parse import urldefrag, urljoin, urlsplit
 # logout link would end the crawl session. Extend as the first real run
 # reveals more (the summary prints a sample of skipped URLs).
 SKIP_PATTERNS = [
-    r"^/admin\b",
+    r"^/admin",  # /admin/ AND /admintools/ (staff search tool - no archive value)
     r"^/logout\b",
     r"^/accounts/log",
     r"^/webclient\b",

--- a/infra/scripts/arx1/arx1_static_export.py
+++ b/infra/scripts/arx1/arx1_static_export.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python
+"""arx1_static_export.py - render the Arx I website to a static HTML tree.
+
+DRAFT - written blind against the arxcode repo; test it against the real
+sqlite snapshot before trusting the output (docs/operations/arx1-archival.md
+carries the how). Runs inside the Arx I Django environment (the old box, or
+anywhere the resurrection kit + db snapshot have been restored):
+
+    cd <arx1 game dir>
+    <venv>/bin/python <path>/arx1_static_export.py --out ~/arx1-site
+
+Approach: a breadth-first crawl of the site through Django's test Client -
+no running webserver, no real HTTP - logged in as a staff account so
+login-gated pages (events, rosters, character sheets, lore) render with
+full content. Spoilers are fine (ruling 2026-08-21: anyone with archive
+access may see anything); what keeps strangers out is the basic-auth gate
+on the serving side, not redaction here. GM/OOC event logs are NOT part of
+the website and are not touched by this script - they live only in the
+private backup tarball.
+
+The output tree is pure static files: <path>/index.html per page, ready for
+`tar | zstd` and the arx1_archive role's sync (which expects index.html at
+the tarball root - pack with `tar -C ~/arx1-site -cf - . | zstd -19
+--long=27 -o arx1-site-export.tar.zst`).
+
+Stdlib + Django only - no bs4, no requests - so it runs on the old box's
+venv as-is.
+"""
+
+import argparse
+from collections import deque
+from html.parser import HTMLParser
+import os
+import re
+import shutil
+import sys
+from urllib.parse import urldefrag, urljoin, urlsplit
+
+# Paths never worth crawling: actions, auth churn, admin, and Django's
+# logout would end the crawl session. Extend as the first real run reveals
+# more (the summary prints every skipped-by-rule URL).
+SKIP_PATTERNS = [
+    r"^/admin\b",
+    r"^/logout\b",
+    r"^/accounts/logout\b",
+    r"^/accounts/login\b",
+    r"^/admindocs\b",
+    r"/delete/",
+    r"/edit/",
+    r"/create/",
+    r"\.(?:json|csv|ics)$",
+]
+SKIP_RE = re.compile("|".join(SKIP_PATTERNS))
+
+# Seed URLs. "/" alone reaches most of the site by links; the extras cover
+# index pages that may only be linked from within themselves. TODO(first
+# real run): confirm these against arxcode's urls.py and add any islands
+# (paginated archives whose page-1 is only reachable via redirect, etc.).
+DEFAULT_SEEDS = [
+    "/",
+    "/dominion/events/",
+    "/character/",
+    "/help_topics/",
+    "/news/",
+    "/support/faq/",
+]
+
+
+class LinkExtractor(HTMLParser):
+    """Collect href/src attribute values from an HTML document."""
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self.links = []
+
+    def handle_starttag(self, tag, attrs):
+        for name, value in attrs:
+            if value and name in ("href", "src"):
+                self.links.append(value)
+
+
+def url_to_relpath(path, query):
+    """Map a site URL to a file path inside the static tree.
+
+    /dominion/events/    -> dominion/events/index.html
+    /dominion/events/5   -> dominion/events/5/index.html   (file_server
+    serves the extensionless dir with an implicit index lookup)
+    /foo/?page=2         -> foo/index__page=2.html  (links rewritten to match)
+    /static/css/site.css -> static/css/site.css     (kept verbatim)
+    """
+    path = path.strip("/")
+    last = path.rsplit("/", 1)[-1]
+    if path and "." in last:
+        base = path
+        if query:
+            stem, ext = base.rsplit(".", 1)
+            return "%s__%s.%s" % (stem, sanitize(query), ext)
+        return base
+    base = (path + "/" if path else "") + "index"
+    if query:
+        return "%s__%s.html" % (base, sanitize(query))
+    return base + ".html"
+
+
+def sanitize(query):
+    return re.sub(r"[^A-Za-z0-9=_-]", "_", query)
+
+
+def rewrite_links(html, mapping):
+    """Point query-string links at their exported filenames.
+
+    Plain path links need no rewriting (the tree mirrors the URL space);
+    only ?query URLs get distinct filenames, so only they are rewritten.
+    """
+    for (path, query), relpath in mapping.items():
+        if not query:
+            continue
+        original = "%s?%s" % (path, query)
+        html = html.replace('href="%s"' % original, 'href="/%s"' % relpath)
+        html = html.replace("href='%s'" % original, "href='/%s'" % relpath)
+    return html
+
+
+def copy_tree(src, dst):
+    """shutil.copytree without dirs_exist_ok, which needs Python 3.8+ -
+    the old box's venv may predate it."""
+    for root_dir, _dirs, files in os.walk(src):
+        rel = os.path.relpath(root_dir, src)
+        target_dir = dst if rel == "." else os.path.join(dst, rel)
+        os.makedirs(target_dir, exist_ok=True)
+        for name in files:
+            shutil.copy2(os.path.join(root_dir, name), os.path.join(target_dir, name))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--out", required=True, help="output directory for the static tree")
+    parser.add_argument(
+        "--settings",
+        default="server.conf.settings",
+        help="DJANGO_SETTINGS_MODULE (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--username", default="", help="staff account to crawl as (default: first superuser)"
+    )
+    parser.add_argument("--seed", action="append", default=[], help="extra seed URL(s); repeatable")
+    parser.add_argument(
+        "--max-pages",
+        type=int,
+        default=200000,
+        help="hard stop against crawler traps (default: %(default)s)",
+    )
+    args = parser.parse_args()
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", args.settings)
+    import django
+
+    django.setup()
+
+    from django.conf import settings
+    from django.contrib.auth import get_user_model
+    from django.test import Client
+
+    user_model = get_user_model()
+    if args.username:
+        user = user_model.objects.get(username=args.username)
+    else:
+        user = user_model.objects.filter(is_superuser=True).order_by("pk").first()
+    if user is None:
+        sys.exit("no superuser found - pass --username")
+    print("crawling as %s" % user.username)
+
+    client = Client()
+    client.force_login(user)
+
+    out = os.path.abspath(args.out)
+    os.makedirs(out, exist_ok=True)
+
+    queue = deque((seed, "") for seed in DEFAULT_SEEDS + args.seed)
+    seen = set(queue)
+    mapping = {}  # (path, query) -> relpath
+    html_pages = {}  # relpath -> body (rewritten + written at the end)
+    skipped, errors = [], []
+
+    while queue and len(mapping) < args.max_pages:
+        path, query = queue.popleft()
+        target = "%s?%s" % (path, query) if query else path
+        try:
+            response = client.get(target, follow=True)
+        except Exception as exc:  # noqa: BLE001 - a page that 500s must not kill the crawl
+            errors.append((target, repr(exc)))
+            continue
+        if response.status_code != 200:
+            errors.append((target, "HTTP %s" % response.status_code))
+            continue
+
+        relpath = url_to_relpath(path, query)
+        mapping[(path, query)] = relpath
+        content_type = response.get("Content-Type", "")
+        body = response.content
+
+        if "text/html" in content_type:
+            html = body.decode(response.charset or "utf-8", errors="replace")
+            html_pages[relpath] = html
+            extractor = LinkExtractor()
+            extractor.feed(html)
+            for link in extractor.links:
+                link, _frag = urldefrag(urljoin(path if path.endswith("/") else path + "/", link))
+                parts = urlsplit(link)
+                if parts.scheme or parts.netloc:  # external
+                    continue
+                new_path, new_query = parts.path, parts.query
+                if not new_path.startswith("/") or SKIP_RE.search(new_path):
+                    skipped.append(link)
+                    continue
+                key = (new_path, new_query)
+                if key not in seen:
+                    seen.add(key)
+                    queue.append(key)
+        else:
+            full = os.path.join(out, relpath)
+            os.makedirs(os.path.dirname(full), exist_ok=True)
+            with open(full, "wb") as fh:
+                fh.write(body)
+
+        if len(mapping) % 500 == 0:
+            print("  %d pages exported, %d queued" % (len(mapping), len(queue)))
+
+    for relpath, html in html_pages.items():
+        full = os.path.join(out, relpath)
+        os.makedirs(os.path.dirname(full), exist_ok=True)
+        with open(full, "w", encoding="utf-8") as fh:
+            fh.write(rewrite_links(html, mapping))
+
+    # Static assets straight from disk - the crawl only picks up assets a
+    # page referenced; this sweeps the rest (css url() references etc.).
+    for setting_name, url_prefix in (("STATIC_ROOT", "static"), ("MEDIA_ROOT", "media")):
+        root = getattr(settings, setting_name, "")
+        if root and os.path.isdir(root):
+            dest = os.path.join(out, url_prefix)
+            print("copying %s -> %s" % (root, dest))
+            copy_tree(root, dest)
+
+    print("\nexported %d pages to %s" % (len(mapping), out))
+    print("errors: %d (first 20 below)" % len(errors))
+    for target, err in errors[:20]:
+        print("  %s -> %s" % (target, err))
+    print("skipped-by-rule (sample): %s" % sorted(set(skipped))[:20])
+    if not os.path.exists(os.path.join(out, "index.html")):
+        sys.exit("no top-level index.html was produced - the sync script will refuse this tree")
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/scripts/arx1/arx1_static_export.py
+++ b/infra/scripts/arx1/arx1_static_export.py
@@ -24,6 +24,9 @@ login-gated pages render. Coverage includes the big lore surfaces:
     render inline in the list - there is no per-journal detail URL)
   - events (/dom/cal/list/ + display pages), crises, boards
     (/comms/boards/), help topics, news
+  - a synthetic /lore/ appendix rendered straight from the DB: all
+    mysteries, revelations, and clues (never-discovered ones included,
+    gm_notes included) - none of which had a crawlable surface in Arx I
 
 Crawl as a STAFF account (the default: first superuser). Ruled 2026-08-21:
 everything written with the intent of being read by staff belongs in the
@@ -216,6 +219,179 @@ def extract_links(html, base_path, seen, queue, skipped):
                 queue.append(key)
 
 
+LORE_CSS = (
+    "<style>body{max-width:60em;margin:2em auto;padding:0 1em;"
+    "font-family:Georgia,serif;line-height:1.5;background:#f8f6f0;color:#222}"
+    "h1,h2,h3{font-family:Palatino,Georgia,serif}article{border-bottom:1px solid #ccc;"
+    "margin-bottom:1.5em;padding-bottom:1em}.meta{color:#666;font-size:.9em}"
+    ".herring{color:#a00}.gm{background:#fff3d6;padding:.5em;margin:.5em 0}"
+    ".undiscovered{color:#666;font-style:italic}</style>"
+)
+CLUES_PER_PAGE = 100
+
+
+def write_page(out, relpath, title, body_html):
+    full = os.path.join(out, relpath)
+    os.makedirs(os.path.dirname(full), exist_ok=True)
+    with open(full, "w", encoding="utf-8") as fh:
+        fh.write(
+            "<!doctype html><html><head><meta charset='utf-8'><title>%s</title>%s"
+            "</head><body><p><a href='/lore/'>Lore appendix</a> | <a href='/'>Archive home</a>"
+            "</p>%s</body></html>" % (title, LORE_CSS, body_html)
+        )
+
+
+def export_lore_appendix(out):
+    """Render mysteries/revelations/clues straight from the DB under /lore/.
+
+    Revelations and mysteries never had a web surface in Arx I (telnet
+    investigation commands + Django admin only), and clues only appeared on
+    the sheets of characters who discovered them - so this appendix is the
+    only place never-discovered lore becomes readable without standing the
+    game back up. Ruled in scope 2026-08-21: all of it was staff-intended
+    (gm_notes included). Pages land under /lore/, a prefix arxcode never
+    used, so nothing collides with the crawled tree.
+    """
+    from html import escape
+
+    from web.character.models import Clue, Mystery, Revelation
+
+    def revelation_html(rev):
+        clues = list(rev.clues.all().order_by("rating", "name"))
+        clue_links = ", ".join(
+            "<a href='/lore/clues/#clue-%d'>%s</a>" % (c.id, escape(c.name or "Clue #%d" % c.id))
+            for c in clues
+        )
+        finders = ", ".join(sorted(str(e) for e in rev.characters.all())) or (
+            "<span class='undiscovered'>never discovered</span>"
+        )
+        parts = [
+            "<article id='rev-%d'><h3>%s%s</h3>"
+            % (
+                rev.id,
+                escape(rev.name or "Revelation #%d" % rev.id),
+                " <span class='herring'>(red herring)</span>" if rev.red_herring else "",
+            ),
+            "<div>%s</div>" % escape(rev.desc).replace("\n", "<br>"),
+        ]
+        if rev.gm_notes:
+            parts.append(
+                "<div class='gm'><b>GM notes:</b> %s</div>"
+                % escape(rev.gm_notes).replace("\n", "<br>")
+            )
+        parts.append("<p class='meta'>Clues: %s</p>" % (clue_links or "none"))
+        parts.append("<p class='meta'>Discovered by: %s</p></article>" % finders)
+        return "".join(parts)
+
+    def clue_html(clue):
+        revs = ", ".join(
+            "<a href='/lore/mysteries/#rev-%d'>%s</a>"
+            % (r.id, escape(r.name or "Revelation #%d" % r.id))
+            for r in clue.revelations.all()
+        )
+        finders = ", ".join(sorted(str(e) for e in clue.characters.all())) or (
+            "<span class='undiscovered'>never discovered</span>"
+        )
+        parts = [
+            "<article id='clue-%d'><h3>%s%s</h3>"
+            % (
+                clue.id,
+                escape(clue.name or "Clue #%d" % clue.id),
+                " <span class='herring'>(red herring)</span>" if clue.red_herring else "",
+            ),
+            "<p class='meta'>%s | rating %s</p>" % (clue.get_clue_type_display(), clue.rating),
+            "<div>%s</div>" % escape(clue.desc).replace("\n", "<br>"),
+        ]
+        if clue.gm_notes:
+            parts.append(
+                "<div class='gm'><b>GM notes:</b> %s</div>"
+                % escape(clue.gm_notes).replace("\n", "<br>")
+            )
+        parts.append("<p class='meta'>Revelations: %s</p>" % (revs or "none"))
+        parts.append("<p class='meta'>Discovered by: %s</p></article>" % finders)
+        return "".join(parts)
+
+    # One page for all mysteries + their revelations (there are far fewer of
+    # these than clues), with mystery-less revelations appended at the end.
+    revs_seen = set()
+    sections = []
+    for mystery in Mystery.objects.all().order_by("category", "name"):
+        revs = list(mystery.revelations.all().order_by("name"))
+        revs_seen.update(r.id for r in revs)
+        sections.append(
+            "<section><h2>%s</h2><p class='meta'>%s</p><div>%s</div>%s</section>"
+            % (
+                escape(mystery.name),
+                escape(mystery.category or ""),
+                escape(mystery.desc).replace("\n", "<br>"),
+                "".join(revelation_html(r) for r in revs),
+            )
+        )
+    orphans = Revelation.objects.exclude(id__in=revs_seen).order_by("name")
+    if orphans:
+        sections.append(
+            "<section><h2>Revelations outside any mystery</h2>%s</section>"
+            % "".join(revelation_html(r) for r in orphans)
+        )
+    write_page(
+        out,
+        "lore/mysteries/index.html",
+        "Mysteries and Revelations",
+        "<h1>Mysteries and Revelations</h1>" + "".join(sections),
+    )
+
+    # Clues, paginated by hand (six years of them will not fit one page).
+    # Bare-string prefetch on purpose: this runs against ARX I's Django, not
+    # this repo's - arxcode has no Prefetch-object convention to honor, and
+    # plain M2M prefetches are exactly right for a one-shot full dump.
+    clues = list(
+        Clue.objects.all().order_by("name", "id").prefetch_related("revelations", "characters")  # noqa: PREFETCH_STRING
+    )
+    total_pages = max(1, (len(clues) + CLUES_PER_PAGE - 1) // CLUES_PER_PAGE)
+    for page in range(total_pages):
+        chunk = clues[page * CLUES_PER_PAGE : (page + 1) * CLUES_PER_PAGE]
+        nav = " | ".join(
+            "<b>%d</b>" % (n + 1)
+            if n == page
+            else "<a href='/lore/clues/%s'>%d</a>" % ("" if n == 0 else "page-%d/" % (n + 1), n + 1)
+            for n in range(total_pages)
+        )
+        relpath = (
+            "lore/clues/index.html" if page == 0 else "lore/clues/page-%d/index.html" % (page + 1)
+        )
+        write_page(
+            out,
+            relpath,
+            "Clues (page %d)" % (page + 1),
+            "<h1>All Clues</h1><p class='meta'>Pages: %s</p>%s<p class='meta'>Pages: %s</p>"
+            % (nav, "".join(clue_html(c) for c in chunk), nav),
+        )
+
+    undiscovered = sum(1 for c in clues if not c.characters.all())
+    write_page(
+        out,
+        "lore/index.html",
+        "Lore Appendix",
+        "<h1>Lore Appendix</h1><p>Rendered straight from the game database - "
+        "including lore no player ever found.</p><ul>"
+        "<li><a href='/lore/mysteries/'>Mysteries and revelations</a> (%d mysteries, "
+        "%d revelations)</li>"
+        "<li><a href='/lore/clues/'>All clues</a> (%d clues, %d never discovered, "
+        "%d pages)</li></ul>"
+        % (
+            Mystery.objects.count(),
+            Revelation.objects.count(),
+            len(clues),
+            undiscovered,
+            total_pages,
+        ),
+    )
+    print(
+        "lore appendix: %d mysteries, %d revelations, %d clues (%d never discovered)"
+        % (Mystery.objects.count(), Revelation.objects.count(), len(clues), undiscovered)
+    )
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--out", required=True, help="output directory for the static tree")
@@ -244,6 +420,13 @@ def main():
         type=int,
         default=300000,
         help="hard stop against crawler traps (default: %(default)s)",
+    )
+    parser.add_argument(
+        "--skip-lore-appendix",
+        action="store_true",
+        help="skip the /lore/ appendix (mysteries/revelations/all-clues "
+        "rendered straight from the DB - on by default because that lore "
+        "has no crawlable surface)",
     )
     args = parser.parse_args()
 
@@ -315,6 +498,9 @@ def main():
 
         if exported % 500 == 0:
             print("  %d exported (%d resumed), %d queued" % (exported, resumed, len(queue)))
+
+    if not args.skip_lore_appendix:
+        export_lore_appendix(out)
 
     # Static assets straight from disk - the crawl only picks up assets a
     # page referenced; this sweeps the rest (css url() references etc.).

--- a/infra/scripts/arx1/arx1_static_export.py
+++ b/infra/scripts/arx1/arx1_static_export.py
@@ -25,15 +25,15 @@ login-gated pages render. Coverage includes the big lore surfaces:
   - events (/dom/cal/list/ + display pages), crises, boards
     (/comms/boards/), help topics, news
 
-WHO YOU CRAWL AS decides what the archive contains (pick via --username):
-  - a STAFF account sees everything: secrets and clues on sheets, GM notes,
-    and ALL black (private) journals mixed into the journal list
-    (JournalListView uses all_permitted_journals(user); a fresh account has
-    read nothing, so the "unread" list IS the full list)
-  - a fresh NON-staff account sees white journals only, but also loses the
-    sheet secrets/clues the archive is supposed to keep
-There is no URL-level way to include clues but exclude black journals -
-that choice is the account you crawl with.
+Crawl as a STAFF account (the default: first superuser). Ruled 2026-08-21:
+everything written with the intent of being read by staff belongs in the
+archive - black journals, secrets, clues, GM notes included (all were
+always staff-viewable and known to be). The staff journal list contains
+every black journal because a fresh account has read nothing, so its
+"unread" list IS the full permitted set. The privacy boundary - messengers,
+player-to-player IC mail staff was never meant to read - cannot leak in:
+messengers have no web view in arxcode (model + telnet handler + Django
+admin only, and /admin is skipped).
 
 Runtime expectation for ~6 years of data: tens of thousands to ~150k pages
 at roughly 100-500ms each through the test client = several hours to

--- a/infra/scripts/arx1/arx1_static_export.py
+++ b/infra/scripts/arx1/arx1_static_export.py
@@ -1,22 +1,46 @@
 #!/usr/bin/env python
 """arx1_static_export.py - render the Arx I website to a static HTML tree.
 
-DRAFT - written blind against the arxcode repo; test it against the real
-sqlite snapshot before trusting the output (docs/operations/arx1-archival.md
-carries the how). Runs inside the Arx I Django environment (the old box, or
-anywhere the resurrection kit + db snapshot have been restored):
+DRAFT - seeds and skip rules were written against arxcode's actual urls.py
+files (web/urls.py, web/character/urls.py, world/msgs/urls.py,
+world/dominion/urls.py as of 2026-08), but test a run against the real
+sqlite snapshot before trusting the output. Runs inside the Arx I Django
+environment (the old box, or anywhere the resurrection kit + db snapshot
+have been restored):
 
     cd <arx1 game dir>
     <venv>/bin/python <path>/arx1_static_export.py --out ~/arx1-site
 
 Approach: a breadth-first crawl of the site through Django's test Client -
-no running webserver, no real HTTP - logged in as a staff account so
-login-gated pages (events, rosters, character sheets, lore) render with
-full content. Spoilers are fine (ruling 2026-08-21: anyone with archive
-access may see anything); what keeps strangers out is the basic-auth gate
-on the serving side, not redaction here. GM/OOC event logs are NOT part of
-the website and are not touched by this script - they live only in the
-private backup tarball.
+no running webserver, no real HTTP - logged in as a chosen account so
+login-gated pages render. Coverage includes the big lore surfaces:
+
+  - rosters + character sheets (/character/active/ ... /character/gone/),
+    and for EVERY discovered sheet the exporter force-enqueues the
+    known sub-pages (story, actions/, clues/, gallery, scenes) rather than
+    trusting the sheet template to link them all
+  - actions: /character/sheet/<id>/actions/ list + per-action detail pages
+  - journals: /comms/journals/list/ (paginated, 20/entry pages; entries
+    render inline in the list - there is no per-journal detail URL)
+  - events (/dom/cal/list/ + display pages), crises, boards
+    (/comms/boards/), help topics, news
+
+WHO YOU CRAWL AS decides what the archive contains (pick via --username):
+  - a STAFF account sees everything: secrets and clues on sheets, GM notes,
+    and ALL black (private) journals mixed into the journal list
+    (JournalListView uses all_permitted_journals(user); a fresh account has
+    read nothing, so the "unread" list IS the full list)
+  - a fresh NON-staff account sees white journals only, but also loses the
+    sheet secrets/clues the archive is supposed to keep
+There is no URL-level way to include clues but exclude black journals -
+that choice is the account you crawl with.
+
+Runtime expectation for ~6 years of data: tens of thousands to ~150k pages
+at roughly 100-500ms each through the test client = several hours to
+overnight, single-threaded. The exporter therefore streams every page to
+disk immediately (constant memory) and supports --resume, which re-parses
+already-saved files for links instead of re-rendering them, so a crash or
+interrupt costs minutes, not the run.
 
 The output tree is pure static files: <path>/index.html per page, ready for
 `tar | zstd` and the arx1_archive role's sync (which expects index.html at
@@ -36,34 +60,57 @@ import shutil
 import sys
 from urllib.parse import urldefrag, urljoin, urlsplit
 
-# Paths never worth crawling: actions, auth churn, admin, and Django's
-# logout would end the crawl session. Extend as the first real run reveals
-# more (the summary prints every skipped-by-rule URL).
+# Paths never worth crawling: mutating/form endpoints, auth churn, admin,
+# the webclient, per-user read/unread bookkeeping, and JSON APIs. Django's
+# logout link would end the crawl session. Extend as the first real run
+# reveals more (the summary prints a sample of skipped URLs).
 SKIP_PATTERNS = [
     r"^/admin\b",
     r"^/logout\b",
-    r"^/accounts/logout\b",
-    r"^/accounts/login\b",
-    r"^/admindocs\b",
-    r"/delete/",
-    r"/edit/",
-    r"/create/",
+    r"^/accounts/log",
+    r"^/webclient\b",
+    r"/delete",
+    r"/edit",
+    r"/create",
+    r"/comment$",
+    r"/upload",
+    r"/select_portrait$",
+    r"/api/",
+    r"/journals/list/read/",
+    r"/boards/unread$",
+    r"/view/unread$",
     r"\.(?:json|csv|ics)$",
 ]
 SKIP_RE = re.compile("|".join(SKIP_PATTERNS))
 
-# Seed URLs. "/" alone reaches most of the site by links; the extras cover
-# index pages that may only be linked from within themselves. TODO(first
-# real run): confirm these against arxcode's urls.py and add any islands
-# (paginated archives whose page-1 is only reachable via redirect, etc.).
+# Seed URLs, checked against arxcode's urls.py (prefixes: /character/,
+# /comms/ for msgs, /dom/ for dominion, /topics/ for help). Rosters cover
+# every state so departed characters' sheets are reached too.
 DEFAULT_SEEDS = [
     "/",
-    "/dominion/events/",
-    "/character/",
-    "/help_topics/",
+    "/character/active/",
+    "/character/available/",
+    "/character/incomplete/",
+    "/character/unavailable/",
+    "/character/inactive/",
+    "/character/gone/",
+    "/character/story/",
+    "/dom/cal/list/",
+    "/comms/journals/list/",
+    "/comms/boards/",
+    "/topics/",
     "/news/",
-    "/support/faq/",
+    "/support/",
 ]
+
+# For every character sheet the crawl discovers, force-enqueue these
+# sub-pages (relative to /character/sheet/<id>/). Deliberately explicit
+# instead of trusting the sheet template's tab links: actions and journals
+# are exactly the lore people will come looking for.
+SHEET_RE = re.compile(r"^/character/sheet/(\d+)/$")
+SHEET_SUBPAGES = ["story", "actions/", "clues/", "gallery", "scenes"]
+
+STATUS_OK = 200
 
 
 class LinkExtractor(HTMLParser):
@@ -82,11 +129,14 @@ class LinkExtractor(HTMLParser):
 def url_to_relpath(path, query):
     """Map a site URL to a file path inside the static tree.
 
-    /dominion/events/    -> dominion/events/index.html
-    /dominion/events/5   -> dominion/events/5/index.html   (file_server
+    /dom/cal/list/       -> dom/cal/list/index.html
+    /character/sheet/5/  -> character/sheet/5/index.html  (file_server
     serves the extensionless dir with an implicit index lookup)
     /foo/?page=2         -> foo/index__page=2.html  (links rewritten to match)
     /static/css/site.css -> static/css/site.css     (kept verbatim)
+
+    Deterministic on the URL alone - link rewriting and resume both rely on
+    that (no crawl-order state involved).
     """
     path = path.strip("/")
     last = path.rsplit("/", 1)[-1]
@@ -106,19 +156,28 @@ def sanitize(query):
     return re.sub(r"[^A-Za-z0-9=_-]", "_", query)
 
 
-def rewrite_links(html, mapping):
-    """Point query-string links at their exported filenames.
+# [^"']* (not +) before the '?': Django pagination emits bare href="?page=2"
+# links with nothing before the query at all.
+HREF_RE = re.compile(r"""(href=["'])([^"']*\?[^"']+)(["'])""")
+
+
+def rewrite_query_links(html, base_path):
+    """Point query-string hrefs at their exported filenames.
 
     Plain path links need no rewriting (the tree mirrors the URL space);
-    only ?query URLs get distinct filenames, so only they are rewritten.
+    only ?query URLs get distinct filenames. url_to_relpath is
+    deterministic, so this needs no global crawl state and each page can be
+    rewritten and written to disk the moment it is fetched.
     """
-    for (path, query), relpath in mapping.items():
-        if not query:
-            continue
-        original = "%s?%s" % (path, query)
-        html = html.replace('href="%s"' % original, 'href="/%s"' % relpath)
-        html = html.replace("href='%s'" % original, "href='/%s'" % relpath)
-    return html
+
+    def repl(match):
+        link, _frag = urldefrag(match.group(2))
+        parts = urlsplit(urljoin(base_path if base_path.endswith("/") else base_path + "/", link))
+        if parts.scheme or parts.netloc or not parts.query:
+            return match.group(0)
+        return match.group(1) + "/" + url_to_relpath(parts.path, parts.query) + match.group(3)
+
+    return HREF_RE.sub(repl, html)
 
 
 def copy_tree(src, dst):
@@ -132,6 +191,31 @@ def copy_tree(src, dst):
             shutil.copy2(os.path.join(root_dir, name), os.path.join(target_dir, name))
 
 
+def extract_links(html, base_path, seen, queue, skipped):
+    """Feed a page's links into the crawl frontier (sheet sub-pages too)."""
+    extractor = LinkExtractor()
+    extractor.feed(html)
+    for raw in extractor.links:
+        link, _frag = urldefrag(
+            urljoin(base_path if base_path.endswith("/") else base_path + "/", raw)
+        )
+        parts = urlsplit(link)
+        if parts.scheme or parts.netloc:  # external
+            continue
+        new_path, new_query = parts.path, parts.query
+        if not new_path.startswith("/") or SKIP_RE.search(new_path):
+            skipped.append(link)
+            continue
+        enqueue = [(new_path, new_query)]
+        sheet = SHEET_RE.match(new_path)
+        if sheet:
+            enqueue.extend((new_path + sub, "") for sub in SHEET_SUBPAGES)
+        for key in enqueue:
+            if key not in seen:
+                seen.add(key)
+                queue.append(key)
+
+
 def main():
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--out", required=True, help="output directory for the static tree")
@@ -141,13 +225,24 @@ def main():
         help="DJANGO_SETTINGS_MODULE (default: %(default)s)",
     )
     parser.add_argument(
-        "--username", default="", help="staff account to crawl as (default: first superuser)"
+        "--username",
+        default="",
+        help="account to crawl as (default: first superuser). STAFF sees "
+        "secrets/clues AND all black journals; a fresh non-staff account "
+        "sees neither - see the module docstring",
     )
     parser.add_argument("--seed", action="append", default=[], help="extra seed URL(s); repeatable")
     parser.add_argument(
+        "--resume",
+        action="store_true",
+        help="skip re-rendering pages whose output file already exists; "
+        "their saved HTML is re-parsed for links so the frontier still "
+        "grows past them (restarts cost minutes, not the run)",
+    )
+    parser.add_argument(
         "--max-pages",
         type=int,
-        default=200000,
+        default=300000,
         help="hard stop against crawler traps (default: %(default)s)",
     )
     args = parser.parse_args()
@@ -168,7 +263,7 @@ def main():
         user = user_model.objects.filter(is_superuser=True).order_by("pk").first()
     if user is None:
         sys.exit("no superuser found - pass --username")
-    print("crawling as %s" % user.username)
+    print("crawling as %s (staff=%s)" % (user.username, user.is_staff or user.is_superuser))
 
     client = Client()
     client.force_login(user)
@@ -178,59 +273,48 @@ def main():
 
     queue = deque((seed, "") for seed in DEFAULT_SEEDS + args.seed)
     seen = set(queue)
-    mapping = {}  # (path, query) -> relpath
-    html_pages = {}  # relpath -> body (rewritten + written at the end)
+    exported = resumed = 0
     skipped, errors = [], []
 
-    while queue and len(mapping) < args.max_pages:
+    while queue and exported + resumed < args.max_pages:
         path, query = queue.popleft()
+        relpath = url_to_relpath(path, query)
+        full = os.path.join(out, relpath)
+
+        if args.resume and os.path.exists(full):
+            resumed += 1
+            if full.endswith(".html"):
+                with open(full, encoding="utf-8", errors="replace") as fh:
+                    extract_links(fh.read(), path, seen, queue, skipped)
+            continue
+
         target = "%s?%s" % (path, query) if query else path
         try:
             response = client.get(target, follow=True)
         except Exception as exc:  # noqa: BLE001 - a page that 500s must not kill the crawl
             errors.append((target, repr(exc)))
             continue
-        if response.status_code != 200:
+        if response.status_code != STATUS_OK:
             errors.append((target, "HTTP %s" % response.status_code))
             continue
 
-        relpath = url_to_relpath(path, query)
-        mapping[(path, query)] = relpath
         content_type = response.get("Content-Type", "")
-        body = response.content
-
-        if "text/html" in content_type:
-            html = body.decode(response.charset or "utf-8", errors="replace")
-            html_pages[relpath] = html
-            extractor = LinkExtractor()
-            extractor.feed(html)
-            for link in extractor.links:
-                link, _frag = urldefrag(urljoin(path if path.endswith("/") else path + "/", link))
-                parts = urlsplit(link)
-                if parts.scheme or parts.netloc:  # external
-                    continue
-                new_path, new_query = parts.path, parts.query
-                if not new_path.startswith("/") or SKIP_RE.search(new_path):
-                    skipped.append(link)
-                    continue
-                key = (new_path, new_query)
-                if key not in seen:
-                    seen.add(key)
-                    queue.append(key)
-        else:
-            full = os.path.join(out, relpath)
-            os.makedirs(os.path.dirname(full), exist_ok=True)
-            with open(full, "wb") as fh:
-                fh.write(body)
-
-        if len(mapping) % 500 == 0:
-            print("  %d pages exported, %d queued" % (len(mapping), len(queue)))
-
-    for relpath, html in html_pages.items():
-        full = os.path.join(out, relpath)
         os.makedirs(os.path.dirname(full), exist_ok=True)
-        with open(full, "w", encoding="utf-8") as fh:
-            fh.write(rewrite_links(html, mapping))
+        if "text/html" in content_type:
+            html = response.content.decode(response.charset or "utf-8", errors="replace")
+            extract_links(html, path, seen, queue, skipped)
+            # Stream to disk NOW - link rewriting is deterministic, so
+            # nothing needs to wait for the crawl to finish, and memory
+            # stays flat no matter how many pages six years produced.
+            with open(full, "w", encoding="utf-8") as fh:
+                fh.write(rewrite_query_links(html, path))
+        else:
+            with open(full, "wb") as fh:
+                fh.write(response.content)
+        exported += 1
+
+        if exported % 500 == 0:
+            print("  %d exported (%d resumed), %d queued" % (exported, resumed, len(queue)))
 
     # Static assets straight from disk - the crawl only picks up assets a
     # page referenced; this sweeps the rest (css url() references etc.).
@@ -241,7 +325,7 @@ def main():
             print("copying %s -> %s" % (root, dest))
             copy_tree(root, dest)
 
-    print("\nexported %d pages to %s" % (len(mapping), out))
+    print("\nexported %d pages (+%d resumed) to %s" % (exported, resumed, out))
     print("errors: %d (first 20 below)" % len(errors))
     for target, err in errors[:20]:
         print("  %s -> %s" % (target, err))

--- a/infra/scripts/standup.sh
+++ b/infra/scripts/standup.sh
@@ -213,11 +213,12 @@ main() {
   tf_read_outputs "${TF_DIR}"   # lib.sh — caches into TF_OUTPUT_JSON; jqr/jqc read it
 
   # Non-sensitive scalars.
-  local ip web_fqdn telnet_fqdn backups_bucket backups_s3_endpoint backups_region
+  local ip web_fqdn telnet_fqdn archive_fqdn backups_bucket backups_s3_endpoint backups_region
   local r2_offsite_bucket r2_s3_endpoint tls_telnet_port
   ip="$(jqr instance_ipv4)"
   web_fqdn="$(jqr web_fqdn)"
   telnet_fqdn="$(jqr telnet_fqdn)"
+  archive_fqdn="$(jqr archive_fqdn)"
   backups_bucket="$(jqr backups_bucket)"
   backups_s3_endpoint="$(jqr backups_s3_endpoint)"
   backups_region="$(jqr region)"
@@ -271,6 +272,11 @@ hostfw_tls_telnet_port: ${tls_telnet_port}
 
 # caddy (roles/caddy/defaults/main.yml)
 caddy_web_fqdn: "${web_fqdn}"
+# The Arx I archive vhost fqdn — wiring it here does NOT enable the vhost:
+# roles/caddy's caddy_archive_enabled also requires the (optional)
+# ARXII_ARX1_ARCHIVE_BASICAUTH_HASH secret to be set. See
+# docs/operations/arx1-archival.md.
+caddy_archive_fqdn: "${archive_fqdn}"
 caddy_acme_email: "${ARXII_ACME_EMAIL:-admin@${TF_VAR_domain}}"
 
 # tls_telnet_cert (roles/tls_telnet_cert/defaults/main.yml)
@@ -326,9 +332,20 @@ EOF
   # specific `never`-tagged role. So `--tags all,content_repo` runs the
   # full ordinary converge PLUS the content-repo refresh, correctly
   # positioned in the play order (see site.yml).
-  local ansible_extra_args=()
+  # Same idiom for the Arx I archive content sync (roles/arx1_archive,
+  # `never`-tagged in site.yml): on-demand, expected roughly once ever. Both
+  # opt-ins compose into ONE --tags list — two separate --tags flags would
+  # not (ansible-playbook keeps only the last one).
+  local ansible_run_tags="all"
   if [[ "${ARXII_RUN_CONTENT_REFRESH:-false}" == "true" ]]; then
-    ansible_extra_args+=(--tags "all,content_repo")
+    ansible_run_tags+=",content_repo"
+  fi
+  if [[ "${ARXII_RUN_ARX1_ARCHIVE_SYNC:-false}" == "true" ]]; then
+    ansible_run_tags+=",arx1_archive"
+  fi
+  local ansible_extra_args=()
+  if [[ "${ansible_run_tags}" != "all" ]]; then
+    ansible_extra_args+=(--tags "${ansible_run_tags}")
   fi
 
   # Backup-writer keys are handed to ansible via env in-memory — never

--- a/infra/terraform/modules/cloudflare_dns/main.tf
+++ b/infra/terraform/modules/cloudflare_dns/main.tf
@@ -32,6 +32,27 @@ resource "cloudflare_record" "web_aaaa" {
   proxied = true
 }
 
+# --- Arx I static archive (proxied / orange) --------------------------------
+# Same origin, own hostname: Caddy serves the read-only Arx I archive as a
+# separate basic-auth-gated vhost (roles/caddy). The record exists whether or
+# not the vhost is enabled yet — an A record pointing at an origin with no
+# matching site block is inert (Caddy answers nothing for that SNI).
+resource "cloudflare_record" "archive_a" {
+  zone_id = cloudflare_zone.this.id
+  name    = var.archive_hostname
+  type    = "A"
+  content = var.origin_ipv4
+  proxied = true
+}
+
+resource "cloudflare_record" "archive_aaaa" {
+  zone_id = cloudflare_zone.this.id
+  name    = var.archive_hostname
+  type    = "AAAA"
+  content = var.origin_ipv6
+  proxied = true
+}
+
 # --- TLS-telnet (DNS-only / grey — bypasses Cloudflare) ---------------------
 resource "cloudflare_record" "telnet_a" {
   zone_id = cloudflare_zone.this.id

--- a/infra/terraform/modules/cloudflare_dns/outputs.tf
+++ b/infra/terraform/modules/cloudflare_dns/outputs.tf
@@ -12,3 +12,8 @@ output "telnet_fqdn" {
   value       = "${var.telnet_hostname}.${var.domain}"
   description = "DNS-only TLS-telnet hostname (origin-direct)."
 }
+
+output "archive_fqdn" {
+  value       = "${var.archive_hostname}.${var.domain}"
+  description = "Proxied Arx I static-archive hostname."
+}

--- a/infra/terraform/modules/cloudflare_dns/variables.tf
+++ b/infra/terraform/modules/cloudflare_dns/variables.tf
@@ -20,6 +20,12 @@ variable "telnet_hostname" {
   description = "Subdomain for TLS-telnet. DNS-only (NOT proxied) — telnet bypasses Cloudflare straight to origin."
 }
 
+variable "archive_hostname" {
+  type        = string
+  default     = "archive"
+  description = "Subdomain for the read-only Arx I static archive (proxied through Cloudflare; basic-auth-gated at Caddy)."
+}
+
 variable "origin_ipv4" {
   type        = string
   description = "Instance public IPv4 (from the compute module)."

--- a/infra/terraform/prod/main.tf
+++ b/infra/terraform/prod/main.tf
@@ -27,16 +27,17 @@ module "firewall" {
 }
 
 module "dns" {
-  source          = "../modules/cloudflare_dns"
-  account_id      = var.cloudflare_account_id
-  domain          = var.domain
-  web_hostname    = var.web_hostname
-  telnet_hostname = var.telnet_hostname
-  origin_ipv4     = module.compute.ipv4
-  origin_ipv6     = module.compute.ipv6
-  dmarc_policy    = var.dmarc_policy
-  dmarc_rua       = var.dmarc_rua
-  resend_records  = var.resend_records
+  source           = "../modules/cloudflare_dns"
+  account_id       = var.cloudflare_account_id
+  domain           = var.domain
+  web_hostname     = var.web_hostname
+  telnet_hostname  = var.telnet_hostname
+  archive_hostname = var.archive_hostname
+  origin_ipv4      = module.compute.ipv4
+  origin_ipv6      = module.compute.ipv6
+  dmarc_policy     = var.dmarc_policy
+  dmarc_rua        = var.dmarc_rua
+  resend_records   = var.resend_records
 }
 
 # Zone security settings + bot-management levers, codified so dashboard-side

--- a/infra/terraform/prod/outputs.tf
+++ b/infra/terraform/prod/outputs.tf
@@ -11,6 +11,9 @@ output "web_fqdn" {
 output "telnet_fqdn" {
   value = module.dns.telnet_fqdn
 }
+output "archive_fqdn" {
+  value = module.dns.archive_fqdn
+}
 output "backups_bucket" {
   value = module.object_storage.bucket
 }

--- a/infra/terraform/prod/variables.tf
+++ b/infra/terraform/prod/variables.tf
@@ -40,6 +40,10 @@ variable "telnet_hostname" {
   type    = string
   default = "telnet"
 }
+variable "archive_hostname" {
+  type    = string
+  default = "archive"
+}
 variable "tls_telnet_port" {
   type    = number
   default = 4003

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,6 +136,22 @@ external = ["STRING_LITERAL", "PREFETCH_STRING", "SHARED_MEMORY", "USE_FILTERSET
     "S607",    # partial executable path for git CLI in tests
 ]
 
+# Arx I archival static-site exporter (docs/operations/arx1-archival.md) —
+# runs inside the RETIRED game's own venv against the arxcode codebase, not
+# this repo's toolchain: stdlib os.path + percent-format on purpose (the old
+# venv's exact Python floor is unverified), function-level imports because
+# django.setup() must precede them, and one deliberately-monolithic crawl
+# loop for a run-roughly-once operator tool.
+"infra/scripts/arx1/arx1_static_export.py" = [
+    "UP031",   # percent-format — oldest-Python-compatible on purpose
+    "PTH100", "PTH103", "PTH110", "PTH112", "PTH118", "PTH120", "PTH123", # os.path ditto
+    "PLC0415", # imports after django.setup(), by necessity
+    "ARG002",  # HTMLParser.handle_starttag's signature is fixed by the stdlib
+    "C901", "PLR0912", "PLR0915", # one monolithic crawl loop, by choice
+    "PLR2004", # HTTP 200
+    "PLW2901", # loop-var reassign in link normalization
+]
+
 # Content push module — subprocess git calls are its core function
 "src/core_management/content_push.py" = [
     "S603",    # subprocess without shell check — git CLI calls


### PR DESCRIPTION
## What

The full pipeline for retiring the Arx I Linode (~$50/mo) without losing anything, per today's in-session rulings (ADR-0225):

1. **Freeze + durable backup** — `infra/scripts/arx1/arx1-freeze.sh` runs on the Arx I box: consistent sqlite snapshot (`.backup` + VACUUM + integrity_check), separate public/GM rpevent tarballs (the GM set is backup-only, never served), and a resurrection kit (game dir incl. venv, pip freeze, configs) so "playable again someday" stays possible at zero standing cost. Everything zstd -19 --long=27 with SHA256SUMS.
2. **Upload + verify** — `arx1-upload.sh` pushes the artifacts to BOTH existing buckets (Linode primary + R2 offsite) under `arx1/` and verifies every object by full re-download (`rclone check --download`), which is the gate before the Linode dies.
3. **Static archive site** — `arx1_static_export.py` (DRAFT; needs a test run against real data) crawls the Arx I site through Django's test client as staff, so login-gated pages render, and writes a plain-HTML tree.
4. **Serving** — `roles/caddy` gains an optional `archive.<domain>` vhost: static `file_server`, basic auth, noindex. The new **optional** gated-Environment secret `ARXII_ARX1_ARCHIVE_BASICAUTH_HASH` (bcrypt via `caddy hash-password`) is the enable switch — unset renders no vhost, same posture as `ARXII_SENTRY_DSN`. Terraform adds the proxied `archive.<domain>` A/AAAA records + `archive_fqdn` output, wired through `standup.sh`.
5. **Content delivery** — new `roles/arx1_archive`, `never`-tagged like `content_repo`, behind a new button checkbox (`run_arx1_archive_sync`): pulls `arx1/arx1-site-export.tar.zst` from the primary bucket via a oneshot unit (creds from the vault EnvironmentFile), checksum-verifies, and installs at `/srv/arx1-archive` with an atomic-ish swap.

Runbook: `docs/operations/arx1-archival.md` (freeze → upload → export → serve → Linode teardown checklist).

## CI-visible mechanics

- `validate.yml`'s caddy job now renders templates by **dropping Jinja control-flow lines** (so the conditionally-rendered archive block is always validated) and stubbing each `{{ }}` with a **unique** placeholder host — two site blocks stubbed to the same host would be an ambiguous-site adapt error. Its shellcheck job now also covers `infra/scripts/arx1/`.
- Both Caddyfile templates stay in lockstep; `caddy_archive_enabled` is consumed with `| bool` everywhere (the folded default renders as a string).
- `acceptance.sh` passes unchanged: the new secret is deliberately NOT in `secrets_map`/`REQUIRED_ARXII` (caddy-step-only, optional).
- Local checks run: shellcheck (as CI invokes it) clean, ansible-lint clean for the new/edited files (the 2 pre-existing missing-collection findings belong to base/postgres and resolve in CI via requirements.yml), both Caddyfile templates render-tested enabled and disabled, ruff clean.

## Not in this PR

- Actually running the freeze/upload (needs SSH to the Arx I box — operator runbook).
- The export script's first real run/tuning against the arxcode urls (draft by design).
- The domain question (arx2.com → arxgame.com) — separate conversation; nothing here hardcodes the domain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vd68aWzVgzQzh9BWukLvjU