### PR TITLE
Dead seeders: game_content/challenges.py and social.py have no CLUSTER_SEEDERS caller — trace intent before deleting or wiring

### DIFF
--- a/src/world/seeds/game_content/challenges.py
+++ b/src/world/seeds/game_content/challenges.py
@@ -1,4 +1,14 @@
-"""ChallengeContent — capabilities, properties, applications, and starter challenges.
+"""ChallengeContent — integration-test content builder, deliberately NOT a runtime seeder.
+
+Builds the Capabilities & Challenges content suite with FactoryBoy factories for the
+pipeline integration tests (``src/integration_tests/pipeline/test_challenge_pipeline.py``,
+``test_situation_pipeline.py``), which import it through the
+``integration_tests.game_content.challenges`` compatibility facade. It is intentionally
+absent from ``CLUSTER_SEEDERS`` — the runtime consequence-layer bootstrap rows come from
+the ``social_actions``/``magic``/``items``/``spy_tasks``/``survivability`` seeders. Born
+as Phase 7 integration-test content (#379); relocated here with the other seed-content
+builders by roadmap 3.2 (#1220); provenance traced in #3090 after it was mistaken for a
+dead seeder.
 
 Creates the full Capabilities & Challenges content suite:
   - 19 CapabilityTypes (physical, magical, social, mental)

--- a/src/world/seeds/game_content/social.py
+++ b/src/world/seeds/game_content/social.py
@@ -1,4 +1,15 @@
-"""SocialContent — consequence pools wired to social action templates.
+"""SocialContent — integration-test content builder, deliberately NOT a runtime seeder.
+
+Builds the social-action content suite with FactoryBoy factories for the pipeline
+integration tests (``src/integration_tests/pipeline/test_social_pipeline.py``,
+``test_social_magic_pipeline.py``, ``test_challenge_pipeline.py``,
+``test_situation_pipeline.py``), which import it through the
+``integration_tests.game_content.social`` compatibility facade. It is intentionally
+absent from ``CLUSTER_SEEDERS`` — the runtime consequence-layer bootstrap rows come from
+the ``social_actions``/``magic``/``items``/``spy_tasks``/``survivability`` seeders. Born
+as Phase 7 integration-test content (#378); relocated here with the other seed-content
+builders by roadmap 3.2 (#1220); provenance traced in #3090 after it was mistaken for a
+dead seeder.
 
 Creates a fully playable social action suite:
   - 6 ActionTemplates with CheckTypes and trait weights


### PR DESCRIPTION
Closes #3090

## Summary

Intent-provenance trace for the two suspected dead seeders in world/seeds/game_content/. Verdict: neither delete nor wire — challenges.py (#379) and social.py (#378) are FactoryBoy test-content builders whose live callers are the four pipeline integration tests, importing through the integration_tests/game_content/ compatibility facades left by the roadmap-3.2 relocation (#1220). They were never CLUSTER_SEEDERS candidates, so never running during the seed window is by design. This PR documents that intent in both module docstrings so the next seed audit doesn't re-file the same finding.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #3090 (in the issue body)
- Brainstorm/plan: skipped (provenance trace + docstring-only change; no behavior)
- Sync-with-main: branch cut from origin/main tip today; sync was a no-op

<!-- last-addressed-comment: 0 -->