### PR TITLE
Deploy hardening: reload survives SSH drops; re-runs re-derive "needs reload"

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -296,7 +296,13 @@ after the box itself is provisioned, the app_deploy role runs (in order):
    service user, in the `arxii.slice` cgroup with the memory cap from
    `base_game_memory_max`). On subsequent deploys it `reloads` instead
    of restarting, so the Portal keeps connected players online across
-   code/deps/migration changes.
+   code/deps/migration changes. The reload is hardened two ways
+   (2026-08-23 standup failure): it survives a dropped SSH connection
+   (ignore-unreachable + reconnect + retry), and "needs a reload" is
+   re-derived from a host-side stamp file (`app_reload_stamp`, written
+   only after a post-reload health check against the localhost backend
+   succeeds) — so a run that dies on the reload task is fixed by simply
+   pressing the button again; the re-run cannot silently skip the reload.
 
 What the button **does not** do (deliberately, by-design):
 - It does not load any game-content fixtures. The plan is to load those

--- a/infra/ansible/roles/app_deploy/defaults/main.yml
+++ b/infra/ansible/roles/app_deploy/defaults/main.yml
@@ -72,6 +72,17 @@ app_frontend_dist_index: "{{ app_release_dir }}/src/web/static/dist/index.html"
 # makes a toolchain-pin bump also force a rebuild.
 app_frontend_toolchain_marker: "{{ app_release_dir }}/src/web/static/dist/.arxii-toolchain"
 
+# Reload hardening (2026-08-23 standup failure: the SSH connection died on
+# the reload task itself and a re-converge would have silently skipped it).
+# Localhost web backend the post-reload health check polls. MUST equal
+# roles/caddy/defaults/main.yml's caddy_backend — same "two roles pinned
+# equal" idiom as app_secret_settings_src above; acceptance.sh pins them.
+app_web_backend: "127.0.0.1:4001"
+# Written (the deployed SHA) only AFTER a reload has passed the health
+# check. Compared on every converge, so a run that died mid-reload gets the
+# reload re-fired by the next button press instead of silently skipped.
+app_reload_stamp: /opt/arxii/reloaded_sha
+
 # First-run Django/Evennia superuser. Username + email are operator choices
 # (set via Environment Variables on the workflow); the password comes from
 # the gated Environment Secret ARXII_DJANGO_SUPERUSER_PASSWORD and is

--- a/infra/ansible/roles/app_deploy/tasks/main.yml
+++ b/infra/ansible/roles/app_deploy/tasks/main.yml
@@ -401,17 +401,90 @@
     state: started
     daemon_reload: true
 
+# --- Reload (drop-resilient + state-derived) --------------------------------
+# Two hardening layers, both from the 2026-08-23 standup failure, where the
+# SSH connection was closed from the host side during this exact task after
+# 84 green ones — and a re-run of the button would have silently skipped the
+# reload, leaving the Server on pre-deploy code while reporting green:
+#
+# 1. "Needs a reload" is derived from HOST state, not only from run-local
+#    change flags. The flags (`app_checkout is changed` etc.) exist only
+#    inside the run that made the changes; a play that dies between the
+#    symlink flip and a confirmed reload loses them, and the next converge
+#    of the same ref sees nothing changed. The stamp file — written only
+#    after the reload passes the health check below — records which release
+#    the Server last provably reloaded into; stamp != checked-out SHA forces
+#    the reload regardless of the flags.
+#
+# 2. The reload itself survives a dropped SSH connection, in the same spirit
+#    as the migrate task's async/poll (2026-08-15 incident): ignore the
+#    unreachable, reconnect, retry. Once systemd accepts a reload job it
+#    completes regardless of the caller, so the retry is at worst a harmless
+#    second reload of an already-current Server (Portal keeps players
+#    connected through it either way).
+- name: Read which release the Server last provably reloaded into
+  ansible.builtin.slurp:
+    src: "{{ app_reload_stamp }}"
+  register: app_reload_stamp_read
+  failed_when: false
+
+# `| bool` on every consumer below — the folded expression renders as the
+# STRING "True"/"False", same gotcha as roles/caddy's caddy_archive_enabled.
+- name: Decide whether Evennia needs a reload (change flags OR stale stamp)
+  ansible.builtin.set_fact:
+    app_needs_reload: >-
+      {{ app_checkout is changed
+         or app_symlink is changed
+         or app_uv_sync is changed
+         or app_frontend_build is changed
+         or app_migrate is changed
+         or app_collectstatic is changed
+         or (app_reload_stamp_read.content | default('') | b64decode | trim)
+            != app_checkout.after }}
+
 - name: Reload Evennia on a code / deps / migration change (Portal keeps players connected)
   ansible.builtin.systemd_service:
     name: "{{ app_service }}"
     state: reloaded
