### PR TITLE
Wire the canon-review request loop + global-scope cap: request_canon_review has zero callers, so the #2003 queue is permanently empty

### DIFF
--- a/docs/roadmap/stories-gm.md
+++ b/docs/roadmap/stories-gm.md
@@ -437,3 +437,26 @@ deliberately does **not** call it — it runs outside story participation.
 `CHARACTER_LEVEL_AT_LEAST` beats now flip in real time on an in-play advance, in
 addition to login catch-up (`catch_up_character_stories`) and retroactive match
 on new story progress.
+
+### Canon-review request loop + GLOBAL-scope gate — DONE (#3304)
+
+The #2003 canon-review lifecycle (`CanonReview`, `CanonReviewViewSet`,
+`story_is_cleared` gating) shipped with no production caller ever creating a
+review row — a Lead GM setting `story impact <id>=regional|world` produced a
+tier that could only clear via a staff hand-created row in Django admin.
+`ensure_canon_review_for_story(story, gm_profile)` (`canon_review.py`) closes
+the loop: the web impact-setting path, telnet `story impact`, and the
+escalation-aware readiness check now all request (and, for a REGIONAL tier
+and an auto-clearing GM level, immediately system-clear) a review. See
+`docs/systems/stories.md`'s "Review-request loop (#3304)" section for the
+full seam-by-seam breakdown.
+
+`allow_global_scope_authoring` (`GMLevelCap`) was similarly unconsumed outside
+factories/admin — GLOBAL-scope story authoring is now gated on it at the
+`assign-to-scope` scope<->target invariant, with the usual staff bypass and
+most-restrictive (refuse) fallback when no cap row exists.
+
+The staff-facing side landed too: `pending_canon_reviews` was already computed
+by `StaffWorkloadView` but never rendered — `PendingCanonReviewsPanel` on
+`StaffWorkloadPage` now lists the pending queue and wires
+`CanonReviewViewSet`'s `clear`/`changes` actions.

--- a/docs/systems/stories.md
+++ b/docs/systems/stories.md
@@ -913,10 +913,48 @@ stake a society-level FACTION subject (`StakeSubjectKind.FACTION` +
 review purposes. Surfaced as a readiness problem, not a hard block; the author's
 `impact_tier` on the model is unchanged.
 
+### Review-request loop (#3304)
+
+`ensure_canon_review_for_story(story, gm_profile)` (`canon_review.py`) is the
+one orchestrator every seam that can raise a story's canon-review tier routes
+through, instead of calling `request_canon_review`/`clear_canon_review`
+directly:
+
+- **tier < REGIONAL** (the *escalated* effective tier, from
+  `escalation_tier_for_story` — not the raw `impact_tier`): no-op, no review.
+- **tier == REGIONAL**: a review is requested; if `gm_profile` is not None and
+  its level cap auto-clears REGIONAL, the review is immediately system-cleared
+  (`reviewer=None`, notes `"auto-cleared by GM level cap"`) — an auditable
+  stamp, not an invisible skip. `clear_canon_review` accepts `reviewer=None`
+  for exactly this path; `CanonReviewViewSet.clear` always passes the
+  authenticated staff account, so the web API can never produce a
+  system-stamped row.
+- **tier == WORLD**: always requested, never auto-cleared, at any GM level.
+
+Callers: the web `story impact` path (`StoryViewSet.perform_update`, whenever
+a PATCH/PUT changes `impact_tier`), telnet's `story impact` (`_handle_impact`
+in `commands/story.py`), and the readiness gate itself
+(`stakes._canon_review_problems`, called from every `validate_stakes_readiness`
+check) — the last of these uses the *escalated* tier, so a GROUP/GLOBAL story
+whose beats trigger the escalation heuristic gets a review even though its
+authored `impact_tier` was never manually raised. All three calls are
+idempotent (safe on every readiness check / impact-tier save).
+
+### GLOBAL-scope authoring gate (#3304)
+
+`GMLevelCap.allow_global_scope_authoring` gates `POST
+/api/stories/{id}/assign-to-scope/` (`AssignStoryInputSerializer`, the
+`scope <-> target` invariant neighborhood): a non-staff Lead GM assigning
+GLOBAL scope needs a permitting cap row (`_gm_allows_global_scope`, mirrors
+`_gm_allows_custom_stakes`'s most-restrictive fallback — no GMProfile or no
+cap row refuses); staff bypass unconditionally.
+
 ### Queue + verbs
 
 - **Staff queue**: `StaffWorkloadView` (`GET /api/stories/staff-workload/`)
-  surfaces `pending_canon_reviews` (aged).
+  surfaces `pending_canon_reviews` (aged); rendered on the frontend as the
+  `PendingCanonReviewsPanel` on `StaffWorkloadPage` (list, clear with notes,
+  request changes — consumes the same `CanonReviewViewSet` actions below).
 - **Web verbs**: `CanonReviewViewSet` (`/api/canon-reviews/`) — staff-only
   `list`/`retrieve` + `clear` (approve) and `changes` (request changes) detail
   actions.

