### PR TITLE
Gatefold polish: upright hero prose, baseline-aligned footer (designer feedback)

### DIFF
--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,5 +1,4 @@
 import { Link } from 'react-router-dom';
-import { Button } from './ui/button';
 import { Separator } from './ui/separator';
 
 export function Footer() {
@@ -7,20 +6,20 @@ export function Footer() {
     <footer className="mt-8">
       <Separator />
       <div className="container flex flex-col items-center gap-2 py-6 text-center text-sm text-muted-foreground">
-        <div className="flex gap-4">
-          <Button variant="ghost" asChild>
-            <Link to="/codex">Codex</Link>
-          </Button>
-          <Button variant="ghost" asChild>
-            <Link to="/roster">Roster</Link>
-          </Button>
-          <Button variant="ghost" asChild>
-            <Link to="/scenes">Scenes</Link>
-          </Button>
-          <Button variant="ghost" asChild>
-            <Link to="/login">Log in</Link>
-          </Button>
-        </div>
+        <nav aria-label="Footer" className="flex items-baseline gap-6">
+          <Link to="/codex" className="px-1 py-2 hover:text-foreground hover:underline">
+            Codex
+          </Link>
+          <Link to="/roster" className="px-1 py-2 hover:text-foreground hover:underline">
+            Roster
+          </Link>
+          <Link to="/scenes" className="px-1 py-2 hover:text-foreground hover:underline">
+            Scenes
+          </Link>
+          <Link to="/login" className="px-1 py-2 hover:text-foreground hover:underline">
+            Log in
+          </Link>
+        </nav>
         <p>
           Powered by{' '}
           <a href="https://www.evennia.com" target="_blank" rel="noreferrer" className="underline">

--- a/frontend/src/home/home.css
+++ b/frontend/src/home/home.css
@@ -62,8 +62,8 @@
   max-width: 34rem;
   font-size: clamp(1.2rem, 1.6vw, 1.4rem);
   line-height: 1.6;
+  font-weight: 500;
   color: #b9b2a2;
-  font-style: italic;
   margin: 0;
 }
 .gatefold-hero-prose em {


### PR DESCRIPTION
Two fixes from graphic-designer feedback relayed by ApostateCD on the shipped Gatefold (#3305 / PR #3317):

- The hero prose block was set italic, reading as an unexplained quotation right after the wordmark (it also violated the folio rule that italic is for voice, never running blocks). Now upright EB Garamond at weight 500; the closing emphasis keeps its brighter parchment color.
- Footer links were shadcn ghost buttons sitting off-baseline next to the credit line; now plain baseline-aligned links in a labeled nav with the same hover affordance.

Prototype artifact updated to match. No behavior changes; typecheck + build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)