### PR TITLE
Drop stdout_callback=yaml from ansible.cfg; smoke-test cfg load in validate

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -88,6 +88,15 @@ jobs:
           if [ -f infra/ansible/site.yml ]; then
             ansible-playbook --syntax-check -i 'localhost,' infra/ansible/site.yml
           fi
+          # The converge scripts load ansible.cfg via ANSIBLE_CONFIG (#3325).
+          # Prove the cfg actually LOADS in this collections environment: a
+          # cfg referencing an unavailable plugin (e.g. stdout_callback =
+          # yaml, no community.general) parses and lints fine but kills the
+          # real converge at startup — exactly the 2026-08-23 19:05 run.
+          # syntax-check above doesn't exercise the callback path; a real
+          # (local, trivial) play does.
+          printf -- '---\n- hosts: localhost\n  connection: local\n  gather_facts: false\n  tasks:\n    - name: Cfg loads\n      ansible.builtin.debug:\n        msg: ok\n' > /tmp/cfg-smoke.yml
+          ANSIBLE_CONFIG=infra/ansible/ansible.cfg ansible-playbook -i 'localhost,' /tmp/cfg-smoke.yml
 
   secrets-scan:
     # Public repo + secrets-adjacent infra => NOT deferrable. Scans full

--- a/infra/ansible/ansible.cfg
+++ b/infra/ansible/ansible.cfg
@@ -3,7 +3,12 @@ inventory = inventory/hosts.yml
 roles_path = roles
 host_key_checking = True
 retry_files_enabled = False
-stdout_callback = yaml
+# No stdout_callback override. `yaml` lived here for years but needs the
+# community.general collection (not in requirements.yml) — harmless while
+# this file was silently unloaded (see the [ssh_connection] note), it
+# instantly killed the first run after #3325 made the file load ("ERROR!
+# Invalid callback for stdout specified: yaml", 2026-08-23 19:05 run). The
+# callback is cosmetic and deprecated upstream; the default is fine.
 # Vault: passphrase supplied at run time via prompt or a non-committed
 # --vault-id (NEVER a committed vault-password-file). standup.sh / the CI
 # workflow supply it from the gated Environment; secrets are never echoed.


### PR DESCRIPTION
## What happened

#3325 made `ansible.cfg` load for the first time ever — and the very next button press (run 32660093642) died in 35 seconds, before any SSH: `ERROR! Invalid callback for stdout specified: yaml`. The `stdout_callback = yaml` line needs `community.general`, which `requirements.yml` doesn't install. It sat harmless for years precisely because the cfg was silently unloaded; it became fatal the moment the file took effect. (Also the final confirmation of #3325's diagnosis — any earlier run that had loaded this cfg would have failed exactly like this.)

## What

- Remove the callback override (cosmetic, deprecated upstream; default callback is fine), with the rationale in place.
- Add a cfg-load smoke test to validate.yml's ansible job: run a trivial local play with `ANSIBLE_CONFIG=infra/ansible/ansible.cfg` in the same collections environment as the deploy. Lint and `--syntax-check` both pass a cfg that references an unavailable plugin — only starting a real play exercises the callback path, so this closes the whole class.

## Verification

Reproduced both sides locally: the old cfg fails the smoke play with the callback error; the fixed cfg runs it green with the config loaded.

After merge: press the button again — this should finally be the run where the reload either completes with the health check green, or fails loudly at systemd's 300s cap and tells us why Server restarts got slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrKwHi3m8c4PHT6PMxYEFR