--- a/frontend/src/generated/api.d.ts
+++ b/frontend/src/generated/api.d.ts
@@ -20166,11 +20166,12 @@ export interface paths {
      *     - GROUP: creates GroupStoryProgress for the given gm_table
      *     - GLOBAL: creates the GlobalStoryProgress singleton
      *
-     *     The scope <-> target invariant is enforced by
-     *     AssignStoryInputSerializer.validate(), so an invalid combination is a
-     *     400 (no scope change, no progress row). Because scope is set before
-     *     the create_*_progress call, StoryNotAssignedError cannot fire — no
-     *     try/except is needed.
+     *     The scope <-> target invariant, AND (for GLOBAL) the
+     *     ``allow_global_scope_authoring`` GMLevelCap gate (#3304), are enforced
+     *     by AssignStoryInputSerializer.validate(), so an invalid combination or
+     *     an under-leveled GM's GLOBAL attempt is a 400 (no scope change, no
+     *     progress row). Because scope is set before the create_*_progress
+     *     call, StoryNotAssignedError cannot fire — no try/except is needed.
      */
     post: operations['stories_assign_to_scope_create'];
     delete?: never;

--- a/frontend/src/stories/__tests__/StaffWorkloadPage.test.tsx
+++ b/frontend/src/stories/__tests__/StaffWorkloadPage.test.tsx
@@ -27,6 +27,8 @@ import type { StaffWorkloadResponse } from '../types';
 vi.mock('../api', () => ({
   getStaffWorkload: vi.fn(),
   expireOverdueBeats: vi.fn(),
+  clearCanonReview: vi.fn(),
+  requestCanonReviewChanges: vi.fn(),
 }));
 
 import * as api from '../api';
@@ -69,12 +71,31 @@ const emptyResponse: StaffWorkloadResponse = {
   pending_agm_claims_count: 0,
   open_session_requests_count: 0,
   counts_by_scope: {},
+  pending_canon_reviews: [],
 };
 
 const fullResponse: StaffWorkloadResponse = {
   pending_agm_claims_count: 3,
   open_session_requests_count: 5,
   counts_by_scope: { character: 4, group: 2, global: 1 },
+  pending_canon_reviews: [
+    {
+      review_id: 30,
+      story_id: 40,
+      story_title: 'The Fracturing Accord',
+      tier: 'world',
+      created_at: '2026-03-01T00:00:00Z',
+      days_aging: 5,
+    },
+    {
+      review_id: 31,
+      story_id: 41,
+      story_title: 'A Quiet Border Dispute',
+      tier: 'regional',
+      created_at: '2026-04-01T00:00:00Z',
+      days_aging: 1,
+    },
+  ],
   per_gm_queue_depth: [
     { gm_profile_id: 1, gm_name: 'Alice GM', episodes_ready: 7, pending_claims: 2 },
     { gm_profile_id: 2, gm_name: 'Bob GM', episodes_ready: 2, pending_claims: 0 },
@@ -137,7 +158,7 @@ describe('StaffWorkloadPage', () => {
   // Section rendering
   // -------------------------------------------------------------------------
 
-  it('renders all five sections with full data', async () => {
+  it('renders all six sections with full data', async () => {
     mockSuccess(fullResponse);
     render(<StaffWorkloadPage />, { wrapper: createWrapper() });
 
@@ -149,6 +170,7 @@ describe('StaffWorkloadPage', () => {
     expect(screen.getByTestId('per-gm-section')).toBeInTheDocument();
     expect(screen.getByTestId('stale-stories-section')).toBeInTheDocument();
     expect(screen.getByTestId('frontier-section')).toBeInTheDocument();
+    expect(screen.getByTestId('pending-canon-reviews-section')).toBeInTheDocument();
     expect(screen.getByTestId('manual-actions-section')).toBeInTheDocument();
   });
 
@@ -233,6 +255,20 @@ describe('StaffWorkloadPage', () => {
     expect(screen.getByText('Rise of Northhold')).toBeInTheDocument();
   });
 
+  it('renders pending canon review rows', async () => {
+    mockSuccess(fullResponse);
+    render(<StaffWorkloadPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pending-canon-reviews-table')).toBeInTheDocument();
+    });
+
+    const rows = screen.getAllByTestId('pending-canon-review-row');
+    expect(rows).toHaveLength(2);
+    expect(screen.getByText('The Fracturing Accord')).toBeInTheDocument();
+    expect(screen.getByText('A Quiet Border Dispute')).toBeInTheDocument();
+  });
+
   // -------------------------------------------------------------------------
   // Empty states
   // -------------------------------------------------------------------------
@@ -267,6 +303,16 @@ describe('StaffWorkloadPage', () => {
       expect(screen.getByTestId('frontier-stories-empty')).toBeInTheDocument();
     });
     expect(screen.getByText('No stories at the authoring frontier.')).toBeInTheDocument();
+  });
+
+  it('renders pending canon reviews empty state when none are pending', async () => {
+    mockSuccess(emptyResponse);
+    render(<StaffWorkloadPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('pending-canon-reviews-empty')).toBeInTheDocument();
+    });
+    expect(screen.getByText('No canon reviews are pending.')).toBeInTheDocument();
   });
 
   // -------------------------------------------------------------------------
@@ -416,6 +462,82 @@ describe('StaffWorkloadPage', () => {
 
     await waitFor(() => {
       expect(toast.success).toHaveBeenCalledWith('Expired 1 overdue beat');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Pending canon review actions: clear / request changes
+  // -------------------------------------------------------------------------
+
+  it('clears a pending canon review from its row dialog', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.clearCanonReview).mockResolvedValue({
+      id: 30,
+      story: 40,
+      tier: 'world',
+      status: 'cleared',
+      reviewer: 1,
+      notes: 'looks good',
+      created_at: '2026-03-01T00:00:00Z',
+      resolved_at: '2026-03-06T00:00:00Z',
+    });
+    mockSuccess(fullResponse);
+    render(<StaffWorkloadPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('clear-canon-review-btn')).toHaveLength(2);
+    });
+
+    await user.click(screen.getAllByTestId('clear-canon-review-btn')[0]);
+    const dialog = screen.getByRole('dialog');
+    await user.click(within(dialog).getByRole('button', { name: 'Clear' }));
+
+    await waitFor(() => {
+      expect(api.clearCanonReview).toHaveBeenCalledWith(30, { notes: '' });
+    });
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Canon review cleared');
+    });
+  });
+
+  it('requests changes on a pending canon review, requiring notes', async () => {
+    const user = userEvent.setup();
+    vi.mocked(api.requestCanonReviewChanges).mockResolvedValue({
+      id: 30,
+      story: 40,
+      tier: 'world',
+      status: 'changes_requested',
+      reviewer: 1,
+      notes: 'narrow the scope',
+      created_at: '2026-03-01T00:00:00Z',
+      resolved_at: '2026-03-06T00:00:00Z',
+    });
+    mockSuccess(fullResponse);
+    render(<StaffWorkloadPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('request-canon-review-changes-btn')).toHaveLength(2);
+    });
+
+    await user.click(screen.getAllByTestId('request-canon-review-changes-btn')[0]);
+    const dialog = screen.getByRole('dialog');
+
+    // Submitting with no notes shows an inline error and does not call the API.
+    await user.click(within(dialog).getByRole('button', { name: 'Request Changes' }));
+    expect(within(dialog).getByText(/notes are required/i)).toBeInTheDocument();
+    expect(api.requestCanonReviewChanges).not.toHaveBeenCalled();
+
+    // Fill in notes and resubmit.
+    await user.type(within(dialog).getByLabelText(/notes/i), 'narrow the scope');
+    await user.click(within(dialog).getByRole('button', { name: 'Request Changes' }));
+
+    await waitFor(() => {
+      expect(api.requestCanonReviewChanges).toHaveBeenCalledWith(30, {
+        notes: 'narrow the scope',
+      });
+    });
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith('Changes requested');
     });
   });
 });

