### PR TITLE
Reframe PlayerMail as the OOC player-message surface it was built as (strip the IC letters framing)

### DIFF
--- a/docs/adr/0116-playermail-is-the-letters-surface-at-mvp.md
+++ b/docs/adr/0116-playermail-is-the-letters-surface-at-mvp.md
@@ -1,5 +1,10 @@
 # PlayerMail is the letters surface at MVP; tenure-routed anonymity is the mechanism
 
+> **Superseded by ADR-0226 (#3303).** The IC-letters framing below is wrong: PlayerMail is
+> the OOC player-to-player message surface (its original identity, per #124/#146,
+> predating this ADR); IC missives (#3289) get their own separate system and storage. The
+> tenure-routed anonymity mechanism described below still stands unchanged.
+
 `world.roster.PlayerMail` (tenure-to-tenure, threaded via `in_reply_to`) is the whole letters
 system for #2160 — compose/inbox at `/profile/mail`, in-scene quick-compose from the character
 card (`SendLetterDialog` pre-filling `ComposeMailForm`), unread badge, and a `MAIL_ARRIVED`

--- a/docs/adr/0226-playermail-is-ooc-ic-missives-are-a-separate-system.md
+++ b/docs/adr/0226-playermail-is-ooc-ic-missives-are-a-separate-system.md
@@ -1,0 +1,17 @@
+# PlayerMail is OOC between players; IC missives are a separate system
+
+Per the #3303 ruling, `world.roster.PlayerMail` reverts to its original identity: the
+out-of-character, player-to-player message surface, tenure-routed so the recipient is
+addressed and displayed as "the current player of Character X" rather than by account
+(unchanged since #124/#146, before the roster restructure). In-character correspondence
+(#3289) is a distinct, not-yet-built system with its own storage - a sent missive is
+authored by a persona, not a tenure; carries an in-fiction transmission mechanism
+(courier, sending spell, ...) and in-character game time, not real-world `sent_date`;
+and models deliveries as a separate concept from read state. We rejected renaming or
+otherwise hammering `PlayerMail` into that shape (adding a persona/transmission/IC-time
+layer onto the existing model, or renaming it to `Letter`) - PlayerMail's anonymity
+mechanism (tenure routing) and IC missives' authorship mechanism (persona identity) are
+opposite design goals, and conflating them would either break player anonymity on mail
+or force IC missives through an anonymity layer that makes no sense for in-fiction mail.
+
+> Status: accepted · Source: #3303 (supersedes ADR-0116; see #3289 for the IC system)

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -170,7 +170,7 @@ treat those names as hints to confirm, not gospel.
 - [0113 — Consent defaults are a category tree, not per-category flags](0113-consent-defaults-are-a-category-tree.md) (extends ADR-0024)
 - [0114 — Player-authored accusations are weight-bearing secrets, gated by consent not the model](0114-accusations-are-weight-bearing-player-secrets.md) (extends ADR-0062/0113)
 - [0115 — Applause is three axes, not one economy: votes=popularity, kudos=graciousness, reactions=expression](0115-applause-three-axes.md)
-- [0116 — PlayerMail is the letters surface at MVP; tenure-routed anonymity is the mechanism](0116-playermail-is-the-letters-surface-at-mvp.md)
+- [0116 — PlayerMail is the letters surface at MVP; tenure-routed anonymity is the mechanism](0116-playermail-is-the-letters-surface-at-mvp.md) (superseded by ADR-0226)
 - [0117 — Relationship reads are scoped to the caller's own outbound rows, plus a soul-tether carve-out](0117-relationship-reads-scoped-to-own-outbound-rows.md)
 - [0118 — Reactive ward costs debit the applier, falling back to the bearer](0118-reactive-costs-debit-the-applier.md) (extends ADR-0060)
 - [0119 — The accusation→heat bridge lives justice-side, and its tier is emergent from the real deed underneath](0119-accusation-heat-bridge-tier-is-emergent-from-the-deed.md) (extends ADR-0114/0010)
@@ -231,6 +231,7 @@ treat those names as hints to confirm, not gospel.
 - [0223 - Technique combat power is measured in damage-equivalents against a reference matchup, with parsed (not probed) mitigation](0223-technique-combat-power-in-damage-equivalents.md) (#3279)
 - [0224 - The CG shop window serves perspective content ungated](0224-cg-shop-window-serves-perspective-content-ungated.md) (#3281; extends ADR-0222)
 - [0225 - Arx I is archived to object storage + a static basic-auth site, not kept running](0225-arx1-archived-to-object-storage-static-site.md)
+- [0226 - PlayerMail is OOC between players; IC missives are a separate system](0226-playermail-is-ooc-ic-missives-are-a-separate-system.md) (#3303; supersedes ADR-0116)
 
 ### Gift & resonance economy
 - [0050 — Gifts are Major or Minor; species abilities are a species-granted Minor Gift](0050-gifts-are-major-or-minor-species-abilities-are-minor-gifts.md)

--- a/docs/systems/INDEX.md
+++ b/docs/systems/INDEX.md
@@ -1956,15 +1956,17 @@ Character lifecycle management with web-first applications and player anonymity.
   hosts the shared `_send_email`/`_get_staff_emails` primitives; `RosterEmailService`
   extends it unchanged. `world.character_creation.email_service.CGEmailService`
   extends the same base — see Character Creation above.
-- **Letters web surface (#2160, ADR-0116):** `PlayerMailViewSet` gained two actions —
+- **OOC mail web surface (#2160, ADR-0226):** `PlayerMailViewSet` gained two actions —
   `POST /api/roster/mail/{id}/mark-read/` (idempotent, recipient-scoped via the queryset) and
   `GET /api/roster/mail/unread-count/` (unread + unarchived, across the requester's tenures).
   Sending mail fires `notify_mail_arrived` via `transaction.on_commit` (the
   `notify_battle_state_changed` pattern), pushing a new `WebsocketMessageType.MAIL_ARRIVED`
   (`src/web/webclient/message_types.py`) payload — `mail_id`/`sender_display`/`subject` only, no
-  account identifiers. Frontend: in-scene quick-compose (`SendLetterDialog` pre-filling
-  `ComposeMailForm`) from the character card, an `UnreadMailBadge` in the header, and a
-  mark-read-on-open flow in `ReceivedMailList`. No telnet mail command exists or is planned.
+  account identifiers. Frontend: in-scene "Message the player" quick-compose
+  (`MessagePlayerDialog` pre-filling `ComposeMailForm`) from the character card, an
+  `UnreadMailBadge` in the header, and a mark-read-on-open flow in `ReceivedMailList`. No
+  telnet mail command exists or is planned. PlayerMail is OOC between players; IC missives
+  are #3289's separate system (ADR-0226).
 - **Game invites (#2483):** `GameInvite` model + `GameInviteViewSet` for
   player-to-friend contextual invites. Trust-gated via `PlayerTrust` (new
   `INVITE` `TrustCategory`, `BASIC` minimum, seeded via the Big Button

--- a/docs/systems/roster.md
+++ b/docs/systems/roster.md
@@ -313,7 +313,7 @@ RosterTenure.objects.for_player(player_data)                 # For specific play
 - `GET /api/roster/tenures/` - List tenures with search by character name
 - `GET /api/roster/tenures/mine/` - Current user's active tenures (for dropdown selection)
 
-### Mail (`/api/roster/mail/`) — the letters surface (#2160, ADR-0116)
+### Mail (`/api/roster/mail/`) — the OOC player-to-player mail surface (#2160, ADR-0226)
 - `GET /api/roster/mail/` - List received mail (newest first)
 - `POST /api/roster/mail/` - Send mail (validates sender_tenure ownership); fires
   `notify_mail_arrived(recipient_tenure, mail)` via `transaction.on_commit`, pushing a
@@ -325,9 +325,10 @@ RosterTenure.objects.for_player(player_data)                 # For specific play
 - `GET /api/roster/mail/unread-count/` - Count of unread, unarchived mail across the
   requester's tenures (`UnreadMailCountSerializer`)
 
-Web-only surface: compose at `/profile/mail` or in-scene via `SendLetterDialog` (pre-fills
-`ComposeMailForm` from the character card quick actions), unread badge in the header
-(`UnreadMailBadge`), mark-read-on-open in `ReceivedMailList`. No telnet mail command.
+Web-only surface: compose at `/profile/mail` or in-scene via `MessagePlayerDialog` (pre-fills
+`ComposeMailForm` from the character card's "Message the player" quick action), unread badge
+in the header (`UnreadMailBadge`), mark-read-on-open in `ReceivedMailList`. No telnet mail
+command.
 
 ### Applications (`/api/roster/applications/`) - staff review queue (#3265)
 - `GET /api/roster/applications/` - List applications; `?status=` filters by

--- a/frontend/src/game/components/CharacterCardDrawer.test.tsx
+++ b/frontend/src/game/components/CharacterCardDrawer.test.tsx
@@ -246,7 +246,7 @@ describe('CharacterCardDrawer', () => {
   });
 
   // #2160 Task 4: quick actions.
-  it('renders both quick actions when entry+live tenure resolve; hides "Send a letter" with no live tenure', () => {
+  it('renders both quick actions when entry+live tenure resolve; hides "Message the player" with no live tenure', () => {
     mockSearchMatch(matchedEntry([liveTenure()]));
     const { unmount } = renderWithProviders(
       <CharacterCardDrawer
@@ -257,7 +257,7 @@ describe('CharacterCardDrawer', () => {
       />
     );
     expect(screen.getByRole('button', { name: /write a journal/i })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /send a letter/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /message the player/i })).toBeInTheDocument();
     unmount();
 
     mockSearchMatch(matchedEntry([endedTenure()]));
@@ -270,7 +270,7 @@ describe('CharacterCardDrawer', () => {
       />
     );
     expect(screen.getByRole('button', { name: /write a journal/i })).toBeInTheDocument();
-    expect(screen.queryByRole('button', { name: /send a letter/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /message the player/i })).not.toBeInTheDocument();
   });
 
   describe('with no public roster match (disguise / temporary / unlisted persona)', () => {

--- a/frontend/src/game/components/CharacterCardDrawer.tsx
+++ b/frontend/src/game/components/CharacterCardDrawer.tsx
@@ -12,7 +12,7 @@ import type { RelationshipWriteupMode } from '@/relationships/components/Relatio
 import type { CharacterRelationshipList } from '@/relationships/api';
 import type { PoseUnitAvatarClickPersona } from '@/scenes/components/PoseUnit';
 import { JournalComposerDialog } from '@/journals/components/JournalComposerDialog';
-import { SendLetterDialog } from './SendLetterDialog';
+import { MessagePlayerDialog } from './MessagePlayerDialog';
 
 /**
  * Decide whether the "Record an impression" quick action opens the
@@ -58,9 +58,10 @@ export interface CharacterCardDrawerProps {
  * Quick actions: "Record an impression" (#2159) opens `RelationshipWriteupDialog`
  * in impression or development mode per `resolveWriteupMode` above. "Write a
  * journal" (#2160) opens `JournalComposerDialog` pre-tagged with the resolved
- * character's name once `entry` resolves. "Send a letter" (#2160) opens
- * `SendLetterDialog` pre-addressed to the character's live tenure
- * (`entry.tenures.find(t => t.end_date === null)`) — hidden when there's no
+ * character's name once `entry` resolves. "Message the player" (#2160) opens
+ * `MessagePlayerDialog` - an OOC message to whoever currently plays this
+ * character, pre-addressed to their live tenure
+ * (`entry.tenures.find(t => t.end_date === null)`) - hidden when there's no
  * live tenure, since a vacant character has no one to address (same gating
  * philosophy as the FriendButton viewer-required gate below).
  *
@@ -86,7 +87,7 @@ export function CharacterCardDrawer({
   const liveTenure = entry?.tenures.find((tenure) => tenure.end_date === null) ?? null;
 
   const [journalOpen, setJournalOpen] = useState(false);
-  const [letterOpen, setLetterOpen] = useState(false);
+  const [messageOpen, setMessageOpen] = useState(false);
 
   // Undefined for a disguise/temporary persona with no public roster match —
   // `useMyRelationshipToTarget` stays disabled and `resolveWriteupMode` falls
@@ -165,9 +166,9 @@ export function CharacterCardDrawer({
                   type="button"
                   variant="outline"
                   size="sm"
-                  onClick={() => setLetterOpen(true)}
+                  onClick={() => setMessageOpen(true)}
                 >
-                  Send a letter
+                  Message the player
                 </Button>
               )}
             </div>
@@ -180,9 +181,9 @@ export function CharacterCardDrawer({
               />
             )}
             {entry && liveTenure && (
-              <SendLetterDialog
-                open={letterOpen}
-                onClose={() => setLetterOpen(false)}
+              <MessagePlayerDialog
+                open={messageOpen}
+                onClose={() => setMessageOpen(false)}
                 recipientTenureId={liveTenure.id}
                 recipientDisplay={entry.character.name}
               />

--- a/frontend/src/game/components/MessagePlayerDialog.tsx
+++ b/frontend/src/game/components/MessagePlayerDialog.tsx
@@ -1,13 +1,15 @@
 /**
- * SendLetterDialog — thin Dialog wrapper around `ComposeMailForm`, pre-addressed
- * to a character from the character-card "Send a letter" quick action (#2160).
+ * MessagePlayerDialog - thin Dialog wrapper around `ComposeMailForm`, pre-addressed
+ * to a character from the character-card "Message the player" quick action (#2160).
+ * This is an OOC affordance - it messages whoever currently plays the character, not
+ * the character in-fiction (see `AGENT_GLOSSARY.md` in `world/roster`, ADR-0226).
  *
  * Externally controlled (`open`/`onClose`), matching `JournalComposerDialog`'s
- * pattern rather than owning its own trigger — `CharacterCardDrawer` opens it
+ * pattern rather than owning its own trigger - `CharacterCardDrawer` opens it
  * from its own quick-action button.
  *
  * `recipientTenureId`/`recipientDisplay` come from the card's resolved live
- * tenure (`entry.tenures.find(t => t.end_date === null)`) — the card only
+ * tenure (`entry.tenures.find(t => t.end_date === null)`) - the card only
  * offers this action when a live tenure exists (a vacant character has no one
  * to address), so both are always required here. `senderTenureId` is optional:
  * only pass it when the viewer's own current tenure is unambiguous from
@@ -18,24 +20,24 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/u
 import { toast } from 'sonner';
 import { ComposeMailForm } from '@/mail/components/ComposeMailForm';
 
-interface SendLetterDialogProps {
+interface MessagePlayerDialogProps {
   open: boolean;
   onClose: () => void;
   /** The pre-addressed recipient's live `RosterTenure` id. */
   recipientTenureId: number;
   /** The pre-addressed recipient's display name, shown as "To: {name}". */
   recipientDisplay: string;
-  /** The viewer's own tenure id, when unambiguous — hides `MyTenureSelect`. */
+  /** The viewer's own tenure id, when unambiguous - hides `MyTenureSelect`. */
   senderTenureId?: number;
 }
 
-export function SendLetterDialog({
+export function MessagePlayerDialog({
   open,
   onClose,
   recipientTenureId,
   recipientDisplay,
   senderTenureId,
-}: SendLetterDialogProps) {
+}: MessagePlayerDialogProps) {
   function handleOpenChange(isOpen: boolean) {
     if (!isOpen) onClose();
   }
@@ -44,14 +46,14 @@ export function SendLetterDialog({
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Send a Letter to {recipientDisplay}</DialogTitle>
+          <DialogTitle>Message the player of {recipientDisplay}</DialogTitle>
         </DialogHeader>
         <ComposeMailForm
           initialRecipientTenureId={recipientTenureId}
           initialRecipientDisplay={recipientDisplay}
           fixedSenderTenureId={senderTenureId}
           onSent={() => {
-            toast.success(`Letter sent to ${recipientDisplay}.`);
+            toast.success(`Message sent to ${recipientDisplay}'s player.`);
             onClose();
           }}
         />

--- a/frontend/src/mail/CLAUDE.md
+++ b/frontend/src/mail/CLAUDE.md
@@ -1,6 +1,10 @@
-# Mail - In-Character Mail System
+# Mail - OOC Player-to-Player Messages
 
-In-character mail system with tenure-based routing and character-to-character communication.
+Out-of-character mail between players, addressed via characters for anonymity
+(tenure-based routing) rather than sent by account. This is NOT the in-character
+letters/missives system (#3289, a separate, not-yet-built system with its own
+storage) - see ADR-0226 and the "Mail (PlayerMail)" entry in
+`src/world/roster/AGENT_GLOSSARY.md`.
 
 ## Key Directories
 
@@ -23,13 +27,16 @@ In-character mail system with tenure-based routing and character-to-character co
 
 ## Key Features
 
-- **Character-based Mail**: Mail tied to character tenures, not user accounts
+- **Tenure-Routed Mail**: Mail is addressed to a character (for anonymity) but
+  delivered to that character's current player, not tied to a user account
 - **Recipient Search**: Send mail using character names
 - **Tenure Routing**: Mail routes to current player of target character
-- **Character Context**: Maintains in-character communication
+- **Player Anonymity**: The recipient is addressed and displayed as "the current
+  player of Character X," never by account
 
 ## Integration Points
 
 - **Backend Models**: Direct integration with world.roster.PlayerMail
 - **Tenure System**: Mail routing through character ownership
-- **Character System**: Integration with character identity management
+- **Character System**: In-scene "Message the player" quick-compose from the
+  character card (`MessagePlayerDialog` in `frontend/src/game/components/`)

--- a/frontend/src/mail/api.ts
+++ b/frontend/src/mail/api.ts
@@ -28,7 +28,7 @@ export async function searchTenures(term: string): Promise<PaginatedResponse<Ros
   return res.json();
 }
 
-/** Mark a received letter as read (idempotent; recipient-only via the scoped queryset). */
+/** Mark a received message as read (idempotent; recipient-only via the scoped queryset). */
 export async function markMailRead(id: number): Promise<PlayerMail> {
   const res = await apiFetch(`/api/roster/mail/${id}/mark-read/`, { method: 'POST' });
   if (!res.ok) {

--- a/frontend/src/mail/components/ComposeMailForm.tsx
+++ b/frontend/src/mail/components/ComposeMailForm.tsx
@@ -13,10 +13,10 @@ interface Props {
   onSent?: () => void;
   /**
    * Pre-fill props for a "compose to a specific character" quick action
-   * (#2160's character-card "Send a letter"). When `initialRecipientTenureId`
-   * is set, the recipient row renders a static "To: {initialRecipientDisplay}"
-   * label instead of `TenureSearch` — that component's display text is
-   * internal state we can't hand it from outside.
+   * (#2160's character-card "Message the player"). When
+   * `initialRecipientTenureId` is set, the recipient row renders a static
+   * "To: {initialRecipientDisplay}" label instead of `TenureSearch` - that
+   * component's display text is internal state we can't hand it from outside.
    */
   initialRecipientTenureId?: number;
   initialRecipientDisplay?: string;
@@ -57,7 +57,7 @@ export function ComposeMailForm({
   }, [replyTo]);
 
   // Syncs the pre-filled recipient/sender when a parent hands us a new one
-  // (e.g. the character-card "Send a letter" dialog is reused for a
+  // (e.g. the character-card "Message the player" dialog is reused for a
   // different character without remounting this form).
   useEffect(() => {
     if (initialRecipientTenureId != null) {

--- a/frontend/src/mail/components/UnreadMailBadge.tsx
+++ b/frontend/src/mail/components/UnreadMailBadge.tsx
@@ -1,8 +1,8 @@
 /**
- * Unread letter counter badge for the top-level navigation.
+ * Unread mail counter badge for the top-level navigation.
  *
- * Shows a red badge with the count of unread received mail across the
- * player's tenures. Clicking navigates to the mail inbox. Mirrors
+ * Shows a red badge with the count of unread OOC mail across the player's
+ * tenures. Clicking navigates to the mail inbox. Mirrors
  * `UnreadNarrativeBadge` (frontend/src/narrative/components/UnreadNarrativeBadge.tsx).
  */
 
@@ -19,9 +19,9 @@ export function UnreadMailBadge() {
     <Link
       to="/profile/mail"
       className="flex items-center gap-1.5"
-      aria-label={`Letters, ${count} unread ${count === 1 ? 'letter' : 'letters'}`}
+      aria-label={`Mail, ${count} unread ${count === 1 ? 'message' : 'messages'}`}
     >
-      Letters
+      Mail
       <Badge variant="destructive" className="bg-red-600 hover:bg-red-700">
         {count}
       </Badge>

--- a/frontend/src/mail/queries.ts
+++ b/frontend/src/mail/queries.ts
@@ -33,7 +33,7 @@ export function useTenureSearch(term: string) {
   });
 }
 
-/** Marks a single received letter read; invalidates the mail list + unread count on success. */
+/** Marks a single received message read; invalidates the mail list + unread count on success. */
 export function useMarkMailRead(id: number) {
   const queryClient = useQueryClient();
   return useMutation({
@@ -45,7 +45,7 @@ export function useMarkMailRead(id: number) {
 }
 
 /**
- * Unread-letter count for the "Letters" header badge — mirrors
+ * Unread-mail count for the "Mail" header badge - mirrors
  * `useUnreadNarrativeCount` (REST count query, guarded on auth so the query
  * doesn't fire on unauthenticated page loads like the login page).
  */

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -26,8 +26,8 @@ function VisibilityPreferences() {
               <Label htmlFor="appear-offline">Quiet (hidden) mode</Label>
               <p className="text-sm text-muted-foreground">
                 When on, you don&apos;t appear in <code>where</code>/<code>who</code> and can&apos;t
-                be paged except by your allowlist. Mail, missions, channels, and same-room presence
-                are unaffected.
+                be paged except by your allowlist. OOC messages, missions, channels, and same-room
+                presence are unaffected.
               </p>
             </div>
             <Switch

--- a/src/commands/presence.py
+++ b/src/commands/presence.py
@@ -89,8 +89,8 @@ class CmdHide(ArxCommand):
         if target:
             self.msg(
                 "You are now |yhidden|n, appearing offline. You're off where/who and "
-                "unpageable except to your allowlist; mail, missions, and channels still work, "
-                "and people in your room still see you. Type unhide to come back."
+                "unpageable except to your allowlist; OOC messages, missions, and channels "
+                "still work, and people in your room still see you. Type unhide to come back."
             )
         else:
             self.msg("You are no longer hidden; you appear online again.")

--- a/src/world/roster/AGENT_GLOSSARY.md
+++ b/src/world/roster/AGENT_GLOSSARY.md
@@ -77,17 +77,20 @@ kinship graph). Root terms live in `AGENT_GLOSSARY_MAP.md`.
   end reasons (disowned / married-out / renounced / annulled), with dates.
   `Kinsperson.family` is only the surname denorm of the active primary
   claim. _Avoid:_ family as a container that owns people.
-- **Letter (PlayerMail)** — a `PlayerMail` row: private, tenure-to-tenure
-  correspondence (`sender_tenure` → `recipient_tenure`, threaded via
-  `in_reply_to`), routed by `RosterTenure` rather than `AccountDB` so it
-  preserves player-anonymity: the recipient is addressed and displayed as
-  the current player of a character, never by account (#2160,
-  ADR-0116). Web is the letters surface — compose/inbox at
-  `/profile/mail`, an in-scene quick-compose from the character card, an
-  unread badge, and a `MAIL_ARRIVED` websocket push on send; there is
-  deliberately no telnet mail command. _Avoid:_ "mail Ariel" as a telnet
-  verb (retired aspiration, never built); messenger/courier (a distinct,
-  not-yet-built in-fiction delivery layer — see ADR-0116).
+- **Mail (PlayerMail)** - a `PlayerMail` row: private, OOC, tenure-to-tenure
+  correspondence between players (`sender_tenure` -> `recipient_tenure`,
+  threaded via `in_reply_to`), routed by `RosterTenure` rather than
+  `AccountDB` so it preserves player-anonymity: the recipient is addressed
+  and displayed as the current player of a character, never by account
+  (#124/#146, reaffirmed #3303, ADR-0226). Web is the mail surface -
+  compose/inbox at `/profile/mail`, an in-scene "Message the player"
+  quick-compose from the character card, an unread badge, and a
+  `MAIL_ARRIVED` websocket push on send; there is deliberately no telnet
+  mail command. _Avoid:_ letters/missives/correspondence for this surface
+  (that framing belongs to #3289's separate, not-yet-built IC messaging
+  system - see ADR-0226); "mail Ariel" as a telnet verb (retired
+  aspiration, never built); messenger/courier (part of that same
+  not-yet-built IC delivery layer).
 
 **Consort**:
 A realm-recognized OFFICIAL secondary partner (#3091) — a realm-scoped `UnionKind` row carrying the stature vocabulary fields (`stature_share_pct=50`, `contributes_to_origin_house=False`, `requires_landed_title=True`, `max_concurrent` = the realm cap: Inferna 3, Umbros/Ariwn/Aythirmok 1). A consort's renown weighs half toward the senior party's house, only while the senior holds a landed `Title`, and never flows back to the consort's origin house. Luxen recognizes no consorts — expressed as the ABSENCE of a Luxen consort row, never a flag. Realm rows carry realm display names; "consort" is the mechanical term in code/docs only (Arx 1 used "consort" for a title holder's spouse — that sense is styled by courtesy titles here, not this word).

--- a/src/world/roster/CLAUDE.md
+++ b/src/world/roster/CLAUDE.md
@@ -52,10 +52,11 @@ This file provides specific guidance for working with the roster system in Arx I
 
 ### Extended Models (evennia_extensions/models.py)
 - **PlayerData**: Extends AccountDB with player preferences and session tracking
-- **PlayerMail**: Letters (mail) with tenure-to-tenure targeting, routed by `RosterTenure` so the
-  current player of a character receives it regardless of who that is. Web-only surface
-  (`/profile/mail` + in-scene quick-compose); no telnet mail command exists or is planned
-  (ADR-0116).
+- **PlayerMail**: OOC, player-to-player mail with tenure-to-tenure targeting, routed by
+  `RosterTenure` so the current player of a character receives it regardless of who that
+  is. Web-only surface (`/profile/mail` + in-scene "Message the player" quick-compose);
+  no telnet mail command exists or is planned (ADR-0226; IC missives are #3289's separate
+  system).
 - **PlayerAllowList**: Social contact allowlist. The old account-level `PlayerBlockList` was
   removed (#1278) — block/mute now lives on `world.scenes.Block`/`Mute` (see
   `world/scenes/CLAUDE.md`).
@@ -83,10 +84,10 @@ When implementing commands like `@ic`, `@characters`, `@apply`:
 - System updates PlayerData.current_character field
 - Must verify character is available via active RosterTenure
 
-### Mail System (Letters)
+### Mail System (OOC player-to-player)
 - Web-only: players compose at `/profile/mail`, or quick-compose in-scene from a character's
-  card (pre-filled `ComposeMailForm` via `SendLetterDialog`, #2160) — no telnet mail command
-  exists; telnet parity is deliberately out of scope (ADR-0116).
+  card (pre-filled `ComposeMailForm` via `MessagePlayerDialog`, #2160) — no telnet mail command
+  exists; telnet parity is deliberately out of scope (ADR-0226).
 - Players target a character name; the system routes to that character's current player via
   `RosterTenure.recipient_tenure`
 - Maintains character context while preserving player anonymity


### PR DESCRIPTION
Closes #3303

## Summary

Reframe PlayerMail as the OOC player-to-player message surface it was built as (TehomCD ruling 2026-08-21/22): strip the IC letters framing (SendLetterDialog -> MessagePlayerDialog, copy, frontend mail CLAUDE.md, glossary), mark ADR-0116 superseded by new ADR-0226 recording the IC/OOC messaging split (IC missives are #3289's separate system). No model or migration changes.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #3303 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Branch up to date with origin/main at sync time; no conflicts.

<!-- last-addressed-comment: 0 -->