### PR TITLE
Gated devcontainer prod SSH access: opt-in key mount, firewall gate, arxops user

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,10 @@
   // Use our copy (arxii-firewall.sh), NOT the claude-code feature's
   // /usr/local/bin/init-firewall.sh — the upstream version flushes the nat
   // table and breaks Docker's embedded DNS resolver. See Dockerfile.
-  "postStartCommand": "sudo /usr/local/bin/arxii-firewall.sh",
+  // The && chain also installs/removes the gated prod-ops SSH key from the
+  // /run/arxii-ops-key mount (docs/operations/ops-access.md) — after the
+  // firewall so both gates read the mount in the same start.
+  "postStartCommand": "sudo /usr/local/bin/arxii-firewall.sh && bash .devcontainer/ops-key-install.sh",
   "remoteEnv": {
     "PATH": "/home/vscode/.local/bin:${containerEnv:PATH}"
   }

--- a/.devcontainer/docker-compose.yml
+++ b/.devcontainer/docker-compose.yml
@@ -43,6 +43,16 @@ services:
       # generates dev.env from src/.env with DATABASE_URL rewritten before
       # `just dc-up` brings the stack up.
       - ./dev.env:/workspaces/arxii/src/.env
+      # Gated prod-ops SSH key (docs/operations/ops-access.md). Default is a
+      # committed EMPTY dir, so a container brought up without the env var —
+      # from VS Code, CI, or a plain `just dc-up` — has no key and the
+      # egress firewall keeps prod SSH blocked (see init-firewall.sh's prod
+      # gate; ops-key-install.sh copies the key into ~/.ssh with 0600 perms,
+      # which a Windows-drive bind mount can't carry). Enable with
+      #   ARXII_OPS_KEY_DIR=<abs path to key dir> just dc-up
+      # and disable by bringing the stack down/up WITHOUT the var. Read-only:
+      # nothing in the container can alter or delete the host-side key.
+      - ${ARXII_OPS_KEY_DIR:-./no-ops-key}:/run/arxii-ops-key:ro
     # ALSO load dev.env as process environment so non-Django tools (gh, curl,
     # etc.) can read variables like GH_TOKEN without sourcing the .env file
     # manually. The bind-mount above is what Django/django-environ reads; this

--- a/.devcontainer/init-firewall.sh
+++ b/.devcontainer/init-firewall.sh
@@ -57,6 +57,23 @@ iptables -A INPUT  -p udp --sport 53 -j ACCEPT
 iptables -A OUTPUT -p tcp --dport 53 -j ACCEPT
 iptables -A INPUT  -p tcp --sport 53 -m state --state ESTABLISHED -j ACCEPT
 
+# Gated prod-ops SSH (docs/operations/ops-access.md). The global port-22
+# ACCEPT below (git-over-SSH) would otherwise reach the prod Linode too, so
+# the ONLY thing separating an agent from prod would be key possession.
+# Belt-and-suspenders: unless the ops key was mounted in (see
+# docker-compose.yml's /run/arxii-ops-key mount — present only when the
+# operator set ARXII_OPS_KEY_DIR at `just dc-up` time), REJECT prod SSH
+# outright, first-match before the ACCEPT. Both gates fail closed and are
+# controlled by the same single env var. Update the IP if the prod Linode
+# is ever rebuilt (= tofu output instance_ipv4).
+ARXII_PROD_IPV4="23.92.20.94"
+if [ ! -s /run/arxii-ops-key/arxii_ops ]; then
+    iptables -A OUTPUT -d "$ARXII_PROD_IPV4" -p tcp --dport 22 -j REJECT
+    echo "Prod ops gate: CLOSED (no ops key mounted; SSH to ${ARXII_PROD_IPV4} rejected)"
+else
+    echo "Prod ops gate: OPEN (ops key mounted; SSH to ${ARXII_PROD_IPV4} allowed)"
+fi
+
 # SSH — allows git-over-SSH and inbound responses.
 iptables -A OUTPUT -p tcp --dport 22 -j ACCEPT
 iptables -A INPUT  -p tcp --sport 22 -m state --state ESTABLISHED -j ACCEPT