-  when: >
-    app_checkout is changed
-    or app_symlink is changed
-    or app_uv_sync is changed
-    or app_frontend_build is changed
-    or app_migrate is changed
-    or app_collectstatic is changed
+  when: app_needs_reload | bool
+  register: app_reload
+  ignore_unreachable: true
+
+- name: Reconnect if the SSH channel dropped mid-reload
+  ansible.builtin.wait_for_connection:
+    timeout: 300
+  when: (app_needs_reload | bool) and (app_reload.unreachable | default(false))
+
+- name: Retry the reload after a reconnect (idempotent; systemd finishes an accepted job anyway)
+  ansible.builtin.systemd_service:
+    name: "{{ app_service }}"
+    state: reloaded
+  when: (app_needs_reload | bool) and (app_reload.unreachable | default(false))
+
+# Direct to the localhost-bound backend (not through Caddy/Cloudflare), with
+# the real Host header — django_hardening's ALLOWED_HOSTS rejects a bare
+# 127.0.0.1 Host with a 400. 301/302 accepted alongside 200: an SSL-redirect
+# answer still proves the Server process is up and serving requests.
+- name: Wait until the reloaded Server answers on the web backend
+  ansible.builtin.uri:
+    url: "http://{{ app_web_backend }}/"
+    headers:
+      Host: "{{ caddy_web_fqdn }}"
+    status_code: [200, 301, 302]
+  register: app_reload_health
+  until: app_reload_health is succeeded
+  retries: 60
+  delay: 5
+  when: app_needs_reload | bool
+
+- name: Stamp the reloaded release SHA (a re-run re-derives "reload landed" from this)
+  ansible.builtin.copy:
+    content: "{{ app_checkout.after }}"
+    dest: "{{ app_reload_stamp }}"
+    owner: root
+    group: root
+    mode: "0644"
+  when: app_needs_reload | bool
 
 # --- Portal-crash watchdog ---------------------------------------------------
 # Type=forking + PIDFile=server.pid (arxii.service.j2) only supervises the

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -126,6 +126,16 @@ chk   "app_deploy migrate runs detached (survives an SSH drop)" \
   "grep -q 'async: \"{{ app_migrate_async_timeout }}\"' infra/ansible/roles/app_deploy/tasks/main.yml"
 chk   "ansible.cfg sets SSH keepalives for long silent tasks" \
   "grep -q 'ServerAliveInterval=30' infra/ansible/ansible.cfg"
+# 2026-08-23: the reload must survive an SSH drop (ignore_unreachable +
+# retry) AND be re-derivable on a re-run (stamp written only after the
+# health check), or a run that dies on the reload leaves the Server on
+# pre-deploy code with the next converge reporting green.
+chk   "app_deploy reload survives an SSH drop (ignore_unreachable + retry)" \
+  "grep -q 'ignore_unreachable: true' infra/ansible/roles/app_deploy/tasks/main.yml && grep -q 'Retry the reload after a reconnect' infra/ansible/roles/app_deploy/tasks/main.yml"
+chk   "app_deploy stamps the reloaded SHA after a health check" \
+  "grep -q 'app_reload_stamp' infra/ansible/roles/app_deploy/tasks/main.yml && grep -q 'Wait until the reloaded Server answers' infra/ansible/roles/app_deploy/tasks/main.yml"
+chk   "app_deploy's health-check backend == caddy's caddy_backend" \
+  "[ \"\$(sed -n 's/^app_web_backend: //p' infra/ansible/roles/app_deploy/defaults/main.yml)\" = \"\$(sed -n 's/^caddy_backend: //p' infra/ansible/roles/caddy/defaults/main.yml | sed 's/ *#.*//')\" ]"
 chk   "app_deploy guards superuser create with an exists-check (idempotent)" \
   "grep -q 'is_superuser=True' infra/ansible/roles/app_deploy/tasks/main.yml && grep -q \"'YES' not in\" infra/ansible/roles/app_deploy/tasks/main.yml"
 chk   "secrets_vault maps ARXII_DJANGO_SUPERUSER_PASSWORD -> DJANGO_SUPERUSER_PASSWORD" \


### PR DESCRIPTION
## Why

The 2026-08-23 standup run (32650354790) died `UNREACHABLE` on the final "Reload Evennia" task — the SSH connection was closed from the host side after 84 green tasks. That exposed two gaps:

1. **A re-run silently skips the reload.** The reload's `when:` keyed only off run-local change flags (`app_checkout is changed` etc.). A play that dies between the symlink flip and a confirmed reload loses those flags, so the next converge of the same ref reports green while the Server keeps running pre-deploy code.
2. **The reload was the only long task with no drop-resilience** (migrate got async/poll after the 2026-08-15 incident).

## What

In `roles/app_deploy`:

- **Stamp file** (`app_reload_stamp`, `/opt/arxii/reloaded_sha`): records the SHA the Server last *provably* reloaded into — written only after the post-reload health check passes. The reload condition now adds `stamp != app_checkout.after`, so pressing the button again always retries an unconfirmed reload. Recovery from any mid-reload failure is now just "press the button again".
- **Drop-resilient reload**: `ignore_unreachable: true` → `wait_for_connection` → one retry. Once systemd accepts a reload job it completes regardless of the caller, so the retry is at worst a harmless second reload.
- **Health check**: polls the localhost backend (`127.0.0.1:4001`, Host header = `caddy_web_fqdn` since `ALLOWED_HOSTS` 400s a bare `127.0.0.1`) until the Server answers (200/301/302), up to 5 min — matching `TimeoutStartSec`.

Plus: `acceptance.sh` pins `app_web_backend == caddy_backend` and guards the new tasks; `infra/README.md` step 8 documents the behavior.

## Verification

- `ansible-lint` on the changed files: clean at the `production` profile. (The repo-wide lint's two `unknown-module` failures are the galaxy-blocked devcontainer, pre-existing in roles this PR doesn't touch; CI installs the collections and is the real gate.)
- `bash -n acceptance.sh` clean; the new equal-pin check verified to pass by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrKwHi3m8c4PHT6PMxYEFR