### PR TITLE
Journal-target weekly votes have no UI: one of three declared vote targets is unreachable

### DIFF
--- a/docs/roadmap/journals.md
+++ b/docs/roadmap/journals.md
@@ -48,6 +48,14 @@ IC writing by players — journals, praises, retorts, and weekly XP awards. Jour
   write-then-filter, since a rejection here can't leak); a mute persists the response normally
   but excludes it from the entry AUTHOR's own read (`JournalEntryViewSet.retrieve`) — any other
   viewer is unaffected.
+- **Weekly-vote UI on public journal entries (#3302)** — `VoteButton` (`targetType="journal"`)
+  is mounted on `JournalsPage`'s public feed rows and the in-scene `JournalTab`, gated by
+  `is_public` and hidden when `entry.author` (a CharacterSheet id) is one of the viewer's own
+  roster characters (the backend already refuses self-votes, via
+  `services/voting.py::get_author_account_for_target`, so this is a UX-only guard). Shares the
+  same weekly budget as pose/action votes and shows up in `VotesPanel`'s history via the
+  existing `journal` target-type label; no backend change was needed, since the JOURNAL vote
+  target was already fully wired.
 
 ## Deferred (depends on systems that don't exist yet)
 - **Relationship gating for retorts** — retorts should validate antagonistic relationship (needs relationships system)

--- a/frontend/src/journals/__tests__/JournalsPage.voteButton.test.tsx
+++ b/frontend/src/journals/__tests__/JournalsPage.voteButton.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Targeted test: VoteButton visibility gating on journal entry rows (#3302).
+ *
+ * Mirrors `scenes/components/__tests__/PoseUnit.voteButton.test.tsx`, using the same
+ * gating shape (VoteButton has no self-guard of its own; the backend rejects
+ * self-votes, so this gate is UX only), applied to `JournalsPage`'s public
+ * feed rows instead of poses. `entry.author` is a CharacterSheet id, so the
+ * gate compares it against the viewer's roster `character_id`s (all owned
+ * characters, matching the account-level self-vote check in
+ * `services/voting.py`'s `get_author_account_for_target`) rather than the
+ * persona-id comparison PoseUnit uses.
+ *
+ * Scope: gating only. VoteButton's own budget-disabled behavior is its own
+ * concern and isn't retested here.
+ */
+
+import { render, screen, within } from '@testing-library/react';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import type { JournalEntrySummary, PaginatedJournalEntries } from '../api';
+
+vi.mock('sonner', () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// Viewer roster resolution, mirroring PoseUnit.voteButton.test.tsx's idiom.
+// character_id 42 is "owned" by the viewer for these tests.
+vi.mock('@/roster/queries', () => ({
+  useMyRosterEntriesQuery: vi.fn(() => ({
+    data: [
+      {
+        id: 1,
+        name: 'ViewerChar',
+        character_id: 42,
+        profile_picture_url: null,
+        primary_persona_id: 7,
+        active_persona_id: 7,
+      },
+    ],
+  })),
+}));
+
+// Vote hooks, mocked so VoteButton renders without hitting the network.
+const mockCastVote = vi.fn();
+const mockRemoveVote = vi.fn();
+vi.mock('@/progression/voteQueries', () => ({
+  useMyVotesQuery: vi.fn(() => ({ data: [] })),
+  useVoteBudgetQuery: vi.fn(() => ({
+    data: { base_votes: 5, scene_bonus_votes: 0, votes_spent: 0, votes_remaining: 5 },
+  })),
+  useCastVoteMutation: vi.fn(() => ({ mutate: mockCastVote, isPending: false })),
+  useRemoveVoteMutation: vi.fn(() => ({ mutate: mockRemoveVote, isPending: false })),
+}));
+
+const mockUseJournalEntries = vi.fn();
+const mockUseMyJournalEntries = vi.fn();
+const mockUseJournalEntry = vi.fn();
+const mockUseRespondToJournal = vi.fn();
+const mockUseCreateJournalEntry = vi.fn();
+
+vi.mock('../queries', () => ({
+  useJournalEntries: () => mockUseJournalEntries(),
+  useMyJournalEntries: () => mockUseMyJournalEntries(),
+  useJournalEntry: () => mockUseJournalEntry(),
+  useRespondToJournal: () => mockUseRespondToJournal(),
+  useCreateJournalEntry: () => mockUseCreateJournalEntry(),
+}));
+
+import { JournalsPage } from '../pages/JournalsPage';
+
+function makeEntry(overrides: Partial<JournalEntrySummary> = {}): JournalEntrySummary {
+  return {
+    id: 1,
+    author: 99,
+    author_name: 'Someone Else',
+    title: 'A Quiet Evening',
+    is_public: true,
+    response_type: null,
+    parent: null,
+    created_at: '2026-01-01T00:00:00Z',
+    edited_at: null,
+    tags: [],
+    response_count: 0,
+    ...overrides,
+  };
+}
+
+function makePage(results: JournalEntrySummary[]): PaginatedJournalEntries {
+  return { count: results.length, next: null, previous: null, results };
+}
+
+function emptyPage(): PaginatedJournalEntries {
+  return makePage([]);
+}
+
+function Wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}
+
+describe('JournalsPage - VoteButton gating (#3302)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseMyJournalEntries.mockReturnValue({ data: emptyPage(), isLoading: false });
+    mockUseJournalEntry.mockReturnValue({ data: undefined, isLoading: false });
+    mockUseRespondToJournal.mockReturnValue({ mutate: vi.fn(), isPending: false });
+    mockUseCreateJournalEntry.mockReturnValue({ mutate: vi.fn(), isPending: false });
+  });
+
+  it("renders VoteButton on another character's public entry", () => {
+    // author 99 is not the viewer (roster character_id 42).
+    const entry = makeEntry({ id: 1, author: 99, is_public: true });
+    mockUseJournalEntries.mockReturnValue({ data: makePage([entry]), isLoading: false });
+
+    render(
+      <Wrapper>
+        <JournalsPage />
+      </Wrapper>
+    );
+
+    const section = screen.getByTestId('public-journals-section');
+    expect(within(section).getByTitle(/vote/i)).toBeInTheDocument();
+  });
+
+  it("hides VoteButton on the viewer's own public entry", () => {
+    // author 42 matches the mocked viewer's roster character_id.
+    const entry = makeEntry({ id: 2, author: 42, is_public: true });
+    mockUseJournalEntries.mockReturnValue({ data: makePage([entry]), isLoading: false });
+
+    render(
+      <Wrapper>
+        <JournalsPage />
+      </Wrapper>
+    );
+
+    const section = screen.getByTestId('public-journals-section');
+    expect(within(section).queryByTitle(/vote/i)).toBeNull();
+  });
+
+  it('hides VoteButton on entries in the "My Journal" section (always own)', () => {
+    const entry = makeEntry({ id: 3, author: 42, is_public: true });
+    mockUseMyJournalEntries.mockReturnValue({ data: makePage([entry]), isLoading: false });
+    mockUseJournalEntries.mockReturnValue({ data: emptyPage(), isLoading: false });
+
+    render(
+      <Wrapper>
+        <JournalsPage />
+      </Wrapper>
+    );
+
+    const section = screen.getByTestId('my-journal-section');
+    expect(within(section).queryByTitle(/vote/i)).toBeNull();
+  });
+});

