### PR TITLE
docs: correct three stale combat claims found by the 2026-08-26 audit

### DIFF
--- a/docs/roadmap/combat.md
+++ b/docs/roadmap/combat.md
@@ -5,8 +5,10 @@
 surface in #3067, closing the last "server-only" gap in the party-combat REST API; the authored
 effect palette shipped (#1584, combat-wired for battlefield shaping by #2206); the frontier is
 embodied combat (companions, mounts, war) and *proving* the WIRED-UNPROVEN paths — not the round
-engine. Champion-duel challenge issuance and Battle staging (`CmdBattle`) remain telnet-first — no
-web GM surface for those two yet. **Lethal NPC duels are reachable (#3068):**
+engine. Champion-duel challenge issuance and Battle round PLAY remain telnet-first: staging
+(create/stage/spawn/enlist) got its web `StagingPanel` in #2010, but round-action declaration
+(all 12 `BattleActionKind`s), the begin/resolve/conclude round lifecycle, and `battle duel` have
+no web surface (verified 2026-08-26 audit; filed as #3389). **Lethal NPC duels are reachable (#3068):**
 `world.combat.duels.create_lethal_duel` — previously a zero-caller service, flagged unreachable by
 the 2026-08-08 combat audit — now has a real GM-initiated caller: a GM proposes a climactic
 PC-vs-significant-NPC duel (web `GMEncounterControls` "Start Lethal Duel" dialog / telnet `encounter
@@ -326,7 +328,10 @@ outcome** (a closed issue or a "SHIPPED" line is not proof). See the ledger's go
 - **Charm / switch-sides** an enemy NPC; **negotiate / parley** an NPC down (built in this PR,
   #1590/#1591, ADR-0058); **dispel** a condition.
 - **Companions / pets / summons** with breath weapons & ordered abilities.
-- **Roles grant techniques** via the one specialization engine (ADR-0055; reverses bonuses-only).
+- **Roles grant techniques** — SHIPPED (#2022 via #2106/#2109, 2026-07-09): `CovenantRoleGiftGrant`
+  + `_grant_role_gifts_and_techniques` on engage, revoked on disengage (`role_source`-stamped rows
+  only); granted techniques resolve through the ordinary cast pipeline. Stale "MVP gap" listing
+  corrected 2026-08-26.
 - **War / battle system** — spine landed (#1592): `Battle` (1:1 Scene extension),
   abstract unit attrition + VP accumulation, `BattleRoundContext` seam, GM + player REGISTRY
   actions, `CmdBattle` telnet namespace, E2E `test_battle_telnet_e2e.py`. Peril/rescue +

--- a/src/actions/CLAUDE.md
+++ b/src/actions/CLAUDE.md
@@ -41,7 +41,10 @@ They do not use the command system, dispatchers, or handlers.
   non-cast/non-clash combat verbs as
   REGISTRY actions: `FleeAction`/`CoverAction`/`InterposeAction`/`SuccorAction`/
   `UseItemManeuverAction`/`ReadyAction`/
-  `UpgradeComboAction`/`RevertComboAction`/`JoinEncounterAction`/`LeaveEncounterAction` (keys
+  `UpgradeComboAction`/`RevertComboAction`/`JoinEncounterAction`/`LeaveEncounterAction`/
+  `RallyAction`/`DemoralizeAction`/`TauntAction`/`ParleyAction` (social maneuvers, #1590/#1591)/
+  `ChargeAction`/`JoustAction` (mounted, #1843)/`EngageAction`/`DisengageAction`
+  (engagement locks, #2020; currently surfaced from NOWHERE, see #3386) (keys
   prefixed `combat_`). `SuccorAction` (key `combat_succor`) wraps `declare_succor` — always
   names a specific ally (no "any ally" path, unlike Interpose). `UseItemManeuverAction`
   (key `combat_use`, #2120) wraps `declare_use_item` — a primary maneuver (consumes the


### PR DESCRIPTION
Agent-facing doc plumbing surfaced by the 2026-08-26 combat audit (fix-on-sight per Docs Are Directives). Docs only, no behavior change.

- `docs/roadmap/combat.md`: the "Battle staging (CmdBattle) remain telnet-first" sentence was stale — staging has full web parity since #2010 (`StagingPanel`). The genuinely telnet-only surface is battle round PLAY (all 12 declaration kinds + begin/resolve/conclude + champion duel), now tracked as #3389.
- `docs/roadmap/combat.md`: "Roles grant techniques" was still listed under the combat gaps that define MVP; it shipped 2026-07-09 (#2022 via #2106/#2109) and the capability ledger already lists it PROVEN.
- `src/actions/CLAUDE.md`: the `combat_maneuvers.py` REGISTRY list omitted eight real, telnet-wired action classes (rally/demoralize/taunt/parley, charge/joust, engage/disengage — the last pair surfaced from nowhere, see #3386).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015chciXimM4WNAdEPonujMK