### PR TITLE
CI speed-up: schema build 6min -> 30s (migrate verbosity=0), CharacterCmdSet 470ms -> 19ms (batched add)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,10 @@ jobs:
           # seconds-per-test varies up to ~2x between apps (actions and
           # world.combat run far slower per test than the small apps).
           # Each shard targets ~344s of test runtime (+~60s fixed setup).
+          # NOTE: the per-app estimates below were measured before the
+          # CharacterCmdSet batched-add fix (object creation dropped from
+          # ~0.5s to ~20ms) and had drifted to ~2x anyway; re-measure from the
+          # --durations output of a green run before the next rebalance.
           # To refresh: pull per-shard "Run tests" step seconds from a green
           # run, scale each app's estimate by its shard's actual/estimated
           # factor, and re-balance greedily (one such iteration converges
@@ -282,6 +286,10 @@ jobs:
       # DB must have tables before `arx test` runs. Migration-chain validity
       # is gated by the makemigrations --check step (ty job) and the nightly
       # migration-replay workflow, not per-shard.
+      # ~30s. It was ~6min until build_schema.py passed verbosity=0 to
+      # migrate: at verbosity>=1 migrate runs the migration autodetector +
+      # optimizer over all ~1,200 (migration-less) models just to print a
+      # "changes not reflected in a migration" hint (ADR-0083 update).
       - name: Build schema from model state
         run: uv run python tools/build_schema.py
       # Build the test DB by CLONING the just-built default DB rather than
@@ -317,7 +325,10 @@ jobs:
             test -n "$PART_LABELS"
             LABELS="$LABELS $PART_LABELS"
           fi
-          uv run arx test --keepdb --parallel $LABELS
+          # `-- --durations 25` passes Django's --durations through the typer
+          # wrapper so every shard log ends with its 25 slowest tests - the
+          # data the matrix rebalance procedure above needs, without a local run.
+          uv run arx test --keepdb --parallel $LABELS -- --durations 25
 
   # Aggregator: succeeds iff every backend-shard matrix entry succeeded.
   # Lets branch protection require a single status check named "backend"

--- a/docs/adr/0083-ci-schema-from-models.md
+++ b/docs/adr/0083-ci-schema-from-models.md
@@ -68,5 +68,15 @@ at once. Per-PR coverage is now the structural `standalone-sql-wiring` hook
 (`tools/check_standalone_sql_wiring.py`); nightly coverage is a full `pg_catalog` diff
 between the two paths (`tools/compare_schemas.py`).
 
+**Update (2026-08-23, CI speed-up):** `build_schema.py`'s 5-6.5 minute "Build schema"
+step was ~98% Django's `migrate` command running the migration **autodetector +
+optimizer** after syncdb - at `verbosity >= 1` it diffs the (empty, migrations-disabled)
+graph against all ~1,200 models to print the "changes not yet reflected in a migration"
+hint, feeding ~1,200 `CreateModel` ops to an O(n^2) optimizer (187M `reduce()` calls).
+The real DDL + SQL files + seeds take ~30s. `build_schema.py` now calls `migrate` with
+`verbosity=0`; the SQLite tier never hit this because Django's `create_test_db` passes
+`verbosity - 1`. The per-job fixed cost is now small enough that caching a `pg_dump` of
+the built schema (rejected alternative (b) above) is not worth its staleness risk.
+
 > Status: accepted · Source: CI-speedup branch, task 5 · Related: ADR-0013 (schema-only
 > migrations pre-production), ADR-0021 (merge queue + single-leaf migration guard)

--- a/src/commands/default_cmdsets.py
+++ b/src/commands/default_cmdsets.py
@@ -525,8 +525,14 @@ class CharacterCmdSet(default_cmds.CharacterCmdSet):
             # #2640 — the Sphinx of Black Quartz's vow-suitability verdict.
             CmdSphinx,
         )