--- a/.devcontainer/ops-key-install.sh
+++ b/.devcontainer/ops-key-install.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# ops-key-install.sh — install (or remove) the gated prod-ops SSH key.
+#
+# Runs at every container start via postStartCommand, AFTER the firewall
+# (both read the same /run/arxii-ops-key mount, so the two gates can never
+# disagree within one start). The bind mount can't be used directly as an
+# IdentityFile: a Windows-drive source arrives world-readable and ssh
+# refuses such a private key, so we copy it into ~/.ssh with 0600 perms.
+# When the mount is the empty no-ops-key default, any previously installed
+# copy is REMOVED — a container restarted without the env var sheds the
+# key instead of keeping a stale one. See docs/operations/ops-access.md.
+set -euo pipefail
+
+src=/run/arxii-ops-key/arxii_ops
+dst="${HOME}/.ssh/arxii_ops"
+
+mkdir -p "${HOME}/.ssh"
+chmod 700 "${HOME}/.ssh"
+
+if [ -s "${src}" ]; then
+  install -m 0600 "${src}" "${dst}"
+  if [ -s "${src}.pub" ]; then
+    install -m 0644 "${src}.pub" "${dst}.pub"
+  fi
+  # Convenience host alias so `ssh arxii-prod` just works. accept-new (not
+  # blind trust, not interactive prompt): first contact pins the host key,
+  # later mismatches still fail hard. arxops is the least-privilege server
+  # user provisioned by infra/ansible/roles/ops_access.
+  if ! grep -qs '^Host arxii-prod$' "${HOME}/.ssh/config"; then
+    {
+      echo 'Host arxii-prod'
+      echo '  HostName 23.92.20.94'
+      echo '  User arxops'
+      echo '  IdentityFile ~/.ssh/arxii_ops'
+      echo '  IdentitiesOnly yes'
+      echo '  StrictHostKeyChecking accept-new'
+    } >> "${HOME}/.ssh/config"
+    chmod 600 "${HOME}/.ssh/config"
+  fi
+  echo "Ops key installed at ${dst} (ssh arxii-prod)"
+else
+  rm -f "${dst}" "${dst}.pub"
+  echo "No ops key mounted; ${dst} absent"
+fi

--- a/.github/workflows/standup.yml
+++ b/.github/workflows/standup.yml
@@ -130,6 +130,13 @@ jobs:
           # read via lookup('env', ...) in roles/caddy/defaults). Set it (a
           # bcrypt hash from `caddy hash-password`) to roll the archive out.
           ARXII_ARX1_ARCHIVE_BASICAUTH_HASH: ${{ secrets.ARXII_ARX1_ARCHIVE_BASICAUTH_HASH }}
+          # Optional — the gated agent-ops PUBLIC key (a Variable, not a
+          # secret: the private half never leaves the operator's machine).
+          # Empty/unset means roles/ops_access writes an EMPTY arxops
+          # authorized_keys (= no agent access; clean converge). Clear the
+          # Variable + press the button to revoke. See
+          # docs/operations/ops-access.md.
+          ARXII_OPS_SSH_PUBKEY: ${{ vars.ARXII_OPS_SSH_PUBKEY }}
           ARXII_CADDY_CF_DNS_TOKEN: ${{ secrets.ARXII_CADDY_CF_DNS_TOKEN }}
           # #3153: ansible-step-only, deliberately never in secrets_map (see
           # secrets.env.example) — the content_repo role's clone task reads

--- a/docs/devcontainer-setup.md
+++ b/docs/devcontainer-setup.md
@@ -19,6 +19,9 @@ This setup provides two independent boundaries:
 - **Network**: an egress firewall (iptables + ipset) runs inside the container on every
   start. It is default-deny for outbound traffic and allows only the destinations Claude
   Code actually needs (Anthropic API, GitHub, PyPI, npm). Everything else is rejected.