--- a/frontend/src/stories/api.ts
+++ b/frontend/src/stories/api.ts
@@ -25,6 +25,9 @@ import type {
   BeatCompletion,
   BeatCreateBody,
   BeatUpdateBody,
+  CanonReview,
+  CanonReviewChangesBody,
+  CanonReviewClearBody,
   Chapter,
   ChapterCreateBody,
   ChapterList,
@@ -115,6 +118,50 @@ export async function getStaffWorkload(): Promise<StaffWorkloadResponse> {
   const res = await apiFetch('/api/stories/staff-workload/');
   if (!res.ok) throw new Error('Failed to load staff workload');
   return res.json() as Promise<StaffWorkloadResponse>;
+}
+
+// ---------------------------------------------------------------------------
+// Canon review lifecycle (#2003/#3304) — staff-only.
+//
+// The PENDING list itself is not fetched separately: StaffWorkloadResponse
+// already carries it (`pending_canon_reviews`), so the panel reuses that
+// query instead of duplicating a list call against /api/canon-reviews/.
+// ---------------------------------------------------------------------------
+
+/** POST /api/canon-reviews/{id}/clear/ — staff approves a PENDING review. */
+export async function clearCanonReview(
+  reviewId: number,
+  body: CanonReviewClearBody
+): Promise<CanonReview> {
+  const res = await apiFetch(`/api/canon-reviews/${reviewId}/clear/`, {
+    method: 'POST',
+    headers: jsonHeaders(),
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const err = new Error('Failed to clear canon review') as Error & { response?: Response };
+    err.response = res;
+    throw err;
+  }
+  return res.json() as Promise<CanonReview>;
+}
+
+/** POST /api/canon-reviews/{id}/changes/ — staff sends a PENDING review back with notes. */
+export async function requestCanonReviewChanges(
+  reviewId: number,
+  body: CanonReviewChangesBody
+): Promise<CanonReview> {
+  const res = await apiFetch(`/api/canon-reviews/${reviewId}/changes/`, {
+    method: 'POST',
+    headers: jsonHeaders(),
+    body: JSON.stringify(body),
+  });
+  if (!res.ok) {
+    const err = new Error('Failed to request changes') as Error & { response?: Response };
+    err.response = res;
+    throw err;
+  }
+  return res.json() as Promise<CanonReview>;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/src/stories/components/PendingCanonReviewsPanel.tsx
+++ b/frontend/src/stories/components/PendingCanonReviewsPanel.tsx
@@ -48,7 +48,10 @@ function ReviewRow({ entry }: { entry: PendingCanonReviewEntry }) {
   const changesMutation = useRequestCanonReviewChanges();
 
   return (
-    <tr className="border-b last:border-0 hover:bg-accent/50" data-testid="pending-canon-review-row">
+    <tr
+      className="border-b last:border-0 hover:bg-accent/50"
+      data-testid="pending-canon-review-row"
+    >
       <td className="py-3 pr-4">
         <Link
           to={`/stories/${entry.story_id}`}

--- a/frontend/src/stories/components/PendingCanonReviewsPanel.tsx
+++ b/frontend/src/stories/components/PendingCanonReviewsPanel.tsx
@@ -1,0 +1,155 @@
+/**
+ * PendingCanonReviewsPanel — staff queue for pending canon-impact reviews
+ * (#2003/#3304), mounted on StaffWorkloadPage.
+ *
+ * The list itself is not fetched separately: it rides
+ * StaffWorkloadResponse.pending_canon_reviews (already built for #2003, just
+ * never rendered). Only the two decision actions (clear / request changes)
+ * are new — both reuse ClearanceNoteDialog (`clearanceShared.tsx`), the same
+ * generic note-dialog the custody-clearance grant/deny/resolve actions use,
+ * rather than hand-rolling a third copy of the same open/note/error dialog
+ * shape.
+ */
+
+import { Link } from 'react-router-dom';
+import { toast } from 'sonner';
+import { formatRelativeTime } from '@/lib/relativeTime';
+import { useClearCanonReview, useRequestCanonReviewChanges } from '../queries';
+import type { PendingCanonReviewEntry } from '../types';
+import { ClearanceNoteDialog, handleInlineError } from './clearanceShared';
+
+interface PendingCanonReviewsPanelProps {
+  entries: PendingCanonReviewEntry[];
+}
+
+const TIER_LABELS: Record<string, string> = {
+  table: 'Table',
+  regional: 'Regional',
+  world: 'World',
+};
+
+function TierBadge({ tier }: { tier: string }) {
+  const isWorld = tier === 'world';
+  return (
+    <span
+      className={
+        isWorld
+          ? 'rounded-full bg-destructive/10 px-2 py-0.5 text-xs font-medium text-destructive'
+          : 'rounded-full bg-muted px-2 py-0.5 text-xs font-medium text-muted-foreground'
+      }
+    >
+      {TIER_LABELS[tier] ?? tier}
+    </span>
+  );
+}
+
+function ReviewRow({ entry }: { entry: PendingCanonReviewEntry }) {
+  const clearMutation = useClearCanonReview();
+  const changesMutation = useRequestCanonReviewChanges();
+
+  return (
+    <tr className="border-b last:border-0 hover:bg-accent/50" data-testid="pending-canon-review-row">
+      <td className="py-3 pr-4">
+        <Link
+          to={`/stories/${entry.story_id}`}
+          className="font-medium text-primary hover:underline"
+        >
+          {entry.story_title}
+        </Link>
+      </td>
+      <td className="py-3 pr-4">
+        <TierBadge tier={entry.tier} />
+      </td>
+      <td className="py-3 pr-4 text-muted-foreground">{formatRelativeTime(entry.created_at)}</td>
+      <td className="py-3 pr-4 tabular-nums">{entry.days_aging}</td>
+      <td className="py-3">
+        <div className="flex gap-2">
+          <ClearanceNoteDialog
+            title="Clear canon review"
+            noteLabel="Notes"
+            placeholder="Any notes for the record…"
+            submitLabel="Clear"
+            pendingLabel="Clearing…"
+            isPending={clearMutation.isPending}
+            successToast="Canon review cleared"
+            errorFallback="Failed to clear canon review."
+            triggerTestId="clear-canon-review-btn"
+            triggerLabel="Clear"
+            onSubmit={(notes, { setError, close }) => {
+              clearMutation.mutate(
+                { reviewId: entry.review_id, body: { notes } },
+                {
+                  onSuccess: () => {
+                    toast.success('Canon review cleared');
+                    close();
+                  },
+                  onError: (err) =>
+                    handleInlineError(err, setError, 'Failed to clear canon review.'),
+                }
+              );
+            }}
+          />
+          <ClearanceNoteDialog
+            title="Request changes"
+            noteLabel="Notes"
+            placeholder="What needs to change before this can clear…"
+            submitLabel="Request Changes"
+            pendingLabel="Sending…"
+            isPending={changesMutation.isPending}
+            successToast="Changes requested"
+            errorFallback="Failed to request changes."
+            submitVariant="destructive"
+            triggerTestId="request-canon-review-changes-btn"
+            triggerLabel="Request Changes"
+            triggerVariant="outline"
+            noteRequired
+            requiredErrorMessage="Notes are required so the Lead GM knows what to change."
+            onSubmit={(notes, { setError, close }) => {
+              changesMutation.mutate(
+                { reviewId: entry.review_id, body: { notes } },
+                {
+                  onSuccess: () => {
+                    toast.success('Changes requested');
+                    close();
+                  },
+                  onError: (err) => handleInlineError(err, setError, 'Failed to request changes.'),
+                }
+              );
+            }}
+          />
+        </div>
+      </td>
+    </tr>
+  );
+}
+
+export function PendingCanonReviewsPanel({ entries }: PendingCanonReviewsPanelProps) {
+  if (entries.length === 0) {
+    return (
+      <p className="py-4 text-muted-foreground" data-testid="pending-canon-reviews-empty">
+        No canon reviews are pending.
+      </p>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto" data-testid="pending-canon-reviews-table">
+      <table className="w-full text-sm">
+        <thead>
+          <tr className="border-b text-left text-muted-foreground">
+            <th className="pb-2 pr-4 font-medium">Story</th>
+            <th className="pb-2 pr-4 font-medium">Tier</th>
+            <th className="pb-2 pr-4 font-medium">Requested</th>
+            <th className="pb-2 pr-4 font-medium">Days Aging</th>
+            <th className="pb-2 font-medium">Actions</th>
+          </tr>
+        </thead>
+        <tbody>
+          {entries.map((entry) => (
+            <ReviewRow key={entry.review_id} entry={entry} />
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/frontend/src/stories/components/clearanceShared.tsx
+++ b/frontend/src/stories/components/clearanceShared.tsx
@@ -91,6 +91,16 @@ interface ClearanceNoteDialogProps {
   triggerLabel: string;
   /** Variant for the trigger button. */
   triggerVariant?: 'default' | 'outline' | 'destructive';
+  /**
+   * When true, the note is required: the "(optional)" label suffix is
+   * hidden and submitting a blank note shows an inline error instead of
+   * calling {@link onSubmit} (mirrors CanonReviewChangesInputSerializer's
+   * required-notes contract, #3304). Defaults to false — every existing
+   * caller (grant/deny/resolve) treats the note as optional.
+   */
+  noteRequired?: boolean;
+  /** Inline error shown when noteRequired is true and the note is blank. */
+  requiredErrorMessage?: string;
 }
 
 /**
@@ -110,6 +120,8 @@ export function ClearanceNoteDialog({
   triggerLabel,
   triggerVariant,
   submitVariant,
+  noteRequired = false,
+  requiredErrorMessage = 'This field is required.',
 }: ClearanceNoteDialogProps) {
   const [open, setOpen] = useState(false);
   const [note, setNote] = useState('');
@@ -126,7 +138,12 @@ export function ClearanceNoteDialog({
   function handleSubmit(e: React.FormEvent) {
     e.preventDefault();
     setError('');
-    onSubmit(note.trim(), {
+    const trimmed = note.trim();
+    if (noteRequired && !trimmed) {
+      setError(requiredErrorMessage);
+      return;
+    }
+    onSubmit(trimmed, {
       setError,
       close: () => handleOpenChange(false),
     });
@@ -146,7 +163,8 @@ export function ClearanceNoteDialog({
           </DialogHeader>
           <div className="mt-4 space-y-1.5">
             <Label htmlFor={`${triggerTestId}-note`}>
-              {noteLabel} <span className="text-muted-foreground">(optional)</span>
+              {noteLabel}{' '}
+              {!noteRequired && <span className="text-muted-foreground">(optional)</span>}
             </Label>
             <Textarea
               id={`${triggerTestId}-note`}

--- a/frontend/src/stories/pages/StaffWorkloadPage.tsx
+++ b/frontend/src/stories/pages/StaffWorkloadPage.tsx
@@ -28,6 +28,7 @@ import { WorkloadStatCard } from '../components/WorkloadStatCard';
 import { PerGMQueueTable } from '../components/PerGMQueueTable';
 import { StaleStoriesTable } from '../components/StaleStoriesTable';
 import { FrontierStoriesTable } from '../components/FrontierStoriesTable';
+import { PendingCanonReviewsPanel } from '../components/PendingCanonReviewsPanel';
 import { ExpireBeatsButton } from '../components/ExpireBeatsButton';
 import { SendGemitDialog } from '@/narrative/components/SendGemitDialog';
 import type { StaffWorkloadResponse } from '../types';
@@ -83,7 +84,14 @@ function LoadingSkeleton() {
       </section>
 
       {/* Tables */}
-      {(['Per-GM Queue Depth', 'Stale Stories', 'Stories at Frontier'] as const).map((title) => (
+      {(
+        [
+          'Per-GM Queue Depth',
+          'Stale Stories',
+          'Stories at Frontier',
+          'Pending Canon Reviews',
+        ] as const
+      ).map((title) => (
         <section key={title}>
           <Skeleton className="mb-4 h-6 w-48" />
           <TableSkeleton rows={3} />
@@ -227,6 +235,16 @@ function StaffWorkloadInner({ data }: { data: StaffWorkloadResponse }) {
         <SectionHeader title="Stories at Frontier" count={data.stories_at_frontier.length} />
         <div className="mt-4">
           <FrontierStoriesTable entries={data.stories_at_frontier} />
+        </div>
+      </section>
+
+      {/* ------------------------------------------------------------------ */}
+      {/* Pending canon reviews (#2003/#3304)                                  */}
+      {/* ------------------------------------------------------------------ */}
+      <section data-testid="pending-canon-reviews-section">
+        <SectionHeader title="Pending Canon Reviews" count={data.pending_canon_reviews.length} />
+        <div className="mt-4">
+          <PendingCanonReviewsPanel entries={data.pending_canon_reviews} />
         </div>
       </section>
 

--- a/frontend/src/stories/queries.ts
+++ b/frontend/src/stories/queries.ts
@@ -32,6 +32,8 @@ import type {
   AssignStoryBody,
   Beat,
   BeatOutcome,
+  CanonReviewChangesBody,
+  CanonReviewClearBody,
   ChapterCreateBody,
   ClearanceDecisionBody,
   ClearanceResolveBody,
@@ -181,6 +183,34 @@ export function useStaffWorkload() {
     queryKey: storiesKeys.staffWorkload(),
     queryFn: api.getStaffWorkload,
     throwOnError: true,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Canon review lifecycle (#2003/#3304) — the PENDING list lives on
+// StaffWorkloadResponse, so only the two decision mutations are needed here;
+// both invalidate staff-workload to refresh the queue.
+// ---------------------------------------------------------------------------
+
+export function useClearCanonReview() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ reviewId, body }: { reviewId: number; body: CanonReviewClearBody }) =>
+      api.clearCanonReview(reviewId, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: storiesKeys.staffWorkload() }).catch(() => {});
+    },
+  });
+}
+
+export function useRequestCanonReviewChanges() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ reviewId, body }: { reviewId: number; body: CanonReviewChangesBody }) =>
+      api.requestCanonReviewChanges(reviewId, body),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: storiesKeys.staffWorkload() }).catch(() => {});
+    },
   });
 }
 

--- a/frontend/src/stories/types.ts
+++ b/frontend/src/stories/types.ts
@@ -237,6 +237,16 @@ export interface FrontierStoryEntry {
   scope: StoryScope;
 }
 
+/** One PENDING canon review in StaffWorkloadView.pending_canon_reviews (#2003/#3304). */
+export interface PendingCanonReviewEntry {
+  review_id: number;
+  story_id: number;
+  story_title: string;
+  tier: string;
+  created_at: string;
+  days_aging: number;
+}
+
 export interface StaffWorkloadResponse {
   per_gm_queue_depth: PerGMQueueEntry[];
   stale_stories: StaleStoryEntry[];
@@ -245,6 +255,22 @@ export interface StaffWorkloadResponse {
   open_session_requests_count: number;
   /** Map of scope → story count */
   counts_by_scope: Record<string, number>;
+  /** Pending canon-impact reviews — the #2003/#3304 review-request queue. */
+  pending_canon_reviews: PendingCanonReviewEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// CanonReviewViewSet (#2003/#3304)
+// ---------------------------------------------------------------------------
+
+export type CanonReview = components['schemas']['CanonReview'];
+
+export interface CanonReviewClearBody {
+  notes?: string;
+}
+
+export interface CanonReviewChangesBody {
+  notes: string;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/commands/story.py
+++ b/src/commands/story.py
@@ -1207,10 +1207,19 @@ class CmdStory(ArxNamespaceCommand):
         story's Lead GM or staff — mirrors ``user_owns_or_leads_story`` exactly
         so telnet can't escalate past the web API. Refuses to lower a tier once
         a review is CLEARED (the tier is frozen at clearance).
+
+        REGIONAL/WORLD calls ``ensure_canon_review_for_story`` (#3304) after
+        saving — this is the telnet half of the impact-tier request-loop seam
+        (the web PATCH-update path is the other half, ``StoryViewSet.
+        perform_update``); requests a review, auto-clearing it for a
+        REGIONAL tier when the caller's GM level permits.
         """
-        from world.stories.constants import ImpactTier  # noqa: PLC0415
+        from world.stories.constants import CanonReviewStatus, ImpactTier  # noqa: PLC0415
         from world.stories.permissions import user_owns_or_leads_story  # noqa: PLC0415
-        from world.stories.services.canon_review import story_is_cleared  # noqa: PLC0415
+        from world.stories.services.canon_review import (  # noqa: PLC0415
+            ensure_canon_review_for_story,
+            story_is_cleared,
+        )
 
         if "=" not in rest:
             raise CommandError(_IMPACT_USAGE)
@@ -1239,6 +1248,14 @@ class CmdStory(ArxNamespaceCommand):
         story.impact_tier = new_tier
         story.save(update_fields=["impact_tier"])
         self.msg(f"Impact tier set to {new_tier} for {story.title}.")
+
+        gm_profile = account.gm_profile_or_none if account else None
+        review = ensure_canon_review_for_story(story, gm_profile)
+        if review is not None:
+            if review.status == CanonReviewStatus.CLEARED:
+                self.msg("Canon review auto-cleared by your GM level.")
+            elif review.status == CanonReviewStatus.PENDING:
+                self.msg("Canon review requested; awaiting staff clearance.")
 
     def _handle_review_status(self, rest: str) -> None:
         """Show a story's impact tier, review state, and readiness problems (#2003).

--- a/src/commands/tests/test_canon_review_command.py
+++ b/src/commands/tests/test_canon_review_command.py
@@ -10,8 +10,11 @@ from django.test import TestCase
 from commands.canon_review import CmdCanonReview
 from commands.story import CmdStory
 from evennia_extensions.factories import AccountFactory
+from world.gm.constants import GMLevel
+from world.gm.factories import GMProfileFactory, seed_default_gm_level_caps
 from world.stories.constants import CanonReviewStatus, ImpactTier
 from world.stories.factories import StoryFactory
+from world.stories.models import CanonReview
 from world.stories.services.canon_review import (
     clear_canon_review,
     request_canon_review,
@@ -77,6 +80,59 @@ class StoryImpactCommandTests(TestCase):
         self.story.refresh_from_db()
         self.assertEqual(self.story.impact_tier, ImpactTier.TABLE)
         self.assertTrue(any("frozen" in m.lower() for m in messages))
+
+
+class StoryImpactRequestsReviewTests(TestCase):
+    """``story impact`` wires ``ensure_canon_review_for_story`` (#3304).
+
+    Setting the tier to REGIONAL/WORLD opens (or auto-clears) a review, so
+    the request loop is reachable from telnet, not just from Django admin.
+    """
+
+    def setUp(self) -> None:
+        seed_default_gm_level_caps()
+        self.owner = AccountFactory()
+        self.caller = MagicMock()
+        self.caller.msg = MagicMock()
+        self.caller.account = self.owner
+        self.story = StoryFactory(impact_tier=ImpactTier.TABLE, owners=[self.owner])
+
+    def _run(self, args: str) -> list[str]:
+        cmd = _make_story_cmd(self.caller, args)
+        cmd.func()
+        return _messages(self.caller)
+
+    def test_world_tier_creates_pending_review(self) -> None:
+        self._run(f"impact {self.story.pk}=world")
+        review = self.story.canon_reviews.get()
+        self.assertEqual(review.status, CanonReviewStatus.PENDING)
+        self.assertEqual(review.tier, ImpactTier.WORLD)
+
+    def test_world_tier_never_auto_clears_even_for_senior_gm(self) -> None:
+        GMProfileFactory(account=self.owner, level=GMLevel.SENIOR)
+        self._run(f"impact {self.story.pk}=world")
+        review = self.story.canon_reviews.get()
+        self.assertEqual(review.status, CanonReviewStatus.PENDING)
+
+    def test_regional_tier_pending_for_gm_without_auto_clear(self) -> None:
+        GMProfileFactory(account=self.owner, level=GMLevel.JUNIOR)
+        messages = self._run(f"impact {self.story.pk}=regional")
+        review = self.story.canon_reviews.get()
+        self.assertEqual(review.status, CanonReviewStatus.PENDING)
+        self.assertTrue(any("awaiting staff" in m.lower() for m in messages))
+
+    def test_regional_tier_auto_clears_for_experienced_gm(self) -> None:
+        GMProfileFactory(account=self.owner, level=GMLevel.EXPERIENCED)
+        messages = self._run(f"impact {self.story.pk}=regional")
+        review = self.story.canon_reviews.get()
+        self.assertEqual(review.status, CanonReviewStatus.CLEARED)
+        self.assertIsNone(review.reviewer)
+        self.assertEqual(review.notes, "auto-cleared by GM level cap")
+        self.assertTrue(any("auto-cleared" in m.lower() for m in messages))
+
+    def test_table_tier_creates_no_review(self) -> None:
+        self._run(f"impact {self.story.pk}=table")
+        self.assertFalse(CanonReview.objects.filter(story=self.story).exists())
 
 
 class StoryReviewStatusCommandTests(TestCase):

--- a/src/schema.json
+++ b/src/schema.json
@@ -32636,11 +32636,12 @@ paths:
         - GROUP: creates GroupStoryProgress for the given gm_table
         - GLOBAL: creates the GlobalStoryProgress singleton
 
-        The scope <-> target invariant is enforced by
-        AssignStoryInputSerializer.validate(), so an invalid combination is a
-        400 (no scope change, no progress row). Because scope is set before
-        the create_*_progress call, StoryNotAssignedError cannot fire — no
-        try/except is needed.
+        The scope <-> target invariant, AND (for GLOBAL) the
+        ``allow_global_scope_authoring`` GMLevelCap gate (#3304), are enforced
+        by AssignStoryInputSerializer.validate(), so an invalid combination or
+        an under-leveled GM's GLOBAL attempt is a 400 (no scope change, no
+        progress row). Because scope is set before the create_*_progress
+        call, StoryNotAssignedError cannot fire — no try/except is needed.
       parameters:
       - in: path
         name: id

--- a/src/world/stories/AGENT_GLOSSARY.md
+++ b/src/world/stories/AGENT_GLOSSARY.md
@@ -150,9 +150,16 @@ canon-touching content before it pays. One PENDING review per story (partial
 unique); `CanonReviewStatus` (PENDING → CLEARED / CHANGES_REQUESTED). The gate
 is auto-downgrade-not-block (pillar-7 pattern): an unreviewed WORLD-tier
 story's staked beats are UNREADY → effective risk NONE (the scene still runs,
-nothing pays) via `validate_stakes_readiness`'s canon-review problem. Surfaced
-on the staff `StaffWorkloadView` pending-queue and decided via the
-`canonreview` telnet command or `CanonReviewViewSet` web verbs.
+nothing pays) via `validate_stakes_readiness`'s canon-review problem. Requested
+(or, for an auto-clearing REGIONAL GM, system-cleared) by
+`ensure_canon_review_for_story` (#3304) whenever the web/telnet `story impact`
+setters or the beat-driven escalation heuristic raise a story's effective
+tier — a system-cleared row stamps `reviewer=None`,
+`notes="auto-cleared by GM level cap"` rather than skipping the row, so
+trust-based clearance stays auditable. Surfaced on the staff
+`StaffWorkloadView` pending-queue (rendered as `PendingCanonReviewsPanel` on
+`StaffWorkloadPage`) and decided via the `canonreview` telnet command or
+`CanonReviewViewSet` web verbs.
 _Avoid_: sign-off (that's `TreasuredSignoff` / custody), approval gate.
 
 **Surrender** (GM):

--- a/src/world/stories/serializers.py
+++ b/src/world/stories/serializers.py
@@ -992,6 +992,19 @@ def _gm_allows_custom_stakes(user) -> bool:
     return cap.allow_custom_stakes
 
 
+def _gm_allows_global_scope(user) -> bool:
+    """Whether a non-staff author's GMLevelCap permits GLOBAL-scope authoring (#3304).
+
+    No GMProfile or no cap row → False (most-restrictive fallback, mirrors
+    ``_gm_allows_custom_stakes``).
+    """
+    try:
+        cap = GMLevelCap.objects.get(level=user.gm_profile.level)
+    except (GMProfile.DoesNotExist, GMLevelCap.DoesNotExist):
+        return False
+    return cap.allow_global_scope_authoring
+
+
 class BeatSerializer(serializers.ModelSerializer):
     """Full serializer for Beat including all Phase 2 predicate config fields."""
 
@@ -2031,7 +2044,23 @@ class AssignStoryInputSerializer(serializers.Serializer):
             raise serializers.ValidationError({"scope": msg})
 
         self._validate_scope_target_invariant(attrs)
+        if attrs["scope"] == StoryScope.GLOBAL:
+            self._validate_global_scope_authoring()
         return attrs
+
+    def _validate_global_scope_authoring(self) -> None:
+        """Gate GLOBAL-scope authoring to staff or a permitting GMLevelCap (#3304).
+
+        Mirrors ``_gm_allows_custom_stakes``'s most-restrictive fallback: no
+        request in context, no GMProfile, or no cap row all refuse.
+        """
+        request = self.context.get("request")
+        user = request.user if request is not None else None
+        if user is not None and user.is_staff:
+            return
+        if user is None or not _gm_allows_global_scope(user):
+            msg = "Your GM level does not permit authoring GLOBAL-scope stories."
+            raise serializers.ValidationError({"scope": msg})
 
     @staticmethod
     def _validate_scope_target_invariant(attrs: Any) -> None:

--- a/src/world/stories/services/canon_review.py
+++ b/src/world/stories/services/canon_review.py
@@ -165,12 +165,26 @@ def ensure_canon_review_for_story(story: Story, gm_profile: GMProfile | None) ->
       the GM's level cap.
 
     Idempotent — safe to call on every readiness check / impact-tier save.
+    A repeat call short-circuits to the existing CLEARED review once one
+    covers the required tier (at or above it), rather than minting a second
+    row: ``request_canon_review``'s own dedup only matches a still-PENDING
+    row, so without this a second call after an auto-clear (PENDING ->
+    CLEARED, nothing PENDING left to match) would open and immediately
+    auto-clear a brand new review every time it's called.
     """
     from world.stories.constants import ImpactTier  # noqa: PLC0415
 
+    tier_order = [ImpactTier.TABLE, ImpactTier.REGIONAL, ImpactTier.WORLD]
     tier = escalation_tier_for_story(story)
     if tier == ImpactTier.TABLE:
         return None
+
+    cleared = (
+        story.canon_reviews.filter(status=CanonReviewStatus.CLEARED).order_by("-created_at").first()
+    )
+    if cleared is not None and tier_order.index(cleared.tier) >= tier_order.index(tier):
+        return cleared
+
     review = request_canon_review(story, tier=tier)
     if (
         review.status == CanonReviewStatus.PENDING

--- a/src/world/stories/services/canon_review.py
+++ b/src/world/stories/services/canon_review.py
@@ -119,10 +119,15 @@ def regional_auto_clears(gm_profile: GMProfile) -> bool:
     return bool(cap and cap.auto_clear_regional)
 
 
-def request_canon_review(story: Story) -> CanonReview:
+def request_canon_review(story: Story, *, tier: str | None = None) -> CanonReview:
     """Create a PENDING ``CanonReview`` for ``story``.
 
-    Idempotent: returns the existing pending review if one is already open.
+    Idempotent: returns the existing pending review if one is already open
+    (its ``tier`` is left as-is — a review already in flight keeps the tier
+    it was opened at). ``tier`` defaults to ``story.impact_tier``;
+    ``ensure_canon_review_for_story`` passes the escalated effective tier
+    explicitly so a beat-driven escalation is recorded even when the
+    author's own ``impact_tier`` hasn't been raised.
     """
     existing = story.canon_reviews.filter(status=CanonReviewStatus.PENDING).first()
     if existing is not None:
@@ -131,18 +136,65 @@ def request_canon_review(story: Story) -> CanonReview:
         review, _created = CanonReview.objects.get_or_create(
             story=story,
             status=CanonReviewStatus.PENDING,
-            defaults={"tier": story.impact_tier},
+            defaults={"tier": tier if tier is not None else story.impact_tier},
         )
+    return review
+
+
+def ensure_canon_review_for_story(story: Story, gm_profile: GMProfile | None) -> CanonReview | None:
+    """Wire the impact-tier request loop end to end (#3304).
+
+    The single orchestrator every seam that can raise a story's canon-review
+    tier routes through: the web/telnet ``story impact`` setters and the
+    beat-driven escalation heuristic (``escalation_tier_for_story``, called
+    from ``stakes._canon_review_problems``) all call this instead of
+    ``request_canon_review`` directly, so none of them can raise the
+    effective tier without a review existing to show for it.
+
+    Uses the *escalated* effective tier (``escalation_tier_for_story``), not
+    the raw ``story.impact_tier`` — a GROUP/GLOBAL story that never had its
+    authored tier raised but whose beats trigger the escalation heuristic
+    still gets a review.
+
+    - Effective tier TABLE: no review needed, returns None.
+    - Effective tier REGIONAL: a review is requested; if ``gm_profile`` is
+      not None and its level cap auto-clears REGIONAL
+      (``regional_auto_clears``), the review is immediately system-cleared
+      (``reviewer=None``, an auditable stamp rather than skipping the row).
+    - Effective tier WORLD: always requested, never auto-cleared, no matter
+      the GM's level cap.
+
+    Idempotent — safe to call on every readiness check / impact-tier save.
+    """
+    from world.stories.constants import ImpactTier  # noqa: PLC0415
+
+    tier = escalation_tier_for_story(story)
+    if tier == ImpactTier.TABLE:
+        return None
+    review = request_canon_review(story, tier=tier)
+    if (
+        review.status == CanonReviewStatus.PENDING
+        and tier == ImpactTier.REGIONAL
+        and gm_profile is not None
+        and regional_auto_clears(gm_profile)
+    ):
+        review = clear_canon_review(review, reviewer=None, notes="auto-cleared by GM level cap")
     return review
 
 
 def clear_canon_review(
     review: CanonReview,
-    reviewer: AccountDB,
+    reviewer: AccountDB | None,
     *,
     notes: str = "",
 ) -> CanonReview:
-    """Mark a PENDING review CLEARED and stamp the resolution."""
+    """Mark a PENDING review CLEARED and stamp the resolution.
+
+    ``reviewer=None`` is the system auto-clear path
+    (``ensure_canon_review_for_story``'s REGIONAL auto-clear branch, #3304).
+    ``CanonReviewViewSet.clear`` always passes the authenticated staff
+    account, so the API path can never produce a system-stamped row.
+    """
     if review.status != CanonReviewStatus.PENDING:
         msg = (
             f"CanonReview {review.pk} is not PENDING (status={review.status!r}); "

--- a/src/world/stories/services/stakes.py
+++ b/src/world/stories/services/stakes.py
@@ -316,15 +316,29 @@ def validate_stakes_readiness(beat: Beat) -> StakesReadinessReport:
 def _canon_review_problems(beat: Beat) -> list[str]:
     """Readiness problems caused by an uncleared canon-impact review (#2003).
 
-    Only WORLD-tier stories are gated here: TABLE is never reviewed, and
-    REGIONAL auto-clears for EXPERIENCED+ GMs (so it never blocks readiness
-    at this seam — the auto-clear decision is a separate concern handled when
-    a review is requested/decided, not at activation time).
+    Only WORLD-tier stories are gated (blocked) here: TABLE is never
+    reviewed, and REGIONAL auto-clears for EXPERIENCED+ GMs (so it never
+    blocks readiness at this seam — the auto-clear decision is a separate
+    concern handled when a review is requested/decided, not at activation
+    time).
+
+    Before checking the WORLD gate, this also ensures a review exists for
+    the beat's *effective* (escalation-aware) tier via
+    ``ensure_canon_review_for_story`` (#3304) — so a GROUP/GLOBAL story whose
+    beats trigger the escalation heuristic (EXTREME risk / society-FACTION
+    stake) cannot dodge review just because its authored ``impact_tier`` was
+    never manually raised to REGIONAL/WORLD.
     """
     from world.stories.constants import ImpactTier  # noqa: PLC0415
-    from world.stories.services.canon_review import story_is_cleared  # noqa: PLC0415
+    from world.stories.services.canon_review import (  # noqa: PLC0415
+        ensure_canon_review_for_story,
+        story_is_cleared,
+    )
 
     story = beat.episode.chapter.story
+    gm_profile = story.primary_table.gm if story.primary_table_id else None
+    ensure_canon_review_for_story(story, gm_profile)
+
     if story.impact_tier != ImpactTier.WORLD:
         return []
     if story_is_cleared(story):

--- a/src/world/stories/tests/test_canon_review.py
+++ b/src/world/stories/tests/test_canon_review.py
@@ -6,7 +6,7 @@ from rest_framework.test import APITestCase
 
 from evennia_extensions.factories import AccountFactory
 from world.gm.constants import GMLevel
-from world.gm.factories import GMProfileFactory, seed_default_gm_level_caps
+from world.gm.factories import GMProfileFactory, GMTableFactory, seed_default_gm_level_caps
 from world.societies.constants import RenownRisk
 from world.stories.constants import (
     BeatOutcome,
@@ -31,6 +31,7 @@ from world.stories.models import Beat, CanonReview, Story, TransitionRequiredOut
 from world.stories.services.canon_review import (
     _notify_story_owners,
     clear_canon_review,
+    ensure_canon_review_for_story,
     latest_review_for_story,
     pending_canon_reviews,
     regional_auto_clears,
@@ -156,6 +157,122 @@ class CanonReviewServiceTests(TestCase):
         clear_canon_review(review, staff)
         with self.assertRaises(ValueError):
             clear_canon_review(review, staff)
+
+
+class EnsureCanonReviewForStoryTests(TestCase):
+    """``ensure_canon_review_for_story`` — the #3304 orchestrator.
+
+    tier >= REGIONAL requests a review; REGIONAL + an auto-clearing GM level
+    system-clears it immediately; WORLD never auto-clears no matter the
+    GM's level.
+    """
+
+    def setUp(self) -> None:
+        seed_default_gm_level_caps()
+
+    def test_table_tier_creates_no_review(self) -> None:
+        story = Story.objects.create(title="T", description="", impact_tier=ImpactTier.TABLE)
+        result = ensure_canon_review_for_story(story, None)
+        self.assertIsNone(result)
+        self.assertFalse(CanonReview.objects.filter(story=story).exists())
+
+    def test_world_tier_requests_pending_review_with_no_gm_profile(self) -> None:
+        story = Story.objects.create(title="T", description="", impact_tier=ImpactTier.WORLD)
+        review = ensure_canon_review_for_story(story, None)
+        self.assertIsNotNone(review)
+        self.assertEqual(review.status, CanonReviewStatus.PENDING)
+        self.assertEqual(review.tier, ImpactTier.WORLD)
+
+    def test_world_tier_never_auto_clears_for_senior_gm(self) -> None:
+        story = Story.objects.create(title="T", description="", impact_tier=ImpactTier.WORLD)
+        senior = GMProfileFactory(level=GMLevel.SENIOR)
+        review = ensure_canon_review_for_story(story, senior)
+        self.assertEqual(review.status, CanonReviewStatus.PENDING)
+
+    def test_regional_tier_pending_without_auto_clearing_gm(self) -> None:
+        story = Story.objects.create(title="T", description="", impact_tier=ImpactTier.REGIONAL)
+        junior = GMProfileFactory(level=GMLevel.JUNIOR)
+        review = ensure_canon_review_for_story(story, junior)
+        self.assertEqual(review.status, CanonReviewStatus.PENDING)
+
+    def test_regional_tier_auto_clears_for_experienced_gm(self) -> None:
+        story = Story.objects.create(title="T", description="", impact_tier=ImpactTier.REGIONAL)
+        experienced = GMProfileFactory(level=GMLevel.EXPERIENCED)
+        review = ensure_canon_review_for_story(story, experienced)
+        self.assertEqual(review.status, CanonReviewStatus.CLEARED)
+        self.assertIsNone(review.reviewer)
+        self.assertEqual(review.notes, "auto-cleared by GM level cap")
+
+    def test_regional_tier_with_no_gm_profile_stays_pending(self) -> None:
+        """No gm_profile (e.g. staff-driven web edit) never auto-clears."""
+        story = Story.objects.create(title="T", description="", impact_tier=ImpactTier.REGIONAL)
+        review = ensure_canon_review_for_story(story, None)
+        self.assertEqual(review.status, CanonReviewStatus.PENDING)
+
+    def test_idempotent_second_call_does_not_re_clear_or_duplicate(self) -> None:
+        story = Story.objects.create(title="T", description="", impact_tier=ImpactTier.REGIONAL)
+        experienced = GMProfileFactory(level=GMLevel.EXPERIENCED)
+        first = ensure_canon_review_for_story(story, experienced)
+        second = ensure_canon_review_for_story(story, experienced)
+        self.assertEqual(first.pk, second.pk)
+        self.assertEqual(CanonReview.objects.filter(story=story).count(), 1)
+
+    def test_uses_escalated_tier_not_raw_impact_tier(self) -> None:
+        """A GROUP story whose beats escalate to REGIONAL gets a review even
+        though its authored impact_tier is still TABLE."""
+        from world.stories.constants import StoryScope
+
+        story = StoryFactory(scope=StoryScope.GROUP, impact_tier=ImpactTier.TABLE)
+        BeatFactory(episode__chapter__story=story, risk=RenownRisk.EXTREME)
+        review = ensure_canon_review_for_story(story, None)
+        self.assertIsNotNone(review)
+        self.assertEqual(review.tier, ImpactTier.REGIONAL)
+        self.assertEqual(story.impact_tier, ImpactTier.TABLE)
+
+
+class ReadinessEnsuresCanonReviewTests(TestCase):
+    """``validate_stakes_readiness`` calls ``ensure_canon_review_for_story``
+    with the escalation-aware tier (#3304) — beat-driven escalation cannot
+    dodge review just because the author never raised ``impact_tier``."""
+
+    def setUp(self) -> None:
+        seed_default_gm_level_caps()
+
+    def test_group_story_extreme_beat_gets_a_review_on_readiness_check(self) -> None:
+        from world.stories.constants import StoryScope
+
+        story = StoryFactory(scope=StoryScope.GROUP, impact_tier=ImpactTier.TABLE)
+        beat = BeatFactory(episode__chapter__story=story, risk=RenownRisk.EXTREME)
+        self.assertFalse(CanonReview.objects.filter(story=story).exists())
+
+        validate_stakes_readiness(beat)
+
+        review = CanonReview.objects.get(story=story)
+        self.assertEqual(review.tier, ImpactTier.REGIONAL)
+        self.assertEqual(review.status, CanonReviewStatus.PENDING)
+
+    def test_group_story_extreme_beat_auto_clears_for_experienced_lead_gm(self) -> None:
+        from world.stories.constants import StoryScope
+
+        lead_gm = GMProfileFactory(level=GMLevel.EXPERIENCED)
+        table = GMTableFactory(gm=lead_gm)
+        story = StoryFactory(
+            scope=StoryScope.GROUP, impact_tier=ImpactTier.TABLE, primary_table=table
+        )
+        beat = BeatFactory(episode__chapter__story=story, risk=RenownRisk.EXTREME)
+
+        validate_stakes_readiness(beat)
+
+        review = CanonReview.objects.get(story=story)
+        self.assertEqual(review.status, CanonReviewStatus.CLEARED)
+
+    def test_character_scope_story_never_gets_a_review_from_readiness(self) -> None:
+        story = StoryFactory(impact_tier=ImpactTier.TABLE)
+        beat = BeatFactory(episode__chapter__story=story, risk=RenownRisk.EXTREME)
+
+        validate_stakes_readiness(beat)
+
+        self.assertFalse(CanonReview.objects.filter(story=story).exists())
 
 
 class CanonReviewReadinessIntegrationTests(TestCase):

--- a/src/world/stories/tests/test_views_story_assign.py
+++ b/src/world/stories/tests/test_views_story_assign.py
@@ -20,7 +20,8 @@ from rest_framework.test import APITestCase
 from core_management.test_utils import suppress_permission_errors
 from evennia_extensions.factories import AccountFactory
 from world.character_sheets.factories import CharacterSheetFactory
-from world.gm.factories import GMProfileFactory, GMTableFactory
+from world.gm.constants import GMLevel
+from world.gm.factories import GMLevelCapFactory, GMProfileFactory, GMTableFactory
 from world.stories.constants import StoryScope
 from world.stories.factories import StoryFactory
 from world.stories.models import (
@@ -41,6 +42,13 @@ class StoryAssignViewSetTest(APITestCase):
         cls.lead_gm_account = AccountFactory()
         cls.lead_gm_profile = GMProfileFactory(account=cls.lead_gm_account)
         cls.gm_table = GMTableFactory(gm=cls.lead_gm_profile)
+        # GLOBAL-scope authoring is cap-gated (#3304). Most tests in this class
+        # exercise the assign *mechanics* (scope <-> target invariant,
+        # progress-row creation), not the GMLevelCap authorization boundary,
+        # so the Lead GM's STARTING-level cap is granted the permission here;
+        # GlobalScopeAuthoringGateTest below exercises the boundary itself
+        # with its own un-permitting cap.
+        GMLevelCapFactory(level=GMLevel.STARTING, allow_global_scope_authoring=True)
 
         cls.unrelated_account = AccountFactory()
 
@@ -276,3 +284,81 @@ class StoryAssignViewSetTest(APITestCase):
         assert not GroupStoryProgress.objects.filter(story=story).exists()
         assert not GlobalStoryProgress.objects.filter(story=story).exists()
         assert StoryProgress.objects.filter(story=story).count() == 1
+
+
+class GlobalScopeAuthoringGateTest(APITestCase):
+    """GLOBAL-scope authoring is gated on GMLevelCap.allow_global_scope_authoring (#3304).
+
+    A non-staff Lead GM whose level cap does not permit GLOBAL-scope authoring
+    is refused with 400 (mirrors ``_gm_allows_custom_stakes``'s gate shape);
+    staff bypass and a permitting cap both succeed.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.lead_gm_account = AccountFactory()
+        cls.lead_gm_profile = GMProfileFactory(account=cls.lead_gm_account, level=GMLevel.STARTING)
+        cls.gm_table = GMTableFactory(gm=cls.lead_gm_profile)
+
+    def _make_story(self):
+        return StoryFactory(
+            owners=[self.lead_gm_account],
+            primary_table=self.gm_table,
+            scope=StoryScope.UNASSIGNED,
+        )
+
+    def _post(self, story):
+        url = reverse("story-assign", kwargs={"pk": story.pk})
+        return self.client.post(
+            url, json.dumps({"scope": "global"}), content_type="application/json"
+        )
+
+    def test_refused_without_permitting_cap(self):
+        """No GMLevelCap row for the Lead GM's level -> refused (most-restrictive fallback)."""
+        story = self._make_story()
+        self.client.force_authenticate(user=self.lead_gm_account)
+
+        response = self._post(story)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.data
+        assert "scope" in response.data
+        story.refresh_from_db()
+        assert story.scope == StoryScope.UNASSIGNED
+        assert not GlobalStoryProgress.objects.filter(story=story).exists()
+
+    def test_refused_with_non_permitting_cap(self):
+        """A GMLevelCap row exists but allow_global_scope_authoring=False -> refused."""
+        GMLevelCapFactory(level=GMLevel.STARTING, allow_global_scope_authoring=False)
+        story = self._make_story()
+        self.client.force_authenticate(user=self.lead_gm_account)
+
+        response = self._post(story)
+
+        assert response.status_code == status.HTTP_400_BAD_REQUEST, response.data
+        story.refresh_from_db()
+        assert story.scope == StoryScope.UNASSIGNED
+
+    def test_allowed_with_permitting_cap(self):
+        """A GMLevelCap row with allow_global_scope_authoring=True -> succeeds."""
+        GMLevelCapFactory(level=GMLevel.STARTING, allow_global_scope_authoring=True)
+        story = self._make_story()
+        self.client.force_authenticate(user=self.lead_gm_account)
+
+        response = self._post(story)
+
+        assert response.status_code == status.HTTP_200_OK, response.data
+        story.refresh_from_db()
+        assert story.scope == StoryScope.GLOBAL
+        assert GlobalStoryProgress.objects.filter(story=story).exists()
+
+    def test_staff_bypasses_the_gate(self):
+        """Staff may assign GLOBAL scope with no GMLevelCap row at all."""
+        story = self._make_story()
+        staff_account = AccountFactory(is_staff=True)
+        self.client.force_authenticate(user=staff_account)
+
+        response = self._post(story)
+
+        assert response.status_code == status.HTTP_200_OK, response.data
+        story.refresh_from_db()
+        assert story.scope == StoryScope.GLOBAL

--- a/src/world/stories/tests/test_views_story_impact.py
+++ b/src/world/stories/tests/test_views_story_impact.py
@@ -1,0 +1,80 @@
+"""Tests for the web impact-tier request-loop seam (#3304).
+
+``StoryViewSet.perform_update`` wires ``ensure_canon_review_for_story`` into
+the generic PATCH /api/stories/{id}/ path whenever ``impact_tier`` changes —
+the web half of the seam telnet's ``story impact`` covers on the other side
+(``commands/tests/test_canon_review_command.py::StoryImpactRequestsReviewTests``).
+
+PATCH on this endpoint is staff-only today (``IsStoryOwnerOrStaff.
+has_permission`` gates every non-safe method to staff — a pre-existing
+constraint, not something this issue changes), so these tests authenticate
+as staff throughout.
+"""
+
+from django.urls import reverse
+from rest_framework.test import APITestCase
+
+from evennia_extensions.factories import AccountFactory
+from world.gm.constants import GMLevel
+from world.gm.factories import GMProfileFactory, seed_default_gm_level_caps
+from world.stories.constants import CanonReviewStatus, ImpactTier
+from world.stories.factories import StoryFactory
+from world.stories.models import CanonReview
+
+
+class StoryImpactUpdateViewSetTest(APITestCase):
+    """PATCH /api/stories/{id}/ with a raised impact_tier requests a review."""
+
+    @classmethod
+    def setUpTestData(cls):
+        seed_default_gm_level_caps()
+        cls.staff_account = AccountFactory(is_staff=True)
+
+    def _patch(self, story, body):
+        url = reverse("story-detail", kwargs={"pk": story.pk})
+        return self.client.patch(url, body, format="json")
+
+    def test_raising_to_world_creates_pending_review(self):
+        story = StoryFactory(impact_tier=ImpactTier.TABLE)
+        self.client.force_authenticate(user=self.staff_account)
+
+        response = self._patch(story, {"impact_tier": "world"})
+
+        assert response.status_code == 200, response.data
+        review = CanonReview.objects.get(story=story)
+        assert review.status == CanonReviewStatus.PENDING
+        assert review.tier == ImpactTier.WORLD
+
+    def test_raising_to_regional_with_no_actor_gm_profile_stays_pending(self):
+        """A staff actor has no GMProfile — auto-clear never applies to them."""
+        story = StoryFactory(impact_tier=ImpactTier.TABLE)
+        self.client.force_authenticate(user=self.staff_account)
+
+        response = self._patch(story, {"impact_tier": "regional"})
+
+        assert response.status_code == 200, response.data
+        review = CanonReview.objects.get(story=story)
+        assert review.status == CanonReviewStatus.PENDING
+
+    def test_raising_to_regional_auto_clears_for_experienced_staff_gm(self):
+        """A staff account that also holds an EXPERIENCED GMProfile auto-clears."""
+        GMProfileFactory(account=self.staff_account, level=GMLevel.EXPERIENCED)
+        story = StoryFactory(impact_tier=ImpactTier.TABLE)
+        self.client.force_authenticate(user=self.staff_account)
+
+        response = self._patch(story, {"impact_tier": "regional"})
+
+        assert response.status_code == 200, response.data
+        review = CanonReview.objects.get(story=story)
+        assert review.status == CanonReviewStatus.CLEARED
+        assert review.reviewer is None
+        assert review.notes == "auto-cleared by GM level cap"
+
+    def test_unchanged_tier_creates_no_review(self):
+        story = StoryFactory(impact_tier=ImpactTier.TABLE)
+        self.client.force_authenticate(user=self.staff_account)
+
+        response = self._patch(story, {"title": "Renamed"})
+
+        assert response.status_code == 200, response.data
+        assert not CanonReview.objects.filter(story=story).exists()

--- a/src/world/stories/views.py
+++ b/src/world/stories/views.py
@@ -441,6 +441,25 @@ class StoryViewSet(viewsets.ModelViewSet):
         story = serializer.save()
         story.owners.add(self.request.user)
 
+    def perform_update(self, serializer: BaseSerializer) -> None:
+        """Persist story edits; wire the canon-review seam when impact_tier changes (#3304).
+
+        ``impact_tier`` is a writable ``StoryDetailSerializer`` field (no dedicated
+        action endpoint exists) — this generic PATCH/PUT is the web half of the
+        impact-tier request-loop seam, mirroring telnet's ``_handle_impact``
+        (``commands/story.py``) so the review queue fills regardless of which
+        surface a Lead GM used.
+        """
+        from world.stories.services.canon_review import (  # noqa: PLC0415
+            ensure_canon_review_for_story,
+        )
+
+        old_tier = serializer.instance.impact_tier if serializer.instance else None
+        story = serializer.save()
+        if story.impact_tier != old_tier:
+            gm_profile = self.request.user.gm_profile_or_none
+            ensure_canon_review_for_story(story, gm_profile)
+
     @action(detail=True, methods=[HTTPMethod.POST], permission_classes=[CanParticipateInStory])
     def apply_to_participate(self, request: Request, pk: int | None = None) -> Response:
         """Apply to participate in a story"""
@@ -611,11 +630,12 @@ class StoryViewSet(viewsets.ModelViewSet):
         - GROUP: creates GroupStoryProgress for the given gm_table
         - GLOBAL: creates the GlobalStoryProgress singleton
 
-        The scope <-> target invariant is enforced by
-        AssignStoryInputSerializer.validate(), so an invalid combination is a
-        400 (no scope change, no progress row). Because scope is set before
-        the create_*_progress call, StoryNotAssignedError cannot fire — no
-        try/except is needed.
+        The scope <-> target invariant, AND (for GLOBAL) the
+        ``allow_global_scope_authoring`` GMLevelCap gate (#3304), are enforced
+        by AssignStoryInputSerializer.validate(), so an invalid combination or
+        an under-leveled GM's GLOBAL attempt is a 400 (no scope change, no
+        progress row). Because scope is set before the create_*_progress
+        call, StoryNotAssignedError cannot fire — no try/except is needed.
         """
         from world.stories.services.progress import (  # noqa: PLC0415
             create_character_progress,
@@ -624,7 +644,9 @@ class StoryViewSet(viewsets.ModelViewSet):
         )
 
         story = self.get_object()
-        ser = AssignStoryInputSerializer(data=request.data, context={"story": story})
+        ser = AssignStoryInputSerializer(
+            data=request.data, context={"story": story, "request": request}
+        )
         ser.is_valid(raise_exception=True)
         data = ser.validated_data
         scope = data["scope"]


### PR DESCRIPTION
Closes #3304

## Summary

Wire the canon-review request loop + GLOBAL-scope cap (#3304). request_canon_review had zero callers, so the #2003 staff queue was permanently empty. New ensure_canon_review_for_story orchestrator (tier >= REGIONAL -> pending review; REGIONAL + GMLevelCap.auto_clear_regional -> auditable system-cleared review; WORLD never auto-clears; idempotent across calls) called from the web impact PATCH path, telnet story impact, and the readiness/escalation check. New _gm_allows_global_scope serializer gate (staff bypass, most-restrictive fallback). Staff dashboard PendingCanonReviewsPanel over the existing clear/changes endpoints. Premise correction recorded on the issue: four of six GMLevelCap caps were already enforced; this closes the two that were not. No migration.

## Follow-ups filed

(none)

## Notes

- Spec: reviewed & approved on #3304 (in the issue body)
- Brainstorm/plan: ran
- Sync-with-main: Up to date with origin/main; no conflicts. Focused modules (96 tests) pass single-process locally.

<!-- last-addressed-comment: 0 -->