### PR TITLE
Cap parallel test workers by available memory, not core count

### DIFF
--- a/justfile
+++ b/justfile
@@ -226,8 +226,10 @@ test-affected *args: _fs-warn
 # including CI's own --keepdb (CI builds the test DB once via
 # tools/build_schema.py, then reuses it across the run). Builds the test DB
 # automatically the first time; pass `--rebuild` to force a rebuild after a
-# model change. Uses --parallel (cpu_count workers). Auto-confirms the
-# destroy-test-DB prompt.
+# model change. Uses --parallel; the worker count is cpu_count() capped by
+# available memory, since each worker holds a full Django+Evennia stack
+# (~350MB) — see _parallel_worker_count in src/cli/arx.py, and override with
+# ARX_TEST_MAX_WORKERS. Auto-confirms the destroy-test-DB prompt.
 #   just regression
 #   just regression --rebuild
 regression *args: _fs-warn

--- a/src/cli/arx.py
+++ b/src/cli/arx.py
@@ -16,6 +16,49 @@ _WINDOWS = "Windows"
 _DJANGO_SETTINGS_KEY = "DJANGO_SETTINGS_MODULE"
 _ALLOW_INTEGRATION_KEY = "ALLOW_INTEGRATION_TESTS"
 
+# Each parallel worker loads a full Django+Evennia stack (~350MB resident), so the
+# ceiling that matters is memory, not cores. Django's bare ``--parallel`` resolves to
+# cpu_count(), which exhausts a memory-capped devcontainer long before it saturates
+# the CPU: two concurrent 8-worker runs from separate worktrees consumed ~6GB and all
+# of swap, wedging the container until the runs were killed. Deriving the count from
+# *available* memory also makes a second concurrent run self-limit, because the first
+# run's resident set has already shrunk what the second one sees.
+_MB_PER_TEST_WORKER = 500
+_MAX_WORKERS_ENV_KEY = "ARX_TEST_MAX_WORKERS"
+
+
+def _available_memory_mb() -> int | None:
+    """Return MemAvailable in MB, or None when the platform does not expose it."""
+    try:
+        with Path("/proc/meminfo").open(encoding="utf-8") as handle:
+            for line in handle:
+                if line.startswith("MemAvailable:"):
+                    return int(line.split()[1]) // 1024
+    except (OSError, ValueError, IndexError):
+        return None
+    return None
+
+
+def _parallel_worker_count() -> int:
+    """Number of test workers to request, capped by available memory.
+
+    ``ARX_TEST_MAX_WORKERS`` overrides the derived value; an unparseable override is
+    ignored rather than fatal, so a bad env var degrades to the default instead of
+    breaking every test invocation.
+    """
+    override = os.environ.get(_MAX_WORKERS_ENV_KEY)
+    if override:
+        try:
+            return max(1, int(override))
+        except ValueError:
+            pass
+    workers = os.cpu_count() or 1
+    available_mb = _available_memory_mb()
+    if available_mb is not None:
+        workers = min(workers, max(1, available_mb // _MB_PER_TEST_WORKER))
+    return workers
+
+
 # Define typer options/arguments as module-level variables to avoid B008
 TEST_ARGS_ARG = typer.Argument(None, help="Test apps/modules to run")
 PARALLEL_OPTION = typer.Option(False, "--parallel", "-p", help="Run tests in parallel")
@@ -168,7 +211,7 @@ def run_tests(  # noqa: C901
 
     # Add performance options
     if parallel:
-        command.append("--parallel")
+        command.append(f"--parallel={_parallel_worker_count()}")
     if keepdb:
         command.append("--keepdb")
     if failfast:

--- a/src/core_management/tests/test_arx_cli.py
+++ b/src/core_management/tests/test_arx_cli.py
@@ -50,3 +50,96 @@ class TestSeedCLICommand(unittest.TestCase):
         """arx seed staging → evennia seed staging (custom target forwarded)"""
         mock_run = self._invoke_seed("staging")
         mock_run.assert_called_once_with(["evennia", "seed", "staging"], check=True)
+
+
+class TestParallelWorkerCount(unittest.TestCase):
+    """Verify that parallel test workers are capped by memory, not just core count.
+
+    A bare ``--parallel`` resolves to cpu_count() inside Django, which exhausts a
+    memory-capped devcontainer: each worker holds a full Django+Evennia stack.
+    """
+
+    def test_memory_caps_below_core_count(self) -> None:
+        """8 cores but only 1GB available → 2 workers, not 8."""
+        from cli.arx import _parallel_worker_count
+
+        with (
+            mock.patch("cli.arx.os.cpu_count", return_value=8),
+            mock.patch("cli.arx._available_memory_mb", return_value=1000),
+            mock.patch.dict("cli.arx.os.environ", {}, clear=True),
+        ):
+            self.assertEqual(_parallel_worker_count(), 2)
+
+    def test_core_count_caps_below_memory(self) -> None:
+        """Ample memory must not push worker count above the core count."""
+        from cli.arx import _parallel_worker_count
+
+        with (
+            mock.patch("cli.arx.os.cpu_count", return_value=8),
+            mock.patch("cli.arx._available_memory_mb", return_value=100_000),
+            mock.patch.dict("cli.arx.os.environ", {}, clear=True),
+        ):
+            self.assertEqual(_parallel_worker_count(), 8)
+
+    def test_never_returns_zero_under_memory_pressure(self) -> None:
+        """Near-zero available memory still yields a usable single worker."""
+        from cli.arx import _parallel_worker_count
+
+        with (
+            mock.patch("cli.arx.os.cpu_count", return_value=8),
+            mock.patch("cli.arx._available_memory_mb", return_value=10),
+            mock.patch.dict("cli.arx.os.environ", {}, clear=True),
+        ):
+            self.assertEqual(_parallel_worker_count(), 1)
+
+    def test_falls_back_to_core_count_without_meminfo(self) -> None:
+        """Platforms with no /proc/meminfo (Windows) keep the old behaviour."""
+        from cli.arx import _parallel_worker_count
+
+        with (
+            mock.patch("cli.arx.os.cpu_count", return_value=4),
+            mock.patch("cli.arx._available_memory_mb", return_value=None),
+            mock.patch.dict("cli.arx.os.environ", {}, clear=True),
+        ):
+            self.assertEqual(_parallel_worker_count(), 4)
+
+    def test_env_override_wins(self) -> None:
+        """ARX_TEST_MAX_WORKERS overrides the derived value."""
+        from cli.arx import _parallel_worker_count
+
+        with (
+            mock.patch("cli.arx.os.cpu_count", return_value=8),
+            mock.patch("cli.arx._available_memory_mb", return_value=100_000),
+            mock.patch.dict("cli.arx.os.environ", {"ARX_TEST_MAX_WORKERS": "3"}, clear=True),
+        ):
+            self.assertEqual(_parallel_worker_count(), 3)
+
+    def test_unparseable_env_override_degrades_to_default(self) -> None:
+        """A bad env var must not break every test invocation."""
+        from cli.arx import _parallel_worker_count
+
+        with (
+            mock.patch("cli.arx.os.cpu_count", return_value=8),
+            mock.patch("cli.arx._available_memory_mb", return_value=100_000),
+            mock.patch.dict("cli.arx.os.environ", {"ARX_TEST_MAX_WORKERS": "lots"}, clear=True),
+        ):
+            self.assertEqual(_parallel_worker_count(), 8)
+
+    def test_parallel_flag_emits_explicit_worker_count(self) -> None:
+        """arx test --parallel → evennia test --parallel=N, never a bare --parallel."""
+        from typer.testing import CliRunner
+
+        from cli.arx import app
+
+        runner = CliRunner()
+        with (
+            mock.patch("cli.arx.subprocess.run") as mock_run,
+            mock.patch("cli.arx.setup_env"),
+            mock.patch("cli.arx._parallel_worker_count", return_value=3),
+        ):
+            mock_run.return_value = mock.MagicMock(returncode=0)
+            runner.invoke(app, ["test", "--parallel"])
+
+        command = mock_run.call_args[0][0]
+        self.assertIn("--parallel=3", command)
+        self.assertNotIn("--parallel", command)


### PR DESCRIPTION
## Problem

`arx test --parallel` appends a bare `--parallel`, which Django resolves to `cpu_count()`. Each worker holds a full Django+Evennia stack (~350MB resident), so on an 8-core machine one run wants ~3GB. The cap that matters is memory, not cores, and nothing enforced one.

This wedged a devcontainer today. Two agent sessions ran `arx test --parallel` concurrently from separate worktrees:

| Worktree | Elapsed | Workers |
|---|---|---|
| `feature-3294-emote-through-your-companion` | 1h 17m | 7 |
| `feature-3304-gmlevelcap-is-a-dead-knob` | 7m | 9 |

Combined demand was ~6GB against a 6GB WSL VM. Swap went to 100% (2045MB of 2048MB). Everything thrashed on swap I/O, including the `devcontainer` CLI's own Node process, so `just dc-shell`, `dc-attach` and `dc-up` all appeared to hang. They were not hung; they were queued behind swap.

## Change

Derive the worker count from `MemAvailable`, capped by `cpu_count()`, and pass it explicitly as `--parallel=N`.

Because the count is read at launch, a second concurrent run self-limits: the first run's resident set has already shrunk what the second one sees. That addresses the concurrency case without a lock.

- `ARX_TEST_MAX_WORKERS` overrides the derived value.
- An unparseable override degrades to the default rather than breaking every test invocation.
- Platforms with no `/proc/meminfo` (Windows) keep the previous `cpu_count()` behaviour.

## Notes

`_MB_PER_TEST_WORKER` is 500, not the measured ~350, to leave headroom for the parent process and the OS.

The second commit corrects a `justfile` comment on the `regression` recipe that still claimed `cpu_count()` workers.

## Testing

`arx test --sqlite core_management.tests.test_arx_cli` — 10 passed. Seven new cases cover the memory cap, the core-count cap, the floor of 1 worker under pressure, the no-`/proc/meminfo` fallback, both env-override paths, and that the emitted argv is `--parallel=N` rather than a bare flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KrLoraZdUYuSarP6cDU7nW