--- a/frontend/src/journals/components/JournalTab.tsx
+++ b/frontend/src/journals/components/JournalTab.tsx
@@ -8,17 +8,27 @@
  * `response_count`, which includes the author's own follow-ups), so a real
  * "responses to me" count would need a new backend shape; out of scope for
  * this task per the brief (no backend changes).
+ *
+ * VoteButton gating (#3302): `entries/mine/` is filtered server-side to the
+ * requesting character's own entries only (`views.py`'s `mine` action), so
+ * every row here is always the viewer's own; the same own-entry gate used
+ * on `JournalsPage` therefore always evaluates to hidden. Wired anyway (not
+ * dead: it's the correctness gate, not a feature) so this list renders
+ * VoteButton the moment it ever surfaces someone else's entry.
  */
 import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import { PenLine } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { VoteButton } from '@/components/VoteButton';
+import { useMyRosterEntriesQuery } from '@/roster/queries';
 import { useMyJournalEntries } from '../queries';
 import { JournalComposerDialog } from './JournalComposerDialog';
 
 export function JournalTab() {
   const [composerOpen, setComposerOpen] = useState(false);
   const { data, isLoading } = useMyJournalEntries();
+  const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
   const recent = (data?.results ?? []).slice(0, 5);
 
   return (
@@ -41,19 +51,24 @@ export function JournalTab() {
         </p>
       ) : (
         <ul className="space-y-2">
-          {recent.map((entry) => (
-            <li key={entry.id}>
-              <Link
-                to="/journals"
-                className="block rounded border px-2 py-1.5 text-sm hover:bg-accent"
-              >
-                <span className="block truncate font-medium">{entry.title}</span>
-                <span className="block text-xs text-muted-foreground">
-                  {new Date(entry.created_at).toLocaleDateString()}
-                </span>
-              </Link>
-            </li>
-          ))}
+          {recent.map((entry) => {
+            const isOwnEntry = myRosterEntries.some((e) => e.character_id === entry.author);
+            const canVote = entry.is_public && !isOwnEntry;
+            return (
+              <li key={entry.id} className="flex items-center gap-1">
+                <Link
+                  to="/journals"
+                  className="block min-w-0 flex-1 rounded border px-2 py-1.5 text-sm hover:bg-accent"
+                >
+                  <span className="block truncate font-medium">{entry.title}</span>
+                  <span className="block text-xs text-muted-foreground">
+                    {new Date(entry.created_at).toLocaleDateString()}
+                  </span>
+                </Link>
+                {canVote ? <VoteButton targetType="journal" targetId={entry.id} /> : null}
+              </li>
+            );
+          })}
         </ul>
       )}
 

--- a/frontend/src/journals/pages/JournalsPage.tsx
+++ b/frontend/src/journals/pages/JournalsPage.tsx
@@ -15,6 +15,8 @@ import { Label } from '@/components/ui/label';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { toast } from 'sonner';
+import { VoteButton } from '@/components/VoteButton';
+import { useMyRosterEntriesQuery } from '@/roster/queries';
 import type { JournalEntrySummary, JournalResponseType } from '../api';
 import {
   useJournalEntries,
@@ -188,34 +190,47 @@ function EntryRow({
   onToggle: () => void;
   showResponseForm: boolean;
 }) {
+  // Own-entry gate for VoteButton (#3302), mirroring PoseUnit's isSelfPose
+  // guard: VoteButton has no self-guard of its own (the backend rejects
+  // self-votes; this is UX only), so the row computes whether `entry.author`
+  // (a CharacterSheet id) is one of the viewer's own characters and decides
+  // whether to mount. Also requires `is_public`, since only public entries
+  // carry a vote target server-side.
+  const { data: myRosterEntries = [] } = useMyRosterEntriesQuery();
+  const isOwnEntry = myRosterEntries.some((e) => e.character_id === entry.author);
+  const canVote = entry.is_public && !isOwnEntry;
+
   return (
     <Card>
-      <button type="button" className="block w-full text-left" onClick={onToggle}>
-        <CardHeader className="p-4">
-          <div className="flex items-center justify-between gap-2">
-            <CardTitle className="text-base">{entry.title}</CardTitle>
-            {!entry.is_public ? <Badge variant="outline">Private</Badge> : null}
-          </div>
-          <div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
-            <span>{entry.author_name}</span>
-            <span>·</span>
-            <span>{new Date(entry.created_at).toLocaleDateString()}</span>
-            {entry.response_count > 0 ? (
-              <>
-                <span>·</span>
-                <span>
-                  {entry.response_count} response{entry.response_count === 1 ? '' : 's'}
-                </span>
-              </>
-            ) : null}
-            {entry.tags.map((tag) => (
-              <Badge key={tag.id} variant="secondary">
-                {tag.name}
-              </Badge>
-            ))}
-          </div>
-        </CardHeader>
-      </button>
+      <div className="flex items-start justify-between gap-2 p-4">
+        <button type="button" className="min-w-0 flex-1 text-left" onClick={onToggle}>
+          <CardHeader className="p-0">
+            <div className="flex items-center justify-between gap-2">
+              <CardTitle className="text-base">{entry.title}</CardTitle>
+              {!entry.is_public ? <Badge variant="outline">Private</Badge> : null}
+            </div>
+            <div className="flex flex-wrap items-center gap-1.5 text-xs text-muted-foreground">
+              <span>{entry.author_name}</span>
+              <span>·</span>
+              <span>{new Date(entry.created_at).toLocaleDateString()}</span>
+              {entry.response_count > 0 ? (
+                <>
+                  <span>·</span>
+                  <span>
+                    {entry.response_count} response{entry.response_count === 1 ? '' : 's'}
+                  </span>
+                </>
+              ) : null}
+              {entry.tags.map((tag) => (
+                <Badge key={tag.id} variant="secondary">
+                  {tag.name}
+                </Badge>
+              ))}
+            </div>
+          </CardHeader>
+        </button>
+        {canVote ? <VoteButton targetType="journal" targetId={entry.id} /> : null}
+      </div>
       {expanded ? (
         <CardContent className="p-4 pt-0">
           <EntryDetail entryId={entry.id} showResponseForm={showResponseForm} />


### PR DESCRIPTION
Closes #3302

## Summary

Journal-target weekly votes UI (#3302): mount VoteButton (targetType=journal) on public journal entries in JournalsPage and the in-scene JournalTab, hidden on the viewer's own entries; VotesPanel already labels journal votes. Frontend-only - backend journal vote support was verified complete. Component tests mirror PoseUnit.voteButton.test.tsx.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #3302 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Up to date with origin/main; no conflicts.

<!-- last-addressed-comment: 0 -->