### PR TITLE
fix(infra): Caddyfile comments contained live Jinja, killing prod converge

### DIFF
--- a/infra/ansible/roles/caddy/templates/Caddyfile.j2
+++ b/infra/ansible/roles/caddy/templates/Caddyfile.j2
@@ -71,7 +71,7 @@
 	# MUST agree, and acceptance.sh asserts they do.
 	#
 	# The prefix is a LITERAL here, not a templated var, on purpose: CI's
-	# validate.yml stubs every whole `{{ ... }}` with a placeholder
+	# validate.yml stubs every whole Jinja substitution with a placeholder
 	# HOSTNAME before `caddy adapt`, and a path matcher that does not
 	# start with "/" is a parse error - a templated prefix would fail
 	# validation as a stub artifact. See roles/arx1_archive for the other

--- a/infra/ansible/roles/caddy/templates/Caddyfile.rehearsal.j2
+++ b/infra/ansible/roles/caddy/templates/Caddyfile.rehearsal.j2
@@ -74,7 +74,7 @@
 	# MUST agree, and acceptance.sh asserts they do.
 	#
 	# The prefix is a LITERAL here, not a templated var, on purpose: CI's
-	# validate.yml stubs every whole `{{ ... }}` with a placeholder
+	# validate.yml stubs every whole Jinja substitution with a placeholder
 	# HOSTNAME before `caddy adapt`, and a path matcher that does not
 	# start with "/" is a parse error - a templated prefix would fail
 	# validation as a stub artifact. See roles/arx1_archive for the other


### PR DESCRIPTION
ApostateCD's first Stand up infra press (run 32788109490) died at TASK [caddy] with a Jinja 'unexpected .' — the template comment documenting validate.yml's stubbing behavior contained a literal `{{ ... }}`, which the real Ansible templater parses. CI validation can't catch this class: the validator stubs Jinja before checking, so the comment describing the blind spot sat inside it. Both lockstep templates (prod + rehearsal) carried the line; both fixed by rephrasing, verified with a real jinja2 parse of every infra .j2 (all clean now).

Unblocks the arxops + migration deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)