### PR TITLE
Reload-wedge fixes: tick-level DB connection healing + deploy restart fallback

### DIFF
--- a/infra/README.md
+++ b/infra/README.md
@@ -303,6 +303,10 @@ after the box itself is provisioned, the app_deploy role runs (in order):
    only after a post-reload health check against the localhost backend
    succeeds) — so a run that dies on the reload task is fixed by simply
    pressing the button again; the re-run cannot silently skip the reload.
+   If the reload itself *fails* (a wedged Server can block a graceful
+   reload forever — the 2026-08-23 dead-DB-connection incident), the play
+   falls back to a full `systemctl restart`: players drop on that path
+   only, and the deploy still lands.
 
 What the button **does not** do (deliberately, by-design):
 - It does not load any game-content fixtures. The plan is to load those

--- a/infra/ansible/roles/app_deploy/tasks/main.yml
+++ b/infra/ansible/roles/app_deploy/tasks/main.yml
@@ -451,33 +451,56 @@
          or (app_reload_stamp_read.content | default('') | b64decode | trim)
             != app_checkout.after }}
 
-# async/poll: the reload blocks for the full Server restart (minutes) with
-# no output; detached-plus-poll keeps the SSH path active every 15 s instead
-# of one long silent block. 600 s comfortably exceeds systemd's own
-# TimeoutStartSec=300 cap on ExecReload, so a genuinely hung reload is
-# failed by systemd (loudly, as a task failure) before the async limit.
-- name: Reload Evennia on a code / deps / migration change (Portal keeps players connected)
-  ansible.builtin.systemd_service:
-    name: "{{ app_service }}"
-    state: reloaded
+# Reload, falling back to a full restart if the reload FAILS. The fallback
+# exists because a reload needs the running Server's cooperation and a
+# wedged Server can withhold it forever: on 2026-08-23 the old Server's
+# main-thread DB connection had died under it (Postgres restart days into
+# its uptime), Evennia's shutdown() raised OperationalError on its very
+# first statement, the Server never stopped, and four consecutive deploys
+# stranded while `evennia reload` waited for a shutdown that could not
+# happen. A restart needs no cooperation: graceful stop is attempted, the
+# stop-timeout SIGKILLs the whole cgroup (sweeping any hung `evennia
+# reload` launchers too), ExecStopPost clears twistd stragglers, and
+# ExecStart brings up the new release cold. Players drop on the fallback
+# path only — acceptable next to a deploy that otherwise cannot land.
+#
+# async/poll on every job: the reload/restart blocks for the full Server
+# restart (minutes) with no output; detached-plus-poll keeps the SSH path
+# active every 15 s instead of one long silent block. 600 s comfortably
+# exceeds systemd's own TimeoutStartSec=300 cap on ExecReload, so a hung
+# reload is failed by systemd (loudly) before the async limit; 900 s on the
+# restart covers stop-timeout + kill + a slow cold start.
+- name: Reload Evennia, restarting instead if the Server cannot cooperate
   when: app_needs_reload | bool
-  register: app_reload
-  ignore_unreachable: true
-  async: 600
-  poll: 15
+  block:
+    - name: Reload Evennia on a code / deps / migration change (Portal keeps players connected)
+      ansible.builtin.systemd_service:
+        name: "{{ app_service }}"
+        state: reloaded
+      register: app_reload
+      ignore_unreachable: true
+      async: 600
+      poll: 15
 
-- name: Reconnect if the SSH channel dropped mid-reload
-  ansible.builtin.wait_for_connection:
-    timeout: 300
-  when: (app_needs_reload | bool) and (app_reload.unreachable | default(false))
+    - name: Reconnect if the SSH channel dropped mid-reload
+      ansible.builtin.wait_for_connection:
+        timeout: 300
+      when: app_reload.unreachable | default(false)
 
