### PR TITLE
Fix deploy reload deaths: ansible.cfg (keepalives) was never loaded in CI

### DIFF
--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -11,6 +11,10 @@ forks = 10
 
 [ssh_connection]
 pipelining = True
+# NOTE: this file is only in effect because standup.sh/rehearse.sh export
+# ANSIBLE_CONFIG pointing here — Ansible does NOT auto-load it from a
+# subdirectory (only from the process CWD), and CI runs from the repo root.
+# It was silently unloaded on every CI run until 2026-08-23; keep the export.
 # Keep long, silent tasks alive. Deploy steps such as `uv sync`, the frontend
 # build and the first-run migration send nothing over the SSH channel for
 # many minutes; an idle-timing-out hop in between then drops the connection,

--- a/infra/ansible/roles/app_deploy/tasks/main.yml
+++ b/infra/ansible/roles/app_deploy/tasks/main.yml
@@ -422,6 +422,15 @@
 #    completes regardless of the caller, so the retry is at worst a harmless
 #    second reload of an already-current Server (Portal keeps players
 #    connected through it either way).
+#
+# The 2026-08-23 evening run proved the drop is not random: reconnect
+# succeeded, then the retry died IDENTICALLY, both attempts at ~260 s — the
+# GitHub runner's Azure SNAT evicting a flow idle for ~4 min. A blocking
+# `systemctl reload` sends nothing for the several minutes a Server restart
+# now takes, and ansible.cfg's keepalives were silently not loaded (fixed in
+# standup.sh/rehearse.sh: ANSIBLE_CONFIG is now exported). async/poll below
+# is the second, independent guard: each 15 s poll is fresh channel traffic,
+# so the reload survives even if the cfg regresses to unloaded again.
 - name: Read which release the Server last provably reloaded into
   ansible.builtin.slurp:
     src: "{{ app_reload_stamp }}"
@@ -442,6 +451,11 @@
          or (app_reload_stamp_read.content | default('') | b64decode | trim)
             != app_checkout.after }}
 
+# async/poll: the reload blocks for the full Server restart (minutes) with
+# no output; detached-plus-poll keeps the SSH path active every 15 s instead
+# of one long silent block. 600 s comfortably exceeds systemd's own
+# TimeoutStartSec=300 cap on ExecReload, so a genuinely hung reload is
+# failed by systemd (loudly, as a task failure) before the async limit.
 - name: Reload Evennia on a code / deps / migration change (Portal keeps players connected)
   ansible.builtin.systemd_service:
     name: "{{ app_service }}"
@@ -449,6 +463,8 @@
   when: app_needs_reload | bool
   register: app_reload
   ignore_unreachable: true
+  async: 600
+  poll: 15
 
 - name: Reconnect if the SSH channel dropped mid-reload
   ansible.builtin.wait_for_connection:
@@ -460,6 +476,8 @@
     name: "{{ app_service }}"
     state: reloaded
   when: (app_needs_reload | bool) and (app_reload.unreachable | default(false))
+  async: 600
+  poll: 15
 
 # Direct to the localhost-bound backend (not through Caddy/Cloudflare), with
 # the real Host header — django_hardening's ALLOWED_HOSTS rejects a bare

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -257,6 +257,18 @@ assert_before "standup.sh unsets LINODE_TOKEN/CLOUDFLARE_API_TOKEN before invoki
   '^[[:space:]]*unset LINODE_TOKEN CLOUDFLARE_API_TOKEN' '^[[:space:]]*ansible-playbook -i' \
   infra/scripts/standup.sh
 
+# ansible.cfg only auto-loads from the process CWD (repo root in CI), so the
+# SSH keepalives/ControlPersist in infra/ansible/ansible.cfg were silently
+# never in effect until ANSIBLE_CONFIG was exported (2026-08-23: both reload
+# attempts died at the Azure SNAT ~4-min idle timeout). Guard the export in
+# BOTH converge scripts, before their ansible-playbook invocations.
+assert_before "standup.sh exports ANSIBLE_CONFIG before invoking ansible-playbook" \
+  '^export ANSIBLE_CONFIG=' '^[[:space:]]*ansible-playbook -i' \
+  infra/scripts/standup.sh
+assert_before "rehearse.sh exports ANSIBLE_CONFIG before invoking ansible-playbook" \
+  '^export ANSIBLE_CONFIG=' '^[[:space:]]*ansible-playbook -i' \
+  infra/scripts/rehearse.sh
+
 # (c) The caddy DNS-01 plugin install and the Caddyfile directive that
 # needs it are paired — if either half disappears the other is stale.
 chk   "caddy role fetches the caddy-dns/cloudflare plugin build" \