-        for command_cls in command_classes:
-            self.add(command_cls())
+        # One batched add, not one add() per command: Evennia's CmdSet.add()
+        # runs commands.count() (an __eq__ set-intersection against every
+        # command already in the set) and then rebuilds list(set(commands))
+        # on EVERY call, so adding ~230 commands one at a time cost ~470ms per
+        # cmdset instantiation - paid on every object creation (at_first_save)
+        # and every cmdset rebuild. Passing the list does the dedup pass once
+        # (~10ms). Same replace-on-duplicate semantics: later entries win.
+        self.add([command_cls() for command_cls in command_classes])
 
 
 class AccountCmdSet(default_cmds.AccountCmdSet):

--- a/tools/build_schema.py
+++ b/tools/build_schema.py
@@ -114,7 +114,7 @@ def main() -> None:
     from django.core.management import call_command  # noqa: PLC0415
     from django.db import connection, transaction  # noqa: PLC0415
 
-    call_command("migrate", run_syncdb=True, interactive=False, verbosity=1)
+    call_command("migrate", run_syncdb=True, interactive=False, verbosity=0)
 
     if _schema_already_built(connection):
         print("schema already built (arxii_interaction is partitioned) — skipping SQL + seeds")


### PR DESCRIPTION
## What

Two root causes behind 16-19 minute backend shards, each a small change:

1. **`tools/build_schema.py` passes `verbosity=0` to `migrate`.** The "Build schema from model state" step cost 5-6.5 min on every one of the 9 backend jobs (measured across the last 10 main runs). Profiling: ~98% of it was `migrate`'s *migration autodetector + optimizer* pass - at `verbosity >= 1` Django diffs the (migrations-disabled, empty) graph against all 1,208 models to print the "changes not yet reflected in a migration" hint, feeding ~1,200 `CreateModel` ops to an O(n^2) optimizer (187M `reduce()` calls). The actual DDL + SQL files + seeds take ~30s (measured locally on a fresh DB, identical output). The SQLite tier never hit this because `create_test_db` passes `verbosity - 1`.

2. **`CharacterCmdSet.at_cmdset_creation` adds its commands with one batched `self.add([...])`** instead of ~230 individual `self.add(cmd)` calls. Evennia's `CmdSet.add()` runs `commands.count(cmd)` (an `__eq__` set-intersection against every command already present) *and* rebuilds `list(set(commands))` on every call - and `Command.__hash__` is the constant `hash("command")`, so that `set()` is itself O(n^2). Result: ~470ms per `CharacterCmdSet` instantiation, paid on every character/object creation (`at_first_save -> basetype_setup -> add_default`) and every cmdset rebuild. Profiling one fixture-heavy test class: 26s of its 28s wall time was inside this chain. After: 19ms, same 230 commands, same unique keys, same replace-on-duplicate semantics. The median `world.items` test was 473ms; the profiled class went from ~1.1s/test to ~0.17s/test. This also speeds up production object creation and cmdset rebuilds.

Also: the backend shards now run with `-- --durations 25`, so every shard log ends with its slowest tests - the data the matrix-rebalance procedure needs without a local run. ADR-0083 gets an update paragraph; ci.yml comments updated.

## Measurements

- `build_schema.py` on a fresh local PG DB: ~6 min (cProfile: 1744s of 1768s in `autodetector.changes`) -> **29.7s**.
- `CharacterCmdSet()`: **471ms -> 19ms** (230 commands, 230 unique keys before and after).
- `world.items.tests.test_crafting_api.FacetQuoteTests` (8 tests): 28s -> ~2s.

## Not in this PR (deliberately)

- Shard rebalance: the per-app estimates in ci.yml are now wrong in the other direction; rebalance from the `--durations` output of a green run after this lands.
- Caching a `pg_dump` of the built schema (ADR-0083's rejected alternative b): at ~30s fixed cost it's no longer worth the staleness risk.

## Verification

- `commands.tests.test_cmdset_handler`, `test_dispatch_command`, `test_dispatchers`, `test_sineater_dispatch`, `test_tether_dispatch`: 61 tests OK (SQLite tier).
- `world.items.tests.test_crafting_api.FacetQuoteTests` + `actions.tests.test_base`: OK.
- CI is the regression gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SRtTQzeRpKQ2ifjGREhy2X