-- name: Retry the reload after a reconnect (idempotent; systemd finishes an accepted job anyway)
-  ansible.builtin.systemd_service:
-    name: "{{ app_service }}"
-    state: reloaded
-  when: (app_needs_reload | bool) and (app_reload.unreachable | default(false))
-  async: 600
-  poll: 15
+    - name: Retry the reload after a reconnect (idempotent; systemd finishes an accepted job anyway)
+      ansible.builtin.systemd_service:
+        name: "{{ app_service }}"
+        state: reloaded
+      when: app_reload.unreachable | default(false)
+      async: 600
+      poll: 15
+  rescue:
+    - name: Fall back to a full restart (wedged Server; players drop, deploy lands)
+      ansible.builtin.systemd_service:
+        name: "{{ app_service }}"
+        state: restarted
+      async: 900
+      poll: 15
 
 # Direct to the localhost-bound backend (not through Caddy/Cloudflare), with
 # the real Host header — django_hardening's ALLOWED_HOSTS rejects a bare

--- a/infra/scripts/acceptance.sh
+++ b/infra/scripts/acceptance.sh
@@ -134,6 +134,11 @@ chk   "app_deploy reload survives an SSH drop (ignore_unreachable + retry)" \
   "grep -q 'ignore_unreachable: true' infra/ansible/roles/app_deploy/tasks/main.yml && grep -q 'Retry the reload after a reconnect' infra/ansible/roles/app_deploy/tasks/main.yml"
 chk   "app_deploy stamps the reloaded SHA after a health check" \
   "grep -q 'app_reload_stamp' infra/ansible/roles/app_deploy/tasks/main.yml && grep -q 'Wait until the reloaded Server answers' infra/ansible/roles/app_deploy/tasks/main.yml"
+# 2026-08-23 reload-wedge: a reload needs the running Server's cooperation
+# (a dead DB connection made shutdown() raise, so the Server never stopped
+# and four deploys stranded); the rescue restart needs none.
+chk   "app_deploy reload falls back to a full restart on failure (wedged Server)" \
+  "grep -q 'rescue:' infra/ansible/roles/app_deploy/tasks/main.yml && grep -q 'state: restarted' infra/ansible/roles/app_deploy/tasks/main.yml"
 chk   "app_deploy's health-check backend == caddy's caddy_backend" \
   "[ \"\$(sed -n 's/^app_web_backend: //p' infra/ansible/roles/app_deploy/defaults/main.yml)\" = \"\$(sed -n 's/^caddy_backend: //p' infra/ansible/roles/caddy/defaults/main.yml | sed 's/ *#.*//')\" ]"
 chk   "app_deploy guards superuser create with an exists-check (idempotent)" \

--- a/src/world/game_clock/scripts.py
+++ b/src/world/game_clock/scripts.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import logging
 
+from django.db import close_old_connections
+
 from typeclasses.scripts import Script
 from world.game_clock.services import get_ic_now
 from world.game_clock.task_registry import run_due_tasks
@@ -28,6 +30,19 @@ class GameTickScript(Script):
         self.start_delay = True
 
     def at_repeat(self) -> None:
+        # Discard dead/expired DB connections BEFORE any query. The Server is
+        # a long-lived process holding one main-thread Django connection; a
+        # Postgres restart under it (e.g. unattended-upgrades) leaves that
+        # connection dead, and every Twisted-side query then raises
+        # OperationalError("the connection is closed") until something closes
+        # it — including Evennia's own shutdown(), whose FIRST statement is a
+        # ServerConfig query, which is how `evennia reload` wedged forever on
+        # 2026-08-23 (four deploys stranded). Web requests self-heal via
+        # Django's request_started signal; this is the equivalent for the
+        # tick path. close() is local (no server roundtrip), so this never
+        # raises, and the next query transparently reopens — bounding the
+        # dead-connection window to one TICK_INTERVAL.
+        close_old_connections()
         ic_now = get_ic_now()
         executed = run_due_tasks(ic_now=ic_now)
         if executed:

--- a/src/world/game_clock/tests/test_scripts.py
+++ b/src/world/game_clock/tests/test_scripts.py
@@ -5,6 +5,32 @@ from unittest.mock import MagicMock, patch
 from django.test import TestCase
 
 