--- a/infra/scripts/rehearse.sh
+++ b/infra/scripts/rehearse.sh
@@ -40,6 +40,10 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; readonly SCRIPT_DIR
 INFRA_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"; readonly INFRA_DIR
 readonly STAGE_DIR="${INFRA_DIR}/terraform/ephemeral-stage"
 readonly ANSIBLE_DIR="${INFRA_DIR}/ansible"
+# Load ansible.cfg explicitly — Ansible only auto-loads it from the process
+# CWD, which is the repo root in CI and wherever the operator happens to be
+# locally. Same fix (and full rationale) as standup.sh.
+export ANSIBLE_CONFIG="${ANSIBLE_DIR}/ansible.cfg"
 readonly INVENTORY_DIR="${ANSIBLE_DIR}/inventory"
 readonly INVENTORY="${INVENTORY_DIR}/hosts.rehearsal.yml"                  # generated, gitignored
 readonly GROUP_VARS_FILE="${INVENTORY_DIR}/group_vars/arxii_rehearsal.yml" # generated, gitignored

--- a/infra/scripts/standup.sh
+++ b/infra/scripts/standup.sh
@@ -25,6 +25,16 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"; readonly SCRIPT_DIR
 INFRA_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"; readonly INFRA_DIR
 readonly TF_DIR="${INFRA_DIR}/terraform/prod"
 readonly ANSIBLE_DIR="${INFRA_DIR}/ansible"
+# Load ansible.cfg EXPLICITLY. Ansible only auto-loads ./ansible.cfg from the
+# process CWD, and both CI and local runs invoke this script from the repo
+# root — so the cfg (SSH keepalives, ControlPersist=600s, pipelining) was
+# silently never in effect on any button press. That is what killed the
+# 2026-08-23 deploys: `systemctl reload` blocked >4 min with zero channel
+# traffic, and the GitHub runner's Azure SNAT drops idle flows at ~4 min
+# (both reload attempts died at ~260 s — the idle timeout, not a hiccup).
+# The 2026-08-15 keepalive "fix" in ansible.cfg never actually applied in CI;
+# the migrate task only survived because async/poll generates traffic.
+export ANSIBLE_CONFIG="${ANSIBLE_DIR}/ansible.cfg"
 readonly INVENTORY_DIR="${ANSIBLE_DIR}/inventory"
 readonly INVENTORY="${INVENTORY_DIR}/hosts.yml"                       # generated, gitignored
 readonly GROUP_VARS_FILE="${INVENTORY_DIR}/group_vars/arxii_prod.yml" # generated, gitignored


### PR DESCRIPTION
## Root cause (proven by #3323's hardening)

Last night's run removed all doubt that the reload-task SSH deaths are deterministic: the new reconnect succeeded, then the retry died **identically** — both attempts at **~260 seconds** (18:39:21→18:43:42, 18:43:43→18:48:07). That's the GitHub-hosted runner's Azure SNAT evicting a TCP flow idle for ~4 minutes.

The keepalives that exist to prevent exactly this (`ansible.cfg`: `ServerAliveInterval=30`, `ControlPersist=600s`, `pipelining` — added after the 2026-08-15 mid-migration drop) have **silently never been in effect on any CI run**: Ansible only auto-loads `ansible.cfg` from the process CWD, and the workflow runs `standup.sh` from the repo root; the script uses absolute paths and never `cd`s or sets `ANSIBLE_CONFIG`. The migrate task survived all along only because its async/poll generates its own channel traffic. The reload became the victim the moment a Server restart started blocking past the 4-minute idle window.

## What

- **`standup.sh` + `rehearse.sh`**: `export ANSIBLE_CONFIG="${ANSIBLE_DIR}/ansible.cfg"` before `ansible-playbook`. `acceptance.sh` asserts the export precedes the invocation in both scripts.
- **Reload + retry tasks**: `async: 600 / poll: 15` (same idiom as migrate) — each poll is fresh traffic, so the reload survives even if the cfg ever regresses to unloaded. 600s exceeds systemd's `TimeoutStartSec=300` cap on `ExecReload`, so a genuinely hung reload still surfaces as a loud task failure, never a silent async cutoff.
- **`ansible.cfg`** now documents that it's only loaded via the export.

## Open question this makes observable

Why a Server restart now takes >4 minutes is a separate issue. With this fix, the next button press answers it either way: the reload completes and the #3323 health check + stamp go green, or systemd kills `ExecReload` at 300s and the task fails with real output instead of `UNREACHABLE`.

## Verification

`ansible-lint` clean on the changed task file (production profile); `bash -n` clean on all three scripts; both new acceptance assertions verified against the actual line ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrKwHi3m8c4PHT6PMxYEFR