+  SSH to the prod Linode is additionally gated: it is rejected unless the operator
+  opted in at `just dc-up` time via `ARXII_OPS_KEY_DIR` — see
+  `docs/operations/ops-access.md`.
 
 This is defense-in-depth, not a full sandbox: a compromised or mistaken agent can still
 modify anything in the bind-mounted workspace and can still send data to the explicitly

--- a/docs/operations/ops-access.md
+++ b/docs/operations/ops-access.md
@@ -1,0 +1,85 @@
+# Gated devcontainer → prod SSH access (agent ops)
+
+Lets the operator grant a devcontainer session SSH access to the prod Linode
+for a specific piece of server work, and revoke it just as deliberately. Both
+sides fail closed: a container brought up without the toggle has no key AND
+no network route; a server converged without the pubkey Variable accepts no
+login for the ops user.
+
+Threat model: an agent inside the devcontainer doing something catastrophic
+on prod without the operator having consciously opened the gate. It does NOT
+defend against host-machine compromise (the key lives on the host), and it
+does not protect the backups from a compromised box — that backstop is
+bucket-side immutability (R2 Object Lock, tracked in #2236 / infra README
+"Known gap: Object Lock").
+
+## The pieces
+
+| Layer | Where | Toggle |
+| --- | --- | --- |
+| Key possession | devcontainer mount → `~/.ssh/arxii_ops` | `ARXII_OPS_KEY_DIR` env var at `just dc-up` time |
+| Network egress | container firewall REJECT of prod:22 | same mount (key absent = blocked) |
+| Server account | `arxops` user, key-only, scoped sudo | `ARXII_OPS_SSH_PUBKEY` gated Environment **Variable** |
+
+The server user `arxops` (roles/ops_access) is least-privilege by design:
+`journalctl` and `/var/log` reads via groups, sudo for exactly
+`systemctl reload/restart/start arxii`, and nothing else — no Postgres, no
+`/etc/arxii` secrets, no user management. Real surgery stays on `arxadmin`,
+performed by a human.
+
+## One-time setup (operator)
+
+1. **Mint the keypair** on your host machine (NOT inside the devcontainer,
+   NOT inside the repo):
+
+   ```bash
+   mkdir -p ~/arxii-ops-key
+   ssh-keygen -t ed25519 -f ~/arxii-ops-key/arxii_ops -C arxii-ops-devcontainer -N ""
+   ```
+
+   The comment matters: it's what you'll grep for in the box's
+   `/var/log/auth.log` to tell agent sessions from your own. Keep the
+   directory OUTSIDE the repo checkout — the repo dir is bind-mounted into
+   the container wholesale, which would defeat the gate (and `git clean
+   -fdx` must never be able to eat a private key).
+
+2. **Authorize it server-side**: set the gated `prod` Environment
+   **Variable** (not secret — it's a public key) `ARXII_OPS_SSH_PUBKEY` to
+   the single-line content of `~/arxii-ops-key/arxii_ops.pub`, then press
+   the button ("Stand up infra"). The converge creates `arxops` and installs
+   the key.
+
+3. **Rebuild the devcontainer image once** after this feature lands
+   (`just dc-build`) — the firewall script is baked at image build time.
+
+## Opening the gate for a session
+
+```bash
+just dc-down
+ARXII_OPS_KEY_DIR=$HOME/arxii-ops-key just dc-up
+```
+
+(From a Windows shell, use the path form your Docker accepts, e.g.
+`C:\Users\you\arxii-ops-key`.) On start, the firewall log line says
+`Prod ops gate: OPEN`, the key is copied to `~/.ssh/arxii_ops` with 0600
+perms, and `ssh arxii-prod` works (host alias written to `~/.ssh/config`;
+first contact pins the host key via `accept-new`).
+
+## Closing the gate
+
+```bash
+just dc-down && just dc-up   # without the env var
+```
+
+The mount reverts to the committed empty `no-ops-key/` dir: the firewall
+REJECTs prod:22 again and the container-side key copy is deleted at start.
+For a stronger revoke (e.g. you suspect the key leaked), also clear the
+`ARXII_OPS_SSH_PUBKEY` Variable and press the button — the server then has
+an empty `authorized_keys` and the key is dead everywhere; re-mint a fresh
+pair before the next session.
+
+## Verifying the gate state
+
+Inside the container: `ssh -o BatchMode=yes -o ConnectTimeout=5 arxii-prod true`
+— exits 0 when open; "Connection refused"/"No route to host" when closed.
+The postStart output also prints the gate state on every container start.

--- a/infra/README.md
+++ b/infra/README.md
@@ -391,6 +391,16 @@ Installed once by the converge, then running unattended on the box:
   first start; `roles/secrets_perms` asserts that posture per file, so do not "harden" the
   cert to `0600` — the next renewal would revert it and fail the converge.
 
+## Gated devcontainer ops access (`arxops`)
+
+A second, deliberately weaker SSH identity exists for devcontainer/agent
+sessions: the `arxops` user (roles/ops_access) — journal + log reads, sudo
+for exactly `systemctl reload/restart/start arxii`, nothing else. Access is
+double-gated (client: `ARXII_OPS_KEY_DIR` mount + container firewall;
+server: the `ARXII_OPS_SSH_PUBKEY` Environment Variable) and both gates
+fail closed. Full setup + session workflow:
+`docs/operations/ops-access.md`.
+
 ## Generating the SSH admin key (one-time)
 
 The button creates a brand-new Linode instance and Ansible needs to SSH into it

--- a/infra/ansible/roles/ops_access/defaults/main.yml
+++ b/infra/ansible/roles/ops_access/defaults/main.yml
@@ -1,0 +1,15 @@
+---
+# Least-privilege server user for gated devcontainer/agent ops sessions
+# (docs/operations/ops-access.md). The user always exists; ACCESS is toggled
+# by whether ops_pubkey is non-empty — an empty value writes an EMPTY
+# authorized_keys, and with password auth globally disabled (ssh_hardening)
+# an empty keyfile means no login at all. Clean-converge posture, same idiom
+# as the optional archive vhost.
+ops_user: arxops
+ops_group: arxops
+# = the ARXII_OPS_SSH_PUBKEY gated Environment VARIABLE (not a secret — this
+# is a public key; the private half never leaves the operator's machine).
+# Read via lookup('env', ...) directly, same idiom as roles/caddy's
+# caddy_archive_basicauth_hash. Clear the Variable and press the button to
+# revoke server-side.
+ops_pubkey: "{{ lookup('env', 'ARXII_OPS_SSH_PUBKEY') }}"

--- a/infra/ansible/roles/ops_access/tasks/main.yml
+++ b/infra/ansible/roles/ops_access/tasks/main.yml
@@ -1,0 +1,54 @@
+---
+# Least-privilege ops user for gated devcontainer/agent sessions — the
+# server half of docs/operations/ops-access.md (the client half is the
+# devcontainer's ARXII_OPS_KEY_DIR mount + firewall gate). Deliberately NOT
+# arxadmin: an agent session gets diagnostics + service bounce, never
+# Postgres, /etc/arxii secrets, user management, or general sudo.
+#
+# systemd-journal: read `journalctl` without sudo. adm: read /var/log
+# (Caddy, auth.log). Both are stock Ubuntu groups.
+- name: Create the arxops user (least-privilege agent-ops account)
+  ansible.builtin.user:
+    name: "{{ ops_user }}"
+    shell: /bin/bash
+    groups: [systemd-journal, adm]
+    append: true
+
+- name: Ensure arxops ~/.ssh exists
+  ansible.builtin.file:
+    path: "/home/{{ ops_user }}/.ssh"
+    state: directory
+    owner: "{{ ops_user }}"
+    group: "{{ ops_group }}"
+    mode: "0700"
+
+# The pubkey's presence IS the server-side access toggle. copy (not
+# ansible.posix.authorized_key) so an empty ops_pubkey deterministically
+# writes an EMPTY file — sshd is key-only (ssh_hardening), so empty means
+# no login. authorized_key's absent-state would need the key value we no
+# longer have at revoke time.
+- name: Install (or clear) arxops authorized_keys — pubkey presence is the toggle
+  ansible.builtin.copy:
+    content: "{{ ops_pubkey ~ '\n' if ops_pubkey else '' }}"
+    dest: "/home/{{ ops_user }}/.ssh/authorized_keys"
+    owner: "{{ ops_user }}"
+    group: "{{ ops_group }}"
+    mode: "0600"
+
+# Exact commands only — NO wildcards. A sudoers glob like `systemctl
+# status arxii*` matches SPACES too, so `arxii --flag $(...)`-shaped
+# arguments would slip through; enumerating exact argv lines closes that.
+# journalctl/status/log-reads need no sudo (groups above); what needs root
+# is exactly the service-bounce set the deploy itself performs.
+- name: Scoped sudoers for arxops (exact commands, visudo-validated)
+  ansible.builtin.copy:
+    dest: /etc/sudoers.d/arxops
+    owner: root
+    group: root
+    mode: "0440"
+    validate: /usr/sbin/visudo -cf %s
+    content: |
+      # Managed by Ansible (ops_access). Least-privilege agent-ops set.
+      arxops ALL=(root) NOPASSWD: /usr/bin/systemctl reload {{ app_service | default('arxii') }}
+      arxops ALL=(root) NOPASSWD: /usr/bin/systemctl restart {{ app_service | default('arxii') }}
+      arxops ALL=(root) NOPASSWD: /usr/bin/systemctl start {{ app_service | default('arxii') }}

--- a/infra/ansible/roles/ssh_hardening/defaults/main.yml
+++ b/infra/ansible/roles/ssh_hardening/defaults/main.yml
@@ -1,4 +1,10 @@
 ---
 ssh_allow_users:
   - arxadmin
+  # arxops: the gated least-privilege agent-ops user (roles/ops_access,
+  # docs/operations/ops-access.md). Always listed — sshd ignores unknown
+  # names, auth is key-only, and roles/ops_access writes an EMPTY
+  # authorized_keys when access is toggled off, so listing it here grants
+  # nothing by itself.
+  - arxops
 ssh_port: 22

--- a/infra/ansible/site.yml
+++ b/infra/ansible/site.yml
@@ -11,6 +11,10 @@
   roles:
     - base
     - ssh_hardening
+    # Gated agent-ops account (docs/operations/ops-access.md): the arxops
+    # user always exists; access is toggled by the ARXII_OPS_SSH_PUBKEY
+    # Environment Variable (empty = empty authorized_keys = no login).
+    - ops_access
     - host_firewall
     - fail2ban
     - unattended_upgrades

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -307,6 +307,17 @@ chk   "base role authorizes SSH keys for arxadmin (authorized_key task)" \
   "grep -q 'ansible.posix.authorized_key' infra/ansible/roles/base/tasks/main.yml && grep -q 'user: arxadmin' infra/ansible/roles/base/tasks/main.yml"
 chk   "ssh_hardening's ssh_allow_users references arxadmin (not the nologin service user)" \
   "grep -A1 '^ssh_allow_users:' infra/ansible/roles/ssh_hardening/defaults/main.yml | grep -q arxadmin"
+# Gated agent-ops access (docs/operations/ops-access.md): the sudoers file
+# must be visudo-validated and wildcard-free (a sudoers glob matches spaces,
+# so `systemctl status arxii*` would authorize arbitrary trailing argv).
+chk   "ops_access sudoers is visudo-validated" \
+  "grep -q 'visudo -cf' infra/ansible/roles/ops_access/tasks/main.yml"
+chkno "ops_access sudoers contains no wildcards" \
+  "grep 'NOPASSWD' infra/ansible/roles/ops_access/tasks/main.yml | grep -F '*'"
+chk   "ops_access clears authorized_keys when the pubkey Variable is empty (revoke path)" \
+  "grep -q \"if ops_pubkey else ''\" infra/ansible/roles/ops_access/tasks/main.yml"
+chk   "devcontainer firewall gates prod SSH on the ops-key mount" \
+  "grep -q 'arxii-ops-key/arxii_ops' .devcontainer/init-firewall.sh && grep -q -- '--dport 22 -j REJECT' .devcontainer/init-firewall.sh"
 
 # (f) The first-run superuser PASSWORD (unlike username/email) is a real
 # secret with no safe default — it must be preflight-required.


### PR DESCRIPTION
## Why

Agents in the devcontainer should be able to do prod server work ONLY when the operator has consciously opened the gate — and today the container's egress firewall allows port 22 everywhere (for git-over-SSH), so the only thing between an agent and prod is the absence of a key. This adds a deliberate, fail-closed on/off switch plus a least-privilege server identity, per the design discussed in-session.

## What

**Client (devcontainer) — one env var drives both gates:**
- compose mounts `${ARXII_OPS_KEY_DIR:-./no-ops-key}` read-only at `/run/arxii-ops-key`; the committed default is an empty dir (VS Code / CI / plain `just dc-up` ⇒ no key).
- `init-firewall.sh` REJECTs prod:22 (first-match, before the global port-22 ACCEPT) whenever that mount holds no key, and logs `Prod ops gate: OPEN/CLOSED` at every start.
- new `ops-key-install.sh` (postStart, after the firewall) copies the key to `~/.ssh/arxii_ops` with 0600 perms (a Windows-drive bind mount can't carry them), writes an `arxii-prod` ssh-config alias (`accept-new` host-key pinning), and **removes** the copy when the mount is empty — a restart without the var sheds the key.

**Server (`roles/ops_access`):**
- `arxops` user: `journalctl`/`/var/log` via `systemd-journal`+`adm` groups; sudo for exactly `systemctl reload/restart/start arxii` — exact argv lines, no sudoers wildcards (globs match spaces), visudo-validated. No Postgres, no `/etc/arxii`, no user management.
- Access toggle = the `ARXII_OPS_SSH_PUBKEY` gated Environment **Variable** (public key, not a secret): empty ⇒ an EMPTY `authorized_keys` ⇒ no login under key-only sshd. `ssh_hardening`'s `AllowUsers` gains `arxops` (grants nothing by itself).

**Docs:** `docs/operations/ops-access.md` is the operator runbook (mint → authorize → open/close/revoke → verify); pointers added to `infra/README.md` and `docs/devcontainer-setup.md`. `acceptance.sh` guards the sudoers validation, no-wildcard rule, revoke path, and firewall gate.

Out of scope by design: backup immutability against a compromised box — that's R2 Object Lock, already tracked in #2236 (blocked on the Cloudflare provider pin).

## Operator follow-ups after merge (see the runbook)

1. `ssh-keygen -t ed25519 -f ~/arxii-ops-key/arxii_ops -C arxii-ops-devcontainer -N ""` (host machine, outside the repo)
2. Set `prod` Environment Variable `ARXII_OPS_SSH_PUBKEY` = the `.pub` content; press the button
3. `just dc-build` once (firewall script is baked at image build)

## Verification

- `ansible-lint` on the new role + touched playbook files: clean (repo-wide run still shows the pre-existing galaxy-blocked `unknown-module` env failure in `base`; CI installs collections and is the gate).
- `shellcheck` + `bash -n` clean on both shell scripts; new acceptance checks verified to pass by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrKwHi3m8c4PHT6PMxYEFR