+class GameTickRepeatTests(TestCase):
+    @patch("world.game_clock.scripts.run_due_tasks")
+    @patch("world.game_clock.scripts.get_ic_now")
+    @patch("world.game_clock.scripts.close_old_connections")
+    def test_at_repeat_heals_connections_before_any_query(
+        self, mock_close: MagicMock, mock_ic_now: MagicMock, mock_run: MagicMock
+    ) -> None:
+        """close_old_connections runs FIRST — before get_ic_now's query.
+
+        Ordering is the contract: a dead connection (Postgres restarted under
+        the long-lived Server) must be discarded before the tick's first
+        query, or the tick raises OperationalError forever (2026-08-23
+        reload-wedge incident).
+        """
+        from world.game_clock.scripts import GameTickScript
+
+        call_order: list[str] = []
+        mock_close.side_effect = lambda: call_order.append("close")
+        mock_ic_now.side_effect = lambda: call_order.append("ic_now")
+        mock_run.return_value = []
+
+        GameTickScript.at_repeat(MagicMock())
+        self.assertEqual(call_order[0], "close")
+        self.assertIn("ic_now", call_order)
+
+
 class EnsureGameTickScriptTests(TestCase):
     @patch("world.game_clock.scripts.GameTickScript")
     def test_skips_creation_when_exists(self, mock_gts: MagicMock) -> None:


### PR DESCRIPTION
## Root cause (from the box journal + server log)

The four stranded 2026-08-23 deploys all trace to one thing: the long-running Server (up since Aug 20) was holding a **dead Postgres connection** — Postgres restarted under it at some point — and Evennia's `shutdown()` raises `OperationalError("the connection is closed")` on its *first statement* (`ServerConfig.objects.conf("server_restart_mode", ...)`). The Server therefore never stops, `evennia reload` waits forever for a shutdown that cannot happen, and systemd's reload-timeout kill only reaps the `uv run` wrapper — four orphaned `evennia reload` launchers were found accumulated in the cgroup. The website kept working because Django heals connections per web request (`request_started`); the Twisted side had no equivalent. The running Server is still the 8/20 release; nothing in the #3313–#3322 batch was at fault.

## What

**1. Tick-level connection healing** (`world/game_clock/scripts.py`): `GameTickScript.at_repeat` now calls `django.db.close_old_connections()` **before any query**. Dead/expired connections are discarded locally (close never raises, no server roundtrip) and the next query transparently reconnects. This heals *all* Server-side DB use — the tick itself (which was also erroring on the dead connection, so the game clock has been down since the Postgres restart) and any later shutdown — bounding the dead-connection window to one `TICK_INTERVAL` (300s). The call-ordering contract is covered by a test.

**2. Deploy restart fallback** (`roles/app_deploy`): the reload tasks move into a `block`/`rescue`. A reload needs the running Server's *cooperation*, and a wedged Server can withhold it forever; a restart needs none — graceful stop attempted, stop-timeout SIGKILLs the whole cgroup (sweeping hung reload launchers too), `ExecStopPost` clears twistd stragglers, `ExecStart` boots the new release cold. Players drop on the fallback path only; the deploy always lands. `acceptance.sh` guards the rescue; `infra/README.md` documents it.

Worth noting upstream: Evennia's `shutdown()` could arguably call `close_old_connections()` itself before that first query — potential upstream issue to file, not fixed in the vendored copy.

## Verification

- `world.game_clock.tests.test_scripts`: 3 tests green on the SQLite tier (includes the new ordering test).
- `ansible-lint` clean at the production profile on the changed task file; `bash -n` clean on acceptance.sh, new checks verified by hand.

## Sequencing

The immediate unwedge of prod is operational (a one-time `systemctl restart arxii`), separate from this PR. Once prod runs a Server with the tick heal in it, this class of wedge can't recur — and if anything else ever wedges a Server, the deploy now recovers by itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RrKwHi3m8c4PHT6PMxYEFR